### PR TITLE
[Cocoa] [GPUP] Compressed fonts are decompressed twice, which is one too many times

### DIFF
--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2009-2022 Apple Inc. All rights reserved.
+// Copyright (C) 2009-2023 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ SYSTEM_FRAMEWORK_SEARCH_PATHS = $(inherited) $(SDK_DIR)$(SYSTEM_LIBRARY_DIR)/Pri
 
 HEADER_SEARCH_PATHS = PAL ForwardingHeaders /usr/include/libxslt /usr/include/libxml2 "$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore" "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(WEBKITADDITIONS_HEADER_SEARCH_PATHS) $(ANGLE_HEADER_SEARCH_PATHS) $(LIBWEBRTC_HEADER_SEARCH_PATHS) $(HEADER_SEARCH_PATHS) $(SRCROOT);
 SYSTEM_HEADER_SEARCH_PATHS = $(PROJECT_DIR)/PAL/ThirdParty/libavif/include $(SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(inherited);
-LIBRARY_SEARCH_PATHS = "$(SDK_DIR)$(WEBCORE_LIBRARY_DIR)" $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
+LIBRARY_SEARCH_PATHS = $(SDK_DIR)/System/Library/PrivateFrameworks/FontServices.framework $(WK_PRIVATE_FRAMEWORK_STUBS_DIR) "$(SDK_DIR)$(WEBCORE_LIBRARY_DIR)" $(SDK_DIR)$(WK_LIBRARY_INSTALL_PATH) $(inherited);
 
 INFOPLIST_FILE = Info.plist;
 
@@ -145,7 +145,7 @@ WK_DEBUG_LDFLAGS =
 WK_DEBUG_LDFLAGS[config=Debug] = -Wl,-debug_variant
 
 // FIXME: Reduce the number of allowable_clients <rdar://problem/31823969>
-OTHER_LDFLAGS = $(inherited) $(WK_RELOCATABLE_FRAMEWORK_LDFLAGS) -weak-lxslt -lsqlite3 -lobjc -allowable_client WebCoreTestSupport -allowable_client WebKitLegacy -allowable_client TestIPC -force_load $(BUILT_PRODUCTS_DIR)/libPAL.a -framework CFNetwork -framework CoreAudio -framework CoreGraphics -framework CoreText -framework Foundation -framework IOSurface -framework ImageIO -framework Metal $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) $(OTHER_LDFLAGS_PLATFORM_$(WK_PLATFORM_NAME)) $(WK_ANGLE_LDFLAGS) $(WK_WEBGPU_LDFLAGS) $(WK_APPKIT_LDFLAGS) $(WK_APPSUPPORT_LDFLAGS) $(WK_AUDIO_UNIT_LDFLAGS) $(WK_CARBON_LDFLAGS) $(WK_CORE_UI_LDFLAGS) $(WK_DATA_DETECTORS_CORE_LDFLAGS) $(WK_GRAPHICS_SERVICES_LDFLAGS) $(WK_IOSURFACE_ACCELERATOR_LDFLAGS) $(WK_LIBWEBRTC_LDFLAGS) $(WK_MOBILE_CORE_SERVICES_LDFLAGS) $(WK_MOBILE_GESTALT_LDFLAGS) $(WK_NETWORK_EXTENSION_LDFLAGS) $(WK_SYSTEM_CONFIGURATION_LDFLAGS) $(WK_CORE_IMAGE_LDFLAGS) $(WK_URL_FORMATTING_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_SCENEKIT_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(PROFILE_GENERATE_OR_USE_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) $(WK_DEBUG_LDFLAGS);
+OTHER_LDFLAGS = $(inherited) $(WK_RELOCATABLE_FRAMEWORK_LDFLAGS) -weak-lxslt -lsqlite3 -lobjc -allowable_client WebCoreTestSupport -allowable_client WebKitLegacy -allowable_client TestIPC -force_load $(BUILT_PRODUCTS_DIR)/libPAL.a -framework CFNetwork -framework CoreAudio -framework CoreGraphics -framework CoreText -framework Foundation -framework IOSurface -framework ImageIO -framework Metal -lFontParser $(OTHER_LDFLAGS_PLATFORM_$(WK_COCOA_TOUCH)) $(OTHER_LDFLAGS_PLATFORM_$(WK_PLATFORM_NAME)) $(WK_ANGLE_LDFLAGS) $(WK_WEBGPU_LDFLAGS) $(WK_APPKIT_LDFLAGS) $(WK_APPSUPPORT_LDFLAGS) $(WK_AUDIO_UNIT_LDFLAGS) $(WK_CARBON_LDFLAGS) $(WK_CORE_UI_LDFLAGS) $(WK_DATA_DETECTORS_CORE_LDFLAGS) $(WK_GRAPHICS_SERVICES_LDFLAGS) $(WK_IOSURFACE_ACCELERATOR_LDFLAGS) $(WK_LIBWEBRTC_LDFLAGS) $(WK_MOBILE_CORE_SERVICES_LDFLAGS) $(WK_MOBILE_GESTALT_LDFLAGS) $(WK_NETWORK_EXTENSION_LDFLAGS) $(WK_SYSTEM_CONFIGURATION_LDFLAGS) $(WK_CORE_IMAGE_LDFLAGS) $(WK_URL_FORMATTING_LDFLAGS) $(WK_UNIFORM_TYPE_IDENTIFIERS_LDFLAGS) $(WK_SCENEKIT_LDFLAGS) $(SOURCE_VERSION_LDFLAGS) $(PROFILE_GENERATE_OR_USE_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS) $(WK_DEBUG_LDFLAGS);
 
 OTHER_LDFLAGS_PLATFORM_cocoatouch = -allowable_client WebKit -allowable_client iTunesU -allowable_client Casablanca -allowable_client Remote -allowable_client TVBooks -allowable_client DumpRenderTree -allowable_client WebKitTestRunner -allowable_client TestWebKitAPI;
 OTHER_LDFLAGS_PLATFORM_macosx = -sub_library libobjc -umbrella WebKit $(PROFILE_GENERATE_OR_USE_LDFLAGS);

--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -32,6 +32,7 @@
 
 #include <CoreText/CoreTextPriv.h>
 #include <OTSVG/OTSVG.h>
+#include <fparse/FPFontParser.h>
 
 #else
 
@@ -231,5 +232,10 @@ CTFontRef CTFontCreateForCharacters(CTFontRef currentFont, const UTF16Char *char
 CGFloat CTFontGetSbixImageSizeForGlyphAndContentsScale(CTFontRef, const CGGlyph, CGFloat contentsScale);
 
 CTFontDescriptorOptions CTFontDescriptorGetOptions(CTFontDescriptorRef);
+
+typedef const struct __FPFont* FPFontRef;
+CFArrayRef FPFontCreateFontsFromData(CFDataRef);
+CFStringRef FPFontCopyPostScriptName(FPFontRef);
+CFDataRef FPFontCopySFNTData(FPFontRef);
 
 WTF_EXTERN_C_END

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -64,8 +64,8 @@ RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer
 {
     RetainPtr<CFDataRef> bufferData = buffer.createCFData();
 
-    RetainPtr<CTFontDescriptorRef> fontDescriptor;
-    auto array = adoptCF(CTFontManagerCreateFontDescriptorsFromData(bufferData.get()));
+    FPFontRef font = nullptr;
+    auto array = adoptCF(FPFontCreateFontsFromData(bufferData.get()));
     if (!array)
         return nullptr;
     auto length = CFArrayGetCount(array.get());
@@ -74,19 +74,29 @@ RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer
     if (!itemInCollection.isNull()) {
         if (auto desiredName = itemInCollection.createCFString()) {
             for (CFIndex i = 0; i < length; ++i) {
-                auto candidate = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(array.get(), i));
-                auto postScriptName = adoptCF(static_cast<CFStringRef>(CTFontDescriptorCopyAttribute(candidate, kCTFontNameAttribute)));
+                auto candidate = static_cast<FPFontRef>(CFArrayGetValueAtIndex(array.get(), i));
+                auto postScriptName = adoptCF(FPFontCopyPostScriptName(candidate));
                 if (CFStringCompare(postScriptName.get(), desiredName.get(), 0) == kCFCompareEqualTo) {
-                    fontDescriptor = candidate;
+                    font = candidate;
                     break;
                 }
             }
         }
     }
-    if (!fontDescriptor)
-        fontDescriptor = static_cast<CTFontDescriptorRef>(CFArrayGetValueAtIndex(array.get(), 0));
+    if (!font)
+        font = static_cast<FPFontRef>(CFArrayGetValueAtIndex(array.get(), 0));
 
-    FontPlatformData::CreationData creationData = { buffer, itemInCollection };
+    // Retain the extracted font contents, so the GPU process doesn't have to extract it a second time later.
+    // This is a power optimization.
+    auto extractedData = adoptCF(FPFontCopySFNTData(font));
+    if (!extractedData) {
+        // Something is wrong with the font.
+        return nullptr;
+    }
+    auto fontDescriptor = adoptCF(CTFontManagerCreateFontDescriptorFromData(extractedData.get()));
+    auto protectedBuffer = SharedBuffer::create(extractedData.get());
+
+    FontPlatformData::CreationData creationData = { WTFMove(protectedBuffer), itemInCollection };
     return adoptRef(new FontCustomPlatformData(fontDescriptor.get(), WTFMove(creationData)));
 }
 

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101500/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101500/libFontParser.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+platform: zippered
+exports:
+  - archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101600/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101600/libFontParser.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+platform: zippered
+exports:
+  - archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/110000/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/110000/libFontParser.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+platform: zippered
+exports:
+  - archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/120000/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/120000/libFontParser.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+platform: zippered
+exports:
+  - archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/130000/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/130000/libFontParser.tbd
@@ -1,0 +1,8 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+platform: zippered
+exports:
+  - archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/15/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/15/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64 ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: tvos
+exports:
+  -
+    archs:           [ x86_64, arm64 ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/16/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/16/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64 ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: tvos
+exports:
+  -
+    archs:           [ x86_64, arm64 ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/15/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/15/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: ios
+exports:
+  -
+    archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/16/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/16/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ x86_64, arm64, arm64e ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: ios
+exports:
+  -
+    archs:           [ x86_64, arm64, arm64e ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/8/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/8/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: watchos
+exports:
+  -
+    archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...

--- a/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/9/libFontParser.tbd
+++ b/WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/9/libFontParser.tbd
@@ -1,0 +1,10 @@
+--- !tapi-tbd-v3
+archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
+install-name:    '/System/Library/PrivateFrameworks/FontServices.framework/libFontParser.dylib'
+objc-constraint: none
+platform: watchos
+exports:
+  -
+    archs:           [ i386, x86_64, arm64, arm64e, arm64_32, armv7k ]
+    symbols:         [ _FPFontCopyPostScriptName, _FPFontCopySFNTData, _FPFontCreateFontsFromData ]
+...


### PR DESCRIPTION
#### 1693e2b8edc6ac2cdc07abcd87d90499250831f9
<pre>
[Cocoa] [GPUP] Compressed fonts are decompressed twice, which is one too many times
<a href="https://bugs.webkit.org/show_bug.cgi?id=257401">https://bugs.webkit.org/show_bug.cgi?id=257401</a>
rdar://109910582

Reviewed by David Kilzer.

Previously, the way we were sharing web fonts between the web process and the GPU process is
by simply transferring the bytes of the file, and asking Core Text to open the data. Both
processes need to use the font, so this means Core Text was being asked to open the data twice.
This actually has somewhat significant cost, as many fonts are compressed, and simply opening
it has to decompress the file.

This patch uses an SPI function to produce the decompressed bytes, without opening the font.
This allows us to retain the decompressed bytes, and send them to the GPU process. By
decompressing early, we can decompress once, and then use the decompressed bytes everywhere.
This means we only have to decompress fonts once.

* Source/WebCore/Configurations/WebCore.xcconfig:
* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::createFontCustomPlatformData):
* WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101500/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/101600/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/110000/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/120000/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/Mac/130000/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/15/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/appletvos/16/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/15/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/iOS/16/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/8/libFontParser.tbd: Added.
* WebKitLibraries/WebKitPrivateFrameworkStubs/watchos/9/libFontParser.tbd: Added.

Canonical link: <a href="https://commits.webkit.org/264750@main">https://commits.webkit.org/264750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3612abb54cf47cfd1067dcc675f2e93698d2af2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8698 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11380 "4 flakes 99 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8613 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9655 "1 flakes 3 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10289 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7748 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15295 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8074 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8366 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7652 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->