### PR TITLE
Remove site isolation processes from DrawingAreaProxy when they are no longer used

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -75,7 +75,7 @@ PageClientImpl::PageClientImpl(GtkWidget* viewWidget)
 }
 
 // PageClient's pure virtual functions
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy&)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
     return makeUnique<DrawingAreaProxyCoordinatedGraphics>(*webkitWebViewBaseGetPage(WEBKIT_WEB_VIEW_BASE(m_viewWidget)));
 }

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -60,7 +60,7 @@ public:
 
 private:
     // PageClient
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
     void setViewNeedsDisplay(const WebCore::Region&) override;
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated) override;
     void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) override;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -63,7 +63,7 @@ UnixFileDescriptor PageClientImpl::hostFileDescriptor()
     return UnixFileDescriptor { wpe_view_backend_get_renderer_host_fd(m_view.backend()), UnixFileDescriptor::Adopt };
 }
 
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& process)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
     return makeUnique<DrawingAreaProxyCoordinatedGraphics>(m_view.page());
 }

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -67,7 +67,7 @@ public:
 
 private:
     // PageClient
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
     void setViewNeedsDisplay(const WebCore::Region&) override;
     void requestScroll(const WebCore::FloatPoint&, const WebCore::IntPoint&, WebCore::ScrollIsAnimated) override;
     WebCore::FloatPoint viewScrollPosition() override;

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -50,6 +50,8 @@ public:
     bool isInAcceleratedCompositingMode() const { return !m_layerTreeContext.isEmpty(); }
     const LayerTreeContext& layerTreeContext() const { return m_layerTreeContext; }
 
+    void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&);
+
 private:
     // DrawingAreaProxy
     void sizeDidChange() override;
@@ -87,9 +89,6 @@ private:
     void discardBackingStoreSoon();
     void discardBackingStore();
 #endif
-
-    void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&) final;
-    void attachToProvisionalFrameProcess(WebProcessProxy&) final { ASSERT_NOT_REACHED(); }
 
     class DrawingMonitor {
         WTF_MAKE_NONCOPYABLE(DrawingMonitor); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -50,16 +50,16 @@ DrawingAreaProxy::DrawingAreaProxy(DrawingAreaType type, WebPageProxy& webPagePr
 {
 }
 
-DrawingAreaProxy::~DrawingAreaProxy()
-{
-    for (auto& process : m_processesWithRegisteredDrawingAreaProxyMessageReceiver)
-        process->removeMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier);
-}
+DrawingAreaProxy::~DrawingAreaProxy() = default;
 
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
     process.addMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier, *this);
-    m_processesWithRegisteredDrawingAreaProxyMessageReceiver.append(process);
+}
+
+void DrawingAreaProxy::stopReceivingMessages(WebProcessProxy& process)
+{
+    process.removeMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier);
 }
 
 DelegatedScrollingMode DrawingAreaProxy::delegatedScrollingMode() const

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -69,8 +69,8 @@ public:
     DrawingAreaType type() const { return m_type; }
     DrawingAreaIdentifier identifier() const { return m_identifier; }
 
-    void startReceivingMessages(WebProcessProxy&);
-    virtual void attachToProvisionalFrameProcess(WebProcessProxy&) = 0;
+    virtual void startReceivingMessages(WebProcessProxy&);
+    virtual void stopReceivingMessages(WebProcessProxy&);
 
     virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
@@ -105,8 +105,6 @@ public:
     virtual void updateDebugIndicator() { }
 
     virtual void waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy&) { }
-    
-    virtual void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&) = 0;
 
     // Hide the content until the currently pending update arrives.
     virtual void hideContentUntilPendingUpdate() { ASSERT_NOT_REACHED(); }
@@ -137,7 +135,6 @@ protected:
     DrawingAreaType m_type;
     DrawingAreaIdentifier m_identifier;
     WebPageProxy& m_webPageProxy;
-    Vector<Ref<WebProcessProxy>> m_processesWithRegisteredDrawingAreaProxyMessageReceiver;
 
     WebCore::IntSize m_size;
     WebCore::IntSize m_scrollOffset;

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -210,7 +210,7 @@ public:
     virtual ~PageClient() { }
 
     // Create a new drawing area proxy for the given page.
