### PR TITLE
Clipping a caret rect results in its size changing instead of actually clipping

### DIFF
--- a/LayoutTests/fast/css/caret-color-expected.html
+++ b/LayoutTests/fast/css/caret-color-expected.html
@@ -5,12 +5,14 @@
 #test-container {
     height: 50px;
     width: 50px;
-    overflow: hidden;
 }
 
 #mock-caret {
-    height: inherit;
-    width: inherit;
+    width: 50px;
+    height: 100px;
+    position: absolute;
+    top: 100px;
+    left: 8px;
     background-color: green;
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-fallback-to-color-expected.html
+++ b/LayoutTests/fast/css/caret-color-fallback-to-color-expected.html
@@ -5,12 +5,14 @@
 #test-container {
     height: 50px;
     width: 50px;
-    overflow: hidden;
 }
 
 #mock-caret {
-    height: inherit;
-    width: inherit;
+    width: 50px;
+    height: 100px;
+    position: absolute;
+    top: 100px;
+    left: 8px;
     background-color: green;
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-fallback-to-color.html
+++ b/LayoutTests/fast/css/caret-color-fallback-to-color.html
@@ -3,17 +3,16 @@
 <head>
 <style>
 #test-container {
-    height: 50px;
-    width: 50px;
+    height: 150px;
+    width: 100px;
     overflow: hidden;
 }
 
 #test {
-    height: inherit;
-    width: inherit;
     color: green;
     transform-origin: left top;
     transform: scale(50, 50);
+    clip-path: inset(1px 99px 0px 0px);
     font-size: 10px; /* Needed for the caret to render in Firefox. */
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-inherit-expected.html
+++ b/LayoutTests/fast/css/caret-color-inherit-expected.html
@@ -5,12 +5,14 @@
 #test-container {
     height: 50px;
     width: 50px;
-    overflow: hidden;
 }
 
 #mock-caret {
-    height: inherit;
-    width: inherit;
+    width: 50px;
+    height: 100px;
+    position: absolute;
+    top: 100px;
+    left: 8px;
     background-color: green;
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-inherit.html
+++ b/LayoutTests/fast/css/caret-color-inherit.html
@@ -3,18 +3,17 @@
 <head>
 <style>
 #test-container {
-    height: 50px;
-    width: 50px;
+    height: 150px;
+    width: 100px;
     overflow: hidden;
     caret-color: green;
 }
 
 #test {
-    height: inherit;
-    width: inherit;
     caret-color: inherit;
     transform-origin: left top;
     transform: scale(50, 50);
+    clip-path: inset(1px 99px 0px 0px);
     font-size: 10px; /* Needed for the caret to render in Firefox. */
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-span-inside-editable-parent-expected.html
+++ b/LayoutTests/fast/css/caret-color-span-inside-editable-parent-expected.html
@@ -5,12 +5,14 @@
 #test-container {
     height: 50px;
     width: 50px;
-    overflow: hidden;
 }
 
 #mock-caret {
-    height: inherit;
-    width: inherit;
+    width: 50px;
+    height: 100px;
+    position: absolute;
+    top: 136px;
+    left: 8px;
     background-color: green;
 }
 </style>

--- a/LayoutTests/fast/css/caret-color-span-inside-editable-parent.html
+++ b/LayoutTests/fast/css/caret-color-span-inside-editable-parent.html
@@ -3,8 +3,8 @@
 <head>
 <style>
 #test-container {
-    height: 50px;
-    width: 50px;
+    height: 150px;
+    width: 100px;
     overflow: hidden;
 }
 
@@ -13,6 +13,7 @@
     color: red;
     transform-origin: left top;
     transform: scale(50, 50);
+    clip-path: inset(1px 99px 0px 0px);
     font-size: 10px; /* Needed for the caret to render in Firefox. */
 }
 

--- a/LayoutTests/fast/css/caret-color.html
+++ b/LayoutTests/fast/css/caret-color.html
@@ -3,8 +3,8 @@
 <head>
 <style>
 #test-container {
-    height: 50px;
-    width: 50px;
+    height: 150px;
+    width: 100px;
     overflow: hidden;
 }
 
@@ -14,6 +14,7 @@
     caret-color: green;
     transform-origin: left top;
     transform: scale(50, 50);
+    clip-path: inset(1px 99px 0px 0px);
     font-size: 10px; /* Needed for the caret to render in Firefox. */
 }
 </style>

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1879,10 +1879,10 @@ void CaretBase::invalidateCaretRect(Node* node, bool caretRectChanged, CaretAnim
     }
 }
 
-void FrameSelection::paintCaret(GraphicsContext& context, const LayoutPoint& paintOffset, const LayoutRect& clipRect)
+void FrameSelection::paintCaret(GraphicsContext& context, const LayoutPoint& paintOffset)
 {
     if (m_selection.isCaret() && m_selection.start().deprecatedNode())
-        CaretBase::paintCaret(*m_selection.start().deprecatedNode(), context, paintOffset, clipRect, m_caretAnimator.ptr());
+        CaretBase::paintCaret(*m_selection.start().deprecatedNode(), context, paintOffset, m_caretAnimator.ptr());
 }
 
 Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* node)
@@ -1908,18 +1908,17 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
 #endif
 }
 
