### PR TITLE
Fixed SqlifyDate function to not return invalid dates when "m" is used.

### DIFF
--- a/Websites/bugs.webkit.org/Bugzilla/Search.pm
+++ b/Websites/bugs.webkit.org/Bugzilla/Search.pm
@@ -2217,7 +2217,20 @@ sub SqlifyDate {
         my ($sec, $min, $hour, $mday, $month, $year, $wday)  = localtime($date);
         if ($sign && $sign eq '+') { $amount = -$amount; }
         $startof = 1 if $amount == 0;
-        if ($unit eq 'w') {                  # convert weeks to days
+# WEBKIT_CHANGES: Fixed invalid date returns on some occasions.
+        if ($unit eq 'm') {
+            $month -= $amount;
+            $year += floor($month/12);
+            $month %= 12;
+            if ($startof) {
+                return sprintf("%4d-%02d-01 00:00:00", $year+1900, $month+1);
+            }
+            else {
+                $amount = 31*$amount;
+                $unit = 'd';
+            }
+        }
+        elseif ($unit eq 'w') {                  # convert weeks to days
             $amount = 7*$amount;
             $amount += $wday if $startof;
             $unit = 'd';
@@ -2237,18 +2250,6 @@ sub SqlifyDate {
             else {
                 return sprintf("%4d-%02d-%02d %02d:%02d:%02d", 
                                $year+1900-$amount, $month+1, $mday, $hour, $min, $sec);
-            }
-        }
-        elsif ($unit eq 'm') {
-            $month -= $amount;
-            $year += floor($month/12);
-            $month %= 12;
-            if ($startof) {
-                return sprintf("%4d-%02d-01 00:00:00", $year+1900, $month+1);
-            }
-            else {
-                return sprintf("%4d-%02d-%02d %02d:%02d:%02d", 
-                               $year+1900, $month+1, $mday, $hour, $min, $sec);
             }
         }
         elsif ($unit eq 'h') {


### PR DESCRIPTION
#### a9b9e3661656d8ee1d65846e646d821fdd36fc12
<pre>
Fixed SqlifyDate function to not return invalid dates when &quot;m&quot; is used.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257546">https://bugs.webkit.org/show_bug.cgi?id=257546</a>
&lt;rdar://problem/110075621&gt;

Reviewed by Alexey Proskuryakov.

Modified the SqlifyDate function such that when &quot;m&quot; is entered, it converts to month multiplied by 31 days, similar to how it treats &quot;d&quot; where it multiplies the number by 7.

* Websites/bugs.webkit.org/Bugzilla/Search.pm:
(SqlifyDate):

Canonical link: <a href="https://commits.webkit.org/264758@main">https://commits.webkit.org/264758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebcba0326f10ee0bd41e640082b9a0d0da810321

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8564 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8786 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8682 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10347 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7949 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11300 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7708 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->