### PR TITLE
Fix syscall sandbox violations in Lockdown Mode

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1028,6 +1028,7 @@
         SYS_csops_audittoken ;; used by WK to get entitlments
         SYS_dup
         SYS_exit
+        SYS_faccessat ;; <rdar://problem/56998930>
         SYS_fcntl
         SYS_fcntl_nocancel
         SYS_fstat64
@@ -1075,6 +1076,7 @@
         SYS_readlink
         SYS_shm_open
         SYS_stat64
+        SYS_statfs64
         SYS_sysctl
         SYS_thread_selfid
         SYS_ulock_wait
@@ -1085,7 +1087,6 @@
 (define (syscall-unix-in-use-after-launch-blocked-in-lockdown-mode) (syscall-number
     SYS_abort_with_payload ;; <rdar://problem/50967271>
     SYS_change_fdguard_np
-    SYS_faccessat ;; <rdar://problem/56998930>
     SYS_fgetattrlist ;; <rdar://problem/50266257>
     SYS_fileport_makefd
     SYS_flock
@@ -1108,15 +1109,17 @@
     SYS_sem_close
     SYS_sem_open
     SYS_shared_region_map_and_slide_2_np ;; <rdar://problem/60294880>
-    SYS_statfs64
     SYS_sysctlbyname
     SYS_ulock_wait2)) ;; <rdar://problem/58743778>
 
 (define (syscall-unix-rarely-in-use)
     (syscall-number
+        SYS_fgetxattr
         SYS_getxattr
+        SYS_iopolicysys
         SYS_openat_nocancel
         SYS_sigprocmask
+        SYS_umask
         SYS_unlink
         SYS_writev))
 
@@ -1124,11 +1127,9 @@
     (syscall-number
         SYS___pthread_sigmask
         SYS___semwait_signal
-        SYS_fgetxattr
         SYS_fsync
         SYS_getattrlistbulk ;; xpc_realpath and directory enumeration
         SYS_getgid
-        SYS_iopolicysys
         SYS_mkdirat
         SYS_open_dprotected_np
         SYS_pread_nocancel
@@ -1141,7 +1142,6 @@
         SYS_sigreturn
 #endif
         SYS_thread_selfusage
-        SYS_umask
         SYS_write))
 
 (define (syscall-unix-rarely-in-use-need-backtrace)
@@ -1339,6 +1339,7 @@
         MSC_mk_timer_destroy
         MSC_semaphore_signal_trap
         MSC_semaphore_timedwait_trap
+        MSC_semaphore_wait_trap
         MSC_swtch_pri
         MSC_syscall_thread_switch
         MSC_task_name_for_pid
@@ -1350,7 +1351,6 @@
         MSC_mach_msg_trap
         MSC_mach_voucher_extract_attr_recipe_trap
         MSC_pid_for_task
-        MSC_semaphore_wait_trap
         MSC_thread_self_trap))
 
 (deny syscall-mach
@@ -1433,7 +1433,8 @@
 
 (define (kernel-mig-routine-rarely-used-need-backtrace)
     (kernel-mig-routine
-        io_service_open_extended))
+        io_service_open_extended
+        mach_vm_region_recurse))
 
 (define (kernel-mig-routine-rarely-used-need-backtrace-blocked-in-lockdown-mode)
     (kernel-mig-routine
@@ -1446,7 +1447,6 @@
         io_service_close
         mach_exception_raise
         mach_vm_region
-        mach_vm_region_recurse
         task_threads_from_user))
 
 (define (kernel-mig-routine-rarely-used)


### PR DESCRIPTION
#### 46d0ad25749cd8ad27e256840c9b45e9e45e5642
<pre>
Fix syscall sandbox violations in Lockdown Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=257542">https://bugs.webkit.org/show_bug.cgi?id=257542</a>
rdar://109916897

Reviewed by Brent Fulgham and Chris Dumez.

Fix syscall sandbox violations in Lockdown Mode in the WebContent process on iOS.
These have been identified from telemetry and local reports.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/264743@main">https://commits.webkit.org/264743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52cc40704fa52fb9515edb098cf831baf809f919

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8535 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9677 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10311 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6975 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8096 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11275 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8388 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7674 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11885 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1001 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->