### PR TITLE
[WGSL] Fix serialization of promoted types

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -31,6 +31,7 @@
 
 namespace WGSL {
 class ConstantRewriter;
+class RewriteGlobalVariables;
 class TypeChecker;
 struct Type;
 
@@ -39,6 +40,7 @@ namespace AST {
 class Expression : public Node {
     WGSL_AST_BUILDER_NODE(Expression);
     friend ConstantRewriter;
+    friend RewriteGlobalVariables;
     friend TypeChecker;
 
 public:

--- a/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
@@ -35,7 +35,7 @@ namespace WGSL::AST {
 // larger node than the one current in the tree. E.g. replacing an identifier
 // with a structure access.
 class IdentityExpression final : public Expression {
-    friend ShaderModule;
+    WGSL_AST_BUILDER_NODE(IdentityExpression);
 public:
     NodeKind kind() const override;
     Expression& expression() { return m_expression.get(); }

--- a/Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl
@@ -1,0 +1,108 @@
+// RUN: %metal main 2>&1 | %check
+
+fn f1(x: array<vec2<f32>, 1>) -> f32 { return x[0][0]; }
+fn f2(x: array<vec2<i32>, 1>) -> i32 { return x[0][0]; }
+fn f4(x: array<array<vec2<f32>, 1>, 1>) -> f32 { return x[0][0][0]; }
+
+const global = array(vec2(0));
+
+fn testCallee()
+{
+    // - Globals in a callee function
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: };
+    // CHECK: f1\(local\d+\)
+    _ = f1(global);
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<int, 2>(0)
+    // CHECK-L: };
+    // CHECK: f2\(local\d+\)
+    _ = f2(global);
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    // - Simple assignment promotion
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: };
+    let x : array<vec2<f32>, 1> = array(vec2(0));
+
+    // - Call with immediate value
+
+    // CHECK-L: f1({
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: })
+    _ = f1(array(vec2(0)));
+
+    // - Call with local constant
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: };
+    const a = array(vec2(0));
+    // CHECK: f1\(local\d+\)
+    _ = f1(a);
+
+    // - Two-level nested vector promotoin
+
+    // CHECK: local\d+ = {
+    // CHECK-L: {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: }
+    // CHECK-L: };
+    const b = array(array(vec2(0)));
+    // CHECK: f4\(local\d+\)
+    _ = f4(b);
+
+    // - Constant promoted to two types
+
+    const c = array(vec2(0));
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: };
+    // CHECK: f1\(local\d+\)
+    _ = f1(c);
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<int, 2>(0)
+    // CHECK-L: };
+    // CHECK: f2\(local\d+\)
+    _ = f2(c);
+
+    // - Global constants
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<float, 2>(0)
+    // CHECK-L: };
+    // CHECK: f1\(local\d+\)
+    _ = f1(global);
+
+    // CHECK: local\d+ = {
+    // CHECK-L: vec<int, 2>(0)
+    // CHECK-L: };
+    // CHECK: f2\(local\d+\)
+    _ = f2(global);
+
+    {
+        // - Test within a nested block
+        // CHECK: local\d+ = {
+        // CHECK-L: vec<float, 2>(0)
+        // CHECK-L: };
+        // CHECK: f1\(local\d+\)
+        _ = f1(global);
+
+        // CHECK: local\d+ = {
+        // CHECK-L: vec<int, 2>(0)
+        // CHECK-L: };
+        // CHECK: f2\(local\d+\)
+        _ = f2(global);
+    }
+
+    _ = testCallee();
+}


### PR DESCRIPTION
#### 98c11ccb36a75ad6e0dc02922a88b8b767842272
<pre>
[WGSL] Fix serialization of promoted types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257558">https://bugs.webkit.org/show_bug.cgi?id=257558</a>
rdar://110075846

Reviewed by Myles C. Maxfield.

The problem happens when we have an array of vectors of abstract int, which later
gets promoted to something other than i32. This can only happen through consts or
calls with an immediate value. The two simplest examples are:

let x : array&lt;vec2&lt;f32&gt;&gt; = array(vec2(0))
f(array(vec2(0)), where f expects array&lt;vec2&lt;f32&gt;&gt;

In both cases, the issues is the same. The type inferred for the expression `array(vec2(0))`
is `array&lt;vec2&lt;abstract-int&gt;&gt;`. However, later we discover this value will be used
as `array&lt;vec2&lt;f32&gt;&gt;`, which is a valid conversion (and currently supported by our
type checker). The problem occurs at serialization time, since we don&apos;t update the
inferred type of the nested expression `vec2(0)`, so we generate a vector or ints.

This gets further complicated when we have a single constant used by two functions,
and the constant gets promoted to two different types. e.g.:

const a = array(vec2(0));
let x: array&lt;vec2&lt;u32&gt;&gt; = a;
let y: array&lt;vec2&lt;f32&gt;&gt; = a;

To solve this problem, we duplicate the constants&apos; declaration at the time of use,
and make sure the new instance has the correct type. Effectively transforming the
above code into:

const a1 : array&lt;vec2&lt;u32&gt;&gt; = array(vec2(0));
let x: array&lt;vec2&lt;u32&gt;&gt; = a1;
const a2 : array&lt;vec2&lt;f32&gt;&gt; = array(vec2(0));
let y: array&lt;vec2&lt;f32&gt;&gt; = a2;

Further, at code generation time, we handle the special case of arrays: this problem
can only occur when we have an abstract compound type inside an array constructor.
So, in the codegen, whenever we see an array constructor, we pass the information
down that it&apos;s arguments should have the same type as the array element type.

* Source/WebGPU/WGSL/AST/ASTExpression.h:
* Source/WebGPU/WGSL/AST/ASTIdentityExpression.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::insertLocalDefinitions):
(WGSL::RewriteGlobalVariables::readVariable):
(WGSL::RewriteGlobalVariables::insertBeforeCurrentStatement):
(WGSL::RewriteGlobalVariables::read): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::visitArguments):
* Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264787@main">https://commits.webkit.org/264787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2cef2953d1533828d8168241490fbc2fda9b990

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10268 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11492 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9777 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10426 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7077 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8196 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8020 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11362 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7776 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2095 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11987 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->