### PR TITLE
Add support for NSTextInputMarkedRangeAttribute for accessibility clients on the Mac

### DIFF
--- a/LayoutTests/accessibility/mac/text-input-marked-range-expected.txt
+++ b/LayoutTests/accessibility/mac/text-input-marked-range-expected.txt
@@ -1,0 +1,13 @@
+This test ensures that the input method marked range is available to accessibility clients.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS !element.textInputMarkedRange is true
+PASS element.textInputMarkedRange is '{0, 4}'
+PASS !element.textInputMarkedRange is true
+PASS element.textInputMarkedRange is '{0, 5}'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-input-marked-range.html
+++ b/LayoutTests/accessibility/mac/text-input-marked-range.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../resources/js-test.js"></script>
+</head>
+<body>
+    <input id="editable" type="text"></input>
+    <script type="text/javascript">
+        description("This test ensures that the input method marked range is available to accessibility clients.");
+        editable.focus();
+        if (window.textInputController && window.accessibilityController) {
+            var element = accessibilityController.accessibleElementById("editable");
+            shouldBeTrue("!element.textInputMarkedRange");
+            textInputController.setMarkedText("test", 1, 0);
+            shouldBe("element.textInputMarkedRange", "'{0, 4}'");
+            textInputController.insertText("t");
+            shouldBeTrue("!element.textInputMarkedRange");
+            textInputController.setMarkedText("test2", 1, 0);
+            shouldBe("element.textInputMarkedRange", "'{0, 5}'");
+        }
+    </script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -616,6 +616,9 @@ TextStream& operator<<(TextStream& stream, AXObjectCache::AXNotification notific
     case AXObjectCache::AXNotification::AXTextChanged:
         stream << "AXTextChanged";
         break;
+    case AXObjectCache::AXNotification::AXTextCompositionChanged:
+        stream << "AXTextCompositionChanged";
+        break;
     case AXObjectCache::AXNotification::AXTextSecurityChanged:
         stream << "AXTextSecurityChanged";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -188,6 +188,7 @@ public:
     void onTextSecurityChanged(HTMLInputElement&);
     void onTitleChange(Document&);
     void onValidityChange(Element&);
+    void onTextCompositionChange(Node&);
     void valueChanged(Element*);
     void checkedStateChanged(Node*);
     void autofillTypeChanged(Node*);
@@ -379,6 +380,7 @@ public:
         AXRequiredStatusChanged,
         AXSortDirectionChanged,
         AXTextChanged,
+        AXTextCompositionChanged,
         AXTextSecurityChanged,
         AXElementBusyChanged,
         AXDraggingStarted,
@@ -445,6 +447,8 @@ public:
     // Returns the IDs of the objects that relate to the given object with the specified relationship.
     std::optional<Vector<AXID>> relatedObjectIDsFor(const AXCoreObject&, AXRelationType);
     void updateRelations(Element&, const QualifiedName&);
+
+    AccessibilityObject* textCompositionObjectForNode(Node&);
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void scheduleObjectRegionsUpdate(bool scheduleImmediately = false) { m_geometryManager->scheduleObjectRegionsUpdate(scheduleImmediately); }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -240,6 +240,7 @@ public:
     bool hasSameStyle(const AXCoreObject&) const override { return false; }
     bool hasUnderline() const override { return false; }
     bool hasHighlighting() const override;
+    std::optional<CharacterRange> textInputMarkedRange() const final;
 
     bool supportsDatetimeAttribute() const override;
     String datetimeAttributeValue() const override;
@@ -811,6 +812,8 @@ private:
 
     // Special handling of click point for links.
     IntPoint linkClickPoint();
+
+    bool isNodeForComposition(const Editor&) const;
 
 protected: // FIXME: Make the data members private.
     AccessibilityChildrenVector m_children;

--- a/Source/WebCore/accessibility/AccessibilityObjectInterface.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInterface.h
@@ -27,6 +27,7 @@
 
 // FIXME: Should rename this file AXCoreObject.h.
 
+#include "CharacterRange.h"
 #include "ColorConversion.h"
 #include "HTMLTextFormControlElement.h"
 #include "LayoutRect.h"
@@ -986,6 +987,7 @@ public:
     bool isStaticText() const { return roleValue() == AccessibilityRole::StaticText; }
     virtual bool hasUnderline() const = 0;
     virtual bool hasHighlighting() const = 0;
+    virtual std::optional<CharacterRange> textInputMarkedRange() const = 0;
 
     virtual bool supportsDatetimeAttribute() const = 0;
     virtual String datetimeAttributeValue() const = 0;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -456,6 +456,7 @@ private:
     bool hasSameStyle(const AXCoreObject&) const override;
     bool hasUnderline() const override { return boolAttributeValue(AXPropertyName::HasUnderline); }
     bool hasHighlighting() const override { return boolAttributeValue(AXPropertyName::HasHighlighting); }
+    std::optional<CharacterRange> textInputMarkedRange() const final { return optionalAttributeValue<CharacterRange>(AXPropertyName::TextInputMarkedRange); }
     Element* element() const override;
     Node* node() const override;
     RenderObject* renderer() const override;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -576,6 +576,13 @@ void AXIsolatedTree::updateNodeProperties(AXCoreObject& axObject, const Vector<A
         case AXPropertyName::SupportsSetSize:
             propertyMap.set(AXPropertyName::SupportsSetSize, axObject.supportsSetSize());
             break;
+        case AXPropertyName::TextInputMarkedRange:
+            // FIXME: We should have a mechanism to remove a property from the map for when textInputMarkedRange is std::nullopt.
+            if (auto textInputMarkedRange = axObject.textInputMarkedRange())
+                propertyMap.set(AXPropertyName::TextInputMarkedRange, *textInputMarkedRange);
+            else
+                propertyMap.set(AXPropertyName::TextInputMarkedRange, nullptr);
+            break;
         case AXPropertyName::URL:
             propertyMap.set(AXPropertyName::URL, axObject.url().isolatedCopy());
             break;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -227,6 +227,7 @@ enum class AXPropertyName : uint16_t {
     SupportsSetSize,
     TableLevel,
     TextContent,
+    TextInputMarkedRange,
     Title,
     TitleAttributeValue,
     TitleUIElement,
@@ -239,7 +240,7 @@ enum class AXPropertyName : uint16_t {
     VisibleRows,
 };
 
-using AXPropertyValueVariant = std::variant<std::nullptr_t, AXID, String, bool, int, unsigned, double, float, uint64_t, AccessibilityButtonState, Color, URL, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, PAL::SessionID, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<AXID, AXID>>, Vector<String>, Path, OptionSet<AXAncestorFlag>, RetainPtr<NSAttributedString>, InsideLink>;
+using AXPropertyValueVariant = std::variant<std::nullptr_t, AXID, String, bool, int, unsigned, double, float, uint64_t, AccessibilityButtonState, Color, URL, LayoutRect, FloatPoint, FloatRect, IntPoint, IntRect, PAL::SessionID, std::pair<unsigned, unsigned>, Vector<AccessibilityText>, Vector<AXID>, Vector<std::pair<AXID, AXID>>, Vector<String>, Path, OptionSet<AXAncestorFlag>, RetainPtr<NSAttributedString>, InsideLink, CharacterRange>;
 using AXPropertyMap = HashMap<AXPropertyName, AXPropertyValueVariant, IntHash<AXPropertyName>, WTF::StrongEnumHashTraits<AXPropertyName>>;
 
 struct AXPropertyChange {

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -483,6 +483,10 @@ using namespace WebCore;
 #define AXHasWebApplicationAncestorAttribute @"AXHasWebApplicationAncestor"
 #endif
 
+#ifndef NSAccessibilityTextInputMarkedRangeAttribute
+#define NSAccessibilityTextInputMarkedRangeAttribute @"AXTextInputMarkedRange"
+#endif
+
 @implementation WebAccessibilityObjectWrapper
 
 - (void)detach
@@ -913,6 +917,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         NSAccessibilityFocusableAncestorAttribute,
         NSAccessibilityEditableAncestorAttribute,
         NSAccessibilityHighestEditableAncestorAttribute,
+        NSAccessibilityTextInputMarkedRangeAttribute,
     ];
     static NeverDestroyed spinButtonCommonAttributes = [] {
         auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:attributes.get().get()]);
@@ -2241,6 +2246,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attributeName isEqualToString:@"AXIsIndeterminate"])
         return [NSNumber numberWithBool: backingObject->isIndeterminate()];
