### PR TITLE
Add quoting for arrays containing whitespace paths in preprocess-sandbox-profile-rule.sh

### DIFF
--- a/Source/WebKit/Scripts/preprocess-sandbox-profile-rule.sh
+++ b/Source/WebKit/Scripts/preprocess-sandbox-profile-rule.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# Build setting vraiables are already shell-escaped, eval as an array to
+# Build setting variables are already shell-escaped, eval as an array to
 # differentiate whitespace in paths from list items.
 eval ARCHS=(${ARCHS})
 eval HEADER_SEARCH_PATHS=(${HEADER_SEARCH_PATHS} ${SYSTEM_HEADER_SEARCH_PATHS})
@@ -10,13 +10,13 @@ eval GCC_PREPROCESSOR_DEFINITIONS=(${GCC_PREPROCESSOR_DEFINITIONS})
 CFLAGS=(
     -isysroot "${SDKROOT}"
     -target ${ARCHS[0]}-${LLVM_TARGET_TRIPLE_VENDOR}-${LLVM_TARGET_TRIPLE_OS_VERSION}${LLVM_TARGET_TRIPLE_SUFFIX}
-    "-F${BUILT_PRODUCTS_DIR}" ${FRAMEWORK_SEARCH_PATHS[@]/#/-F}
-    "-I${BUILT_PRODUCTS_DIR}" ${HEADER_SEARCH_PATHS[@]/#/-I}
+    "-F${BUILT_PRODUCTS_DIR}" "${FRAMEWORK_SEARCH_PATHS[@]/#/-F}"
+    "-I${BUILT_PRODUCTS_DIR}" "${HEADER_SEARCH_PATHS[@]/#/-I}"
     ${GCC_PREPROCESSOR_DEFINITIONS[@]/#/-D}
 )
 if [ "${USE_SYSTEM_CONTENT_PATH}" = YES ]; then
     CFLAGS+=(-DUSE_SYSTEM_CONTENT_PATH=1 -DSYSTEM_CONTENT_PATH="${SYSTEM_CONTENT_PATH}")
 fi
 
-grep -o '^[^;]*' "${INPUT_FILE_PATH}" | clang -E -P -w -DRELEASE_WITHOUT_OPTIMIZATIONS -MD -MF "${DERIVED_FILES_DIR}/${INPUT_FILE_PATH}.d" ${CFLAGS[@]} -include "wtf/Platform.h" - > "${SCRIPT_OUTPUT_FILE_0}"
+grep -o '^[^;]*' "${INPUT_FILE_PATH}" | clang -E -P -w -DRELEASE_WITHOUT_OPTIMIZATIONS -MD -MF "${DERIVED_FILES_DIR}/${INPUT_FILE_PATH}.d" "${CFLAGS[@]}" -include "wtf/Platform.h" - > "${SCRIPT_OUTPUT_FILE_0}"
 


### PR DESCRIPTION
#### 6f04c95bf8f346bf66b311ee0448fce8d60b1791
<pre>
Add quoting for arrays containing whitespace paths in preprocess-sandbox-profile-rule.sh
<a href="https://bugs.webkit.org/show_bug.cgi?id=257276">https://bugs.webkit.org/show_bug.cgi?id=257276</a>
rdar://problem/109790387

Unreviewed build fix.

When ${FRAMEWORK_SEARCH_PATHS[@]} and ${HEADER_SEARCH_PATHS[@]} are
expanded, they need to be quoted, so that the shell keeps
whitespace-containing paths as a single argument.

* Source/WebKit/Scripts/preprocess-sandbox-profile-rule.sh:

Canonical link: <a href="https://commits.webkit.org/264752@main">https://commits.webkit.org/264752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8906d609f1d393f6e33f38c73d4ca4c30ec2546e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8825 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/9039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/10190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/10190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/8681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/9039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/8666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/9039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/10346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/9039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/9039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1006 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/8172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->