### PR TITLE
[ iOS, macOS ] imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.html is a flaky text failure: A VideoFrame was destroyed without having been closed explicitly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Test we can clone a VideoFrame.
-FAIL Verify closing a frame doesn't affect its clones. assert_equals: expected 100 but got 0
+PASS Verify closing a frame doesn't affect its clones.
 PASS Verify cloning a closed frame throws.
 PASS Verify closing frames does not propagate accross contexts.
 PASS Verify transferring frames closes them.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Test we can clone a VideoFrame.
-FAIL Verify closing a frame doesn't affect its clones. assert_equals: expected 100 but got 0
+PASS Verify closing a frame doesn't affect its clones.
 PASS Verify cloning a closed frame throws.
 PASS Verify closing frames does not propagate accross contexts.
 PASS Verify transferring frames closes them.

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -2,7 +2,7 @@
 Harness Error (TIMEOUT), message = null
 
 PASS Test we can construct a VideoFrame.
-FAIL Test closed VideoFrame. assert_equals: timestamp expected 10 but got 0
+FAIL Test closed VideoFrame. null is not an object (evaluating 'frame.colorSpace.primaries')
 PASS Test we can construct a VideoFrame with a negative timestamp.
 PASS Test that timestamp is required when constructing VideoFrame from ImageBitmap
 PASS Test that timestamp is required when constructing VideoFrame from OffscreenCanvas

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Test we can construct a VideoFrame.
-FAIL Test closed VideoFrame. assert_equals: timestamp expected 10 but got 0
+FAIL Test closed VideoFrame. null is not an object (evaluating 'frame.colorSpace.primaries')
 PASS Test we can construct a VideoFrame with a negative timestamp.
 PASS Test that timestamp is required when constructing VideoFrame from ImageBitmap
 PASS Test that timestamp is required when constructing VideoFrame from OffscreenCanvas

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -502,12 +502,24 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::clone(ScriptExecution
 // https://w3c.github.io/webcodecs/#close-videoframe
 void WebCodecsVideoFrame::close()
 {
-    m_data = { };
+    m_data.internalFrame = nullptr;
+
+    m_isDetached = true;
+
+    m_data.format = { };
+
+    m_data.codedWidth = 0;
+    m_data.codedHeight = 0;
+    m_data.displayWidth = 0;
+    m_data.displayHeight = 0;
+    m_data.visibleWidth = 0;
+    m_data.visibleHeight = 0;
+    m_data.visibleLeft = 0;
+    m_data.visibleTop = 0;
 
     m_codedRect = nullptr;
     m_visibleRect = nullptr;
     m_colorSpace = nullptr;
-    m_isDetached = true;
 }
 
 DOMRectReadOnly* WebCodecsVideoFrame::codedRect() const


### PR DESCRIPTION
#### fc1d86930378e691a495b9a6c6b74c6e3b534424
<pre>
[ iOS, macOS ] imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.html is a flaky text failure: A VideoFrame was destroyed without having been closed explicitly
<a href="https://bugs.webkit.org/show_bug.cgi?id=257354">https://bugs.webkit.org/show_bug.cgi?id=257354</a>
rdar://109854552

Reviewed by Eric Carlson.

The test was flaky since we were failing an assert and not calling close().
We are updating VideoFrame.close() according spec which makes the test pass.
This will fix the flakiness.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::close):

Canonical link: <a href="https://commits.webkit.org/264730@main">https://commits.webkit.org/264730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e1a4bc675dc8f7d0c74a5f1e42c482e0383ad71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10109 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11355 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9630 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10263 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7724 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15282 "1 flakes 151 failures") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8049 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7628 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2053 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8086 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->