### PR TITLE
[ Ventura Debug ] TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation is a flaky timeout.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -938,7 +938,12 @@ window.webkit.messageHandlers.regularPage.postMessage("PASS");
 </script>
 )SWRESOURCE"_s;
 
+// fix me when rdar://110012082 is resolved
+#if PLATFORM(MAC)
+TEST(ServiceWorkers, DISABLED_SWProcessConnectionCreation)
+#else
 TEST(ServiceWorkers, SWProcessConnectionCreation)
+#endif
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 


### PR DESCRIPTION
#### 7d8c4b27d5a957e378c295f3a4c42f648926e4bf
<pre>
[ Ventura Debug ] TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation is a flaky timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257498">https://bugs.webkit.org/show_bug.cgi?id=257498</a>
rdar://110012082

Unreviewed test gardening.

Disabling API test while investigated.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:

Canonical link: <a href="https://commits.webkit.org/264740@main">https://commits.webkit.org/264740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864f1deaf9a3667c847f82d79f91e1b4cfb92eaa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10160 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/11405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9681 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10315 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6979 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/7771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8392 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11889 "Failed to checkout and rebase branch from PR 14540") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1000 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->