### PR TITLE
Freshen up CSS Highlight implementation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6467,6 +6467,11 @@ imported/w3c/web-platform-tests/css/css-tables/zero-rowspan-001.html [ ImageOnly
 imported/w3c/web-platform-tests/css/css-tables/zero-rowspan-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-fixed-layout-1.html [ Pass Failure ]
 
+# This test started failing when we started supporting passing a Range to the Highlight constructor.
+# We used to only support StaticRange objects and thus ignore the passed in parameter, which
+# caused the test to pass by luck.
+imported/w3c/web-platform-tests/css/css-pseudo/highlight-painting-currentcolor-005.html [ ImageOnlyFailure ]
+
 # New failures after re-importing css-overflow
 imported/w3c/web-platform-tests/css/css-overflow/margin-block-end-scroll-area-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-margin-010.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike-expected.txt
@@ -1,0 +1,28 @@
+abc
+
+PASS Highlight initializes empty (if no ranges are provided) and with priority 0.
+PASS Highlight add and has methods work as expected (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight delete method works as expected (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight constructor behaves like a set when using equal ranges (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight constructor works as expected when called with one range (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight constructor works as expected when called with two ranges (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight clear method works as expected (using the following combination of ranges [[object Range], [object Range], [object Range]])
+PASS Highlight add and has methods work as expected (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight delete method works as expected (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight constructor behaves like a set when using equal ranges (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight constructor works as expected when called with one range (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight constructor works as expected when called with two ranges (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight clear method works as expected (using the following combination of ranges [[object StaticRange], [object StaticRange], [object StaticRange]])
+PASS Highlight add and has methods work as expected (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight delete method works as expected (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight constructor behaves like a set when using equal ranges (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight constructor works as expected when called with one range (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight constructor works as expected when called with two ranges (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight clear method works as expected (using the following combination of ranges [[object Range], [object StaticRange], [object Range]])
+PASS Highlight add and has methods work as expected (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+PASS Highlight delete method works as expected (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+PASS Highlight constructor behaves like a set when using equal ranges (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+PASS Highlight constructor works as expected when called with one range (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+PASS Highlight constructor works as expected when called with two ranges (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+PASS Highlight clear method works as expected (using the following combination of ranges [[object StaticRange], [object Range], [object StaticRange]])
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<title> Highlight has a setlike interface </title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id='testDiv'>abc</div>
+<script>
+  'use strict';
+  let priority = 123;
+
+  test(() => {
+    let customHighlight = new Highlight();
+    assert_equals(customHighlight.priority, 0, 'Highlight uses 0 as priority by default.');
+
+    customHighlight.priority = priority;
+    assert_equals(customHighlight.priority, priority, 'Highlight sets priority correctly.');
+
+    assert_equals(customHighlight.size, 0, 'Highlight starts empty');
+  }, 'Highlight initializes empty (if no ranges are provided) and with priority 0.');
+
+  let range0 = new Range();
+  let range1 = new Range();
+  let range2 = new Range();
+
+  let container = document.getElementById('testDiv');
+  let staticRange0 = new StaticRange({startContainer: container, startOffset: 0, endContainer: container, endOffset: 0});
+  let staticRange1 = new StaticRange({startContainer: container, startOffset: 0, endContainer: container, endOffset: 0});
+  let staticRange2 = new StaticRange({startContainer: container, startOffset: 0, endContainer: container, endOffset: 0});
+
+  let rangeCollections = [[range0,range1,range2], [staticRange0,staticRange1,staticRange2], [range0,staticRange1,range2], [staticRange0,range1,staticRange2]]
+
+  var i;
+  for(i=0; i<rangeCollections.length; i++){
+    let rangesCombinationDescription = " (using the following combination of ranges [";
+    var j;
+    for(j=0; j<rangeCollections[i].length; j++){
+      if(j!=0) rangesCombinationDescription += ", ";
+      rangesCombinationDescription = rangesCombinationDescription + Object.prototype.toString.call(rangeCollections[i][j]);
+    }
+    rangesCombinationDescription += "])";
+
+    test(() => {
+      let customHighlight = new Highlight();
+      assert_false(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+      assert_false(customHighlight.has(rangeCollections[i][1]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+      assert_false(customHighlight.has(rangeCollections[i][2]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+      customHighlight.add(rangeCollections[i][0]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it contains the range which is passed as the argument');
+      assert_false(customHighlight.has(rangeCollections[i][1]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+      assert_false(customHighlight.has(rangeCollections[i][2]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+
+      assert_equals(customHighlight.size, 1, 'Highlight.size is 1 after only adding 1 range');
+      customHighlight.add(rangeCollections[i][0]);
+      assert_equals(customHighlight.size, 1, 'Highlight.size is 1 after only adding same range twice');
+
+      customHighlight.add(rangeCollections[i][1]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it contains the range which is passed as the argument');
+      assert_true(customHighlight.has(rangeCollections[i][1]), 'Highlight.has returns true when it contains the range which is passed as the argument');
+      assert_false(customHighlight.has(rangeCollections[i][2]), 'Highlight.has returns false when it doesn\'t contain the range which is passed as the argument');
+
+      assert_equals(customHighlight.size, 2, 'Highlight.size is 2 after only adding two different ranges');
+    }, 'Highlight add and has methods work as expected' + rangesCombinationDescription);
+
+    test(() => {
+      let customHighlight = new Highlight(rangeCollections[i][0], rangeCollections[i][1]);
+      assert_false(customHighlight.delete(rangeCollections[i][2]), 'Highlight.delete returns false when trying to delete a range that is not in the highlight');
+      assert_true(customHighlight.delete(rangeCollections[i][1]), 'Highlight.delete returns true when trying to delete a range that is in the highlight');
+      assert_false(customHighlight.delete(rangeCollections[i][1]), 'Highlight.delete returns false when trying to delete a range that was in the highlight before but it\'s not there anymore');
+      assert_true(customHighlight.delete(rangeCollections[i][0]), 'Highlight.delete returns true when trying to delete a range that is in the highlight');
+      assert_false(customHighlight.delete(rangeCollections[i][0]), 'Highlight.delete returns false when trying to delete a range that was in the highlight before but it\'s not there anymore');
+    }, 'Highlight delete method works as expected' + rangesCombinationDescription);
+
+    test(() => {
+      let customHighlight = new Highlight(rangeCollections[i][0], rangeCollections[i][0]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it is called with the range used twice in the constructor');
+      assert_equals(customHighlight.size, 1, 'Highlight behaves like a set when constructing it with two equal ranges.');
+
+      customHighlight = new Highlight(rangeCollections[i][0], rangeCollections[i][1], rangeCollections[i][0], rangeCollections[i][1]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it is called with one of the ranges used twice in the constructor');
+      assert_true(customHighlight.has(rangeCollections[i][1]), 'Highlight.has returns true when it is called with the other range used twice in the constructor');
+      assert_equals(customHighlight.size, 2, 'Highlight behaves like a set when constructing it with two pairs of equal ranges.');
+    }, 'Highlight constructor behaves like a set when using equal ranges' + rangesCombinationDescription);
+
+    test(() => {
+      let customHighlight = new Highlight(rangeCollections[i][0]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it is called with the range used in its constructor');
+      assert_equals(customHighlight.size, 1, 'Highlight.size is 1 after constructing it with one range');
+    }, 'Highlight constructor works as expected when called with one range' + rangesCombinationDescription);
+
+    test(() => {
+      let customHighlight = new Highlight(rangeCollections[i][0], rangeCollections[i][1]);
+      assert_true(customHighlight.has(rangeCollections[i][0]), 'Highlight.has returns true when it is called with the first range used in its constructor');
+      assert_true(customHighlight.has(rangeCollections[i][1]), 'Highlight.has returns true when it is called with the second range used in its constructor');
+      assert_equals(customHighlight.size, 2, 'Highlight.size is 2 after constructing it with two ranges');
+    }, 'Highlight constructor works as expected when called with two ranges' + rangesCombinationDescription);
+
+    test(() => {
+      let customHighlight = new Highlight(rangeCollections[i][0], rangeCollections[i][1]);
+      assert_equals(customHighlight.size, 2, 'Highlight has size 2 after constructing it with two ranges');
+      customHighlight.clear();
+      assert_equals(customHighlight.size, 0, 'Highlight becomes empty after executing clear()');
+      customHighlight.clear();
+      assert_equals(customHighlight.size, 0, 'Highlight is still empty after executing clear() twice');
+    }, 'Highlight clear method works as expected' + rangesCombinationDescription);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
@@ -4,18 +4,18 @@ PASS idl_test validation
 PASS Partial namespace CSS: original namespace defined
 PASS Partial namespace CSS: member names are unique
 PASS Highlight interface: existence and properties of interface object
-FAIL Highlight interface object length assert_equals: wrong value for Highlight.length expected 0 but got 1
+PASS Highlight interface object length
 PASS Highlight interface object name
 PASS Highlight interface: existence and properties of interface prototype object
 PASS Highlight interface: existence and properties of interface prototype object's "constructor" property
 PASS Highlight interface: existence and properties of interface prototype object's @@unscopables property
 PASS Highlight interface: setlike<AbstractRange>
-FAIL Highlight interface: attribute priority assert_true: The prototype object must have a property "priority" expected true got false
-FAIL Highlight interface: attribute type assert_true: The prototype object must have a property "type" expected true got false
-FAIL Highlight must be primary interface of new Highlight(new Range()) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
-FAIL Stringification of new Highlight(new Range()) assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
-FAIL Highlight interface: new Highlight(new Range()) must inherit property "priority" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
-FAIL Highlight interface: new Highlight(new Range()) must inherit property "type" with the proper type assert_equals: Unexpected exception when evaluating object expected null but got object "TypeError: Argument 1 ('range') to the Highlight constructor must be an instance of StaticRange"
+PASS Highlight interface: attribute priority
+PASS Highlight interface: attribute type
+PASS Highlight must be primary interface of new Highlight(new Range())
+PASS Stringification of new Highlight(new Range())
+PASS Highlight interface: new Highlight(new Range()) must inherit property "priority" with the proper type
+PASS Highlight interface: new Highlight(new Range()) must inherit property "type" with the proper type
 FAIL HighlightRegistry interface: existence and properties of interface object assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
 FAIL HighlightRegistry interface object length assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing
 FAIL HighlightRegistry interface object name assert_own_property: self does not have own property "HighlightRegistry" expected property "HighlightRegistry" missing

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,33 +30,17 @@
 #include "JSDOMSetLike.h"
 #include "JSStaticRange.h"
 #include "NodeTraversal.h"
+#include "Range.h"
 #include "RenderBlockFlow.h"
 #include "StaticRange.h"
 
 namespace WebCore {
 
-Highlight::Highlight(Ref<StaticRange>&& range)
-{
-    auto myRange = WTFMove(range);
-    addToSetLike(myRange.get());
-}
-
-Ref<Highlight> Highlight::create(StaticRange& range)
-{
-    return adoptRef(*new Highlight(range));
-}
-
-void Highlight::initializeSetLike(DOMSetAdapter& set)
-{
-    for (auto& rangeData : m_rangesData)
-        set.add<IDLInterface<StaticRange>>(rangeData->range);
-}
-
-static void repaintRange(const SimpleRange& range)
+static void repaintRange(const AbstractRange& range)
 {
     // FIXME: Unclear precisely why we need to handle out of order cases here, but not unordered cases.
-    auto sortedRange = range;
-    if (is_gt(treeOrder<ComposedTree>(range.start, range.end)))
+    SimpleRange sortedRange = makeSimpleRange(range);
+    if (is_gt(treeOrder<ComposedTree>(sortedRange.start, sortedRange.end)))
         std::swap(sortedRange.start, sortedRange.end);
     for (auto& node : intersectingNodes(sortedRange)) {
         if (auto renderer = node.renderer())
@@ -64,35 +48,60 @@ static void repaintRange(const SimpleRange& range)
     }
 }
 
-bool Highlight::removeFromSetLike(const StaticRange& range)
+Ref<Highlight> Highlight::create(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&& initialRanges)
+{
+    return adoptRef(*new Highlight(WTFMove(initialRanges)));
+}
+
+Highlight::Highlight(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&& initialRanges)
+{
+    m_rangesData.reserveInitialCapacity(initialRanges.size());
+    for (auto& range : initialRanges) {
+        repaintRange(range.get());
+        m_rangesData.uncheckedAppend(HighlightRangeData::create(Ref { range.get() }));
+    }
+}
+
+void Highlight::initializeSetLike(DOMSetAdapter& set)
+{
+    for (auto& rangeData : m_rangesData)
+        set.add<IDLInterface<AbstractRange>>(rangeData->range());
+}
+
+bool Highlight::removeFromSetLike(const AbstractRange& range)
 {
     return m_rangesData.removeFirstMatching([&range](const Ref<HighlightRangeData>& current) {
         repaintRange(range);
-        return current.get().range.get() == range;
+        return &current->range() == &range;
     });
 }
 
 void Highlight::clearFromSetLike()
 {
     for (auto& data : m_rangesData)
-        repaintRange(data->range);
+        repaintRange(data->range());
     m_rangesData.clear();
 }
 
-bool Highlight::addToSetLike(StaticRange& range)
+bool Highlight::addToSetLike(AbstractRange& range)
 {
-    if (notFound != m_rangesData.findIf([&range](const Ref<HighlightRangeData>& current) { return current.get().range.get() == range; }))
-        return false;
-    repaintRange(range);
-    m_rangesData.append(HighlightRangeData::create(range));
-    return true;
+    auto index = m_rangesData.findIf([&range](const Ref<HighlightRangeData>& current) { return &current->range() == &range; });
+    if (index == notFound) {
+        repaintRange(range);
+        m_rangesData.append(HighlightRangeData::create(range));
+        return true;
+    }
+    // Move to last since SetLike is an ordered set.
+    m_rangesData.append(WTFMove(m_rangesData[index]));
+    m_rangesData.remove(index);
+    return false;
 }
 
 void Highlight::repaint()
 {
     for (auto& data : m_rangesData)
-        repaintRange(data->range);
+        repaintRange(data->range());
 }
 
-}
+} // namespace WebCore
 

--- a/Source/WebCore/Modules/highlight/Highlight.h
+++ b/Source/WebCore/Modules/highlight/Highlight.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,42 +32,60 @@
 
 namespace WebCore {
 
+class AbstractRange;
 class CSSStyleDeclaration;
 class DOMSetAdapter;
 class PropertySetCSSStyleDeclaration;
-class StaticRange;
 
-
-struct HighlightRangeData : RefCounted<HighlightRangeData>, public CanMakeWeakPtr<HighlightRangeData> {
-    HighlightRangeData(Ref<StaticRange>&& range)
-        : range(WTFMove(range))
-    {
-    }
-    static Ref<HighlightRangeData> create(Ref<StaticRange>&& range)
+class HighlightRangeData : public RefCounted<HighlightRangeData>, public CanMakeWeakPtr<HighlightRangeData> {
+public:
+    static Ref<HighlightRangeData> create(Ref<AbstractRange>&& range)
     {
         return adoptRef(*new HighlightRangeData(WTFMove(range)));
     }
-    Ref<StaticRange> range;
-    std::optional<Position> startPosition;
-    std::optional<Position> endPosition;
+
+    AbstractRange& range() const { return m_range.get(); }
+    const Position& startPosition() const { return m_startPosition; }
+    void setStartPosition(Position&& startPosition) { m_startPosition = WTFMove(startPosition); }
+    const Position& endPosition() const { return m_endPosition; }
+    void setEndPosition(Position&& endPosition) { m_endPosition = WTFMove(endPosition); }
+
+private:
+    explicit HighlightRangeData(Ref<AbstractRange>&& range)
+        : m_range(WTFMove(range))
+    {
+    }
+
+    Ref<AbstractRange> m_range;
+    Position m_startPosition;
+    Position m_endPosition;
 };
 
 class Highlight : public RefCounted<Highlight> {
 public:
-    WEBCORE_EXPORT static Ref<Highlight> create(StaticRange&);
+    WEBCORE_EXPORT static Ref<Highlight> create(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&&);
     void clearFromSetLike();
-    bool addToSetLike(StaticRange&);
-    bool removeFromSetLike(const StaticRange&);
+    bool addToSetLike(AbstractRange&);
+    bool removeFromSetLike(const AbstractRange&);
     void initializeSetLike(DOMSetAdapter&);
-    
+
+    enum class Type : uint8_t { Highlight, SpellingError, GrammarError };
+    Type type() const { return m_type; }
+    void setType(Type type) { m_type = type; }
+
+    int priority() const { return m_priority; }
+    void setPriority(int priority) { m_priority = priority; }
+
     void repaint();
     const Vector<Ref<HighlightRangeData>>& rangesData() const { return m_rangesData; }
 
     // FIXME: Add WEBCORE_EXPORT CSSStyleDeclaration& style();
 private:
-    Vector<Ref<HighlightRangeData>> m_rangesData; // FIXME: use a HashSet instead of a Vector <rdar://problem/57760614>
-    explicit Highlight(Ref<StaticRange>&&);
+    explicit Highlight(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&&);
+
+    Vector<Ref<HighlightRangeData>> m_rangesData;
+    Type m_type { Type::Highlight };
+    int m_priority { 0 };
 };
 
-}
-
+} // namespace WebCore

--- a/Source/WebCore/Modules/highlight/Highlight.idl
+++ b/Source/WebCore/Modules/highlight/Highlight.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,12 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum HighlightType {
+    "highlight",
+    "spelling-error",
+    "grammar-error"
+};
+
 [
     EnabledByDeprecatedGlobalSetting=HighlightAPIEnabled,
     Exposed=Window
 ] interface Highlight {
-    constructor(StaticRange range);
+    constructor(AbstractRange... initialRanges);
 
-    setlike<StaticRange>;
+    setlike<AbstractRange>;
+    attribute long priority;
+    attribute HighlightType type;
     // FIXME: Add readonly attribute CSSStyleDeclaration style;
 };

--- a/Source/WebCore/Modules/highlight/HighlightRegister.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegister.cpp
@@ -74,7 +74,7 @@ void HighlightRegister::addAnnotationHighlightWithRange(Ref<StaticRange>&& value
     if (m_map.contains(annotationHighlightKey()))
         m_map.get(annotationHighlightKey())->addToSetLike(value);
     else
-        setFromMapLike(annotationHighlightKey(), Highlight::create(WTFMove(value)));
+        setFromMapLike(annotationHighlightKey(), Highlight::create({ WTFMove(value) }));
 }
 
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -148,6 +148,7 @@ class HTMLMapElement;
 class HTMLMediaElement;
 class HTMLMetaElement;
 class HTMLVideoElement;
+class HighlightRangeData;
 class HighlightRegister;
 class HitTestLocation;
 class HitTestRequest;
@@ -248,7 +249,6 @@ struct ApplicationManifest;
 struct BoundaryPoint;
 struct ClientOrigin;
 struct FocusOptions;
-struct HighlightRangeData;
 struct IntersectionObserverData;
 struct SecurityPolicyViolationEventInit;
 

--- a/Source/WebCore/rendering/HighlightData.cpp
+++ b/Source/WebCore/rendering/HighlightData.cpp
@@ -97,11 +97,11 @@ void HighlightData::setRenderRange(const RenderRange& renderRange)
 
 bool HighlightData::setRenderRange(const HighlightRangeData& rangeData)
 {
-    if (!rangeData.startPosition || !rangeData.endPosition)
+    if (rangeData.startPosition().isNull() || rangeData.endPosition().isNull())
         return false;
     
-    auto startPosition = rangeData.startPosition.value();
-    auto endPosition = rangeData.endPosition.value();
+    auto startPosition = rangeData.startPosition();
+    auto endPosition = rangeData.endPosition();
     
     if (!startPosition.containerNode() || !endPosition.containerNode())
         return false;

--- a/Source/WebCore/rendering/HighlightData.h
+++ b/Source/WebCore/rendering/HighlightData.h
@@ -34,8 +34,9 @@
 
 namespace WebCore {
 
-struct HighlightRangeData;
 struct TextBoxSelectableRange;
+
+class HighlightRangeData;
 class RenderMultiColumnSpannerPlaceholder;
 class RenderText;
 


### PR DESCRIPTION
#### 4ed2d20fb3ad4f99b9d92288b3e82b5f26e23b4b
<pre>
Freshen up CSS Highlight implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257520">https://bugs.webkit.org/show_bug.cgi?id=257520</a>

Reviewed by Wenson Hsieh and Darin Adler.

Freshen up CSS Highlight implementation:
- <a href="https://drafts.csswg.org/css-highlight-api-1/#highlight">https://drafts.csswg.org/css-highlight-api-1/#highlight</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/Highlight-setlike.html: Added.
Import test coverage for Hightlight&apos;s SetLike behavior.

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt:
Rebaseline WPT test now that more checks are passing.

* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::repaintRange):
Take an AbstractRange instead of a SimpleRange for convenience, now that we support all
AbstractRange types.

(WebCore::Highlight::create):
(WebCore::Highlight::Highlight):
Update constructor to take in a FixedVector of AbstractRanges, to match the latest IDL.

(WebCore::Highlight::initializeSetLike):
Switch from StaticRange to AbstractRange to match the latest IDL.

(WebCore::Highlight::removeFromSetLike):
Do pointer comparison instead of using StaticRange&apos;s operator==(), to match JS&apos;s behavior.
This was causing Highlight-setlike.html to crash in debug.

(WebCore::Highlight::clearFromSetLike):
(WebCore::Highlight::repaint):
Use range getter now that HighlightRangeData&apos;s data members are private.

(WebCore::Highlight::addToSetLike):
The implementation was incorrect:
- It failed to move the range to the end if already present (since SetLike is an ordered set)
- It relies on StaticRange&apos;s operator==() instead of doing pointer comparison. In JS 2 staticRange
  objects are equal if they have the same pointer, no deep compare is happening. Our C++
  implementation needs to match this.

* Source/WebCore/Modules/highlight/Highlight.h:
(WebCore::HighlightRangeData::create):
(WebCore::HighlightRangeData::range const):
(WebCore::HighlightRangeData::startPosition const):
(WebCore::HighlightRangeData::endPosition const):
(WebCore::HighlightRangeData::HighlightRangeData):
- Make it a class instead of a struct, with a private constructor and private
  data members, since this subclasses RefCounted. Refcounted classes should
  never have a public constructor and it is too error-prone.
- Add public getters / setters now that the data members are private.
- Store an AbstractRange instead of a StaticRange to match the latest IDL.

(WebCore::Highlight::type const):
(WebCore::Highlight::setType):
(WebCore::Highlight::priority const):
(WebCore::Highlight::setPriority):
Add basic support for `type` and `priority` IDL attributes.

* Source/WebCore/Modules/highlight/Highlight.idl:
Synchronize with the specification:
- <a href="https://drafts.csswg.org/css-highlight-api-1/#highlight">https://drafts.csswg.org/css-highlight-api-1/#highlight</a>
In particular, we now use AbstractRange instead of StaticRange
and the `type` &amp; `priority` attributes were added. Also, the
constructor can now take in several ranges, not just one.

* Source/WebCore/Modules/highlight/HighlightRegister.cpp:
(WebCore::HighlightRegister::addAnnotationHighlightWithRange):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateHighlightPositions):
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/HighlightData.cpp:
(WebCore::HighlightData::setRenderRange):
* Source/WebCore/rendering/HighlightData.h:

Canonical link: <a href="https://commits.webkit.org/264739@main">https://commits.webkit.org/264739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6c3a48ff05768f157ee227205f100cf3dec71db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8485 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10152 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9673 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10307 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15314 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11267 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8384 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7675 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2058 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11881 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->