-void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const LayoutPoint& paintOffset, const LayoutRect& clipRect, CaretAnimator* caretAnimator) const
+void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const LayoutPoint& paintOffset, CaretAnimator* caretAnimator) const
 {
 #if ENABLE(TEXT_CARET)
     auto caretPresentationProperties = caretAnimator ? caretAnimator->presentationProperties() : CaretAnimator::PresentationProperties();
     if (m_caretVisibility == CaretVisibility::Hidden || caretPresentationProperties.blinkState == CaretAnimator::PresentationProperties::BlinkState::Off)
         return;
 
-    auto drawingRect = localCaretRectWithoutUpdate();
+    auto caret = localCaretRectWithoutUpdate();
     if (auto* renderer = rendererForCaretPainting(&node))
-        renderer->flipForWritingMode(drawingRect);
-    drawingRect.moveBy(paintOffset);
-    auto caret = intersection(drawingRect, clipRect);
+        renderer->flipForWritingMode(caret);
+    caret.moveBy(paintOffset);
     if (caret.isEmpty())
         return;
 
@@ -1937,7 +1936,6 @@ void CaretBase::paintCaret(const Node& node, GraphicsContext& context, const Lay
     UNUSED_PARAM(node);
     UNUSED_PARAM(context);
     UNUSED_PARAM(paintOffset);
-    UNUSED_PARAM(clipRect);
     UNUSED_PARAM(caretAnimator);
 #endif
 }
@@ -2366,16 +2364,15 @@ void FrameSelection::setFocusedElementIfNeeded()
         CheckedRef(m_document->page()->focusController())->setFocusedElement(nullptr, *m_document->frame());
 }
 
-void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset, const LayoutRect& clipRect) const
+void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset) const
 {
 #if ENABLE(TEXT_CARET)
     if (m_position.deepEquivalent().deprecatedNode() && m_position.deepEquivalent().deprecatedNode()->document().frame() == frame)
-        paintCaret(*m_position.deepEquivalent().deprecatedNode(), p, paintOffset, clipRect);
+        paintCaret(*m_position.deepEquivalent().deprecatedNode(), p, paintOffset);
 #else
     UNUSED_PARAM(frame);
     UNUSED_PARAM(p);
     UNUSED_PARAM(paintOffset);
-    UNUSED_PARAM(clipRect);
 #endif
 }
 

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -67,7 +67,7 @@ protected:
     void clearCaretRect();
     bool updateCaretRect(Document&, const VisiblePosition& caretPosition);
     bool shouldRepaintCaret(const RenderView*, bool isContentEditable) const;
-    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect, CaretAnimator* = nullptr) const;
+    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, CaretAnimator* = nullptr) const;
 
     const LayoutRect& localCaretRectWithoutUpdate() const { return m_caretLocalRect; }
 
@@ -91,7 +91,7 @@ public:
     DragCaretController();
 
     RenderBlock* caretRenderer() const;
-    void paintDragCaret(LocalFrame*, GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect) const;
+    void paintDragCaret(LocalFrame*, GraphicsContext&, const LayoutPoint&) const;
 
     bool isContentEditable() const { return m_position.rootEditableElement(); }
     WEBCORE_EXPORT bool isContentRichlyEditable() const;
@@ -196,7 +196,7 @@ public:
     void textWasReplaced(CharacterData&, unsigned offset, unsigned oldLength, unsigned newLength);
 
     void setCaretVisible(bool caretIsVisible) { setCaretVisibility(caretIsVisible ? CaretVisibility::Visible : CaretVisibility::Hidden, ShouldUpdateAppearance::Yes); }
-    void paintCaret(GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect);
+    void paintCaret(GraphicsContext&, const LayoutPoint&);
 
     // Used to suspend caret blinking while the mouse is down.
     WEBCORE_EXPORT void setCaretBlinkingSuspended(bool);

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1233,9 +1233,9 @@ void RenderBlock::paintCaret(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 
     if (caretPainter == this && (isContentEditable || settings().caretBrowsingEnabled())) {
         if (type == CursorCaret)
-            frame().selection().paintCaret(paintInfo.context(), paintOffset, paintInfo.rect);
+            frame().selection().paintCaret(paintInfo.context(), paintOffset);
         else
-            page().dragCaretController().paintDragCaret(&frame(), paintInfo.context(), paintOffset, paintInfo.rect);
+            page().dragCaretController().paintDragCaret(&frame(), paintInfo.context(), paintOffset);
     }
 }
 


### PR DESCRIPTION
#### bcf18f7a8a9ac7060cefc6d942c2561e84f879ed
<pre>
Clipping a caret rect results in its size changing instead of actually clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=257512">https://bugs.webkit.org/show_bug.cgi?id=257512</a>
rdar://110012236

Reviewed by Megan Gardner.

When the caret is being clipped, such as when it&apos;s within an `overflow: hidden` div and partially
hidden, the caret rect is actually being resized to a different size, instead of actually being clipped.

This is because when painting the caret, we were resizing the caret rect to be the intersection of the
original rect and the clipping rect.

This PR fixes this by removing that resizing logic, which maintains the caret&apos;s size, and still results
in the caret being properly clipped.

Also rebaselines some related caret layout tests/

* LayoutTests/fast/css/caret-color-expected.html:
* LayoutTests/fast/css/caret-color-fallback-to-color-expected.html:
* LayoutTests/fast/css/caret-color-fallback-to-color.html:
* LayoutTests/fast/css/caret-color-inherit-expected.html:
* LayoutTests/fast/css/caret-color-inherit.html:
* LayoutTests/fast/css/caret-color-span-inside-editable-parent-expected.html:
* LayoutTests/fast/css/caret-color-span-inside-editable-parent.html:
* LayoutTests/fast/css/caret-color.html:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::paintCaret):
(WebCore::CaretBase::paintCaret const):
(WebCore::DragCaretController::paintDragCaret const):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintCaret):

Canonical link: <a href="https://commits.webkit.org/264708@main">https://commits.webkit.org/264708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8f3af85368c0aee428269de06d638930a5b19a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10061 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10675 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/8641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11318 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9591 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10216 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7680 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11177 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8297 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6764 "Exiting early after 60 failures. 57038 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2029 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->