### PR TITLE
Move Page::renderingUpdateCompleted call to outside loop in Page::finalizeRenderingUpdate

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1974,6 +1974,9 @@ void Page::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> flags
 {
     for (auto& rootFrame : m_rootFrames)
         finalizeRenderingUpdateForRootFrame(rootFrame, flags);
+
+    ASSERT(m_renderingUpdateRemainingSteps.last().isEmpty());
+    renderingUpdateCompleted();
 }
 
 void Page::finalizeRenderingUpdateForRootFrame(LocalFrame& rootFrame, OptionSet<FinalizeRenderingUpdateFlags> flags)
@@ -2003,12 +2006,6 @@ void Page::finalizeRenderingUpdateForRootFrame(LocalFrame& rootFrame, OptionSet<
         scrollingCoordinator->didCompleteRenderingUpdate();
     }
 #endif
-
-    // FIXME: this should be moved to outside the loop in Page::finalizeRenderingUpdate
-    // but it currently asserts in some tests, sometimes because m_rootFrames is empty.
-    // We shouldn't ever be asking for rendering updates from a Page with no root frames.
-    ASSERT(m_renderingUpdateRemainingSteps.last().isEmpty());
-    renderingUpdateCompleted();
 }
 
 void Page::renderingUpdateCompleted()

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -330,7 +330,10 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     // This function is not reentrant, e.g. a rAF callback may force repaint.
     if (m_inUpdateRendering)
         return;
-    
+
+    if (auto* page = m_webPage.corePage(); page && !page->rootFrames().computeSize())
+        return;
+
     scaleViewToFitDocumentIfNeeded();
 
     SetForScope change(m_inUpdateRendering, true);


### PR DESCRIPTION
#### 89749ad62db146e79a4ae1c307efee7fba9a94ec
<pre>
Move Page::renderingUpdateCompleted call to outside loop in Page::finalizeRenderingUpdate
<a href="https://bugs.webkit.org/show_bug.cgi?id=257127">https://bugs.webkit.org/show_bug.cgi?id=257127</a>
rdar://109664043

Reviewed by Tim Horton.

This is a retry of 264330@main with a line that prevents drawing pages that have no root frames,
which can happen after the last LocalFrame in a process is removed with a stack like this:

1   WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer()
2   WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate()
3   WebKit::RemoteLayerTreeDrawingArea::setRootCompositingLayer(WebCore::Frame&amp;, WebCore::GraphicsLayer*)
4   WebKit::WebPage::exitAcceleratedCompositingMode(WebCore::Frame&amp;)
5   WebKit::WebChromeClient::attachRootGraphicsLayer(WebCore::LocalFrame&amp;, WebCore::GraphicsLayer*)
6   WebCore::RenderLayerCompositor::detachRootLayer()
7   WebCore::RenderLayerCompositor::setIsInWindow(bool)
8   WebCore::RenderView::setIsInWindow(bool)
9   WebCore::LocalFrameView::setIsInWindow(bool)
10  WebCore::Document::documentWillBecomeInactive()
11  WebCore::Document::destroyRenderTree()
12  WebCore::Document::willBeRemovedFromFrame()
13  WebCore::LocalFrame::setView(...)
14  WebKit::WebFrame::didCommitLoadInAnotherProcess(...)

Even preventing the timer from being started doesn&apos;t prevent the assertions.  We need to catch
it when the timer fires, then check if there are any root frames, and exit early if there are none.

This will once again not affect any behavior with site isolation off because there will always be
exactly one root frame in that case, the main frame.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::finalizeRenderingUpdate):
(WebCore::Page::finalizeRenderingUpdateForRootFrame):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/264751@main">https://commits.webkit.org/264751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7900253bbfa6bf74e54707699f5b65e05ed5dc6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8444 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11350 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9627 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15268 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7864 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11215 "8 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8335 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11832 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1005 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->