### PR TITLE
Rename isAllSpecialCharacters() to containsOnly()

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -47,10 +47,10 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
         size_t length = strlen(string);
         Vector<UChar, 1024> buffer(length);
         UChar* p = buffer.data();
-        bool sourceIsAllASCII;
+        bool sourceContainsOnlyASCII;
         const LChar* stringStart = reinterpret_cast<const LChar*>(string);
-        if (convertUTF8ToUTF16(string, string + length, &p, p + length, &sourceIsAllASCII)) {
-            if (sourceIsAllASCII)
+        if (convertUTF8ToUTF16(string, string + length, &p, p + length, &sourceContainsOnlyASCII)) {
+            if (sourceContainsOnlyASCII)
                 return &OpaqueJSString::create(stringStart, length).leakRef();
             return &OpaqueJSString::create(buffer.data(), p - buffer.data()).leakRef();
         }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1429,7 +1429,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBtoa, (JSGlobalObject* globalObject, CallFrame*
     if (stringToEncode.isNull())
         return JSValue::encode(jsEmptyString(vm));
 
-    if (!stringToEncode.isAllLatin1())
+    if (!stringToEncode.containsOnlyLatin1())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in argument for btoa."_s)));
 
     String encodedString = base64EncodeToStringReturnNullIfOverflow(stringToEncode.latin1());

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -74,7 +74,7 @@ static int32_t parseDecimalInt32(const CharType* characters, unsigned length)
 static void handleFraction(Duration& duration, int factor, StringView fractionString, TemporalUnit fractionType)
 {
     auto fractionLength = fractionString.length();
-    ASSERT(fractionLength && fractionLength <= 9 && fractionString.isAllASCII());
+    ASSERT(fractionLength && fractionLength <= 9 && fractionString.containsOnlyASCII());
     ASSERT(fractionType == TemporalUnit::Hour || fractionType == TemporalUnit::Minute || fractionType == TemporalUnit::Second);
 
     Vector<LChar, 9> padded(9, '0');

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -304,7 +304,7 @@ UCollationResult IntlCollator::compareStrings(JSGlobalObject* globalObject, Stri
             return compareASCIIWithUCADUCET(x.characters16(), x.length(), y.characters16(), y.length());
         }
 
-        if (x.is8Bit() && y.is8Bit() && x.isAllASCII() && y.isAllASCII())
+        if (x.is8Bit() && y.is8Bit() && x.containsOnlyASCII() && y.containsOnlyASCII())
             return ucol_strcollUTF8(m_collator.get(), bitwise_cast<const char*>(x.characters8()), x.length(), bitwise_cast<const char*>(y.characters8()), y.length(), &status);
 
         return std::nullopt;
@@ -502,7 +502,7 @@ void IntlCollator::checkICULocaleInvariants(const LocaleSet& locales)
                         CRASH();
                     }
                 } else {
-                    if (StringView(buffer.data(), buffer.size()).isAllASCII()) {
+                    if (StringView(buffer.data(), buffer.size()).containsOnlyASCII()) {
                         dataLogLn("BAD ", locale, " ", String(buffer.data(), buffer.size()), " including ASCII tailored characters");
                         CRASH();
                     }

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -146,7 +146,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
 
     // https://tc39.es/proposal-intl-displaynames/#sec-canonicalcodefordisplaynames
     auto canonicalizeCodeForDisplayNames = [](Type type, String&& code) -> CString {
-        ASSERT(code.isAllASCII());
+        ASSERT(code.containsOnlyASCII());
         switch (type) {
         case Type::Language: {
             return canonicalizeUnicodeLocaleID(code.ascii()).ascii();
@@ -231,7 +231,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
             throwRangeError(globalObject, scope, "argument is not a well-formed currency code"_s);
             return { };
         }
-        ASSERT(code.isAllASCII());
+        ASSERT(code.containsOnlyASCII());
 
         UCurrNameStyle style = UCURR_LONG_NAME;
         switch (m_style) {

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -90,7 +90,7 @@ bool LocaleIDBuilder::initialize(const String& tag)
 {
     if (!isStructurallyValidLanguageTag(tag))
         return false;
-    ASSERT(tag.isAllASCII());
+    ASSERT(tag.containsOnlyASCII());
     m_buffer = localeIDBufferForLanguageTagWithNullTerminator(tag.ascii());
     return m_buffer.size();
 }
@@ -152,7 +152,7 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
         else
             hasAppended = true;
 
-        ASSERT(subtag.isAllASCII());
+        ASSERT(subtag.containsOnlyASCII());
         if (subtag.is8Bit())
             buffer.append(subtag.characters8(), subtag.length());
         else
@@ -162,7 +162,7 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
     if (endOfLanguageScriptRegionVariant != length) {
         auto rest = localeIDView.right(length - endOfLanguageScriptRegionVariant);
 
-        ASSERT(rest.isAllASCII());
+        ASSERT(rest.containsOnlyASCII());
         if (rest.is8Bit())
             buffer.append(rest.characters8(), rest.length());
         else
@@ -177,7 +177,7 @@ void LocaleIDBuilder::setKeywordValue(ASCIILiteral key, StringView value)
 {
     ASSERT(m_buffer.size());
 
-    ASSERT(value.isAllASCII());
+    ASSERT(value.containsOnlyASCII());
     Vector<char, 32> rawValue(value.length() + 1);
     value.getCharacters(reinterpret_cast<LChar*>(rawValue.data()));
     rawValue[value.length()] = '\0';

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -113,14 +113,14 @@ Vector<String> IntlNumberFormat::localeData(const String& locale, RelevantExtens
 static inline unsigned computeCurrencySortKey(const String& currency)
 {
     ASSERT(currency.length() == 3);
-    ASSERT(currency.isAllSpecialCharacters<isASCIIUpper>());
+    ASSERT(currency.containsOnly<isASCIIUpper>());
     return (currency[0] << 16) + (currency[1] << 8) + currency[2];
 }
 
 static inline unsigned computeCurrencySortKey(const char* currency)
 {
     ASSERT(strlen(currency) == 3);
-    ASSERT(isAllSpecialCharacters<isASCIIUpper>(currency, 3));
+    ASSERT(containsOnly<isASCIIUpper>(currency, 3));
     return (currency[0] << 16) + (currency[1] << 8) + currency[2];
 }
 

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -431,10 +431,10 @@ static void addScriptlessLocaleIfNeeded(LocaleSet& availableLocales, StringView 
         return;
 
     Vector<char, 12> buffer;
-    ASSERT(subtags[0].is8Bit() && subtags[0].isAllASCII());
+    ASSERT(subtags[0].is8Bit() && subtags[0].containsOnlyASCII());
     buffer.append(reinterpret_cast<const char*>(subtags[0].characters8()), subtags[0].length());
     buffer.append('-');
-    ASSERT(subtags[2].is8Bit() && subtags[2].isAllASCII());
+    ASSERT(subtags[2].is8Bit() && subtags[2].containsOnlyASCII());
     buffer.append(reinterpret_cast<const char*>(subtags[2].characters8()), subtags[2].length());
 
     availableLocales.add(StringImpl::createStaticStringImpl(buffer.data(), buffer.size()));
@@ -799,7 +799,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
             }
 
             if (isStructurallyValidLanguageTag(tag)) {
-                ASSERT(tag.isAllASCII());
+                ASSERT(tag.containsOnlyASCII());
                 String canonicalizedTag = canonicalizeUnicodeLocaleID(tag.ascii());
                 if (!canonicalizedTag.isNull()) {
                     if (seenSet.add(canonicalizedTag).isNewEntry)
@@ -1112,21 +1112,21 @@ Vector<String> numberingSystemsForLocale(const String& locale)
 bool isUnicodeLanguageSubtag(StringView string)
 {
     auto length = string.length();
-    return length >= 2 && length <= 8 && length != 4 && string.isAllSpecialCharacters<isASCIIAlpha>();
+    return length >= 2 && length <= 8 && length != 4 && string.containsOnly<isASCIIAlpha>();
 }
 
 // unicode_script_subtag = alpha{4} ;
 bool isUnicodeScriptSubtag(StringView string)
 {
-    return string.length() == 4 && string.isAllSpecialCharacters<isASCIIAlpha>();
+    return string.length() == 4 && string.containsOnly<isASCIIAlpha>();
 }
 
 // unicode_region_subtag = alpha{2} | digit{3} ;
 bool isUnicodeRegionSubtag(StringView string)
 {
     auto length = string.length();
-    return (length == 2 && string.isAllSpecialCharacters<isASCIIAlpha>())
-        || (length == 3 && string.isAllSpecialCharacters<isASCIIDigit>());
+    return (length == 2 && string.containsOnly<isASCIIAlpha>())
+        || (length == 3 && string.containsOnly<isASCIIDigit>());
 }
 
 // unicode_variant_subtag = (alphanum{5,8} | digit alphanum{3}) ;
@@ -1134,15 +1134,15 @@ bool isUnicodeVariantSubtag(StringView string)
 {
     auto length = string.length();
     if (length >= 5 && length <= 8)
-        return string.isAllSpecialCharacters<isASCIIAlphanumeric>();
-    return length == 4 && isASCIIDigit(string[0]) && string.substring(1).isAllSpecialCharacters<isASCIIAlphanumeric>();
+        return string.containsOnly<isASCIIAlphanumeric>();
+    return length == 4 && isASCIIDigit(string[0]) && string.substring(1).containsOnly<isASCIIAlphanumeric>();
 }
 
 using VariantCode = uint64_t;
 static VariantCode parseVariantCode(StringView string)
 {
     ASSERT(isUnicodeVariantSubtag(string));
-    ASSERT(string.isAllASCII());
+    ASSERT(string.containsOnlyASCII());
     ASSERT(string.length() <= 8);
     ASSERT(string.length() >= 1);
     struct Code {
@@ -1174,7 +1174,7 @@ static constexpr unsigned numberOfUnicodeSingletons = 10 + 26; // Digits + Alpha
 static bool isUnicodeExtensionAttribute(StringView string)
 {
     auto length = string.length();
-    return length >= 3 && length <= 8 && string.isAllSpecialCharacters<isASCIIAlphanumeric>();
+    return length >= 3 && length <= 8 && string.containsOnly<isASCIIAlphanumeric>();
 }
 
 static bool isUnicodeExtensionKey(StringView string)
@@ -1185,19 +1185,19 @@ static bool isUnicodeExtensionKey(StringView string)
 static bool isUnicodeExtensionTypeComponent(StringView string)
 {
     auto length = string.length();
-    return length >= 3 && length <= 8 && string.isAllSpecialCharacters<isASCIIAlphanumeric>();
+    return length >= 3 && length <= 8 && string.containsOnly<isASCIIAlphanumeric>();
 }
 
 static bool isUnicodePUExtensionValue(StringView string)
 {
     auto length = string.length();
-    return length >= 1 && length <= 8 && string.isAllSpecialCharacters<isASCIIAlphanumeric>();
+    return length >= 1 && length <= 8 && string.containsOnly<isASCIIAlphanumeric>();
 }
 
 static bool isUnicodeOtherExtensionValue(StringView string)
 {
     auto length = string.length();
-    return length >= 2 && length <= 8 && string.isAllSpecialCharacters<isASCIIAlphanumeric>();
+    return length >= 2 && length <= 8 && string.containsOnly<isASCIIAlphanumeric>();
 }
 
 static bool isUnicodeTKey(StringView string)
@@ -1208,7 +1208,7 @@ static bool isUnicodeTKey(StringView string)
 static bool isUnicodeTValueComponent(StringView string)
 {
     auto length = string.length();
-    return length >= 3 && length <= 8 && string.isAllSpecialCharacters<isASCIIAlphanumeric>();
+    return length >= 3 && length <= 8 && string.containsOnly<isASCIIAlphanumeric>();
 }
 
 // The IsStructurallyValidLanguageTag abstract operation verifies that the locale argument (which must be a String value)
@@ -1534,7 +1534,7 @@ bool isUnicodeLanguageId(StringView string)
 
 bool isWellFormedCurrencyCode(StringView currency)
 {
-    return currency.length() == 3 && currency.isAllSpecialCharacters<isASCIIAlpha>();
+    return currency.length() == 3 && currency.containsOnly<isASCIIAlpha>();
 }
 
 std::optional<Vector<char, 32>> canonicalizeLocaleIDWithoutNullTerminator(const char* localeID)

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -191,7 +191,7 @@ static std::optional<LChar> decodeEscapeSequence(StringView input, unsigned inde
 
 static String decodeEscapeSequencesFromParsedURL(StringView input)
 {
-    ASSERT(input.isAllASCII());
+    ASSERT(input.containsOnlyASCII());
 
     auto length = input.length();
     if (length < 3 || !input.contains('%'))
@@ -426,7 +426,7 @@ static bool appendEncodedHostname(Vector<UChar, 512>& buffer, StringView string)
 {
     // hostnameBuffer needs to be big enough to hold an IDN-encoded name.
     // For host names bigger than this, we won't do IDN encoding, which is almost certainly OK.
-    if (string.length() > URLParser::hostnameBufferLength || string.isAllASCII()) {
+    if (string.length() > URLParser::hostnameBufferLength || string.containsOnlyASCII()) {
         append(buffer, string);
         return true;
     }

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -798,7 +798,7 @@ String mapHostNames(const String& string, URLDecodeFunction decodeFunction)
 {
     // Generally, we want to optimize for the case where there is one host name that does not need mapping.
     
-    if (decodeFunction && string.isAllASCII())
+    if (decodeFunction && string.containsOnlyASCII())
         return string;
     
     // Make a list of ranges that actually need mapping.

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1099,7 +1099,7 @@ URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* non
 
     ASSERT(!m_url.m_isValid
         || m_didSeeSyntaxViolation == (m_url.string() != m_inputString)
-        || (m_inputString.isAllSpecialCharacters<isC0ControlOrSpace>() && m_url.m_string == base.m_string.left(base.m_queryEnd))
+        || (m_inputString.containsOnly<isC0ControlOrSpace>() && m_url.m_string == base.m_string.left(base.m_queryEnd))
         || (base.isValid() && base.protocolIsFile()));
     ASSERT(internalValuesConsistent(m_url));
 #if ASSERT_ENABLED
@@ -2536,7 +2536,7 @@ void URLParser::addNonSpecialDotSlash()
 template<typename CharacterType> std::optional<URLParser::LCharBuffer> URLParser::domainToASCII(StringImpl& domain, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition)
 {
     LCharBuffer ascii;
-    if (domain.isAllASCII() && !subdomainStartsWithXNDashDash(domain)) {
+    if (domain.containsOnlyASCII() && !subdomainStartsWithXNDashDash(domain)) {
         size_t length = domain.length();
         if (domain.is8Bit()) {
             const LChar* characters = domain.characters8();

--- a/Source/WTF/wtf/cf/URLCF.cpp
+++ b/Source/WTF/wtf/cf/URLCF.cpp
@@ -60,7 +60,7 @@ RetainPtr<CFURLRef> URL::createCFURL() const
         return emptyCFURL();
 
     RetainPtr<CFURLRef> result;
-    if (LIKELY(m_string.is8Bit() && m_string.isAllASCII()))
+    if (LIKELY(m_string.is8Bit() && m_string.containsOnlyASCII()))
         result = adoptCF(CFURLCreateAbsoluteURLWithBytes(nullptr, m_string.characters8(), m_string.length(), kCFStringEncodingUTF8, nullptr, true));
     else {
         CString utf8 = m_string.utf8();

--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -69,7 +69,7 @@ template<> struct NonASCIIMask<8, LChar> {
 
 
 template<typename CharacterType>
-inline bool isAllASCII(MachineWord word)
+inline bool containsOnlyASCII(MachineWord word)
 {
     return !(word & NonASCIIMask<sizeof(MachineWord), CharacterType>::value());
 }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -164,12 +164,12 @@ struct HashAndUTF8CharactersTranslator {
         UChar* target;
         auto newString = StringImpl::createUninitialized(buffer.utf16Length, target);
 
-        bool isAllASCII;
+        bool containsOnlyASCII;
         const char* source = buffer.characters;
-        if (!convertUTF8ToUTF16(source, source + buffer.length, &target, target + buffer.utf16Length, &isAllASCII))
+        if (!convertUTF8ToUTF16(source, source + buffer.length, &target, target + buffer.utf16Length, &containsOnlyASCII))
             RELEASE_ASSERT_NOT_REACHED();
 
-        if (isAllASCII)
+        if (containsOnlyASCII)
             newString = StringImpl::create(buffer.characters, buffer.length);
 
         auto* pointer = &newString.leakRef();

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -189,9 +189,9 @@ void StringBuilder::shrinkToFit()
     }
 }
 
-bool StringBuilder::isAllASCII() const
+bool StringBuilder::containsOnlyASCII() const
 {
-    return StringView { *this }.isAllASCII();
+    return StringView { *this }.containsOnlyASCII();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -102,7 +102,7 @@ public:
     WTF_EXPORT_PRIVATE bool shouldShrinkToFit() const;
     WTF_EXPORT_PRIVATE void shrinkToFit();
 
-    WTF_EXPORT_PRIVATE bool isAllASCII() const;
+    WTF_EXPORT_PRIVATE bool containsOnlyASCII() const;
 
 private:
     static unsigned expandedCapacity(unsigned capacity, unsigned requiredCapacity);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -86,7 +86,7 @@ template<typename> struct HashAndCharactersTranslator;
 // Define STRING_STATS to 1 turn on runtime statistics of string sizes and memory usage.
 #define STRING_STATS 0
 
-template<bool isSpecialCharacter(UChar), typename CharacterType> bool isAllSpecialCharacters(const CharacterType*, size_t length);
+template<bool isSpecialCharacter(UChar), typename CharacterType> bool containsOnly(const CharacterType*, size_t length);
 
 #if STRING_STATS
 
@@ -442,9 +442,9 @@ public:
     WTF_EXPORT_PRIVATE Ref<StringImpl> trim(CodeUnitMatchFunction);
     template<typename Predicate> Ref<StringImpl> removeCharacters(const Predicate&);
 
-    bool isAllASCII() const;
-    bool isAllLatin1() const;
-    template<bool isSpecialCharacter(UChar)> bool isAllSpecialCharacters() const;
+    bool containsOnlyASCII() const;
+    bool containsOnlyLatin1() const;
+    template<bool isSpecialCharacter(UChar)> bool containsOnly() const;
 
     size_t find(LChar character, unsigned start = 0);
     size_t find(char character, unsigned start = 0);
@@ -851,14 +851,14 @@ inline Ref<StringImpl> StringImpl::isolatedCopy() const
     return create(m_data16, m_length);
 }
 
-inline bool StringImpl::isAllASCII() const
+inline bool StringImpl::containsOnlyASCII() const
 {
     if (is8Bit())
         return charactersAreAllASCII(characters8(), length());
     return charactersAreAllASCII(characters16(), length());
 }
 
-inline bool StringImpl::isAllLatin1() const
+inline bool StringImpl::containsOnlyLatin1() const
 {
     if (is8Bit())
         return true;
@@ -869,7 +869,7 @@ inline bool StringImpl::isAllLatin1() const
     return isLatin1(mergedCharacterBits);
 }
 
-template<bool isSpecialCharacter(UChar), typename CharacterType> inline bool isAllSpecialCharacters(const CharacterType* characters, size_t length)
+template<bool isSpecialCharacter(UChar), typename CharacterType> inline bool containsOnly(const CharacterType* characters, size_t length)
 {
     for (size_t i = 0; i < length; ++i) {
         if (!isSpecialCharacter(characters[i]))
@@ -878,11 +878,11 @@ template<bool isSpecialCharacter(UChar), typename CharacterType> inline bool isA
     return true;
 }
 
-template<bool isSpecialCharacter(UChar)> inline bool StringImpl::isAllSpecialCharacters() const
+template<bool isSpecialCharacter(UChar)> inline bool StringImpl::containsOnly() const
 {
     if (is8Bit())
-        return WTF::isAllSpecialCharacters<isSpecialCharacter>(characters8(), length());
-    return WTF::isAllSpecialCharacters<isSpecialCharacter>(characters16(), length());
+        return WTF::containsOnly<isSpecialCharacter>(characters8(), length());
+    return WTF::containsOnly<isSpecialCharacter>(characters16(), length());
 }
 
 inline StringImpl::StringImpl(unsigned length, Force8Bit)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -104,7 +104,7 @@ public:
     // Return characters8() or characters16() depending on CharacterType.
     template<typename CharacterType> const CharacterType* characters() const;
 
-    bool isAllASCII() const;
+    bool containsOnlyASCII() const;
 
     String toString() const;
     String toStringWithoutCopying() const;
@@ -179,7 +179,7 @@ public:
     WTF_EXPORT_PRIVATE bool containsIgnoringASCIICase(StringView) const;
     WTF_EXPORT_PRIVATE bool containsIgnoringASCIICase(StringView, unsigned start) const;
 
-    template<bool isSpecialCharacter(UChar)> bool isAllSpecialCharacters() const;
+    template<bool isSpecialCharacter(UChar)> bool containsOnly() const;
 
     WTF_EXPORT_PRIVATE bool startsWith(UChar) const;
     WTF_EXPORT_PRIVATE bool startsWith(StringView) const;
@@ -481,7 +481,7 @@ template<> ALWAYS_INLINE const UChar* StringView::characters<UChar>() const
     return characters16();
 }
 
-inline bool StringView::isAllASCII() const
+inline bool StringView::containsOnlyASCII() const
 {
     if (is8Bit())
         return charactersAreAllASCII(characters8(), length());
@@ -575,11 +575,11 @@ inline bool StringView::contains(CodeUnitMatchFunction&& function) const
     return find(std::forward<CodeUnitMatchFunction>(function)) != notFound;
 }
 
-template<bool isSpecialCharacter(UChar)> inline bool StringView::isAllSpecialCharacters() const
+template<bool isSpecialCharacter(UChar)> inline bool StringView::containsOnly() const
 {
     if (is8Bit())
-        return WTF::isAllSpecialCharacters<isSpecialCharacter>(characters8(), length());
-    return WTF::isAllSpecialCharacters<isSpecialCharacter>(characters16(), length());
+        return WTF::containsOnly<isSpecialCharacter>(characters8(), length());
+    return WTF::containsOnly<isSpecialCharacter>(characters16(), length());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters8(CharacterType* destination) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -46,7 +46,7 @@ WTF_EXPORT_PRIVATE float charactersToFloat(const UChar*, size_t, bool* ok = null
 WTF_EXPORT_PRIVATE float charactersToFloat(const LChar*, size_t, size_t& parsedLength);
 WTF_EXPORT_PRIVATE float charactersToFloat(const UChar*, size_t, size_t& parsedLength);
 
-template<bool isSpecialCharacter(UChar), typename CharacterType> bool isAllSpecialCharacters(const CharacterType*, size_t);
+template<bool isSpecialCharacter(UChar), typename CharacterType> bool containsOnly(const CharacterType*, size_t);
 
 enum TrailingZerosTruncatingPolicy { KeepTrailingZeros, TruncateTrailingZeros };
 
@@ -287,9 +287,9 @@ public:
     // Determines the writing direction using the Unicode Bidi Algorithm rules P2 and P3.
     std::optional<UCharDirection> defaultWritingDirection() const;
 
-    bool isAllASCII() const { return !m_impl || m_impl->isAllASCII(); }
-    bool isAllLatin1() const { return !m_impl || m_impl->isAllLatin1(); }
-    template<bool isSpecialCharacter(UChar)> bool isAllSpecialCharacters() const { return !m_impl || m_impl->isAllSpecialCharacters<isSpecialCharacter>(); }
+    bool containsOnlyASCII() const { return !m_impl || m_impl->containsOnlyASCII(); }
+    bool containsOnlyLatin1() const { return !m_impl || m_impl->containsOnlyLatin1(); }
+    template<bool isSpecialCharacter(UChar)> bool containsOnly() const { return !m_impl || m_impl->containsOnly<isSpecialCharacter>(); }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     String(WTF::HashTableDeletedValueType) : m_impl(WTF::HashTableDeletedValue) { }
@@ -588,7 +588,7 @@ using WTF::makeStringByReplacingAll;
 using WTF::nullString;
 using WTF::equal;
 using WTF::find;
-using WTF::isAllSpecialCharacters;
+using WTF::containsOnly;
 using WTF::reverseFind;
 
 #include <wtf/text/AtomString.h>

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -100,7 +100,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
 
         if (parameterName.length()
             && isValidHTTPToken(parameterName)
-            && parameterValue.isAllSpecialCharacters<isHTTPQuotedStringTokenCodePoint>()) {
+            && parameterValue.containsOnly<isHTTPQuotedStringTokenCodePoint>()) {
             parameters.ensure(parameterName.toString(), [&] { return parameterValue.toString(); });
         }
     }

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -66,7 +66,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(PaymentRequest);
 static bool isWellFormedCurrencyCode(const String& currency)
 {
     if (currency.length() == 3)
-        return currency.isAllSpecialCharacters<isASCIIAlpha>();
+        return currency.containsOnly<isASCIIAlpha>();
     return false;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -460,7 +460,7 @@ const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const u
         if ((headerName == HTTPHeaderName::SecWebSocketExtensions
             || headerName == HTTPHeaderName::SecWebSocketAccept
             || headerName == HTTPHeaderName::SecWebSocketProtocol)
-            && !value.isAllASCII()) {
+            && !value.containsOnlyASCII()) {
             m_failureReason = makeString(name, " header value should only contain ASCII characters");
             return nullptr;
         }

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -116,7 +116,7 @@ String TextCodecLatin1::decode(const char* bytes, size_t length, bool, bool, boo
                 while (source < alignedEnd) {
                     auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
 
-                    if (!WTF::isAllASCII<LChar>(chunk))
+                    if (!WTF::containsOnlyASCII<LChar>(chunk))
                         goto useLookupTable;
 
                     copyASCIIMachineWord(destination, source);
@@ -171,7 +171,7 @@ upConvertTo16Bit:
                 while (source < alignedEnd) {
                     auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
                     
-                    if (!WTF::isAllASCII<LChar>(chunk))
+                    if (!WTF::containsOnlyASCII<LChar>(chunk))
                         goto useLookupTable16;
                     
                     copyASCIIMachineWord(destination16, source);

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -326,7 +326,7 @@ String TextCodecUTF8::decode(const char* bytes, size_t length, bool flush, bool 
                 if (WTF::isAlignedToMachineWord(source)) {
                     while (source < alignedEnd) {
                         auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
-                        if (!WTF::isAllASCII<LChar>(chunk))
+                        if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
                         copyASCIIMachineWord(destination, source);
                         source += sizeof(WTF::MachineWord);
@@ -406,7 +406,7 @@ upConvertTo16Bit:
                 if (WTF::isAlignedToMachineWord(source)) {
                     while (source < alignedEnd) {
                         auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
-                        if (!WTF::isAllASCII<LChar>(chunk))
+                        if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
                         copyASCIIMachineWord(destination16, source);
                         source += sizeof(WTF::MachineWord);

--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -294,7 +294,7 @@ template<typename CharacterType> static const char* atomCanonicalTextEncodingNam
 
 const char* atomCanonicalTextEncodingName(StringView alias)
 {
-    if (alias.isEmpty() || !alias.isAllASCII())
+    if (alias.isEmpty() || !alias.containsOnlyASCII())
         return nullptr;
 
     if (alias.is8Bit())

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -120,7 +120,7 @@ bool AccessibilityList::childHasPseudoVisibleListItemMarkers(Node* node)
     // those renderers as "ignored" objects.
 #if USE(ATSPI)
     String text = axBeforePseudo->textUnderElement();
-    return !text.isEmpty() && !text.isAllSpecialCharacters<isASCIIWhitespace>();
+    return !text.isEmpty() && !text.containsOnly<isASCIIWhitespace>();
 #else
     return false;
 #endif

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -605,7 +605,7 @@ bool AccessibilityNodeObject::computeAccessibilityIsIgnored() const
             return true;
 
         // Whitespace only text elements should be ignored when they have no renderer.
-        if (stringValue().isAllSpecialCharacters<deprecatedIsSpaceOrNewline>())
+        if (stringValue().containsOnly<deprecatedIsSpaceOrNewline>())
             return true;
     }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1036,7 +1036,7 @@ bool AccessibilityRenderObject::isAllowedChildOfTree() const
 static AccessibilityObjectInclusion objectInclusionFromAltText(const String& altText)
 {
     // Don't ignore an image that has an alt tag.
-    if (!altText.isAllSpecialCharacters<isASCIIWhitespace>())
+    if (!altText.containsOnly<isASCIIWhitespace>())
         return AccessibilityObjectInclusion::IncludeObject;
 
     // The informal standard is to ignore images with zero-length alt strings:
@@ -1153,7 +1153,7 @@ bool AccessibilityRenderObject::computeAccessibilityIsIgnored() const
         }
 
         // text elements that are just empty whitespace should not be returned
-        return renderText.text().isAllSpecialCharacters<isASCIIWhitespace>();
+        return renderText.text().containsOnly<isASCIIWhitespace>();
     }
     
     if (isHeading())

--- a/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySVGElement.cpp
@@ -229,7 +229,7 @@ bool AccessibilitySVGElement::computeAccessibilityIsIgnored() const
     // The SVG AAM states text elements should also be included, if they have content.
     if (m_renderer->isSVGText() || m_renderer->isSVGTextPath()) {
         for (auto& child : childrenOfType<RenderText>(downcast<RenderElement>(*m_renderer))) {
-            if (!child.isAllCollapsibleWhitespace())
+            if (!child.containsOnlyCollapsibleWhitespace())
                 return false;
         }
     }

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
@@ -45,7 +45,7 @@ String identifierToString(JSGlobalObject& lexicalGlobalObject, const Identifier&
 
 static inline bool throwIfInvalidByteString(JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope, const String& string)
 {
-    if (UNLIKELY(!string.isAllLatin1())) {
+    if (UNLIKELY(!string.containsOnlyLatin1())) {
         throwTypeError(&lexicalGlobalObject, scope);
         return true;
     }

--- a/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionsBackend.cpp
@@ -166,7 +166,7 @@ auto ContentExtensionsBackend::actionsForResourceLoad(const ResourceLoadInfo& re
         return { };
 
     const String& urlString = resourceLoadInfo.resourceURL.string();
-    ASSERT_WITH_MESSAGE(urlString.isAllASCII(), "A decoded URL should only contain ASCII characters. The matching algorithm assumes the input is ASCII.");
+    ASSERT_WITH_MESSAGE(urlString.containsOnlyASCII(), "A decoded URL should only contain ASCII characters. The matching algorithm assumes the input is ASCII.");
 
     Vector<ActionsFromContentRuleList> actionsVector;
     actionsVector.reserveInitialCapacity(m_contentExtensions.size());

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -371,7 +371,7 @@ URLFilterParser::~URLFilterParser() = default;
 
 URLFilterParser::ParseStatus URLFilterParser::addPattern(StringView pattern, bool patternIsCaseSensitive, uint64_t patternId)
 {
-    if (!pattern.isAllASCII())
+    if (!pattern.containsOnlyASCII())
         return NonASCII;
     if (pattern.isEmpty())
         return EmptyPattern;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -7586,7 +7586,7 @@ static Vector<String> parseGridTemplateAreasColumnNames(StringView gridRowNames)
 
 bool parseGridTemplateAreasRow(StringView gridRowNames, NamedGridAreaMap& gridAreaMap, const size_t rowCount, size_t& columnCount)
 {
-    if (gridRowNames.isAllSpecialCharacters<isCSSSpace>())
+    if (gridRowNames.containsOnly<isCSSSpace>())
         return false;
 
     auto columnNames = parseGridTemplateAreasColumnNames(gridRowNames);

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -228,7 +228,7 @@ namespace CSSPropertyParserHelpersWorkerSafe {
 static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     StringView parsedURL = CSSPropertyParserHelpers::consumeURLRaw(range);
-    String urlString = !parsedURL.is8Bit() && parsedURL.isAllASCII() ? String::make8Bit(parsedURL.characters16(), parsedURL.length()) : parsedURL.toString();
+    String urlString = !parsedURL.is8Bit() && parsedURL.containsOnlyASCII() ? String::make8Bit(parsedURL.characters16(), parsedURL.length()) : parsedURL.toString();
     auto location = context.completeURL(urlString);
     if (location.resolvedURL.isNull())
         return nullptr;

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -314,7 +314,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
 {
     ASSERT(m_element.isConnected());
     ASSERT(!m_loadableScript);
-    if (!StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
+    if (!StringView(sourceURL).containsOnly<isASCIIWhitespace<UChar>>()) {
         auto script = LoadableClassicScript::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(),
             m_element.attributeWithoutSynchronization(HTMLNames::crossoriginAttr), scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree(), hasAsyncAttribute());
 
@@ -353,7 +353,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         ASSERT(m_element.isConnected());
 
         String sourceURL = sourceAttributeValue();
-        if (StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
+        if (StringView(sourceURL).containsOnly<isASCIIWhitespace<UChar>>()) {
             dispatchErrorEvent();
             return false;
         }
@@ -398,7 +398,7 @@ bool ScriptElement::requestImportMap(LocalFrame& frame, const String& sourceURL)
 {
     ASSERT(m_element.isConnected());
     ASSERT(!m_loadableScript);
-    if (!StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
+    if (!StringView(sourceURL).containsOnly<isASCIIWhitespace<UChar>>()) {
         auto script = LoadableImportMap::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(),
             m_element.attributeWithoutSynchronization(HTMLNames::crossoriginAttr), m_element.localName(), m_element.isInUserAgentShadowTree(), hasAsyncAttribute());
 

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1023,7 +1023,7 @@ void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* sty
     {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
-        if (node.renderer()->isText() && static_cast<RenderText*>(node.renderer())->isAllCollapsibleWhitespace())
+        if (node.renderer()->isText() && static_cast<RenderText*>(node.renderer())->containsOnlyCollapsibleWhitespace())
             return;
         if (node.renderer()->isBR() && !node.renderer()->style().preserveNewline())
             return;

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -71,7 +71,7 @@ public:
 
 protected:
     unsigned length() const { return m_markup.length(); }
-    bool isAllASCII() const { return m_markup.isAllASCII(); }
+    bool containsOnlyASCII() const { return m_markup.containsOnlyASCII(); }
 
     StringBuilder takeMarkup();
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -330,12 +330,12 @@ public:
 
     void prependMetaCharsetUTF8TagIfNonASCIICharactersArePresent()
     {
-        if (!isAllASCII())
+        if (!containsOnlyASCII())
             m_reversedPrecedingMarkup.append("<meta charset=\"UTF-8\">"_s);
     }
 
 private:
-    bool isAllASCII() const;
+    bool containsOnlyASCII() const;
     void appendStyleNodeOpenTag(StringBuilder&, StyleProperties*, Document&, bool isBlock = false);
     const String& styleNodeCloseTag(bool isBlock = false);
 
@@ -485,13 +485,13 @@ const String& StyledMarkupAccumulator::styleNodeCloseTag(bool isBlock)
     return isBlock ? divClose : styleSpanClose;
 }
 
-bool StyledMarkupAccumulator::isAllASCII() const
+bool StyledMarkupAccumulator::containsOnlyASCII() const
 {
     for (auto& preceding : m_reversedPrecedingMarkup) {
-        if (!preceding.isAllASCII())
+        if (!preceding.containsOnlyASCII())
             return false;
     }
-    return MarkupAccumulator::isAllASCII();
+    return MarkupAccumulator::containsOnlyASCII();
 }
 
 String StyledMarkupAccumulator::takeResults()

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -216,7 +216,7 @@ bool HTMLObjectElement::hasFallbackContent() const
     for (RefPtr<Node> child = firstChild(); child; child = child->nextSibling()) {
         // Ignore whitespace-only text, and <param> tags, any other content is fallback content.
         if (is<Text>(*child)) {
-            if (!downcast<Text>(*child).data().isAllSpecialCharacters<isASCIIWhitespace>())
+            if (!downcast<Text>(*child).data().containsOnly<isASCIIWhitespace>())
                 return true;
         } else if (!is<HTMLParamElement>(*child))
             return true;
@@ -376,7 +376,7 @@ static inline bool preventsParentObjectFromExposure(const Node& child)
     if (is<Element>(child))
         return preventsParentObjectFromExposure(downcast<Element>(child));
     if (is<Text>(child))
-        return !downcast<Text>(child).data().isAllSpecialCharacters<isASCIIWhitespace>();
+        return !downcast<Text>(child).data().containsOnly<isASCIIWhitespace>();
     return true;
 }
 

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -64,7 +64,7 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
         break;
     case AttributeNames::backgroundAttr:
-        if (!StringView(value).isAllSpecialCharacters<isASCIIWhitespace<UChar>>())
+        if (!StringView(value).containsOnly<isASCIIWhitespace<UChar>>())
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(value), LoadedFromOpaqueSource::No)));
         break;
     case AttributeNames::valignAttr:

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -241,7 +241,7 @@ bool HTMLVideoElement::isURLAttribute(const Attribute& attribute) const
 const AtomString& HTMLVideoElement::imageSourceURL() const
 {
     const auto& url = attributeWithoutSynchronization(posterAttr);
-    if (!StringView(url).isAllSpecialCharacters<isASCIIWhitespace<UChar>>())
+    if (!StringView(url).containsOnly<isASCIIWhitespace<UChar>>())
         return url;
     return m_defaultPosterURL;
 }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -85,16 +85,6 @@ static inline TextPosition uninitializedPositionValue1()
     return TextPosition(OrdinalNumber::fromOneBasedInt(-1), OrdinalNumber());
 }
 
-static inline bool isAllWhitespace(const String& string)
-{
-    return string.isAllSpecialCharacters<isASCIIWhitespace>();
-}
-
-static inline bool isAllWhitespaceOrReplacementCharacters(const String& string)
-{
-    return string.isAllSpecialCharacters<isASCIIWhitespaceOrReplacementCharacter>();
-}
-
 #if ASSERT_ENABLED
 static bool isTableBodyContextTag(TagName tagName)
 {
@@ -2696,7 +2686,7 @@ void HTMLTreeBuilder::processCharacterBufferForInBody(ExternalCharacterTokenBuff
 #else
     m_tree.insertTextNode(characters);
 #endif
-    if (m_framesetOk && !isAllWhitespaceOrReplacementCharacters(characters))
+    if (m_framesetOk && !characters.containsOnly<isASCIIWhitespaceOrReplacementCharacter>())
         m_framesetOk = false;
 }
 
@@ -2830,7 +2820,7 @@ void HTMLTreeBuilder::defaultForInTableText()
 {
     String characters = m_pendingTableCharacters.toString();
     m_pendingTableCharacters.clear();
-    if (!isAllWhitespace(characters)) {
+    if (!characters.containsOnly<isASCIIWhitespace>()) {
         // FIXME: parse error
         HTMLConstructionSite::RedirectToFosterParentGuard redirecter(m_tree);
         m_tree.reconstructTheActiveFormattingElements();
@@ -3092,7 +3082,7 @@ void HTMLTreeBuilder::processTokenInForeignContent(AtomHTMLToken&& token)
     case HTMLToken::Type::Character: {
         String characters = token.characters();
         m_tree.insertTextNode(characters);
-        if (m_framesetOk && !isAllWhitespaceOrReplacementCharacters(characters))
+        if (m_framesetOk && !characters.containsOnly<isASCIIWhitespaceOrReplacementCharacter>())
             m_framesetOk = false;
         break;
     }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -326,7 +326,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
-    if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASCIIWhitespace>()) {
+    if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).containsOnly<isASCIIWhitespace>()) {
         m_currentRegion = VTTRegion::create(m_document);
         return true;
     }
@@ -355,7 +355,7 @@ bool WebVTTParser::checkStyleSheet(StringView line)
     // line starts with the substring "STYLE" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
-    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASCIIWhitespace>())
+    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).containsOnly<isASCIIWhitespace>())
         return true;
 
     return false;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2493,16 +2493,16 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
     return value;
 }
 
-static bool containsOnlyHTMLWhitespace(Node* node)
+static bool containsOnlyASCIIWhitespace(Node* node)
 {
     // FIXME: Respect ignoreWhitespace setting from inspector front end?
-    return is<Text>(node) && downcast<Text>(*node).data().isAllSpecialCharacters<isASCIIWhitespace>();
+    return is<Text>(node) && downcast<Text>(*node).data().containsOnly<isASCIIWhitespace>();
 }
 
 Node* InspectorDOMAgent::innerFirstChild(Node* node)
 {
     node = node->firstChild();
-    while (containsOnlyHTMLWhitespace(node))
+    while (containsOnlyASCIIWhitespace(node))
         node = node->nextSibling();
     return node;
 }
@@ -2511,7 +2511,7 @@ Node* InspectorDOMAgent::innerNextSibling(Node* node)
 {
     do {
         node = node->nextSibling();
-    } while (containsOnlyHTMLWhitespace(node));
+    } while (containsOnlyASCIIWhitespace(node));
     return node;
 }
 
@@ -2519,7 +2519,7 @@ Node* InspectorDOMAgent::innerPreviousSibling(Node* node)
 {
     do {
         node = node->previousSibling();
-    } while (containsOnlyHTMLWhitespace(node));
+    } while (containsOnlyASCIIWhitespace(node));
     return node;
 }
 
@@ -2618,7 +2618,7 @@ void InspectorDOMAgent::addEventListenersToNode(Node& node)
 
 void InspectorDOMAgent::didInsertDOMNode(Node& node)
 {
-    if (containsOnlyHTMLWhitespace(&node))
+    if (containsOnlyASCIIWhitespace(&node))
         return;
 
     // We could be attaching existing subtree. Forget the bindings.
@@ -2645,7 +2645,7 @@ void InspectorDOMAgent::didInsertDOMNode(Node& node)
 
 void InspectorDOMAgent::didRemoveDOMNode(Node& node)
 {
-    if (containsOnlyHTMLWhitespace(&node))
+    if (containsOnlyASCIIWhitespace(&node))
         return;
 
     ContainerNode* parent = node.parentNode();
@@ -2667,7 +2667,7 @@ void InspectorDOMAgent::didRemoveDOMNode(Node& node)
 
 void InspectorDOMAgent::willDestroyDOMNode(Node& node)
 {
-    if (containsOnlyHTMLWhitespace(&node))
+    if (containsOnlyASCIIWhitespace(&node))
         return;
 
     auto nodeId = m_nodeToId.take(node);

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -183,7 +183,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // Do not load any image if the 'src' attribute is missing or if it is
     // an empty string.
     CachedResourceHandle<CachedImage> newImage = nullptr;
-    if (!attr.isNull() && !StringView(attr).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
+    if (!attr.isNull() && !StringView(attr).containsOnly<isASCIIWhitespace<UChar>>()) {
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
         options.contentSecurityPolicyImposition = element().isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
         options.loadedFromPluginElement = is<HTMLPlugInElement>(element()) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
@@ -488,7 +488,7 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
     }
 
     auto attr = element().imageSourceURL();
-    if (StringView(attr).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
+    if (StringView(attr).containsOnly<isASCIIWhitespace<UChar>>()) {
         rejectDecodePromises("Missing source URL."_s);
         return;
     }

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -165,7 +165,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     stringBuilder.append("\"\r\n\r\n");
 
     // We use utf8() below instead of ascii() as ascii() replaces CRLFs with ?? (we still only have put ASCII characters in it).
-    ASSERT(stringBuilder.toString().isAllASCII());
+    ASSERT(stringBuilder.toString().containsOnlyASCII());
     CString asciiString = stringBuilder.toString().utf8();
     SharedBufferBuilder mhtmlData;
     mhtmlData.append(asciiString.data(), asciiString.length());

--- a/Source/WebCore/page/Base64Utilities.cpp
+++ b/Source/WebCore/page/Base64Utilities.cpp
@@ -35,7 +35,7 @@ ExceptionOr<String> Base64Utilities::btoa(const String& stringToEncode)
     if (stringToEncode.isNull())
         return String();
 
-    if (!stringToEncode.isAllLatin1())
+    if (!stringToEncode.containsOnlyLatin1())
         return Exception { InvalidCharacterError };
 
     return base64EncodeToString(stringToEncode.latin1());

--- a/Source/WebCore/platform/graphics/FourCC.cpp
+++ b/Source/WebCore/platform/graphics/FourCC.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 std::optional<FourCC> FourCC::fromString(StringView string)
 {
-    if (string.length() != 4 || !string.isAllASCII())
+    if (string.length() != 4 || !string.containsOnlyASCII())
         return std::nullopt;
     return { { {
         static_cast<char>(string[0]),

--- a/Source/WebCore/platform/mac/PublicSuffixMac.mm
+++ b/Source/WebCore/platform/mac/PublicSuffixMac.mm
@@ -52,7 +52,7 @@ String topPrivatelyControlledDomain(const String& domain)
 {
     if (domain.isEmpty())
         return { };
-    if (!domain.isAllASCII())
+    if (!domain.containsOnlyASCII())
         return domain;
 
     static Lock cacheLock;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -162,7 +162,7 @@ static void addStringToSHA1(SHA1& sha1, const String& string)
     if (string.isEmpty())
         return;
 
-    if (string.is8Bit() && string.isAllASCII()) {
+    if (string.is8Bit() && string.containsOnlyASCII()) {
         const uint8_t nullByte = 0;
         sha1.addBytes(string.characters8(), string.length());
         sha1.addBytes(&nullByte, 1);

--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -60,7 +60,7 @@ void stopResolveDNS(uint64_t identifier)
     WebCore::DNSResolveQueue::singleton().stopResolve(identifier);
 }
 
-bool IPAddress::isAllZeros() const
+bool IPAddress::containsOnlyZeros() const
 {
     return std::visit(WTF::makeVisitor([] (const WTF::HashTableEmptyValueType&) {
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -62,7 +62,7 @@ public:
 
     bool isIPv4() const { return std::holds_alternative<struct in_addr>(m_address); }
     bool isIPv6() const { return std::holds_alternative<struct in6_addr>(m_address); }
-    bool isAllZeros() const;
+    bool containsOnlyZeros() const;
 
     const struct in_addr& ipv4Address() const { return std::get<struct in_addr>(m_address); }
     const struct in6_addr& ipv6Address() const { return std::get<struct in6_addr>(m_address); }

--- a/Source/WebCore/platform/network/ParsedContentRange.cpp
+++ b/Source/WebCore/platform/network/ParsedContentRange.cpp
@@ -81,7 +81,7 @@ static bool parseContentRange(StringView headerValue, int64_t& firstBytePosition
         return false;
 
     auto firstByteString = headerValue.substring(prefixLength, byteSeparatorTokenLoc - prefixLength);
-    if (!firstByteString.isAllSpecialCharacters<isASCIIDigit>())
+    if (!firstByteString.containsOnly<isASCIIDigit>())
         return false;
 
     auto optionalFirstBytePosition = parseInteger<int64_t>(firstByteString);
@@ -90,7 +90,7 @@ static bool parseContentRange(StringView headerValue, int64_t& firstBytePosition
     firstBytePosition = *optionalFirstBytePosition;
 
     auto lastByteString = headerValue.substring(byteSeparatorTokenLoc + 1, instanceLengthSeparatorToken - (byteSeparatorTokenLoc + 1));
-    if (!lastByteString.isAllSpecialCharacters<isASCIIDigit>())
+    if (!lastByteString.containsOnly<isASCIIDigit>())
         return false;
 
     auto optionalLastBytePosition = parseInteger<int64_t>(lastByteString);
@@ -102,7 +102,7 @@ static bool parseContentRange(StringView headerValue, int64_t& firstBytePosition
     if (instanceString == "*"_s)
         instanceLength = ParsedContentRange::unknownLength;
     else {
-        if (!instanceString.isAllSpecialCharacters<isASCIIDigit>())
+        if (!instanceString.containsOnly<isASCIIDigit>())
             return false;
 
         auto optionalInstanceLength = parseInteger<int64_t>(instanceString);

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -102,7 +102,7 @@ public:
     {
         m_hasReceivedIPv4 |= address.isIPv4();
         m_hasReceivedIPv6 |= address.isIPv6();
-        if (!address.isAllZeros())
+        if (!address.containsOnlyZeros())
             m_addresses.append(WTFMove(address));
     }
 

--- a/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequestCFNet.h
@@ -118,7 +118,7 @@ inline CFURLRequestPriority toPlatformRequestPriority(ResourceLoadPriority prior
 
 inline RetainPtr<CFStringRef> httpHeaderValueUsingSuitableEncoding(HTTPHeaderMap::const_iterator::KeyValue header)
 {
-    if (header.keyAsHTTPHeaderName && *header.keyAsHTTPHeaderName == HTTPHeaderName::LastEventID && !header.value.isAllASCII()) {
+    if (header.keyAsHTTPHeaderName && *header.keyAsHTTPHeaderName == HTTPHeaderName::LastEventID && !header.value.containsOnlyASCII()) {
         auto utf8Value = header.value.utf8();
         // Constructing a string with the UTF-8 bytes but claiming that it’s Latin-1 is the way to get CFNetwork to put those UTF-8 bytes on the wire.
         return adoptCF(CFStringCreateWithBytes(nullptr, utf8Value.dataAsUInt8Ptr(), utf8Value.length(), kCFStringEncodingISOLatin1, false));

--- a/Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp
@@ -56,7 +56,7 @@ String topPrivatelyControlledDomain(const String& domain)
 {
     if (domain.isEmpty())
         return String();
-    if (URL::hostIsIPAddress(domain) || !domain.isAllASCII())
+    if (URL::hostIsIPAddress(domain) || !domain.containsOnlyASCII())
         return domain;
 
     String lowercaseDomain = domain.convertToASCIILowercase();

--- a/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixSoup.cpp
@@ -64,7 +64,7 @@ String topPrivatelyControlledDomain(const String& domain)
 {
     if (domain.isEmpty())
         return String();
-    if (!domain.isAllASCII())
+    if (!domain.containsOnlyASCII())
         return domain;
 
     String lowercaseDomain = domain.convertToASCIILowercase();

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -122,7 +122,7 @@ int SQLiteStatement::bindText(int index, StringView text)
     ASSERT(static_cast<unsigned>(index) <= bindParameterCount());
 
     // Fast path when the input text is all ASCII.
-    if (text.is8Bit() && text.isAllASCII())
+    if (text.is8Bit() && text.containsOnlyASCII())
         return sqlite3_bind_text(m_statement, index, text.length() ? reinterpret_cast<const char*>(text.characters8()) : "", text.length(), SQLITE_TRANSIENT);
 
     auto utf8Text = text.utf8();

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -690,7 +690,7 @@ void Pasteboard::writeURLToDataObject(const URL& kurl, const String& titleStr)
     WebCore::writeURL(m_writableDataObject.get(), kurl, titleStr, true, true);
 
     String url = kurl.string();
-    ASSERT(url.isAllASCII()); // URL::string() is URL encoded.
+    ASSERT(url.containsOnlyASCII()); // URL::string() is URL encoded.
 
     String fsPath = fileSystemPathFromURLOrTitle(url, titleStr, ".URL"_s, true);
     String contentString("[InternetShortcut]\r\nURL=" + url + "\r\n");

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4227,7 +4227,7 @@ static inline bool isVisibleRenderText(const RenderObject& renderer)
         return false;
 
     auto& renderText = downcast<RenderText>(renderer);
-    return !renderText.linesBoundingBox().isEmpty() && !renderText.text().isAllSpecialCharacters<isASCIIWhitespace>();
+    return !renderText.linesBoundingBox().isEmpty() && !renderText.text().containsOnly<isASCIIWhitespace>();
 }
 
 static inline bool resizeTextPermitted(const RenderObject& renderer)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -321,7 +321,7 @@ inline bool RenderElement::shouldRepaintForStyleDifference(StyleDifference diff)
 {
     auto hasImmediateNonWhitespaceTextChild = [&] {
         for (auto& child : childrenOfType<RenderText>(*this)) {
-            if (!child.isAllCollapsibleWhitespace())
+            if (!child.containsOnlyCollapsibleWhitespace())
                 return true;
         }
         return false;

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -998,7 +998,7 @@ bool isEmptyInline(const RenderInline& renderer)
         if (current.isFloatingOrOutOfFlowPositioned())
             continue;
         if (is<RenderText>(current)) {
-            if (!downcast<RenderText>(current).isAllCollapsibleWhitespace())
+            if (!downcast<RenderText>(current).containsOnlyCollapsibleWhitespace())
                 return false;
             continue;
         }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5285,7 +5285,7 @@ static void determineNonLayerDescendantsPaintedContent(const RenderElement& rend
             if (renderer.style().effectiveUserSelect() != UserSelect::None)
                 request.setHasPaintedContent();
 
-            if (!renderText.text().isAllSpecialCharacters<isASCIIWhitespace>())
+            if (!renderText.text().containsOnly<isASCIIWhitespace>())
                 request.setHasPaintedContent();
 
             if (request.isSatisfied())

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -151,7 +151,7 @@ public:
 
     void momentarilyRevealLastTypedCharacter(unsigned offsetAfterLastTypedCharacter);
 
-    bool isAllCollapsibleWhitespace() const;
+    bool containsOnlyCollapsibleWhitespace() const;
 
     bool canUseSimpleFontCodePath() const { return m_canUseSimpleFontCodePath; }
 
@@ -170,7 +170,7 @@ public:
 
     StringView stringView(unsigned start = 0, std::optional<unsigned> stop = std::nullopt) const;
     
-    bool containsOnlyHTMLWhitespace(unsigned from, unsigned length) const;
+    bool containsOnlyCSSWhitespace(unsigned from, unsigned length) const;
 
     Vector<std::pair<unsigned, unsigned>> draggedContentRangesBetweenOffsets(unsigned startOffset, unsigned endOffset) const;
 
@@ -239,7 +239,7 @@ private:
                            // just dirtying everything when character data is modified (e.g., appended/inserted
                            // or removed).
     unsigned m_needsVisualReordering : 1 { false };
-    unsigned m_isAllASCII : 1 { false };
+    unsigned m_containsOnlyASCII : 1 { false };
     unsigned m_canUseSimpleFontCodePath : 1 { false };
     mutable unsigned m_knownToHaveNoOverflowAndNoFallbackFonts : 1 { false };
     unsigned m_useBackslashAsYenSymbol : 1 { false };

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -110,7 +110,7 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
     ASSERT(startOffset < endOffset);
 
     if (m_context.detectingContentfulPaint()) {
-        if (!textRun.text().isAllSpecialCharacters<isASCIIWhitespace>())
+        if (!textRun.text().containsOnly<isASCIIWhitespace>())
             m_context.setContentfulPaintDetected();
         return;
     }

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -862,7 +862,7 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements, bool
                     // Don't try to hyphenate at the final break of a block, since this means there is
                     // no more content, and a hyphenated single word would end up on a line by itself. This looks
                     // bad so just don't allow it.
-                    if (canHyphenate && !m_width.fitsOnLine() && (m_nextObject || !renderer.containsOnlyHTMLWhitespace(m_current.offset(), renderer.text().length() - m_current.offset()) || isLineEmpty)) {
+                    if (canHyphenate && !m_width.fitsOnLine() && (m_nextObject || !renderer.containsOnlyCSSWhitespace(m_current.offset(), renderer.text().length() - m_current.offset()) || isLineEmpty)) {
                         tryHyphenating(renderer, font, style.computedLocale(), consecutiveHyphenatedLines, m_blockStyle.hyphenationLimitLines(), style.hyphenationLimitBefore(), style.hyphenationLimitAfter(), lastSpace, m_current.offset(), m_width.currentWidth() - additionalTempWidth, m_width.availableWidth(), isFixedPitch, m_collapseWhiteSpace, lastSpaceWordSpacing, m_lineBreak, m_current.nextBreakablePosition(), m_lineBreaker.m_hyphenated);
                         if (m_lineBreaker.m_hyphenated) {
                             m_atEnd = true;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -163,7 +163,7 @@ void RenderTreeUpdater::updateRenderTree(ContainerNode& root)
             auto& text = downcast<Text>(node);
             auto* textUpdate = m_styleUpdate->textUpdate(text);
             bool didCreateParent = parent().update && parent().update->change == Style::Change::Renderer;
-            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text.data().isAllSpecialCharacters<isASCIIWhitespace>();
+            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text.data().containsOnly<isASCIIWhitespace>();
             if (didCreateParent || textUpdate || mayNeedUpdateWhitespaceOnlyRenderer)
                 updateTextRenderer(text, textUpdate);
 
@@ -441,7 +441,7 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
         return true;
     if (!textNode.length())
         return false;
-    if (!textNode.data().isAllSpecialCharacters<isASCIIWhitespace>())
+    if (!textNode.data().containsOnly<isASCIIWhitespace>())
         return true;
     if (is<RenderText>(renderingParent.previousChildRenderer))
         return true;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -837,7 +837,7 @@ void TreeResolver::resolveComposedTree()
                 m_update->addText(text, parent.element, WTFMove(textUpdate));
             }
 
-            if (!text.data().isAllSpecialCharacters<isASCIIWhitespace>())
+            if (!text.data().containsOnly<isASCIIWhitespace>())
                 parent.resolvedFirstLineAndLetterChild = true;
 
             text.setHasValidStyle();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -86,7 +86,7 @@ static void hashString(SHA1& sha1, const String& string)
     if (string.isNull())
         return;
 
-    if (string.is8Bit() && string.isAllASCII()) {
+    if (string.is8Bit() && string.containsOnlyASCII()) {
         const uint8_t nullByte = 0;
         sha1.addBytes(string.characters8(), string.length());
         sha1.addBytes(&nullByte, 1);

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -414,21 +414,21 @@ void ProvisionalPageProxy::decidePolicyForNavigationActionSync(FrameIdentifier f
 
 void ProvisionalPageProxy::logDiagnosticMessageFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     m_page->logDiagnosticMessage(message, description, shouldSample);
 }
 
 void ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     m_page->logDiagnosticMessageWithEnhancedPrivacy(message, description, shouldSample);
 }
 
 void ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess(const String& message, const String& description, const WebCore::DiagnosticLoggingClient::ValueDictionary& valueDictionary, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     m_page->logDiagnosticMessageWithValueDictionary(message, description, valueDictionary, shouldSample);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8557,7 +8557,7 @@ void WebPageProxy::logDiagnosticMessage(const String& message, const String& des
 
 void WebPageProxy::logDiagnosticMessageFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessage(message, description, shouldSample);
 }
@@ -8573,7 +8573,7 @@ void WebPageProxy::logDiagnosticMessageWithResult(const String& message, const S
 
 void WebPageProxy::logDiagnosticMessageWithResultFromWebProcess(const String& message, const String& description, uint32_t result, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessageWithResult(message, description, result, shouldSample);
 }
@@ -8589,7 +8589,7 @@ void WebPageProxy::logDiagnosticMessageWithValue(const String& message, const St
 
 void WebPageProxy::logDiagnosticMessageWithValueFromWebProcess(const String& message, const String& description, double value, unsigned significantFigures, ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessageWithValue(message, description, value, significantFigures, shouldSample);
 }
@@ -8605,7 +8605,7 @@ void WebPageProxy::logDiagnosticMessageWithEnhancedPrivacy(const String& message
 
 void WebPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessageWithEnhancedPrivacy(message, description, shouldSample);
 }
@@ -8633,7 +8633,7 @@ void WebPageProxy::logDiagnosticMessageWithValueDictionary(const String& message
 
 void WebPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess(const String& message, const String& description, const WebCore::DiagnosticLoggingClient::ValueDictionary& valueDictionary, WebCore::ShouldSample shouldSample)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessageWithValueDictionary(message, description, valueDictionary, shouldSample);
 }
@@ -8649,7 +8649,7 @@ void WebPageProxy::logDiagnosticMessageWithDomain(const String& message, WebCore
 
 void WebPageProxy::logDiagnosticMessageWithDomainFromWebProcess(const String& message, WebCore::DiagnosticLoggingDomain domain)
 {
-    MESSAGE_CHECK(m_process, message.isAllASCII());
+    MESSAGE_CHECK(m_process, message.containsOnlyASCII());
 
     logDiagnosticMessageWithDomain(message, domain);
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -363,7 +363,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
                 postLayoutData.selectedEditableImage = contextForElement(*imageElement);
         }
         // FIXME: We should disallow replace when the string contains only CJ characters.
-        postLayoutData.isReplaceAllowed = result.isContentEditable && !result.isInPasswordField && !selectedText.isAllSpecialCharacters<isASCIIWhitespace>();
+        postLayoutData.isReplaceAllowed = result.isContentEditable && !result.isInPasswordField && !selectedText.containsOnly<isASCIIWhitespace>();
     }
 
 #if USE(DICTATION_ALTERNATIVES)

--- a/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
+++ b/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
@@ -283,7 +283,7 @@ void BinaryPropertyListPlan::writeStringObject(const String& string)
 {
     unsigned length = string.length();
     m_byteCount += markerPlusLengthByteCount(length) + length;
-    if (!string.isAllASCII())
+    if (!string.containsOnlyASCII())
         m_byteCount += length;
 }
 
@@ -690,7 +690,7 @@ void BinaryPropertyListSerializer::appendStringObject(const String& string)
 {
     startObject();
     unsigned length = string.length();
-    if (string.isAllASCII()) {
+    if (string.containsOnlyASCII()) {
         if (length <= maxLengthInMarkerByte)
             appendByte(static_cast<unsigned char>(asciiStringMarkerByte | length));
         else {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -976,13 +976,13 @@ TEST(WTF, StringViewTrim)
     EXPECT_TRUE(nullView.trim(isA) == nullView);
 }
 
-TEST(WTF, StringViewIsAllASCII)
+TEST(WTF, StringViewContainsOnlyASCII)
 {
-    EXPECT_TRUE(StringView(String("Hello"_s)).isAllASCII());
-    EXPECT_TRUE(StringView(String("Cocoa"_s)).isAllASCII());
-    EXPECT_FALSE(StringView(String::fromLatin1("📱")).isAllASCII());
-    EXPECT_FALSE(StringView(String::fromLatin1("\u0080")).isAllASCII());
-    EXPECT_TRUE(StringView(String(bitwise_cast<const UChar*>(u"Hello"), 0)).isAllASCII());
+    EXPECT_TRUE(StringView(String("Hello"_s)).containsOnlyASCII());
+    EXPECT_TRUE(StringView(String("Cocoa"_s)).containsOnlyASCII());
+    EXPECT_FALSE(StringView(String::fromLatin1("📱")).containsOnlyASCII());
+    EXPECT_FALSE(StringView(String::fromLatin1("\u0080")).containsOnlyASCII());
+    EXPECT_TRUE(StringView(String(bitwise_cast<const UChar*>(u"Hello"), 0)).containsOnlyASCII());
 }
 
 TEST(WTF, StringViewUpconvert)


### PR DESCRIPTION
#### 3539f609da3d98f6ea798412ecd7de9befee762f
<pre>
Rename isAllSpecialCharacters() to containsOnly()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257251">https://bugs.webkit.org/show_bug.cgi?id=257251</a>
rdar://110048833

Reviewed by Darin Adler.

This is a clearer and simpler name. In addition:

- Rename isAllASCII and isAllLatin1 to containsOnlyASCII and
  containsOnlyLatin1, respectively. Including when used as variables.
- Inline isAllWhitespace and isAllWhitespaceOrReplacementCharacters as
  they were not clear about the type of whitespace and did not carry
  their &quot;weight&quot;.
- Rename containsOnlyHTMLWhitespace to containsOnlyASCIIWhitespace in
  InspectorDOMAgent.
- Rename containsOnlyHTMLWhitespace to containsOnlyCSSWhitespace in
  RenderText as it cared about the isCSSSpace definition (though is not
  directly using that: FIXME added).
- Rename isAllZeros in DNS to containsOnlyZeros.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString):
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::handleFraction):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::compareStrings const):
(JSC::IntlCollator::checkICULocaleInvariants):
* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::initialize):
(JSC::LocaleIDBuilder::overrideLanguageScriptRegion):
(JSC::LocaleIDBuilder::setKeywordValue):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::computeCurrencySortKey):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::addScriptlessLocaleIfNeeded):
(JSC::canonicalizeLocaleList):
(JSC::isUnicodeLanguageSubtag):
(JSC::isUnicodeScriptSubtag):
(JSC::isUnicodeRegionSubtag):
(JSC::isUnicodeVariantSubtag):
(JSC::parseVariantCode):
(JSC::isUnicodeExtensionAttribute):
(JSC::isUnicodeExtensionTypeComponent):
(JSC::isUnicodePUExtensionValue):
(JSC::isUnicodeOtherExtensionValue):
(JSC::isUnicodeTValueComponent):
(JSC::isWellFormedCurrencyCode):
* Source/WTF/wtf/URL.cpp:
(WTF::decodeEscapeSequencesFromParsedURL):
(WTF::appendEncodedHostname):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::mapHostNames):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::URLParser):
(WTF::URLParser::domainToASCII):
* Source/WTF/wtf/cf/URLCF.cpp:
(WTF::URL::createCFURL const):
* Source/WTF/wtf/text/ASCIIFastPath.h:
(WTF::containsOnlyASCII):
(WTF::isAllASCII): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashAndUTF8CharactersTranslator::translate):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::containsOnlyASCII const):
(WTF::StringBuilder::isAllASCII const): Deleted.
* Source/WTF/wtf/text/StringBuilder.h:
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::containsOnlyASCII const):
(WTF::StringImpl::containsOnlyLatin1 const):
(WTF::containsOnly):
(WTF::isSpecialCharacter const):
(WTF::StringImpl::isAllASCII const): Deleted.
(WTF::StringImpl::isAllLatin1 const): Deleted.
(WTF::isAllSpecialCharacters): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::containsOnlyASCII const):
(WTF::isSpecialCharacter const):
(WTF::StringView::isAllASCII const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::parseParameters):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::isWellFormedCurrencyCode):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::readHTTPHeaders):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::atomCanonicalTextEncodingName):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::childHasPseudoVisibleListItemMarkers):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeAccessibilityIsIgnored const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::objectInclusionFromAltText):
(WebCore::AccessibilityRenderObject::computeAccessibilityIsIgnored const):
* Source/WebCore/accessibility/AccessibilitySVGElement.cpp:
(WebCore::AccessibilitySVGElement::computeAccessibilityIsIgnored const):
* Source/WebCore/bindings/js/JSDOMConvertStrings.cpp:
(WebCore::throwIfInvalidByteString):
* Source/WebCore/contentextensions/ContentExtensionsBackend.cpp:
(WebCore::ContentExtensions::ContentExtensionsBackend::actionsForResourceLoad const):
* Source/WebCore/contentextensions/URLFilterParser.cpp:
(WebCore::ContentExtensions::URLFilterParser::addPattern):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::parseGridTemplateAreasRow):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestClassicScript):
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::requestImportMap):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
* Source/WebCore/editing/MarkupAccumulator.h:
(WebCore::MarkupAccumulator::containsOnlyASCII const):
(WebCore::MarkupAccumulator::isAllASCII const): Deleted.
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::containsOnlyASCII const):
(WebCore::StyledMarkupAccumulator::isAllASCII const): Deleted.
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::hasFallbackContent const):
(WebCore::preventsParentObjectFromExposure):
* Source/WebCore/html/HTMLTablePartElement.cpp:
(WebCore::HTMLTablePartElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::imageSourceURL const):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::processCharacterBufferForInBody):
(WebCore::HTMLTreeBuilder::defaultForInTableText):
(WebCore::HTMLTreeBuilder::processTokenInForeignContent):
(WebCore::isAllWhitespace): Deleted.
(WebCore::isAllWhitespaceOrReplacementCharacters): Deleted.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion):
(WebCore::WebVTTParser::checkStyleSheet):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::containsOnlyASCIIWhitespace):
(WebCore::InspectorDOMAgent::innerFirstChild):
(WebCore::InspectorDOMAgent::innerNextSibling):
(WebCore::InspectorDOMAgent::innerPreviousSibling):
(WebCore::InspectorDOMAgent::didInsertDOMNode):
(WebCore::InspectorDOMAgent::didRemoveDOMNode):
(WebCore::InspectorDOMAgent::willDestroyDOMNode):
(WebCore::containsOnlyHTMLWhitespace): Deleted.
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::decode):
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/page/Base64Utilities.cpp:
(WebCore::Base64Utilities::btoa):
* Source/WebCore/platform/graphics/FourCC.cpp:
(WebCore::FourCC::fromString):
* Source/WebCore/platform/mac/PublicSuffixMac.mm:
(WebCore::topPrivatelyControlledDomain):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::addStringToSHA1):
* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::containsOnlyZeros const):
(WebCore::IPAddress::isAllZeros const): Deleted.
* Source/WebCore/platform/network/DNS.h:
* Source/WebCore/platform/network/ParsedContentRange.cpp:
(WebCore::parseContentRange):
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::addIPAddress):
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.h:
(WebCore::httpHeaderValueUsingSuitableEncoding):
* Source/WebCore/platform/network/curl/PublicSuffixCurl.cpp:
(WebCore::topPrivatelyControlledDomain):
* Source/WebCore/platform/soup/PublicSuffixSoup.cpp:
(WebCore::topPrivatelyControlledDomain):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::bindText):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::writeURLToDataObject):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::isVisibleRenderText):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::shouldRepaintForStyleDifference const):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::isEmptyInline):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::RenderText):
(WebCore::RenderText::trimmedPreferredWidths):
(WebCore::RenderText::computePreferredLogicalWidths):
(WebCore::containsOnlyCollapsibleWhitespace):
(WebCore::RenderText::containsOnlyCollapsibleWhitespace const):
(WebCore::containsOnlyPossiblyCollapsibleWhitespace):
(WebCore::RenderText::containsOnlyCSSWhitespace const):
(WebCore::RenderText::setRenderedText):
(WebCore::RenderText::previousOffset const):
(WebCore::RenderText::nextOffset const):
(WebCore::RenderText::computeCanUseSimpleFontCodePath const):
(WebCore::isAllCollapsibleWhitespace): Deleted.
(WebCore::RenderText::isAllCollapsibleWhitespace const): Deleted.
(WebCore::isAllPossiblyCollapsibleWhitespace): Deleted.
(WebCore::RenderText::containsOnlyHTMLWhitespace const): Deleted.
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::textRendererIsNeeded):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp:
(WebKit::NetworkCache::hashString):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::logDiagnosticMessageFromWebProcess):
(WebKit::ProvisionalPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess):
(WebKit::ProvisionalPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::logDiagnosticMessageFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithResultFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithValueFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithDomainFromWebProcess):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp:
(BinaryPropertyListPlan::writeStringObject):
(BinaryPropertyListSerializer::appendStringObject):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264748@main">https://commits.webkit.org/264748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2b719344ab184d1c19e735235d7d4d6b2e8266a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11407 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9680 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10314 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7772 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/7307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11274 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8139 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8667 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7677 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2093 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2062 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11888 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8892 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8136 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2212 "Passed tests") | 
<!--EWS-Status-Bubble-End-->