-    virtual std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) = 0;
+    virtual std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() = 0;
 
     // Tell the view to invalidate the given region. The region is in view coordinates.
     virtual void setViewNeedsDisplay(const WebCore::Region&) = 0;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -177,7 +177,7 @@ void ProvisionalPageProxy::cancel()
 
 void ProvisionalPageProxy::initializeWebPage(RefPtr<API::WebsitePolicies>&& websitePolicies)
 {
-    m_drawingArea = m_page->pageClient().createDrawingAreaProxy(m_process);
+    m_drawingArea = m_page->pageClient().createDrawingAreaProxy();
 
     auto parameters = m_page->creationParameters(m_process, *m_drawingArea, WTFMove(websitePolicies));
     parameters.isProcessSwap = true;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -42,7 +42,7 @@ class RemoteScrollingCoordinatorTransaction;
 
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy {
 public:
-    RemoteLayerTreeDrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
+    RemoteLayerTreeDrawingAreaProxy(WebPageProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxy();
 
     virtual bool isRemoteLayerTreeDrawingAreaProxyMac() const { return false; }
@@ -88,13 +88,9 @@ private:
     void minimumSizeForAutoLayoutDidChange() final;
     void sizeToContentAutoSizeMaximumSizeDidChange() final;
     void didUpdateGeometry();
-    void attachToProvisionalFrameProcess(WebProcessProxy&) final;
-    void startReceivingRemoteLayerTreeDrawingAreaProxyMessages(WebProcessProxy&);
+    void startReceivingMessages(WebProcessProxy&) final;
+    void stopReceivingMessages(WebProcessProxy&) final;
 
-    // For now, all callbacks are called before committing changes, because that's what the only client requires.
-    // Once we have other callbacks, it may make sense to have a before-commit/after-commit option.
-    void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&) final;
-    
     virtual void scheduleDisplayRefreshCallbacks() { }
     virtual void pauseDisplayRefreshCallbacks() { }
 
@@ -154,8 +150,6 @@ private:
     ActivityStateChangeID m_activityStateChangeID { ActivityStateChangeAsynchronous };
     
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
-
-    Vector<Ref<WebProcessProxy>> m_processesWithRegisteredRemoteLayerTreeDrawingAreaProxyMessageReceiver;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -35,7 +35,7 @@ namespace WebKit {
 
 class RemoteLayerTreeDrawingAreaProxyIOS final : public RemoteLayerTreeDrawingAreaProxy {
 public:
-    RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy&, WebProcessProxy&);
+    RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy&);
     virtual ~RemoteLayerTreeDrawingAreaProxyIOS();
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -155,8 +155,8 @@ namespace WebKit {
 using namespace IPC;
 using namespace WebCore;
 
-RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy& pageProxy, WebProcessProxy& processProxy)
-    : RemoteLayerTreeDrawingAreaProxy(pageProxy, processProxy)
+RemoteLayerTreeDrawingAreaProxyIOS::RemoteLayerTreeDrawingAreaProxyIOS(WebPageProxy& pageProxy)
+    : RemoteLayerTreeDrawingAreaProxy(pageProxy)
 {
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -43,7 +43,7 @@ class RemoteScrollingCoordinatorTransaction;
 class RemoteLayerTreeDrawingAreaProxyMac final : public RemoteLayerTreeDrawingAreaProxy {
 friend class RemoteScrollingCoordinatorProxyMac;
 public:
-    RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy&, WebProcessProxy&);
+    RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy&);
     ~RemoteLayerTreeDrawingAreaProxyMac();
 
     void didRefreshDisplay() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -82,8 +82,8 @@ void RemoteLayerTreeDisplayLinkClient::displayLinkFired(WebCore::PlatformDisplay
     });
 }
 
-RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy& pageProxy, WebProcessProxy& processProxy)
-    : RemoteLayerTreeDrawingAreaProxy(pageProxy, processProxy)
+RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac(WebPageProxy& pageProxy)
+    : RemoteLayerTreeDrawingAreaProxy(pageProxy)
     , m_displayLinkClient(makeUnique<RemoteLayerTreeDisplayLinkClient>(pageProxy.identifier()))
 {
 }

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
+#include <WebCore/RegistrableDomain.h>
 
 namespace IPC {
 class Connection;
@@ -62,13 +63,13 @@ struct FrameInfoData;
 class SubframePageProxy : public RefCounted<SubframePageProxy>, public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<SubframePageProxy> create(WebPageProxy& page, WebProcessProxy& process) { return adoptRef(*new SubframePageProxy(page, process)); }
+    static Ref<SubframePageProxy> create(WebPageProxy& page, WebProcessProxy& process, const WebCore::RegistrableDomain& domain) { return adoptRef(*new SubframePageProxy(page, process, domain)); }
     ~SubframePageProxy();
 
     WebProcessProxy& process() { return m_process.get(); }
 
 private:
-    SubframePageProxy(WebPageProxy&, WebProcessProxy&);
+    SubframePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::RegistrableDomain&);
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
@@ -76,9 +77,10 @@ private:
     void decidePolicyForResponse(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, uint64_t listenerID);
     void didCommitLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
 
-    WebCore::PageIdentifier m_webPageID;
-    Ref<WebProcessProxy> m_process;
+    const WebCore::PageIdentifier m_webPageID;
+    const Ref<WebProcessProxy> m_process;
     WeakPtr<WebPageProxy> m_page;
+    const WebCore::RegistrableDomain m_domain;
 };
 
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -396,7 +396,6 @@ void WebFrameProxy::commitProvisionalFrame(FrameIdentifier frameID, FrameInfoDat
 
         RegistrableDomain oldDomain(url());
         m_subframePageProxy = m_page->subpageFrameProxyForRegistrableDomain(RegistrableDomain(request.url()));
-        m_page->removeSubpageFrameProxyIfUnused(oldDomain);
     }
     m_page->didCommitLoadForFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2160,8 +2160,8 @@ public:
 #endif
 
     SubframePageProxy* subpageFrameProxyForRegistrableDomain(WebCore::RegistrableDomain) const;
-    void addSubframePageProxy(const WebCore::RegistrableDomain&, Ref<SubframePageProxy>&&);
-    void removeSubpageFrameProxyIfUnused(const WebCore::RegistrableDomain&);
+    void addSubframePageProxy(const WebCore::RegistrableDomain&, WeakPtr<SubframePageProxy>&&);
+    void removeSubpageFrameProxy(const WebCore::RegistrableDomain&);
 
     void createRemoteSubframesInOtherProcesses(WebFrameProxy&);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1859,11 +1859,8 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
 
     if (!frame.isMainFrame() && page.preferences().siteIsolationEnabled()) {
         RegistrableDomain navigationDomain(navigation.currentRequest().url());
-        if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain) {
-            auto subframePageProxy = SubframePageProxy::create(page, process);
-            frame.setSubframePageProxy(subframePageProxy.get());
-            page.addSubframePageProxy(navigationDomain, WTFMove(subframePageProxy));
-        }
+        if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain)
+            frame.setSubframePageProxy(SubframePageProxy::create(page, process, navigationDomain));
     }
 
     // We are process-swapping so automatic process prewarming would be beneficial if the client has not explicitly enabled / disabled it.

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -60,7 +60,7 @@ public:
     
 private:
     // PageClient
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
     void setViewNeedsDisplay(const WebCore::Region&) override;
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated) override;
     WebCore::FloatPoint viewScrollPosition() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -96,9 +96,9 @@ PageClientImpl::~PageClientImpl()
 {
 }
 
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& process)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
-    return [m_contentView _createDrawingAreaProxy:process];
+    return [m_contentView _createDrawingAreaProxy];
 }
 
 void PageClientImpl::setViewNeedsDisplay(const Region&)

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -372,7 +372,7 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
             return;
         }
 
