### PR TITLE
[JSC] Add Imm64 concept to ARM64 Air

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -731,6 +731,16 @@ private:
         return Arg();
     }
 
+    Arg imm64(Value* value)
+    {
+        if (value->hasInt()) {
+            int64_t intValue = value->asInt();
+            if (Arg::isValidImm64Form(intValue))
+                return Arg::imm64(intValue);
+        }
+        return Arg();
+    }
+
     Arg bitImm(Value* value)
     {
         if (value->hasInt()) {
@@ -989,6 +999,21 @@ private:
                 // A non-commutative operation could have an immediate in left.
                 if (imm(left)) {
                     append(opcode, imm(left), tmp(right), result);
+                    return;
+                }
+            }
+        }
+
+        if (isValidForm(opcode, Arg::Imm64, Arg::Tmp, Arg::Tmp)) {
+            if (commutativity == Commutative) {
+                if (imm64(right)) {
+                    append(opcode, imm64(right), tmp(left), result);
+                    return;
+                }
+            } else {
+                // A non-commutative operation could have an immediate in left.
+                if (imm64(left)) {
+                    append(opcode, imm64(left), tmp(right), result);
                     return;
                 }
             }

--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -112,6 +112,7 @@ unsigned Arg::jsHash() const
     case WidthArg:
         result += static_cast<unsigned>(m_offset);
         break;
+    case Imm64:
     case BigImm:
     case BitImm64:
         result += static_cast<unsigned>(m_offset);
@@ -156,6 +157,9 @@ void Arg::dump(PrintStream& out) const
         return;
     case Imm:
         out.print("$", m_offset);
+        return;
+    case Imm64:
+        out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
         return;
     case BigImm:
         out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
@@ -245,6 +249,9 @@ void printInternal(PrintStream& out, Arg::Kind kind)
         return;
     case Arg::Imm:
         out.print("Imm");
+        return;
+    case Arg::Imm64:
+        out.print("Imm64");
         return;
     case Arg::BigImm:
         out.print("BigImm");

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -39,6 +39,7 @@
 # Argument kinds:
 # Tmp => temporary or register
 # Imm => 32-bit immediate int
+# Imm64 => 64-bit immediate int with special-shift
 # BigImm => TrustedImm64 on 64-bit targets, TrustedImm32 on 32-bit targets
 # Addr => address as temporary/register+offset
 # Index => BaseIndex address
@@ -146,6 +147,7 @@ x86: Add16 U:G:16, UD:G:16
     x86: Imm, Addr
     x86: Imm, Index
     Imm, Tmp
+    arm64: Imm64, Tmp
     x86: Addr, Tmp
     x86: Index, Tmp
     x86: Tmp, Addr
@@ -154,6 +156,7 @@ x86: Add16 U:G:16, UD:G:16
 64: Add64 U:G:64, U:G:64, D:G:64
     Imm, Tmp, Tmp
     Tmp, Tmp, Tmp
+    arm64: Imm64, Tmp, Tmp
 
 # note that this pseudoinstruction (and others like it) exist right now because
 # air doesn't track live flags: we do support 64-bit addition on e.g. armv7
@@ -203,6 +206,7 @@ arm: Sub32 U:G:32, U:G:32, ZD:G:32
     x86: Imm, Addr
     x86: Imm, Index
     Imm, Tmp
+    arm64: Imm64, Tmp
     x86: Addr, Tmp
     x86: Index, Tmp
     x86: Tmp, Addr
@@ -211,6 +215,7 @@ arm: Sub32 U:G:32, U:G:32, ZD:G:32
 arm64: Sub64 U:G:64, U:G:64, D:G:64
     Tmp, Tmp, Tmp
     Tmp, Imm, Tmp
+    Tmp, Imm64, Tmp
 
 # note see note above, on Add64
 32: Sub64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, D:G:32
@@ -1460,7 +1465,8 @@ Compare32 U:G:32, U:G:32, U:G:32, ZD:G:32
 
 64: Compare64 U:G:32, U:G:64, U:G:64, ZD:G:32
     RelCond, Tmp, Tmp, Tmp
-    x86: RelCond, Tmp, Imm, Tmp
+    RelCond, Tmp, Imm, Tmp
+    arm64: RelCond, Tmp, Imm64, Tmp
 
 Test32 U:G:32, U:G:32, U:G:32, ZD:G:32
     x86: ResCond, Addr, Imm, Tmp
@@ -1499,6 +1505,7 @@ Branch32 U:G:32, U:G:32, U:G:32 /branch
     x86: RelCond, Addr, Tmp
     x86: RelCond, Addr, Imm
     x86: RelCond, Index, Tmp
+    arm64: RelCond, Tmp, Imm64
 
 BranchTest8 U:G:32, U:G:8, U:G:8 /branch
     x86: ResCond, Addr, BitImm
@@ -1605,6 +1612,7 @@ BranchNeg32 U:G:32, UZD:G:32 /branch
 64: MoveConditionally64 U:G:32, U:G:64, U:G:64, U:G:Ptr, U:G:Ptr, D:G:Ptr
     RelCond, Tmp, Tmp, Tmp, Tmp, Tmp
     RelCond, Tmp, Imm, Tmp, Tmp, Tmp
+    arm64: RelCond, Tmp, Imm64, Tmp, Tmp, Tmp
 
 64: MoveConditionallyTest32 U:G:32, U:G:32, U:G:32, U:G:Ptr, UD:G:Ptr
     ResCond, Tmp, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -229,7 +229,7 @@ def isGF(token)
 end
 
 def isKind(token)
-    token =~ /\A((Tmp)|(Imm)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond)|(SIMDInfo))\Z/
+    token =~ /\A((Tmp)|(Imm)|(Imm64)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond)|(SIMDInfo))\Z/
 end
 
 def isArch(token)