+
+    if ([attributeName isEqualToString:NSAccessibilityTextInputMarkedRangeAttribute]) {
+        auto range = backingObject->textInputMarkedRange();
+        return range ? [NSValue valueWithRange:*range] : nil;
+    }
 
     return nil;
 }

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -1345,6 +1345,12 @@ static JSValueRef getSelectedTextRangeCallback(JSContextRef context, JSObjectRef
     return JSValueMakeString(context, selectedTextRange.get());
 }
 
+static JSValueRef getTextInputMarkedRangeCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
+{
+    auto textInputMarkedRange = toAXElement(thisObject)->textInputMarkedRange();
+    return JSValueMakeString(context, textInputMarkedRange.get());
+}
+
 static JSValueRef getIsAtomicLiveRegionCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
 {
     return JSValueMakeBoolean(context, toAXElement(thisObject)->isAtomicLiveRegion());
@@ -1983,6 +1989,7 @@ JSClassRef AccessibilityUIElement::getJSClass()
         { "columnCount", columnCountCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "insertionPointLineNumber", getInsertionPointLineNumberCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "selectedTextRange", getSelectedTextRangeCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
+        { "textInputMarkedRange", getTextInputMarkedRangeCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "isAtomicLiveRegion", getIsAtomicLiveRegionCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "isBusy", getIsBusyCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },
         { "isEnabled", getIsEnabledCallback, 0, kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete },

--- a/Tools/DumpRenderTree/AccessibilityUIElement.h
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.h
@@ -147,6 +147,7 @@ public:
     JSRetainPtr<JSStringRef> valueDescription();
     int insertionPointLineNumber();
     JSRetainPtr<JSStringRef> selectedTextRange();
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const;
     bool isAtomicLiveRegion() const;
     bool isBusy() const;
     bool isEnabled();

--- a/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
@@ -1058,6 +1058,11 @@ void AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
 {
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    return WTR::createJSString();
+}
+
 void AccessibilityUIElement::increment()
 {
     [m_element accessibilityIncrement];

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -75,6 +75,10 @@
 #define NSAccessibilitySelectedTextMarkerRangeAttribute @"AXSelectedTextMarkerRange"
 #endif
 
+#ifndef NSAccessibilityTextInputMarkedRangeAttribute
+#define NSAccessibilityTextInputMarkedRangeAttribute @"AXTextInputMarkedRange"
+#endif
+
 typedef void (*AXPostedNotificationCallback)(id element, NSString* notification, void* context);
 
 @interface NSObject (WebKitAccessibilityAdditions)
@@ -167,6 +171,10 @@ static NSString* attributesOfElement(id accessibilityObject)
         BEGIN_AX_OBJC_EXCEPTIONS
         id valueObject = [accessibilityObject accessibilityAttributeValue:attribute];
         NSString* value = descriptionOfValue(valueObject, accessibilityObject);
+
+        if ([attribute isEqualToString:NSAccessibilityTextInputMarkedRangeAttribute] && !value)
+            continue;
+
         [attributesString appendFormat:@"%@: %@\n", attribute, value];
         END_AX_OBJC_EXCEPTIONS
     }
@@ -1369,6 +1377,16 @@ void AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
     BEGIN_AX_OBJC_EXCEPTIONS
     [m_element accessibilitySetValue:textRangeValue forAttribute:NSAccessibilitySelectedTextRangeAttribute];
     END_AX_OBJC_EXCEPTIONS
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    id value = [m_element accessibilityAttributeValue:NSAccessibilityTextInputMarkedRangeAttribute];
+    if ([value isKindOfClass:[NSValue class]])
+        return [NSStringFromRange([value rangeValue]) createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+    return nullptr;
 }
 
 void AccessibilityUIElement::setValue(JSStringRef valueText)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -177,6 +177,7 @@ public:
     JSRetainPtr<JSStringRef> valueDescription();
     int insertionPointLineNumber();
     JSRetainPtr<JSStringRef> selectedTextRange();
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const;
     bool isAtomicLiveRegion() const;
     bool isBusy() const;
     bool isEnabled();

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -63,6 +63,7 @@
     readonly attribute DOMString orientation;
     readonly attribute long insertionPointLineNumber;
     readonly attribute DOMString selectedTextRange;
+    readonly attribute DOMString textInputMarkedRange;
 
     DOMString stringDescriptionOfAttributeValue(DOMString attr);
     DOMString stringAttributeValue(DOMString attr);

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1437,6 +1437,11 @@ bool AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
     return true;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    return nullptr;
+}
+
 void AccessibilityUIElement::increment()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -983,6 +983,11 @@ bool AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
     return true;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    return WTR::createJSString();
+}
+
 void AccessibilityUIElement::increment()
 {
     [m_element accessibilityIncrement];

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -81,6 +81,10 @@
 #define NSAccessibilitySelectedTextMarkerRangeAttribute @"AXSelectedTextMarkerRange"
 #endif
 
+#ifndef NSAccessibilityTextInputMarkedRangeAttribute
+#define NSAccessibilityTextInputMarkedRangeAttribute @"AXTextInputMarkedRange"
+#endif
+
 typedef void (*AXPostedNotificationCallback)(id element, NSString* notification, void* context);
 
 @interface NSObject (WebKitAccessibilityAdditions)
@@ -628,6 +632,10 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
             continue;
 
         auto value = descriptionOfValue(attributeValue(attribute).get());
+
+        if ([attribute isEqualToString:NSAccessibilityTextInputMarkedRangeAttribute] && !value)
+            continue;
+
         [values appendFormat:@"%@: %@\n", attribute, value.get()];
     }
 
