### PR TITLE
[WGSL] Make all types constant

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -62,7 +62,7 @@ bool satisfies(const Type* type, Constraint constraint)
     }
 }
 
-Type* satisfyOrPromote(Type* type, Constraint constraint, const TypeStore& types)
+const Type* satisfyOrPromote(const Type* type, Constraint constraint, const TypeStore& types)
 {
     auto* primitive = std::get_if<Types::Primitive>(type);
     if (!primitive) {

--- a/Source/WebGPU/WGSL/Constraints.h
+++ b/Source/WebGPU/WGSL/Constraints.h
@@ -65,6 +65,6 @@ constexpr Constraint Number = Float | Integer;
 }
 
 bool satisfies(const Type*, Constraint);
-Type* satisfyOrPromote(Type*, Constraint, const TypeStore&);
+const Type* satisfyOrPromote(const Type*, Constraint, const TypeStore&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -69,7 +69,7 @@ private:
     Vector<MemberOrParameter> m_builtins;
     Vector<MemberOrParameter> m_parameters;
     AST::Statement::List m_materializations;
-    Type* m_structType;
+    const Type* m_structType;
     String m_structTypeName;
     String m_structParameterName;
     Reflection::EntryPointInformation m_information;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -95,7 +95,7 @@ private:
     PrepareResult& m_result;
     HashMap<String, Global> m_globals;
     IndexMap<Vector<std::pair<unsigned, Global*>>> m_groupBindingMap;
-    IndexMap<Type*> m_structTypes;
+    IndexMap<const Type*> m_structTypes;
     HashMap<String, AST::Variable*> m_defs;
     HashSet<String> m_reads;
     Reflection::EntryPointInformation* m_entryPointInformation { nullptr };

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -51,30 +51,30 @@ inline void logLn(Arguments&&... arguments)
 struct ViableOverload {
     const OverloadCandidate* candidate;
     FixedVector<unsigned> ranks;
-    FixedVector<Type*> parameters;
-    Type* result;
+    FixedVector<const Type*> parameters;
+    const Type* result;
 };
 
 class OverloadResolver {
 public:
-    OverloadResolver(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions);
+    OverloadResolver(TypeStore&, const Vector<OverloadCandidate>&, const Vector<const Type*>& valueArguments, const Vector<const Type*>& typeArguments, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions);
 
     std::optional<SelectedOverload> resolve();
 
 private:
     FixedVector<std::optional<ViableOverload>> considerCandidates();
     std::optional<ViableOverload> considerCandidate(const OverloadCandidate&);
-    ConversionRank calculateRank(const AbstractType&, Type*);
-    ConversionRank calculateRank(const AbstractScalarType&, Type*);
-    ConversionRank conversionRank(Type*, Type*) const;
+    ConversionRank calculateRank(const AbstractType&, const Type*);
+    ConversionRank calculateRank(const AbstractScalarType&, const Type*);
+    ConversionRank conversionRank(const Type*, const Type*) const;
 
-    bool unify(const TypeVariable*, Type*);
-    bool unify(const AbstractType&, Type*);
-    bool unify(const AbstractScalarType&, Type*);
-    bool assign(TypeVariable, Type*);
-    Type* resolve(TypeVariable) const;
-    Type* materialize(const AbstractType&) const;
-    Type* materialize(const AbstractScalarType&) const;
+    bool unify(const TypeVariable*, const Type*);
+    bool unify(const AbstractType&, const Type*);
+    bool unify(const AbstractScalarType&, const Type*);
+    bool assign(TypeVariable, const Type*);
+    const Type* resolve(TypeVariable) const;
+    const Type* materialize(const AbstractType&) const;
+    const Type* materialize(const AbstractScalarType&) const;
 
     bool unify(const AbstractValue&, unsigned);
     void assign(NumericVariable, unsigned);
@@ -83,13 +83,13 @@ private:
 
     TypeStore& m_types;
     const Vector<OverloadCandidate>& m_candidates;
-    const Vector<Type*>& m_valueArguments;
-    const Vector<Type*>& m_typeArguments;
-    FixedVector<Type*> m_typeSubstitutions;
+    const Vector<const Type*>& m_valueArguments;
+    const Vector<const Type*>& m_typeArguments;
+    FixedVector<const Type*> m_typeSubstitutions;
     FixedVector<std::optional<unsigned>> m_numericSubstitutions;
 };
 
-OverloadResolver::OverloadResolver(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions)
+OverloadResolver::OverloadResolver(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<const Type*>& valueArguments, const Vector<const Type*>& typeArguments, unsigned numberOfTypeSubstitutions, unsigned numberOfValueSubstitutions)
     : m_types(types)
     , m_candidates(candidates)
     , m_valueArguments(valueArguments)
@@ -139,28 +139,28 @@ std::optional<SelectedOverload> OverloadResolver::resolve()
     return { { WTFMove(selectedCandidate->parameters), selectedCandidate->result } };
 }
 
-Type* OverloadResolver::materialize(const AbstractType& abstractType) const
+const Type* OverloadResolver::materialize(const AbstractType& abstractType) const
 {
     return WTF::switchOn(abstractType,
-        [&](Type* type) -> Type* {
+        [&](const Type* type) -> const Type* {
             return type;
         },
-        [&](TypeVariable variable) -> Type* {
-            Type* type = resolve(variable);
+        [&](TypeVariable variable) -> const Type* {
+            const Type* type = resolve(variable);
             if (!type)
                 return nullptr;
             type = satisfyOrPromote(type, variable.constraints, m_types);
             RELEASE_ASSERT(type);
             return type;
         },
-        [&](const AbstractVector& vector) -> Type* {
+        [&](const AbstractVector& vector) -> const Type* {
             if (auto* element = materialize(vector.element)) {
                 auto size = materialize(vector.size);
                 return m_types.vectorType(element, size);
             }
             return nullptr;
         },
-        [&](const AbstractMatrix& matrix) -> Type* {
+        [&](const AbstractMatrix& matrix) -> const Type* {
             if (auto* element = materialize(matrix.element)) {
                 auto columns = materialize(matrix.columns);
                 auto rows = materialize(matrix.rows);
@@ -168,21 +168,21 @@ Type* OverloadResolver::materialize(const AbstractType& abstractType) const
             }
             return nullptr;
         },
-        [&](const AbstractTexture& texture) -> Type* {
+        [&](const AbstractTexture& texture) -> const Type* {
             if (auto* element = materialize(texture.element))
                 return m_types.textureType(element, texture.kind);
             return nullptr;
         });
 }
 
-Type* OverloadResolver::materialize(const AbstractScalarType& abstractScalarType) const
+const Type* OverloadResolver::materialize(const AbstractScalarType& abstractScalarType) const
 {
     return WTF::switchOn(abstractScalarType,
-        [&](Type* type) -> Type* {
+        [&](const Type* type) -> const Type* {
             return type;
         },
-        [&](TypeVariable variable) -> Type* {
-            Type* type = resolve(variable);
+        [&](TypeVariable variable) -> const Type* {
+            const Type* type = resolve(variable);
             if (!type)
                 return nullptr;
             type = satisfyOrPromote(type, variable.constraints, m_types);
@@ -233,7 +233,7 @@ std::optional<ViableOverload> OverloadResolver::considerCandidate(const Overload
     ViableOverload viableOverload {
         &candidate,
         FixedVector<unsigned>(m_valueArguments.size()),
-        FixedVector<Type*>(m_valueArguments.size()),
+        FixedVector<const Type*>(m_valueArguments.size()),
         nullptr
     };
     for (unsigned i = 0; i < m_valueArguments.size(); ++i) {
@@ -275,7 +275,7 @@ std::optional<ViableOverload> OverloadResolver::considerCandidate(const Overload
     return { WTFMove(viableOverload) };
 }
 
-ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, Type* argumentType)
+ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, const Type* argumentType)
 {
     if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
         auto* resolvedType = resolve(*variable);
@@ -303,11 +303,11 @@ ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, Ty
         return calculateRank(textureParameter->element, textureArgument.element);
     }
 
-    auto* parameterType = std::get<Type*>(parameter);
+    auto* parameterType = std::get<const Type*>(parameter);
     return conversionRank(argumentType, parameterType);
 }
 
-ConversionRank OverloadResolver::calculateRank(const AbstractScalarType& parameter, Type* argumentType)
+ConversionRank OverloadResolver::calculateRank(const AbstractScalarType& parameter, const Type* argumentType)
 {
     if (auto* variable = std::get_if<TypeVariable>(&parameter)) {
         auto* resolvedType = resolve(*variable);
@@ -315,11 +315,11 @@ ConversionRank OverloadResolver::calculateRank(const AbstractScalarType& paramet
         return conversionRank(argumentType, resolvedType);
     }
 
-    auto* parameterType = std::get<Type*>(parameter);
+    auto* parameterType = std::get<const Type*>(parameter);
     return conversionRank(argumentType, parameterType);
 }
 
-bool OverloadResolver::unify(const TypeVariable* variable, Type* argumentType)
+bool OverloadResolver::unify(const TypeVariable* variable, const Type* argumentType)
 {
     auto* resolvedType = resolve(*variable);
     if (!resolvedType)
@@ -362,7 +362,7 @@ bool OverloadResolver::unify(const TypeVariable* variable, Type* argumentType)
     return !!argumentConversionRank;
 }
 
-bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
+bool OverloadResolver::unify(const AbstractType& parameter, const Type* argumentType)
 {
     logLn("unify parameter type '", parameter, "' with argument '", *argumentType, "'");
     if (auto* variable = std::get_if<TypeVariable>(&parameter))
@@ -403,17 +403,17 @@ bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
         return unify(textureParameter->element, textureArgument->element);
     }
 
-    auto* parameterType = std::get<Type*>(parameter);
+    auto* parameterType = std::get<const Type*>(parameter);
     return !!conversionRank(argumentType, parameterType);
 }
 
-bool OverloadResolver::unify(const AbstractScalarType& parameter, Type* argumentType)
+bool OverloadResolver::unify(const AbstractScalarType& parameter, const Type* argumentType)
 {
     logLn("unify parameter type '", parameter, "' with argument '", *argumentType, "'");
     if (auto* variable = std::get_if<TypeVariable>(&parameter))
         return unify(variable, argumentType);
 
-    auto* parameterType = std::get<Type*>(parameter);
+    auto* parameterType = std::get<const Type*>(parameter);
     return !!conversionRank(argumentType, parameterType);
 }
 
@@ -431,7 +431,7 @@ bool OverloadResolver::unify(const AbstractValue& parameter, unsigned argumentVa
     return *resolvedValue == argumentValue;
 }
 
-bool OverloadResolver::assign(TypeVariable variable, Type* type)
+bool OverloadResolver::assign(TypeVariable variable, const Type* type)
 {
     logLn("assign ", variable, " => ", *type);
     if (variable.constraints) {
@@ -448,7 +448,7 @@ void OverloadResolver::assign(NumericVariable variable, unsigned value)
     m_numericSubstitutions[variable.id] = { value };
 }
 
-Type* OverloadResolver::resolve(TypeVariable variable) const
+const Type* OverloadResolver::resolve(TypeVariable variable) const
 {
     return m_typeSubstitutions[variable.id];
 }
@@ -458,14 +458,14 @@ std::optional<unsigned> OverloadResolver::resolve(NumericVariable variable) cons
     return m_numericSubstitutions[variable.id];
 }
 
-ConversionRank OverloadResolver::conversionRank(Type* from, Type* to) const
+ConversionRank OverloadResolver::conversionRank(const Type* from, const Type* to) const
 {
     auto rank = ::WGSL::conversionRank(from, to);
     logLn("conversionRank(from: ", *from, ", to: ", *to, ") = ", rank.value());
     return rank;
 }
 
-std::optional<SelectedOverload> resolveOverloads(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments)
+std::optional<SelectedOverload> resolveOverloads(TypeStore& types, const Vector<OverloadCandidate>& candidates, const Vector<const Type*>& valueArguments, const Vector<const Type*>& typeArguments)
 {
 
     unsigned numberOfTypeSubstitutions = 0;
@@ -506,7 +506,7 @@ void printInternal(PrintStream& out, const WGSL::TypeVariable& variable)
 void printInternal(PrintStream& out, const WGSL::AbstractType& type)
 {
     WTF::switchOn(type,
-        [&](WGSL::Type* type) {
+        [&](const WGSL::Type* type) {
             printInternal(out, *type);
         },
         [&](WGSL::TypeVariable variable) {
@@ -539,7 +539,7 @@ void printInternal(PrintStream& out, const WGSL::AbstractType& type)
 void printInternal(PrintStream& out, const WGSL::AbstractScalarType& type)
 {
     WTF::switchOn(type,
-        [&](WGSL::Type* type) {
+        [&](const WGSL::Type* type) {
             printInternal(out, *type);
         },
         [&](WGSL::TypeVariable variable) {

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -49,12 +49,12 @@ using AbstractType = std::variant<
     AbstractMatrix,
     AbstractTexture,
     TypeVariable,
-    Type*
+    const Type*
 >;
 
 using AbstractScalarType = std::variant<
     TypeVariable,
-    Type*
+    const Type*
 >;
 
 struct AbstractVector {
@@ -81,11 +81,11 @@ struct OverloadCandidate {
 };
 
 struct SelectedOverload {
-    FixedVector<Type*> parameters;
-    Type* result;
+    FixedVector<const Type*> parameters;
+    const Type* result;
 };
 
-std::optional<SelectedOverload> resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<Type*>& valueArguments, const Vector<Type*>& typeArguments);
+std::optional<SelectedOverload> resolveOverloads(TypeStore&, const Vector<OverloadCandidate>&, const Vector<const Type*>& valueArguments, const Vector<const Type*>& typeArguments);
 
 } // namespace WGSL
 

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -51,14 +51,14 @@ using namespace Types;
 // Texture: kind << 16
 // Reference: AddressSpace + AccessMode compacted into 1 byte and shifted 24 bits left
 struct VectorKey {
-    Type* elementType;
+    const Type* elementType;
     uint8_t size;
 
     uint64_t extra() const { return size; }
 };
 
 struct MatrixKey {
-    Type* elementType;
+    const Type* elementType;
     uint8_t columns;
     uint8_t rows;
 
@@ -66,21 +66,21 @@ struct MatrixKey {
 };
 
 struct ArrayKey {
-    Type* elementType;
+    const Type* elementType;
     std::optional<unsigned> size;
 
     uint64_t extra() const { return size.has_value() ? static_cast<uint64_t>(*size) << 32 : 0; }
 };
 
 struct TextureKey {
-    Type* elementType;
+    const Type* elementType;
     Texture::Kind kind;
 
     uint64_t extra() const { return static_cast<uint64_t>(kind) << 16; }
 };
 
 struct ReferenceKey {
-    Type* elementType;
+    const Type* elementType;
     AddressSpace addressSpace;
     AccessMode accessMode;
 
@@ -99,7 +99,7 @@ struct ReferenceKey {
 };
 
 template<typename Key>
-Type* TypeStore::TypeCache::find(const Key& key) const
+const Type* TypeStore::TypeCache::find(const Key& key) const
 {
     auto it = m_storage.find(std::pair(key.elementType, key.extra()));
     if (it != m_storage.end())
@@ -108,7 +108,7 @@ Type* TypeStore::TypeCache::find(const Key& key) const
 }
 
 template<typename Key>
-void TypeStore::TypeCache::insert(const Key& key, Type* type)
+void TypeStore::TypeCache::insert(const Key& key, const Type* type)
 {
     auto it = m_storage.add(std::pair(key.elementType, key.extra()), type);
     ASSERT_UNUSED(it, it.isNewEntry);
@@ -154,21 +154,21 @@ TypeStore::TypeStore()
     allocateConstructor(&TypeStore::textureType, AST::ParameterizedTypeName::Base::TextureStorage3d, Texture::Kind::TextureStorage3d);
 }
 
-Type* TypeStore::structType(AST::Structure& structure)
+const Type* TypeStore::structType(AST::Structure& structure)
 {
     return allocateType<Struct>(structure);
 }
 
-Type* TypeStore::constructType(AST::ParameterizedTypeName::Base base, Type* elementType)
+const Type* TypeStore::constructType(AST::ParameterizedTypeName::Base base, const Type* elementType)
 {
     auto& typeConstructor = m_typeConstrutors[WTF::enumToUnderlyingType(base)];
     return typeConstructor.construct(elementType);
 }
 
-Type* TypeStore::arrayType(Type* elementType, std::optional<unsigned> size)
+const Type* TypeStore::arrayType(const Type* elementType, std::optional<unsigned> size)
 {
     ArrayKey key { elementType, size };
-    Type* type = m_cache.find(key);
+    const Type* type = m_cache.find(key);
     if (type)
         return type;
     type = allocateType<Array>(elementType, size);
@@ -176,10 +176,10 @@ Type* TypeStore::arrayType(Type* elementType, std::optional<unsigned> size)
     return type;
 }
 
-Type* TypeStore::vectorType(Type* elementType, uint8_t size)
+const Type* TypeStore::vectorType(const Type* elementType, uint8_t size)
 {
     VectorKey key { elementType, size };
-    Type* type = m_cache.find(key);
+    const Type* type = m_cache.find(key);
     if (type)
         return type;
     type = allocateType<Vector>(elementType, size);
@@ -187,10 +187,10 @@ Type* TypeStore::vectorType(Type* elementType, uint8_t size)
     return type;
 }
 
-Type* TypeStore::matrixType(Type* elementType, uint8_t columns, uint8_t rows)
+const Type* TypeStore::matrixType(const Type* elementType, uint8_t columns, uint8_t rows)
 {
     MatrixKey key { elementType, columns, rows };
-    Type* type = m_cache.find(key);
+    const Type* type = m_cache.find(key);
     if (type)
         return type;
     type = allocateType<Matrix>(elementType, columns, rows);
@@ -198,10 +198,10 @@ Type* TypeStore::matrixType(Type* elementType, uint8_t columns, uint8_t rows)
     return type;
 }
 
-Type* TypeStore::textureType(Type* elementType, Texture::Kind kind)
+const Type* TypeStore::textureType(const Type* elementType, Texture::Kind kind)
 {
     TextureKey key { elementType, kind };
-    Type* type = m_cache.find(key);
+    const Type* type = m_cache.find(key);
     if (type)
         return type;
     type = allocateType<Texture>(elementType, kind);
@@ -209,15 +209,15 @@ Type* TypeStore::textureType(Type* elementType, Texture::Kind kind)
     return type;
 }
 
-Type* TypeStore::functionType(WTF::Vector<Type*>&& parameters, Type* result)
+const Type* TypeStore::functionType(WTF::Vector<const Type*>&& parameters, const Type* result)
 {
     return allocateType<Function>(WTFMove(parameters), result);
 }
 
-Type* TypeStore::referenceType(AddressSpace addressSpace, Type* element, AccessMode accessMode)
+const Type* TypeStore::referenceType(AddressSpace addressSpace, const Type* element, AccessMode accessMode)
 {
     ReferenceKey key { element, addressSpace, accessMode };
-    Type* type = m_cache.find(key);
+    const Type* type = m_cache.find(key);
     if (type)
         return type;
     type = allocateType<Reference>(addressSpace, accessMode, element);
@@ -226,7 +226,7 @@ Type* TypeStore::referenceType(AddressSpace addressSpace, Type* element, AccessM
 }
 
 template<typename TypeKind, typename... Arguments>
-Type* TypeStore::allocateType(Arguments&&... arguments)
+const Type* TypeStore::allocateType(Arguments&&... arguments)
 {
     m_types.append(std::unique_ptr<Type>(new Type(TypeKind { std::forward<Arguments>(arguments)... })));
     return m_types.last().get();
@@ -236,7 +236,7 @@ template<typename TargetConstructor, typename Base, typename... Arguments>
 void TypeStore::allocateConstructor(TargetConstructor constructor, Base base, Arguments&&... arguments)
 {
     m_typeConstrutors[WTF::enumToUnderlyingType(base)] =
-        TypeConstructor { [this, constructor, arguments...](Type* elementType) -> Type* {
+        TypeConstructor { [this, constructor, arguments...](const Type* elementType) -> const Type* {
             return (this->*constructor)(elementType, arguments...);
         } };
 }

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -43,66 +43,66 @@ class TypeStore {
 public:
     TypeStore();
 
-    Type* bottomType() const { return m_bottom; }
-    Type* voidType() const { return m_void; }
-    Type* boolType() const { return m_bool; }
+    const Type* bottomType() const { return m_bottom; }
+    const Type* voidType() const { return m_void; }
+    const Type* boolType() const { return m_bool; }
 
-    Type* abstractIntType() const { return m_abstractInt; }
-    Type* i32Type() const { return m_i32; }
-    Type* u32Type() const { return m_u32; }
+    const Type* abstractIntType() const { return m_abstractInt; }
+    const Type* i32Type() const { return m_i32; }
+    const Type* u32Type() const { return m_u32; }
 
-    Type* abstractFloatType() const { return m_abstractFloat; }
-    Type* f32Type() const { return m_f32; }
-    Type* samplerType() const { return m_sampler; }
-    Type* textureExternalType() const { return m_textureExternal; }
+    const Type* abstractFloatType() const { return m_abstractFloat; }
+    const Type* f32Type() const { return m_f32; }
+    const Type* samplerType() const { return m_sampler; }
+    const Type* textureExternalType() const { return m_textureExternal; }
 
-    Type* structType(AST::Structure&);
-    Type* arrayType(Type*, std::optional<unsigned>);
-    Type* vectorType(Type*, uint8_t);
-    Type* matrixType(Type*, uint8_t columns, uint8_t rows);
-    Type* textureType(Type*, Types::Texture::Kind);
-    Type* functionType(Vector<Type*>&&, Type*);
-    Type* referenceType(AddressSpace, Type*, AccessMode);
+    const Type* structType(AST::Structure&);
+    const Type* arrayType(const Type*, std::optional<unsigned>);
+    const Type* vectorType(const Type*, uint8_t);
+    const Type* matrixType(const Type*, uint8_t columns, uint8_t rows);
+    const Type* textureType(const Type*, Types::Texture::Kind);
+    const Type* functionType(Vector<const Type*>&&, const Type*);
+    const Type* referenceType(AddressSpace, const Type*, AccessMode);
 
-    Type* constructType(AST::ParameterizedTypeName::Base, Type*);
+    const Type* constructType(AST::ParameterizedTypeName::Base, const Type*);
 
 private:
     class TypeCache {
     public:
         template<typename Key>
-        Type* find(const Key&) const;
+        const Type* find(const Key&) const;
 
         template<typename Key>
-        void insert(const Key&, Type*);
+        void insert(const Key&, const Type*);
 
     private:
-        HashMap<std::pair<Type*, uint64_t>, Type*> m_storage;
+        HashMap<std::pair<const Type*, uint64_t>, const Type*> m_storage;
     };
 
     template<typename TypeKind, typename... Arguments>
-    Type* allocateType(Arguments&&...);
+    const Type* allocateType(Arguments&&...);
 
     template<typename TargetConstructor, typename Base, typename... Arguments>
     void allocateConstructor(TargetConstructor, Base, Arguments&&...);
 
     struct TypeConstructor {
-        std::function<Type*(Type*)> construct;
+        std::function<const Type*(const Type*)> construct;
     };
 
-    Vector<std::unique_ptr<Type>> m_types;
+    Vector<std::unique_ptr<const Type>> m_types;
     FixedVector<TypeConstructor> m_typeConstrutors;
     TypeCache m_cache;
 
-    Type* m_bottom;
-    Type* m_abstractInt;
-    Type* m_abstractFloat;
-    Type* m_void;
-    Type* m_bool;
-    Type* m_i32;
-    Type* m_u32;
-    Type* m_f32;
-    Type* m_sampler;
-    Type* m_textureExternal;
+    const Type* m_bottom;
+    const Type* m_abstractInt;
+    const Type* m_abstractFloat;
+    const Type* m_void;
+    const Type* m_bool;
+    const Type* m_i32;
+    const Type* m_u32;
+    const Type* m_f32;
+    const Type* m_sampler;
+    const Type* m_textureExternal;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -129,7 +129,7 @@ constexpr unsigned primitivePair(Types::Primitive::Kind first, Types::Primitive:
 }
 
 // https://www.w3.org/TR/WGSL/#conversion-rank
-ConversionRank conversionRank(Type* from, Type* to)
+ConversionRank conversionRank(const Type* from, const Type* to)
 {
     using namespace WGSL::Types;
 

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -88,40 +88,40 @@ struct Texture {
         TextureStorage3d,
     };
 
-    Type* element;
+    const Type* element;
     Kind kind;
 };
 
 struct Vector {
-    Type* element;
+    const Type* element;
     uint8_t size;
 };
 
 struct Matrix {
-    Type* element;
+    const Type* element;
     uint8_t columns;
     uint8_t rows;
 };
 
 struct Array {
-    Type* element;
+    const Type* element;
     std::optional<unsigned> size;
 };
 
 struct Struct {
     AST::Structure& structure;
-    HashMap<String, Type*> fields { };
+    HashMap<String, const Type*> fields { };
 };
 
 struct Function {
-    WTF::Vector<Type*> parameters;
-    Type* result;
+    WTF::Vector<const Type*> parameters;
+    const Type* result;
 };
 
 struct Reference {
     AddressSpace addressSpace;
     AccessMode accessMode;
-    Type* element;
+    const Type* element;
 };
 
 struct Bottom {
@@ -158,7 +158,7 @@ struct Type : public std::variant<
 };
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;
-ConversionRank conversionRank(Type* from, Type* to);
+ConversionRank conversionRank(const Type* from, const Type* to);
 
 bool isPrimitive(const Type*, Types::Primitive::Kind);
 bool isPrimitiveReference(const Type*, Types::Primitive::Kind);


### PR DESCRIPTION
#### 2e8170d57461f680582c1fc20a7c4d5b759bbb5d
<pre>
[WGSL] Make all types constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=257556">https://bugs.webkit.org/show_bug.cgi?id=257556</a>
rdar://110075257

Reviewed by Myles C. Maxfield.

Types are immutable, just change the API to reflect it. The one exception, which
is documented in the TypeChecker, is that we have to insert fields of struct types
after creation. Given it&apos;s such a small exception, we just const_cast in that one
case and use const types everywhere else.

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/Constraints.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::OverloadResolver):
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::considerCandidate):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WGSL::OverloadResolver::assign):
(WGSL::OverloadResolver::resolve const):
(WGSL::OverloadResolver::conversionRank const):
(WGSL::resolveOverloads):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitStructMembers):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::vectorFieldAccess):
(WGSL::TypeChecker::chooseOverload):
(WGSL::TypeChecker::infer):
(WGSL::TypeChecker::resolve):
(WGSL::TypeChecker::inferred):
(WGSL::TypeChecker::unify):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeCache::find const):
(WGSL::TypeStore::TypeCache::insert):
(WGSL::TypeStore::structType):
(WGSL::TypeStore::constructType):
(WGSL::TypeStore::arrayType):
(WGSL::TypeStore::vectorType):
(WGSL::TypeStore::matrixType):
(WGSL::TypeStore::textureType):
(WGSL::TypeStore::functionType):
(WGSL::TypeStore::referenceType):
(WGSL::TypeStore::allocateType):
(WGSL::TypeStore::allocateConstructor):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::bottomType const):
(WGSL::TypeStore::voidType const):
(WGSL::TypeStore::boolType const):
(WGSL::TypeStore::abstractIntType const):
(WGSL::TypeStore::i32Type const):
(WGSL::TypeStore::u32Type const):
(WGSL::TypeStore::abstractFloatType const):
(WGSL::TypeStore::f32Type const):
(WGSL::TypeStore::samplerType const):
(WGSL::TypeStore::textureExternalType const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::conversionRank):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/264782@main">https://commits.webkit.org/264782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2a9248f4486b5c2a7e1898c8e3a23405993c8c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8508 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8551 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10332 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6993 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15339 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6874 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7692 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2088 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->