@@ -303,7 +303,7 @@ class Parser
 
     def consumeKind
         result = token.string
-        parseError("Expected kind (Imm, BigImm, BitImm, BitImm64, ZeroReg, Tmp, SimpleAddr, Addr, ExtendedOffsetAddr, Index, PreIndex, PostIndex, RelCond, ResCond, DoubleCond, or StatusCond)") unless isKind(result)
+        parseError("Expected kind (Imm, Imm64, BigImm, BitImm, BitImm64, ZeroReg, Tmp, SimpleAddr, Addr, ExtendedOffsetAddr, Index, PreIndex, PostIndex, RelCond, ResCond, DoubleCond, or StatusCond)") unless isKind(result)
         advance
         result
     end
@@ -471,7 +471,7 @@ class Parser
                         parseError("Form has wrong number of arguments for overload") unless kinds.length == signature.length
                         kinds.each_with_index {
                             | kind, index |
-                            if kind.name == "Imm" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64"
+                            if kind.name == "Imm" or kind.name == "Imm64" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64"
                                 if signature[index].role != "U"
                                     parseError("Form has an immediate for a non-use argument")
                                 end
@@ -585,14 +585,14 @@ def matchForms(outp, speed, forms, columnIndex, columnGetter, filter, callback)
     outp.puts "switch (#{columnGetter[columnIndex]}) {"
     groups.each_pair {
         | key, value |
-        outp.puts "#if USE(JSVALUE64)" if key == "BitImm64"
+        outp.puts "#if USE(JSVALUE64)" if key == "Imm64" || key == "BitImm64"
         Kind.argKinds(key).each {
             | argKind |
             outp.puts "case Arg::#{argKind}:"
         }
         matchForms(outp, speed, value, columnIndex + 1, columnGetter, filter, callback)
         outp.puts "break;"
-        outp.puts "#endif // USE(JSVALUE64)" if key == "BitImm64"
+        outp.puts "#endif // USE(JSVALUE64)" if key == "Imm64" || key == "BitImm64"
     }
     outp.puts "default:"
     outp.puts "break;"
@@ -936,6 +936,9 @@ writeH("OpcodeGenerated") {
                 when "Imm"
                     outp.puts "if (!Arg::isValidImmForm(args[#{index}].value()))"
                     outp.puts "OPGEN_RETURN(false);"
+                when "Imm64"
+                    outp.puts "if (!Arg::isValidImm64Form(args[#{index}].value()))"
+                    outp.puts "OPGEN_RETURN(false);"
                 when "BitImm"
                     outp.puts "if (!Arg::isValidBitImmForm(args[#{index}].value()))"
                     outp.puts "OPGEN_RETURN(false);"
@@ -1267,7 +1270,7 @@ writeH("OpcodeGenerated") {
                     outp.print "args[#{index}].asTrustedImm32()"
                 when "BigImm"
                     outp.print "args[#{index}].asTrustedBigImm()"
-                when "BitImm64"
+                when "Imm64", "BitImm64"
                     outp.print "args[#{index}].asTrustedImm64()"
                 when "ZeroReg"
                     outp.print "args[#{index}].asZeroReg()"

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -245,6 +245,13 @@ template<size_t divisor, typename T> constexpr T roundDownToMultipleOf(T x)
     return roundDownToMultipleOf(divisor, x);
 }
 
+template<typename IntType>
+constexpr IntType toTwosComplement(IntType integer)
+{
+    using UnsignedIntType = typename std::make_unsigned_t<IntType>;
+    return static_cast<IntType>((~static_cast<UnsignedIntType>(integer)) + static_cast<UnsignedIntType>(1));
+}
+
 enum BinarySearchMode {
     KeyMustBePresentInArray,
     KeyMightNotBePresentInArray,
@@ -703,3 +710,4 @@ using WTF::safeCast;
 using WTF::tryBinarySearch;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
+using WTF::toTwosComplement;


### PR DESCRIPTION
#### 69748fe9d91871e2d5dca2b32348864df28d882e
<pre>
[JSC] Add Imm64 concept to ARM64 Air
<a href="https://bugs.webkit.org/show_bug.cgi?id=257559">https://bugs.webkit.org/show_bug.cgi?id=257559</a>
rdar://110076490

Reviewed by Mark Lam.

ARM64 can represent wider range of imm in instruction if the instruction is 64bit-wide (not 32bit instruction).
To leverage this, we introduce Imm64 concept to Air. This Imm64 can be seen only in 64bit-wide instructions (e.g. Add64),
and it can accept wider range of imm.

1. Add toTwosComplement function to safely negate int32_t / int64_t without considering about overflow UB effect.
2. Add Imm64 concept.
3. Add some missing Imm handling (compare64 etc.) in Air for ARM64

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add32):
(JSC::MacroAssemblerARM64::add64):
(JSC::MacroAssemblerARM64::sub32):
(JSC::MacroAssemblerARM64::sub64):
(JSC::MacroAssemblerARM64::moveConditionally32):
(JSC::MacroAssemblerARM64::moveConditionally64):
(JSC::MacroAssemblerARM64::moveDoubleConditionally32):
(JSC::MacroAssemblerARM64::moveDoubleConditionally64):
(JSC::MacroAssemblerARM64::branch32):
(JSC::MacroAssemblerARM64::branch64):
(JSC::MacroAssemblerARM64::branchAdd32):
(JSC::MacroAssemblerARM64::branchAdd64):
(JSC::MacroAssemblerARM64::branchSub32):
(JSC::MacroAssemblerARM64::branchSub64):
(JSC::MacroAssemblerARM64::compare32):
(JSC::MacroAssemblerARM64::compare64):
(JSC::MacroAssemblerARM64::tryFoldBaseAndOffsetPart):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::jsHash const):
(JSC::B3::Air::Arg::dump const):
(WTF::printInternal):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::imm64):
(JSC::B3::Air::Arg::isImm64 const):
(JSC::B3::Air::Arg::isSomeImm const):
(JSC::B3::Air::Arg::isGP const):
(JSC::B3::Air::Arg::isFP const):
(JSC::B3::Air::Arg::hasBank const):
(JSC::B3::Air::Arg::isValidImmForm):
(JSC::B3::Air::Arg::isValidImm64Form):
(JSC::B3::Air::Arg::isValidForm const):
(JSC::B3::Air::Arg::asTrustedImm64 const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/WTF/wtf/StdLibExtras.h:
(WTF::toTwosComplement):

Canonical link: <a href="https://commits.webkit.org/265006@main">https://commits.webkit.org/265006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4adec3791adb86270fdcb68cd820f36d986f0e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11143 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9702 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11301 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/8104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/9050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9650 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9901 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1081 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/9044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->