### PR TITLE
URI Fragments Cached After 301 Redirect

### DIFF
--- a/LayoutTests/http/tests/links/redirect-301-clear-memory-cache-expected.txt
+++ b/LayoutTests/http/tests/links/redirect-301-clear-memory-cache-expected.txt
@@ -1,0 +1,2 @@
+
+PASS: document.getElementById("first_load").contentWindow.location.hash should be #key=foo and is. PASS: document.getElementById("second_load").contentWindow.location.hash should be #key=bar and is.

--- a/LayoutTests/http/tests/links/redirect-301-clear-memory-cache.html
+++ b/LayoutTests/http/tests/links/redirect-301-clear-memory-cache.html
@@ -1,0 +1,44 @@
+<html>
+<head>
+<title>301 Redirect</title>
+
+<iframe id="first_load" width="200" height="200" src="resources/redirect-helper.pl?301#key=foo"></iframe>
+<iframe id="second_load" width="200" height="200"></iframe>
+<div id="console"></div>
+
+<script>
+    function shouldBe(a, b)
+    {
+        var log = (s) => { document.getElementById("console").appendChild(document.createTextNode(s + "\n")); }
+
+        var evalA = eval(a);
+        if (evalA == b) 
+            log("PASS: " + a + " should be " + b + " and is.\n", "green");
+        else {
+            log("FAIL: " + a + " should be " + b + " but instead is " + evalA + ".", "red");
+        }
+    }
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+    }
+
+    document.getElementById('first_load').onload = function() {
+        shouldBe('document.getElementById("first_load").contentWindow.location.hash', "#key=foo");
+
+        // Clear memory cache
+        internals.clearMemoryCache();
+
+        document.getElementById('second_load').src = "resources/redirect-helper.pl?301#key=bar"
+
+        document.getElementById('second_load').onload = function() {
+            shouldBe('document.getElementById("second_load").contentWindow.location.hash', "#key=bar");
+
+            if (window.testRunner) {
+              testRunner.dumpAsText();
+              testRunner.notifyDone();
+            }
+        }
+    }
+</script>
+</html>

--- a/LayoutTests/http/tests/links/redirect-301-no-inital-fragments-expected.txt
+++ b/LayoutTests/http/tests/links/redirect-301-no-inital-fragments-expected.txt
@@ -1,0 +1,2 @@
+
+PASS: document.getElementById("first_load").contentWindow.location.hash should be and is. PASS: document.getElementById("second_load").contentWindow.location.hash should be #key=bar and is.

--- a/LayoutTests/http/tests/links/redirect-301-no-inital-fragments.html
+++ b/LayoutTests/http/tests/links/redirect-301-no-inital-fragments.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+<title>301 Redirect</title>
+
+<iframe id="first_load" width="200" height="200" src="resources/redirect-helper.pl?301"></iframe>
+<iframe id="second_load" width="200" height="200"></iframe>
+<div id="console"></div>
+
+<script>
+    function shouldBe(a, b)
+    {
+        var log = (s) => { document.getElementById("console").appendChild(document.createTextNode(s + "\n")); }
+
+        var evalA = eval(a);
+        if (evalA == b) 
+            log("PASS: " + a + " should be " + b + " and is.\n", "green");
+        else {
+            log("FAIL: " + a + " should be " + b + " but instead is " + evalA + ".", "red");
+        }
+    }
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+    }
+
+    document.getElementById('first_load').onload = function() {
+        shouldBe('document.getElementById("first_load").contentWindow.location.hash', "");
+
+        document.getElementById('second_load').src = "resources/redirect-helper.pl?301#key=bar"
+
+        document.getElementById('second_load').onload = function() {
+            shouldBe('document.getElementById("second_load").contentWindow.location.hash', "#key=bar");
+
+            if (window.testRunner) {
+              testRunner.dumpAsText();
+              testRunner.notifyDone();
+            }
+        }
+    }
+</script>
+</html>

--- a/LayoutTests/http/tests/links/redirect-301-with-fragments-expected.txt
+++ b/LayoutTests/http/tests/links/redirect-301-with-fragments-expected.txt
@@ -1,0 +1,2 @@
+
+PASS: document.getElementById("first_load").contentWindow.location.hash should be #key=foo and is. PASS: document.getElementById("second_load").contentWindow.location.hash should be #key=bar and is.

--- a/LayoutTests/http/tests/links/redirect-301-with-fragments.html
+++ b/LayoutTests/http/tests/links/redirect-301-with-fragments.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+<title>301 Redirect</title>
+
+<iframe id="first_load" width="200" height="200" src="resources/redirect-helper.pl?301#key=foo"></iframe>
+<iframe id="second_load" width="200" height="200"></iframe>
+<div id="console"></div>
+
+<script>
+    function shouldBe(a, b)
+    {
+        var log = (s) => { document.getElementById("console").appendChild(document.createTextNode(s + "\n")); }
+
+        var evalA = eval(a);
+        if (evalA == b) 
+            log("PASS: " + a + " should be " + b + " and is.\n", "green");
+        else {
+            log("FAIL: " + a + " should be " + b + " but instead is " + evalA + ".", "red");
+        }
+    }
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+    }
+
+    document.getElementById('first_load').onload = function() {
+        shouldBe('document.getElementById("first_load").contentWindow.location.hash', "#key=foo");
+
+        document.getElementById('second_load').src = "resources/redirect-helper.pl?301#key=bar"
+
+        document.getElementById('second_load').onload = function() {
+            shouldBe('document.getElementById("second_load").contentWindow.location.hash', "#key=bar");
+
+            if (window.testRunner) {
+              testRunner.dumpAsText();
+              testRunner.notifyDone();
+            }
+        }
+    }
+</script>
+</html>