-        drawingArea->dispatchAfterEnsuringDrawing([pageID, gestureID] {
+        m_webPageProxy.callAfterNextPresentationUpdate([pageID, gestureID] {
             if (auto gestureController = controllerForGesture(pageID, gestureID))
                 gestureController->willCommitPostSwipeTransitionLayerTree(true);
         });

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -96,7 +96,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WKWebView *)webView;
 - (UIView *)rootContentView;
 
-- (std::unique_ptr<WebKit::DrawingAreaProxy>)_createDrawingAreaProxy:(WebKit::WebProcessProxy&)process;
+- (std::unique_ptr<WebKit::DrawingAreaProxy>)_createDrawingAreaProxy;
 - (void)_processDidExit;
 #if ENABLE(GPU_PROCESS)
 - (void)_gpuProcessDidExit;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -717,9 +717,9 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 
 #pragma mark PageClientImpl methods
 
-- (std::unique_ptr<WebKit::DrawingAreaProxy>)_createDrawingAreaProxy:(WebKit::WebProcessProxy&)process
+- (std::unique_ptr<WebKit::DrawingAreaProxy>)_createDrawingAreaProxy
 {
-    return makeUnique<WebKit::RemoteLayerTreeDrawingAreaProxyIOS>(*_page, process);
+    return makeUnique<WebKit::RemoteLayerTreeDrawingAreaProxyIOS>(*_page);
 }
 
 - (void)_processDidExit

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -64,7 +64,7 @@ public:
 
 private:
     // PageClient
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
     void setViewNeedsDisplay(const WebCore::Region&) override;
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated) override;
     WebCore::FloatPoint viewScrollPosition() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -120,9 +120,9 @@ void PageClientImpl::setImpl(WebViewImpl& impl)
     m_impl = impl;
 }
 
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& process)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
-    return m_impl->createDrawingAreaProxy(process);
+    return m_impl->createDrawingAreaProxy();
 }
 
 void PageClientImpl::setViewNeedsDisplay(const WebCore::Region&)

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -38,7 +38,6 @@ public:
 
 private:
     // DrawingAreaProxy
-    void attachToProvisionalFrameProcess(WebProcessProxy&) final { ASSERT_NOT_REACHED(); }
     void deviceScaleFactorDidChange() override;
     void sizeDidChange() override;
     void colorSpaceDidChange() override;
@@ -54,7 +53,6 @@ private:
 
     void waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy&) override;
     void dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection&, Vector<IPC::AsyncReplyID>&&) final;
-    void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&) final;
 
     void willSendUpdateGeometry();
 

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -206,16 +206,6 @@ void TiledCoreAnimationDrawingAreaProxy::commitTransientZoom(double scale, Float
     m_webPageProxy.send(Messages::DrawingArea::CommitTransientZoom(scale, origin), m_identifier);
 }
 
-void TiledCoreAnimationDrawingAreaProxy::dispatchAfterEnsuringDrawing(CompletionHandler<void()>&& callback)
-{
-    if (!m_webPageProxy.hasRunningProcess()) {
-        callback();
-        return;
-    }
-
-    m_webPageProxy.sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), WTFMove(callback), m_identifier.toUInt64());
-}
-
 void TiledCoreAnimationDrawingAreaProxy::dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection& connection, Vector<IPC::AsyncReplyID>&& callbackIDs)
 {
     for (auto& callbackID : callbackIDs) {

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -228,7 +228,7 @@ public:
     void setFixedLayoutSize(CGSize);
     CGSize fixedLayoutSize() const;
 
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&);
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy();
     bool isUsingUISideCompositing() const;
     void setDrawingAreaSize(CGSize);
     void updateLayer();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1674,13 +1674,13 @@ CGSize WebViewImpl::fixedLayoutSize() const
     return m_page->fixedLayoutSize();
 }
 
-std::unique_ptr<WebKit::DrawingAreaProxy> WebViewImpl::createDrawingAreaProxy(WebProcessProxy& process)
+std::unique_ptr<WebKit::DrawingAreaProxy> WebViewImpl::createDrawingAreaProxy()
 {
     switch (m_drawingAreaType) {
     case DrawingAreaType::TiledCoreAnimation:
         return makeUnique<TiledCoreAnimationDrawingAreaProxy>(m_page);
     case DrawingAreaType::RemoteLayerTree:
-        return makeUnique<RemoteLayerTreeDrawingAreaProxyMac>(m_page, process);
+        return makeUnique<RemoteLayerTreeDrawingAreaProxyMac>(m_page);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -48,7 +48,7 @@ PageClientImpl::PageClientImpl(PlayStationWebView& view)
 }
 
 // PageClient's pure virtual functions
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy&)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
 #if USE(GRAPHICS_LAYER_WC)
     return makeUnique<DrawingAreaProxyWC>(*m_view.page());

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -46,7 +46,7 @@ public:
 
 private:
     // Create a new drawing area proxy for the given page.
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
 
     // Tell the view to invalidate the given region. The region is in view coordinates.
     void setViewNeedsDisplay(const WebCore::Region&) override;

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -62,11 +62,6 @@ void DrawingAreaProxyWC::sizeDidChange()
     m_webPageProxy.send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size), m_identifier);
 }
 
