### PR TITLE
[GLIB] GResources being re-regenerated due to bad dependency file

### DIFF
--- a/Source/WebKit/InspectorGResources.cmake
+++ b/Source/WebKit/InspectorGResources.cmake
@@ -11,8 +11,9 @@ macro(WEBKIT_BUILD_INSPECTOR_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/InspectorGResourceBundle.c ${_derived_sources_dir}/InspectorGResourceBundle.deps
         DEPENDS ${_derived_sources_dir}/InspectorGResourceBundle.xml
-        DEPFILE {_derived_sources_dir}/InspectorGResourceBundle.deps
+        DEPFILE ${_derived_sources_dir}/InspectorGResourceBundle.deps
         COMMAND glib-compile-resources --generate --sourcedir=${_derived_sources_dir}/InspectorResources/WebInspectorUI --target=${_derived_sources_dir}/InspectorGResourceBundle.c --dependency-file=${_derived_sources_dir}/InspectorGResourceBundle.deps ${_derived_sources_dir}/InspectorGResourceBundle.xml
+        COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${_derived_sources_dir}/InspectorGResourceBundle.deps ${_derived_sources_dir}/InspectorGResourceBundle.xml ${CMAKE_BINARY_DIR}
         VERBATIM
     )
 endmacro()

--- a/Source/WebKit/ModernMediaControlsGResources.cmake
+++ b/Source/WebKit/ModernMediaControlsGResources.cmake
@@ -10,8 +10,9 @@ macro(WEBKIT_BUILD_MODERN_MEDIA_CONTROLS_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
         DEPENDS ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
-        DEPFILE {_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
+        DEPFILE ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
         COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/modern-media-controls/images/adwaita --target=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c --dependency-file=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
+        COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml ${CMAKE_BINARY_DIR}
         VERBATIM
     )
 endmacro()

--- a/Source/WebKit/PdfJSGResources.cmake
+++ b/Source/WebKit/PdfJSGResources.cmake
@@ -15,6 +15,7 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
         DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundle.xml
         DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundle.deps
         COMMAND glib-compile-resources --generate --sourcedir=${THIRDPARTY_DIR}/pdfjs --target=${_derived_sources_dir}/PdfJSGResourceBundle.c --dependency-file=${_derived_sources_dir}/PdfJSGResourceBundle.deps ${_derived_sources_dir}/PdfJSGResourceBundle.xml
+        COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${_derived_sources_dir}/PdfJSGResourceBundle.deps ${_derived_sources_dir}/PdfJSGResourceBundle.xml ${CMAKE_BINARY_DIR}
         VERBATIM
     )
 
@@ -30,7 +31,8 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
         OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
         DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
+        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c --dependency-file=${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
+        COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml ${CMAKE_BINARY_DIR}
         VERBATIM
     )
 endmacro()

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -460,6 +460,7 @@ add_custom_command(
     DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
     DEPFILE ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
     COMMAND glib-compile-resources --generate --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/Resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebKit/Resources/gtk --target=${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c --dependency-file=${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
+    COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml ${CMAKE_BINARY_DIR}
     VERBATIM
 )
 

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -335,6 +335,7 @@ add_custom_command(
     DEPENDS ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
     DEPFILE ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
     COMMAND glib-compile-resources --generate --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/Resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources --target=${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c --dependency-file=${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
+    COMMAND ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resource-deps-target.py ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml ${CMAKE_BINARY_DIR}
     VERBATIM
 )
 

--- a/Tools/glib/fix-glib-resource-deps-target.py
+++ b/Tools/glib/fix-glib-resource-deps-target.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import traceback
+
+
+# Workaround glib-compile-resources dependency file issue https://gitlab.gnome.org/GNOME/glib/-/issues/2829
+def main():
+
+    if len(sys.argv) != 4:
+        print("Usage: python3 script.py GResource.deps GResourceFile.xml Parent")
+        sys.exit(1)
+
+    deps_file = sys.argv[1]
+    xml_file = sys.argv[2]
+    parent_path = sys.argv[3]
+    c_file = os.path.splitext(xml_file)[0] + ".c"
+
+    with open(deps_file, "r+", encoding="utf-8") as file:
+        content = file.read()
+        # Ignore likely fixed files
+        if not content.startswith(xml_file):
+            return
+
+        # Also workaround ninja expecting relative paths as targets in deps files
+        relative_c_file = re.sub(f"{re.escape(parent_path)}/?", "", c_file)
+        updated_content = re.sub(
+            f"({re.escape(xml_file)}):", f"{relative_c_file}: {xml_file}", content
+        )
+        file.seek(0)
+        file.write(updated_content)
+        file.truncate()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"Failed to process dependency file {sys.argv[1]}:", file=sys.stderr)
+        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)

--- a/Tools/gtk/manifest.txt.in
+++ b/Tools/gtk/manifest.txt.in
@@ -95,6 +95,7 @@ exclude Tools/gtk/make-dist.py
 exclude Tools/gtk/ycm_extra_conf.py
 
 file Tools/glib/common.py
+file Tools/glib/fix-glib-resource-deps-target.py
 file Tools/glib/generate-inspector-gresource-manifest.py
 file Tools/glib/generate-modern-media-controls-gresource-manifest.py
 file Tools/glib/generate-pdfjs-resource-manifest.py

--- a/Tools/wpe/manifest.txt.in
+++ b/Tools/wpe/manifest.txt.in
@@ -89,6 +89,7 @@ exclude Tools/wpe/jhbuild.modules
 exclude Tools/wpe/jhbuildrc
 
 file Tools/glib/common.py
+file Tools/glib/fix-glib-resource-deps-target.py
 file Tools/glib/generate-inspector-gresource-manifest.py
 file Tools/glib/generate-modern-media-controls-gresource-manifest.py
 file Tools/glib/generate-pdfjs-resource-manifest.py


### PR DESCRIPTION
#### 86eec72a6ebdd5cd5c3ef5edb69f900d052cd854
<pre>
[GLIB] GResources being re-regenerated due to bad dependency file
<a href="https://bugs.webkit.org/show_bug.cgi?id=257516">https://bugs.webkit.org/show_bug.cgi?id=257516</a>

Reviewed by NOBODY (OOPS!).

Add a workaround script for glib-compile-resources issue <a href="https://gitlab.gnome.org/GNOME/glib/-/issues/2829">https://gitlab.gnome.org/GNOME/glib/-/issues/2829</a>

The script will fix the dependency rule while this is sorted in glib,
avoiding unnecessary recompilations by rewriting the dep file target.

* Source/WebKit/InspectorGResources.cmake:
* Source/WebKit/ModernMediaControlsGResources.cmake:
* Source/WebKit/PdfJSGResources.cmake:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Tools/glib/fix-glib-resource-deps-target.py: Added.
* Tools/gtk/manifest.txt.in: Add new script entry
* Tools/wpe/manifest.txt.in: Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86eec72a6ebdd5cd5c3ef5edb69f900d052cd854

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11473 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8734 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9758 "2 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15385 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6923 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7752 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->