### PR TITLE
Use StringView more in ScriptElement and EmailInputType

### DIFF
--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -177,7 +177,7 @@ std::optional<ScriptType> ScriptElement::determineScriptType(LegacyTypeSupport s
     return std::nullopt;
 }
 
-// http://dev.w3.org/html5/spec/Overview.html#prepare-a-script
+// https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
 bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition, LegacyTypeSupport supportLegacyTypes)
 {
     if (m_alreadyStarted)
@@ -231,7 +231,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition, Legac
     if (!document.frame()->script().canExecuteScripts(ReasonForCallingCanExecuteScripts::AboutToExecuteScript))
         return false;
 
-    if (scriptType == ScriptType::Classic && !isScriptForEventSupported())
+    if (scriptType == ScriptType::Classic && isScriptPreventedByAttributes())
         return false;
 
     // According to the spec, the module tag ignores the "charset" attribute as the same to the worker's
@@ -605,22 +605,6 @@ void ScriptElement::executePendingScript(PendingScript& pendingScript)
 bool ScriptElement::ignoresLoadRequest() const
 {
     return m_alreadyStarted || m_isExternalScript || m_parserInserted == ParserInserted::Yes || !m_element.isConnected();
-}
-
-bool ScriptElement::isScriptForEventSupported() const
-{
-    String eventAttribute = eventAttributeValue();
-    String forAttribute = forAttributeValue();
-    if (!eventAttribute.isNull() && !forAttribute.isNull()) {
-        forAttribute = forAttribute.trim(isASCIIWhitespace);
-        if (!equalLettersIgnoringASCIICase(forAttribute, "window"_s))
-            return false;
-
-        eventAttribute = eventAttribute.trim(isASCIIWhitespace);
-        if (!equalLettersIgnoringASCIICase(eventAttribute, "onload"_s) && !equalLettersIgnoringASCIICase(eventAttribute, "onload()"_s))
-            return false;
-    }
-    return true;
 }
 
 String ScriptElement::scriptContent() const

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -108,7 +108,6 @@ private:
 
     std::optional<ScriptType> determineScriptType(LegacyTypeSupport) const;
     bool ignoresLoadRequest() const;
-    bool isScriptForEventSupported() const;
     void dispatchLoadEventRespectingUserGestureIndicator();
 
     bool requestClassicScript(const String& sourceURL);
@@ -119,10 +118,10 @@ private:
     virtual String charsetAttributeValue() const = 0;
     virtual String typeAttributeValue() const = 0;
     virtual String languageAttributeValue() const = 0;
-    virtual String forAttributeValue() const = 0;
-    virtual String eventAttributeValue() const = 0;
     virtual ReferrerPolicy referrerPolicy() const = 0;
     virtual RequestPriority fetchPriorityHint() const { return RequestPriority::Auto; }
+
+    virtual bool isScriptPreventedByAttributes() const { return false; }
 
     Element& m_element;
     OrdinalNumber m_startLineNumber { OrdinalNumber::beforeFirst() };

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -41,7 +41,7 @@ using namespace HTMLNames;
 // From https://html.spec.whatwg.org/#valid-e-mail-address.
 static constexpr ASCIILiteral emailPattern = "^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"_s;
 
-static bool isValidEmailAddress(const String& address)
+static bool isValidEmailAddress(StringView address)
 {
     int addressLength = address.length();
     if (!addressLength)
@@ -68,7 +68,7 @@ bool EmailInputType::typeMismatchFor(const String& value) const
     if (!element()->multiple())
         return !isValidEmailAddress(value);
     for (auto& address : value.splitAllowingEmptyEntries(',')) {
-        if (!isValidEmailAddress(address.trim(isASCIIWhitespace)))
+        if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<UChar>)))
             return true;
     }
     return false;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -145,16 +145,6 @@ String HTMLScriptElement::languageAttributeValue() const
     return attributeWithoutSynchronization(languageAttr).string();
 }
 