--- a/LayoutTests/http/tests/links/resources/redirect-helper.pl
+++ b/LayoutTests/http/tests/links/resources/redirect-helper.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/perl
+# Script to generate a 30x HTTP redirect (determined by the query parameter)
+
+$REDIRECT_CODE = $ENV{'QUERY_STRING'} || '301';
+
+$STATUS_TEXTS = {
+  '301' => 'Moved Permanently',
+  '302' => 'Moved Temporarily',
+  '303' => 'See Other',
+  '307' => 'Moved Temporarily'
+};
+
+print "Status: $REDIRECT_CODE $STATUS_TEXTS{$REDIRECT_CODE}\r\n";
+print "Location: redirect-target.html\r\n";
+print "Content-type: text/html\r\n";
+print "\r\n";
+
+print <<HERE_DOC_END
+<html>
+<head>
+<title>$REDIRECT_CODE Redirect</title>
+
+<body>This page is a $REDIRECT_CODE redirect.</body>
+</html>
+HERE_DOC_END

--- a/LayoutTests/http/tests/links/resources/redirect-target.html
+++ b/LayoutTests/http/tests/links/resources/redirect-target.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<title>Redirect Target</title>
+<body>
+<p>This page is the target of a redirect.</p>
+</body>
+</html>

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -453,6 +453,12 @@ void CachedResource::redirectReceived(ResourceRequest&& request, const ResourceR
 {
     CACHEDRESOURCE_RELEASE_LOG("redirectReceived:");
 
+    // Remove redirect urls from the memory cache if they contain a fragment.
+    // If we cache localhost/#key=foo we will return the same parameters key=foo
+    // on the next visit to the domain even if the parameters have been updated.
+    if (request.url().hasFragmentIdentifier())
+        MemoryCache::singleton().remove(*this);
+
     m_requestedFromNetworkingLayer = true;
     if (!response.isNull())
         updateRedirectChainStatus(m_redirectChainCacheStatus, response);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1494,6 +1494,11 @@ CachedResourceLoader::RevalidationPolicy CachedResourceLoader::determineRevalida
         return Reload;
     }
 
+    // FIXME: We should be able to USE the data here, but cannot currently due to a bug
+    // concerning redirect and URL fragments. https://bugs.webkit.org/show_bug.cgi?id=258934
+    if (cachedResourceRequest.hasFragmentIdentifier() && existingResource->hasRedirections())
+        return Load;
+
     return Use;
 }
 

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -106,6 +106,7 @@ public:
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
 
+    bool hasFragmentIdentifier() const { return !m_fragmentIdentifier.isEmpty(); }
     String&& releaseFragmentIdentifier() { return WTFMove(m_fragmentIdentifier); }
     void clearFragmentIdentifier() { m_fragmentIdentifier = { }; }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -115,7 +115,7 @@ enum class RetrieveDecision {
     NoDueToHTTPMethod,
     NoDueToConditionalRequest,
     NoDueToReloadIgnoringCache,
-    NoDueToStreamingMedia,
+    NoDueToStreamingMedia
 };
 
 enum class StoreDecision {
@@ -127,6 +127,7 @@ enum class StoreDecision {
     NoDueToNoStoreRequest,
     NoDueToUnlikelyToReuse,
     NoDueToStreamingMedia,
+    NoDueToRequestContainingFragments
 };
 
 enum class UseDecision {
@@ -136,7 +137,8 @@ enum class UseDecision {
     NoDueToVaryingHeaderMismatch,
     NoDueToMissingValidatorFields,
     NoDueToDecodeFailure,
-    NoDueToExpiredRedirect
+    NoDueToExpiredRedirect,
+    NoDueToRequestContainingFragments
 };
 
 enum class CacheOption : uint8_t {


### PR DESCRIPTION
#### 205444531ae8c5213c84b0b63cd0d6ec51cf7735
<pre>
URI Fragments Cached After 301 Redirect
<a href="https://bugs.webkit.org/show_bug.cgi?id=255924">https://bugs.webkit.org/show_bug.cgi?id=255924</a>
rdar://problem/108535944

Reviewed by Youenn Fablet.

We end up reusing the fragments when performing a redirect and as such end up serving old parameters.
For now we will just disable caching redirects with fragments. This is a temporary fix; a more proper
solution of handling fragment caching in the future is required.

* LayoutTests/http/tests/links/redirect-301-clear-memory-cache-expected.txt: Added.
* LayoutTests/http/tests/links/redirect-301-clear-memory-cache.html: Added.
* LayoutTests/http/tests/links/redirect-301-no-inital-fragments-expected.txt: Added.
* LayoutTests/http/tests/links/redirect-301-no-inital-fragments.html: Added.
* LayoutTests/http/tests/links/redirect-301-with-fragments-expected.txt: Added.
* LayoutTests/http/tests/links/redirect-301-with-fragments.html: Added.
* LayoutTests/http/tests/links/resources/redirect-helper.pl: Added.
* LayoutTests/http/tests/links/resources/redirect-target.html: Added.
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::redirectReceived):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::hasFragmentIdentifier const):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeUseDecision):
(WebKit::NetworkCache::makeStoreDecision):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:

Canonical link: <a href="https://commits.webkit.org/265906@main">https://commits.webkit.org/265906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0293aa532ba4ac7d238287e894aace810e844200

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11708 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14395 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14295 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18131 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14348 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3002 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->