-void DrawingAreaProxyWC::dispatchAfterEnsuringDrawing(CompletionHandler<void()>&& completionHandler)
-{
-    completionHandler();
-}
-
 void DrawingAreaProxyWC::update(uint64_t backingStoreStateID, UpdateInfo&& updateInfo)
 {
     if (backingStoreStateID == m_currentBackingStoreStateID)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -46,8 +46,6 @@ private:
     // DrawingAreaProxy
     void deviceScaleFactorDidChange() override { }
     void sizeDidChange() override;
-    void dispatchAfterEnsuringDrawing(CompletionHandler<void()>&&) override;
-    void attachToProvisionalFrameProcess(WebProcessProxy&) final { ASSERT_NOT_REACHED(); }
     bool shouldSendWheelEventsToEventDispatcher() const final { return true; }
 
     // message handers

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -52,7 +52,7 @@ PageClientImpl::PageClientImpl(WebView& view)
 }
 
 // PageClient's pure virtual functions
-std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy&)
+std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
 #if USE(GRAPHICS_LAYER_WC)
     if (m_view.page()->preferences().useGPUProcessForWebGLEnabled())

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -58,7 +58,7 @@ public:
     HWND viewWidget();
 private:
     // PageClient
-    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy(WebProcessProxy&) override;
+    std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;
     void setViewNeedsDisplay(const WebCore::Region&) override;
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated) override;
     WebCore::FloatPoint viewScrollPosition() override;


### PR DESCRIPTION
#### ca25989d0d7802ddc9a3b8d83a1776ddfcbbcfe2
<pre>
Remove site isolation processes from DrawingAreaProxy when they are no longer used
<a href="https://bugs.webkit.org/show_bug.cgi?id=257510">https://bugs.webkit.org/show_bug.cgi?id=257510</a>
rdar://110027492

Reviewed by Tim Horton.

This is cleanup necessary for and working towards having more than 1 layout test with site isolation enabled.

I made symmetric add/remove, start/stop, attach/detach calls and tied them to object lifetimes instead of
having them be called at other times that are hard to get right.

Instead of having the DrawingAreaProxy keep track of which processes with which it has registered as a
message receiver, move the registration/unregistration responsibility to WebPageProxy, which already
keeps track of the site isolation processes.  In the non-site-isolated case, there is only ever 1 web
content process drawing at a time for a given WebPageProxy.

Because there is RemoteLayerTreeDrawingAreaProxy which has its own message receiver, I kept the
startReceivingMessages/stopReceivingMessages pattern to keep the platform specific code in the inheritance chain.

* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::startReceivingMessages):
(WebKit::DrawingAreaProxy::stopReceivingMessages):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::attachToRemoteFrameProcess):
(WebKit::RemoteLayerTreeDrawingAreaProxy::detachFromRemoteFrameProcess):
(WebKit::RemoteLayerTreeDrawingAreaProxy::startReceivingRemoteLayerTreeDrawingAreaProxyMessages):
(WebKit::RemoteLayerTreeDrawingAreaProxy::stopReceivingRemoteLayerTreeDrawingAreaProxyMessages):
(WebKit::RemoteLayerTreeDrawingAreaProxy::attachToProvisionalFrameProcess): Deleted.
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
(WebKit::SubframePageProxy::SubframePageProxy):
(WebKit::SubframePageProxy::~SubframePageProxy):
* Source/WebKit/UIProcess/SubframePageProxy.h:
(WebKit::SubframePageProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createRemoteSubframesInOtherProcesses):
Add a null check and an assertion.  If it is hit, then our bookkeeping of the processes has an issue.
This makes it more obvious what is going on when debugging.
(WebKit::WebPageProxy::addSubframePageProxy):
(WebKit::WebPageProxy::removeSubpageFrameProxy):
(WebKit::WebPageProxy::removeSubpageFrameProxyIfUnused): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:

Canonical link: <a href="https://commits.webkit.org/264754@main">https://commits.webkit.org/264754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44197d39eead4faf18bad6a8e63301dddf263a73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8470 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9606 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10237 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6904 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15253 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11191 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8315 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11812 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1007 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->