### PR TITLE
[GTK][WPE] Test gardening for 'fast/text/initial-advance-in-intermediate-run-complex'

### DIFF
--- a/LayoutTests/fast/text/initial-advance-in-intermediate-run-complex-expected.html
+++ b/LayoutTests/fast/text/initial-advance-in-intermediate-run-complex-expected.html
@@ -6,6 +6,7 @@
 <p>This test makes sure a CTRun with an initial advance doesn't get incorporated incorrectly when glyph origins are used. The test passes if the lower dots do not appear too low.</p>
 <div style="position: relative;">
 <span style="font-family: Helvetica, Arial, sans-serif;" dir="RTL">AAA <span>&#x634;&#x633;&#x6cc;&#x634;&#x633;&#x6cc;</span> <span>&#x634;&#x633;&#x6cc;&#x634;&#x633;&#x6cc;</span> <span>&#x634;&#x633;&#x6cc;&#x634;&#x633;&#x6cc;</span> <span>&#x6af;&#x632;&#x6cc;&#x646;&#x647;&#x654;</span> <span>&#x634;&#x633;&#x6cc;&#x634;&#x633;&#x6cc;&#x02e;</span>
+</span>
 <div style="position: absolute; left: 0px; top: -2px; width: 100px; height: 25px; background: black;"></div>
 </div>
 </body>


### PR DESCRIPTION
#### 407f23d9e583bc1540b45d2e3452d534b9ab25a3
<pre>
[GTK][WPE] Test gardening for &apos;fast/text/initial-advance-in-intermediate-run-complex&apos;

Unreviewed test gardening.

Fixes test by adding in a missing closing span tag. This was only noticeable
when test began failing after 255598@main, as the work in that patch
enabled out of flow positioned content for IFC:

&quot;Absolute positioning [1]... ignores normal layout entirely, pulling
the element out of flow [2] and positioning it relative to its containing
block [3] with no regard for other content.&quot;
[1] <a href="https://www.w3.org/TR/css-position-3/#absolute-position">https://www.w3.org/TR/css-position-3/#absolute-position</a>
[2] <a href="https://www.w3.org/TR/css-display-3/#out-of-flow">https://www.w3.org/TR/css-display-3/#out-of-flow</a>
[3] <a href="https://www.w3.org/TR/css-display-3/#containing-block">https://www.w3.org/TR/css-display-3/#containing-block</a>

See 255598@main patch for more details (patch doesn&apos;t mention the
above web standards, but they do apply to this test and that patch).

* LayoutTests/fast/text/initial-advance-in-intermediate-run-complex-expected.html:
Fix test by adding in a closing (missing) span tag.

Canonical link: <a href="https://commits.webkit.org/264771@main">https://commits.webkit.org/264771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b65e5f3d203afdeeaea1de280185a1cbbcdb468

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9716 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10354 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7811 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15355 "1 flakes 149 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11309 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8438 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7715 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2082 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->