### PR TITLE
[WGSL] Type check user-defined function calls

### DIFF
--- a/Source/WebGPU/WGSL/ContextProvider.h
+++ b/Source/WebGPU/WGSL/ContextProvider.h
@@ -53,16 +53,16 @@ protected:
 
     ContextProvider();
 
-    const ContextValue& introduceVariable(const AST::Identifier&, const ContextValue&);
-    const ContextValue* readVariable(const AST::Identifier&) const;
+    const ContextValue& introduceVariable(const String&, const ContextValue&);
+    const ContextValue* readVariable(const String&) const;
 
 private:
     class Context {
     public:
         Context(const Context *const parent);
 
-        const ContextValue* lookup(const AST::Identifier&) const;
-        const ContextValue& add(const AST::Identifier&, const ContextValue&);
+        const ContextValue* lookup(const String&) const;
+        const ContextValue& add(const String&, const ContextValue&);
 
     private:
         const Context* m_parent { nullptr };

--- a/Source/WebGPU/WGSL/ContextProviderInlines.h
+++ b/Source/WebGPU/WGSL/ContextProviderInlines.h
@@ -37,9 +37,9 @@ ContextProvider<Value>::Context::Context(const Context *const parent)
 }
 
 template<typename Value>
-const Value* ContextProvider<Value>::Context::lookup(const AST::Identifier& name) const
+const Value* ContextProvider<Value>::Context::lookup(const String& name) const
 {
-    auto it = m_map.find(name.id());
+    auto it = m_map.find(name);
     if (it != m_map.end())
         return &it->value;
     if (m_parent)
@@ -48,9 +48,9 @@ const Value* ContextProvider<Value>::Context::lookup(const AST::Identifier& name
 }
 
 template<typename Value>
-const Value& ContextProvider<Value>::Context::add(const AST::Identifier& name, const Value& value)
+const Value& ContextProvider<Value>::Context::add(const String& name, const Value& value)
 {
-    auto result = m_map.add(name.id(), value);
+    auto result = m_map.add(name, value);
     ASSERT(result.isNewEntry);
     return result.iterator->value;
 }
@@ -80,13 +80,13 @@ ContextProvider<Value>::ContextProvider()
 }
 
 template<typename Value>
-auto ContextProvider<Value>::introduceVariable(const AST::Identifier& name, const Value& value) -> const Value&
+auto ContextProvider<Value>::introduceVariable(const String& name, const Value& value) -> const Value&
 {
     return m_context->add(name, value);
 }
 
 template<typename Value>
-auto ContextProvider<Value>::readVariable(const AST::Identifier& name) const -> const Value*
+auto ContextProvider<Value>::readVariable(const String& name) const -> const Value*
 {
     return m_context->lookup(name);
 }

--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -1,0 +1,21 @@
+// RUN: %not %wgslc | %check
+
+fn f1(x: f32) -> f32 { return x; }
+
+fn f2() {
+    // CHECK-L: type in function call does not match parameter type: expected 'f32', found 'i32'
+    _ = f1(0i);
+
+    // CHECK-L: Cannot call value of type: 'i32'
+    let f3: i32 = 0;
+    _ = f3();
+
+    // CHECK-L: cannot initialize var of type 'i32' with value of type 'f32'
+    let x: i32 = f1(0);
+
+    // CHECK-L: funtion call has too few arguments: expected 1, found 0
+    _ = f1();
+
+    // CHECK-L: funtion call has too many arguments: expected 1, found 2
+    _ = f1(0, 0);
+}


### PR DESCRIPTION
#### 89a790ad2a426bfdcb8f91242716cab722a972dd
<pre>
[WGSL] Type check user-defined function calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=257557">https://bugs.webkit.org/show_bug.cgi?id=257557</a>
rdar://110075508

Reviewed by Myles C. Maxfield.

Before resolving overloads, check if a user-defined function is available when
type checking function calls. The implementation is rather similar to how we
validate struct initializers, but trying to share the code made the code more
confusing than concise, so for now the two paths are kept separately.

* Source/WebGPU/WGSL/ContextProvider.h:
* Source/WebGPU/WGSL/ContextProviderInlines.h:
(WGSL::ContextProvider&lt;Value&gt;::Context::lookup const):
(WGSL::ContextProvider&lt;Value&gt;::Context::add):
(WGSL::ContextProvider&lt;Value&gt;::introduceVariable const):
(WGSL::ContextProvider&lt;Value&gt;::readVariable const const):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264784@main">https://commits.webkit.org/264784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be641b795b355ba7bfcc30da9eb4130bcbd69202

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11418 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6994 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15336 "4 flakes 109 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11287 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7693 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2089 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->