### PR TITLE
Selecting OptGroup label does not deselect selected item

### DIFF
--- a/LayoutTests/fast/forms/select/optgroup-clicking-expected.txt
+++ b/LayoutTests/fast/forms/select/optgroup-clicking-expected.txt
@@ -7,6 +7,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 Click enabled option
 PASS $("listbox").selectedIndex is 1
 
+Click on optgroup, should not deselect selectedIndex
+PASS $("listbox").selectedIndex is 1
+
 Click disabled option - doesn't change selectedIndex
 PASS $("listbox").selectedIndex is 1
 

--- a/LayoutTests/fast/forms/select/optgroup-clicking.html
+++ b/LayoutTests/fast/forms/select/optgroup-clicking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body onload="test()">
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../resources/common.js"></script>
 
 <form id="form">
@@ -62,6 +62,12 @@ function test()
     eventSender.mouseUp();
     shouldBe('$("listbox").selectedIndex', '1');
 
+    debug("\nClick on optgroup, should not deselect selectedIndex");
+    mouseMoveToIndexInListbox(0, 'listbox'); // Select on optgroup
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+    shouldBe('$("listbox").selectedIndex', '1');
+
     debug("\nClick disabled option - doesn't change selectedIndex");
     mouseMoveToIndexInListbox(5 + 2, 'listbox'); // +2 for optgroup's
     eventSender.mouseDown();
@@ -78,6 +84,5 @@ function test()
     finishJSTest();
 }
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1317,6 +1317,10 @@ void HTMLSelectElement::updateSelectedState(int listIndex, bool multi, bool shif
     if (listIndex < 0 || listIndex >= listSize)
         return;
 
+    auto& clickedElement = *items[listIndex];
+    if (is<HTMLOptGroupElement>(clickedElement))
+        return;
+
     // Save the selection so it can be compared to the new selection when
     // dispatching change events during mouseup, or after autoscroll finishes.
     saveLastSelection();
@@ -1326,7 +1330,6 @@ void HTMLSelectElement::updateSelectedState(int listIndex, bool multi, bool shif
     bool shiftSelect = m_multiple && shift;
     bool multiSelect = m_multiple && multi && !shift;
 
-    auto& clickedElement = *items[listIndex];
     if (is<HTMLOptionElement>(clickedElement)) {
         // Keep track of whether an active selection (like during drag
         // selection), should select or deselect.


### PR DESCRIPTION
#### 734687da6292d68e3d571f781719887cc8e74bbd
<pre>
Selecting OptGroup label does not deselect selected item

<a href="https://bugs.webkit.org/show_bug.cgi?id=257553">https://bugs.webkit.org/show_bug.cgi?id=257553</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=171470

In &apos;listbox&apos; selected item should not get deselected, upon clicking
on &apos;optgroup&apos; label. This patch adds return for &apos;selected&apos; item
to not update if there is &apos;optGroup&apos;.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::updateSelectedState): As above
* LayoutTests/fast/forms/select/optgroup-clicking.html: Add new sub-test
* LayoutTests/fast/forms/select/optgroup-clicking-expected.txt: Add new sub-test expectation

Canonical link: <a href="https://commits.webkit.org/264767@main">https://commits.webkit.org/264767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e292f8fa8749c3af9154ea83641240e14592e21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11431 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9706 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10339 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15342 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8417 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7700 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7715 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->