### PR TITLE
REGRESSION(264306@main) [Cocoa] Moving to next video on YouTube.com while in PiP resizes video contents incorrectly

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8505,13 +8505,15 @@ FloatSize HTMLMediaElement::naturalSize()
 
 FloatSize HTMLMediaElement::videoInlineSize() const
 {
-    if (m_player)
-        return m_player->videoInlineSize();
-    return { };
+    return m_videoInlineSize;
 }
 
 void HTMLMediaElement::setVideoInlineSizeFenced(const FloatSize& size, const WTF::MachSendRight& fence)
 {
+    if (m_videoInlineSize == size)
+        return;
+
+    m_videoInlineSize = size;
     if (m_player)
         m_player->setVideoInlineSizeFenced(size, fence);
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -642,6 +642,8 @@ public:
 
     WEBCORE_EXPORT LayerHostingContextID layerHostingContextID();
     WEBCORE_EXPORT WebCore::FloatSize naturalSize();
+
+    FloatSize mediaPlayerVideoInlineSize() const override { return videoInlineSize(); }
     WEBCORE_EXPORT WebCore::FloatSize videoInlineSize() const;
     void setVideoInlineSizeFenced(const FloatSize&, const WTF::MachSendRight&);
     void updateMediaState();
@@ -1317,6 +1319,8 @@ private:
     bool m_userPrefersTextDescriptions { false };
     bool m_userPrefersExtendedDescriptions { false };
     bool m_changingSynthesisState { false };
+
+    FloatSize m_videoInlineSize { };
 
 #if !RELEASE_LOG_DISABLED
     RefPtr<Logger> m_logger;

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -918,7 +918,7 @@ bool MediaPlayer::isVideoFullscreenStandby() const
 
 FloatSize MediaPlayer::videoInlineSize() const
 {
-    return m_private->videoInlineSize();
+    return client().mediaPlayerVideoInlineSize();
 }
 
 void MediaPlayer::setVideoInlineSizeFenced(const FloatSize& size, const WTF::MachSendRight& fence)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -295,6 +295,8 @@ public:
 
     virtual bool mediaPlayerShouldDisableHDR() const { return false; }
 
+    virtual FloatSize mediaPlayerVideoInlineSize() const { return { }; }
+
 #if !RELEASE_LOG_DISABLED
     virtual const void* mediaPlayerLogIdentifier() { return nullptr; }
     virtual const Logger& mediaPlayerLogger() = 0;

--- a/Source/WebCore/platform/graphics/VideoLayerManager.h
+++ b/Source/WebCore/platform/graphics/VideoLayerManager.h
@@ -39,7 +39,7 @@ public:
     virtual ~VideoLayerManager() = default;
 
     virtual PlatformLayer* videoInlineLayer() const = 0;
-    virtual void setVideoLayer(PlatformLayer*, IntSize) = 0;
+    virtual void setVideoLayer(PlatformLayer*, FloatSize) = 0;
     virtual void didDestroyVideoLayer() = 0;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -643,7 +643,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     [m_videoLayer addObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay" options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextAVPlayerLayer];
     updateVideoLayerGravity();
     [m_videoLayer setContentsScale:player()->playerContentsScale()];
-    m_videoLayerManager->setVideoLayer(m_videoLayer.get(), player()->presentationSize());
+    m_videoLayerManager->setVideoLayer(m_videoLayer.get(), player()->videoInlineSize());
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     if ([m_videoLayer respondsToSelector:@selector(setPIPModeEnabled:)])

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -938,7 +938,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer()
 
     if (m_mediaSourcePrivate)
         m_mediaSourcePrivate->setVideoLayer(m_sampleBufferDisplayLayer.get());
-    m_videoLayerManager->setVideoLayer(m_sampleBufferDisplayLayer.get(), m_player->presentationSize());
+    m_videoLayerManager->setVideoLayer(m_sampleBufferDisplayLayer.get(), m_player->videoInlineSize());
     m_player->renderingModeChanged();
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h
@@ -59,7 +59,7 @@ public:
 
     WEBCORE_EXPORT PlatformLayer* videoInlineLayer() const final;
 
-    WEBCORE_EXPORT void setVideoLayer(PlatformLayer*, IntSize) final;
+    WEBCORE_EXPORT void setVideoLayer(PlatformLayer*, FloatSize) final;
     WEBCORE_EXPORT void didDestroyVideoLayer() final;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -61,7 +61,7 @@ PlatformLayer* VideoLayerManagerObjC::videoInlineLayer() const
     return m_videoInlineLayer.get();
 }
 
-void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, IntSize contentSize)
+void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, FloatSize contentSize)
 {
     ALWAYS_LOG(LOGIDENTIFIER, contentSize.width(), ", ", contentSize.height());
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -345,6 +345,7 @@ private:
     void currentTimeChanged(const MediaTime&);
 
 #if PLATFORM(COCOA)
+    WebCore::FloatSize mediaPlayerVideoInlineSize() const final { return m_configuration.videoInlineSize; }
     void setVideoInlineSizeIfPossible(const WebCore::FloatSize&);
     void nativeImageForCurrentTime(CompletionHandler<void(std::optional<WTF::MachSendRight>&&, WebCore::DestinationColorSpace)>&&);
     void colorSpace(CompletionHandler<void(WebCore::DestinationColorSpace)>&&);
@@ -391,7 +392,6 @@ private:
     Seconds m_videoPlaybackMetricsUpdateInterval;
     MonotonicTime m_nextPlaybackQualityMetricsUpdateTime;
 
-    WebCore::FloatSize m_videoInlineSize;
     float m_videoContentScale { 1.0 };
     WebCore::LayoutRect m_playerContentBoxRect;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h
@@ -54,6 +54,7 @@ struct RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize { };
+    WebCore::FloatSize videoInlineSize { };
     uint64_t logIdentifier { 0 };
     bool shouldUsePersistentCache { false };
     bool isVideo { false };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in
@@ -39,6 +39,7 @@ struct WebKit::RemoteMediaPlayerProxyConfiguration {
 #endif
     WebCore::SecurityOriginData documentSecurityOrigin;
     WebCore::IntSize presentationSize;
+    WebCore::FloatSize videoInlineSize;
     uint64_t logIdentifier;
     bool shouldUsePersistentCache;
     bool isVideo;

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -56,7 +56,7 @@ void RemoteMediaPlayerProxy::setVideoInlineSizeIfPossible(const WebCore::FloatSi
 void RemoteMediaPlayerProxy::mediaPlayerFirstVideoFrameAvailable()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    setVideoInlineSizeIfPossible(m_videoInlineSize);
+    setVideoInlineSizeIfPossible(m_configuration.videoInlineSize);
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::FirstVideoFrameAvailable(), m_id);
 }
 
@@ -86,7 +86,7 @@ void RemoteMediaPlayerProxy::setVideoInlineSizeFenced(const WebCore::FloatSize& 
     if (m_inlineLayerHostingContext)
         m_inlineLayerHostingContext->setFencePort(machSendRight.sendRight());
 
-    m_videoInlineSize = size;
+    m_configuration.videoInlineSize = size;
     setVideoInlineSizeIfPossible(size);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -174,6 +174,7 @@ std::unique_ptr<MediaPlayerPrivateInterface> RemoteMediaPlayerManager::createRem
     proxyConfiguration.documentSecurityOrigin = documentSecurityOrigin;
 
     proxyConfiguration.presentationSize = player->presentationSize();
+    proxyConfiguration.videoInlineSize = player->videoInlineSize();
 
     proxyConfiguration.allowedMediaContainerTypes = player->allowedMediaContainerTypes();
     proxyConfiguration.allowedMediaCodecTypes = player->allowedMediaCodecTypes();


### PR DESCRIPTION
#### ab72213571733c4284711044d37f4db1248ac11c
<pre>
REGRESSION(264306@main) [Cocoa] Moving to next video on YouTube.com while in PiP resizes video contents incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=257564">https://bugs.webkit.org/show_bug.cgi?id=257564</a>
rdar://110026753

Reviewed by Eric Carlson.

In 264306@main, we stopped resizing the video contents layer whenever normal layout starts, to avoid breaking layout
of media that&apos;s currently displayed in fullscreen or pip modes. However, this had the paradoxical effect of breaking
layout when a media element moves from one src to another.

This is because the `videoInlineSize` last set by the fullscreen or pip window is cached at the MediaPlayerPrivate
layer, and this value is lost when the media is unloaded and new src loaded. The MediaPlayerPrivate will use the
`presentationSize` as the initial size of the layer (which is the inline size; `videoInlineSize` needs to be renamed
to `videoLayerSize`).

Cache the `videoInlineSize` value at the HTMLMediaElement level. Add a new MediaPlayerClient method so that the
MediaPlayer can query the HTMLMediaElement for that size at creation time. Pass that value across the WC -&gt; GPU
process boundary in RemoteMediaPlayerProxyConfiguration.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::videoInlineSize const):
(WebCore::HTMLMediaElement::setVideoInlineSizeFenced):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::videoInlineSize const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerVideoInlineSize const):
* Source/WebCore/platform/graphics/VideoLayerManager.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setVideoLayer):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::RemoteMediaPlayerProxy):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxyConfiguration.serialization.in:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::createRemoteMediaPlayer):

Canonical link: <a href="https://commits.webkit.org/264795@main">https://commits.webkit.org/264795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048e51bc3c85bffc2a40735701534f856f807498

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9041 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11433 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8683 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9711 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10348 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11304 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7709 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2100 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->