@@ -1525,6 +1533,16 @@ bool AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
     setAttributeValue(m_element.getAutoreleased(), NSAccessibilitySelectedTextRangeAttribute, textRangeValue);
 
     return true;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto value = attributeValue(NSAccessibilityTextInputMarkedRangeAttribute);
+    if (value)
+        return [NSStringFromRange([value rangeValue]) createJSStringRef];
+    END_AX_OBJC_EXCEPTIONS
+    return nullptr;
 }
 
 void AccessibilityUIElement::dismiss()

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -664,6 +664,12 @@ bool AccessibilityUIElement::setSelectedTextRange(unsigned, unsigned)
     return false;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    notImplemented();
+    return nullptr;
+}
+
 void AccessibilityUIElement::increment()
 {
     notImplemented();


### PR DESCRIPTION
#### 94b6fbfe0984cb20f96b9eb6eeac0b6c2d75f1b7
<pre>
Add support for NSTextInputMarkedRangeAttribute for accessibility clients on the Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=257566">https://bugs.webkit.org/show_bug.cgi?id=257566</a>
rdar://problem/110080851

Reviewed by Tyler Wilcock.

Adding support for NSTextInputMarkedRangeAttribute gives macOS accessibility clients knowledge of where input method events are occurring.
Without this information, it&apos;s impossible for an assistive technology to know if the user is in an input-method composition context.

Test: accessibility/mac/text-input-marked-range.html

* LayoutTests/accessibility/mac/text-input-marked-range-expected.txt: Added.
* LayoutTests/accessibility/mac/text-input-marked-range.html: Added.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onTextCompositionChange):
(WebCore::AXObjectCache::updateIsolatedTree):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::textInputMarkedRange const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityObjectInterface.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateNodeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setComposition):
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(getTextInputMarkedRangeCallback):
(AccessibilityUIElement::getJSClass):
* Tools/DumpRenderTree/AccessibilityUIElement.h:
* Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm:
(AccessibilityUIElement::textInputMarkedRange const):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::textInputMarkedRange const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElement::textInputMarkedRange const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElement::textInputMarkedRange const):

Canonical link: <a href="https://commits.webkit.org/264911@main">https://commits.webkit.org/264911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44b87b3caae31c454e5afee4e94ca14757fddc82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11878 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10190 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10885 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15770 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11760 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7295 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8193 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->