-String HTMLScriptElement::forAttributeValue() const
-{
-    return attributeWithoutSynchronization(forAttr).string();
-}
-
-String HTMLScriptElement::eventAttributeValue() const
-{
-    return attributeWithoutSynchronization(eventAttr).string();
-}
-
 bool HTMLScriptElement::hasAsyncAttribute() const
 {
     return hasAttributeWithoutSynchronization(asyncAttr);
@@ -181,6 +171,21 @@ void HTMLScriptElement::dispatchLoadEvent()
     setHaveFiredLoadEvent(true);
 
     dispatchEvent(Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
+}
+
+bool HTMLScriptElement::isScriptPreventedByAttributes() const
+{
+    auto& eventAttribute = attributeWithoutSynchronization(eventAttr);
+    auto& forAttribute = attributeWithoutSynchronization(forAttr);
+    if (!eventAttribute.isNull() && !forAttribute.isNull()) {
+        if (!equalLettersIgnoringASCIICase(StringView(forAttribute).trim(isASCIIWhitespace<UChar>), "window"_s))
+            return true;
+
+        auto eventAttributeView = StringView(eventAttribute).trim(isASCIIWhitespace<UChar>);
+        if (!equalLettersIgnoringASCIICase(eventAttributeView, "onload"_s) && !equalLettersIgnoringASCIICase(eventAttributeView, "onload()"_s))
+            return true;
+    }
+    return false;
 }
 
 Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(Document& targetDocument)

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -75,14 +75,14 @@ private:
     String charsetAttributeValue() const final;
     String typeAttributeValue() const final;
     String languageAttributeValue() const final;
-    String forAttributeValue() const final;
-    String eventAttributeValue() const final;
     bool hasAsyncAttribute() const final;
     bool hasDeferAttribute() const final;
     bool hasNoModuleAttribute() const final;
     bool hasSourceAttribute() const final;
 
     void dispatchLoadEvent() final;
+
+    bool isScriptPreventedByAttributes() const final;
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&) final;
 };

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -59,8 +59,6 @@ private:
     String charsetAttributeValue() const final { return String(); }
     String typeAttributeValue() const final { return getAttribute(SVGNames::typeAttr).string(); }
     String languageAttributeValue() const final { return String(); }
-    String forAttributeValue() const final { return String(); }
-    String eventAttributeValue() const final { return String(); }
     bool hasAsyncAttribute() const final { return false; }
     bool hasDeferAttribute() const final { return false; }
     bool hasNoModuleAttribute() const final { return false; }


### PR DESCRIPTION
#### f8eaba1e91892d09b40add74c79e92bff1a8fc49
<pre>
Use StringView more in ScriptElement and EmailInputType
<a href="https://bugs.webkit.org/show_bug.cgi?id=257500">https://bugs.webkit.org/show_bug.cgi?id=257500</a>
rdar://110047074

Reviewed by Darin Adler.

Move the logic for the for and event attributes to HTMLScriptElement as
SVGScriptElement does not have to care for them and also avoid going
from AtomString to String and then allocating a new String when
trimming.

As RegularExpression::match() already takes a StringView make
isValidEmailAddress() match that.

* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::isScriptForEventSupported const): Deleted.
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::isScriptPreventedByForAndEventAttributes const):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::isValidEmailAddress):
(WebCore::EmailInputType::typeMismatchFor const):
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::isScriptPreventedByForAndEventAttributes const):
(WebCore::HTMLScriptElement::forAttributeValue const): Deleted.
(WebCore::HTMLScriptElement::eventAttributeValue const): Deleted.
* Source/WebCore/html/HTMLScriptElement.h:
* Source/WebCore/svg/SVGScriptElement.h:

Canonical link: <a href="https://commits.webkit.org/264736@main">https://commits.webkit.org/264736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de72495728b8a4b2f0b58424a75c2ebef7008220

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10145 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8524 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9667 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15309 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7905 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11260 "6 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8377 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7663 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2055 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11874 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->