### PR TITLE
[WGSL] GlobalVariableRewriter should visit callees before entrypoint

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -154,14 +154,14 @@ void RewriteGlobalVariables::visitCallee(const CallGraph::Callee& callee)
 
 void RewriteGlobalVariables::visit(AST::Function& function)
 {
+    for (auto& callee : m_callGraph.callees(function))
+        visitCallee(callee);
+
     for (auto& parameter : function.parameters())
         def(parameter.name(), nullptr);
 
     // FIXME: detect when we shadow a global that a callee needs
     visit(function.body());
-
-    for (auto& callee : m_callGraph.callees(function))
-        visitCallee(callee);
 }
 
 void RewriteGlobalVariables::visit(AST::Variable& variable)

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -1,0 +1,19 @@
+// RUN: %metal main 2>&1 | %check
+
+var<private> x: i32;
+var<private> y: i32;
+
+// CHECK: void f\(int parameter\d\)
+fn f() {
+    //CHECK: parameter\d
+    _ = y;
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    // CHECK: int local\d;
+    // CHECK: int local\d;
+    _ = x;
+    // CHECK: f\(local\d\)
+    _ = f();
+}


### PR DESCRIPTION
#### fd9da075bd46bed693596a3337f63eafeb6da4ad
<pre>
[WGSL] GlobalVariableRewriter should visit callees before entrypoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=257561">https://bugs.webkit.org/show_bug.cgi?id=257561</a>
rdar://110077039

Reviewed by Myles C. Maxfield.

When collecting used globals, a function should collect its callees&apos; used variables before
its own, but currently we have it inverted. As it currently stands, not only we might miss
globals used by callees, but we&apos;d also add variables used by the caller to the callee. Fixing
it is just a matter of reordering the operations in the visitor.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264791@main">https://commits.webkit.org/264791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea1d95c461a35d97eceb5c7988c89f52ca3db33a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11497 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9782 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7082 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8512 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7782 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11993 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->