### PR TITLE
Support move-only types in IPC messages.in, and use it for StreamServerConnection::Handle.

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages_unittest.py
+++ b/Source/WebKit/Scripts/webkit/messages_unittest.py
@@ -51,6 +51,7 @@ _test_receiver_names = [
     'TestWithStreamBatched',
     'TestWithStreamBuffer',
     'TestWithCVPixelBuffer',
+    'TestWithStreamServerConnectionHandle',
 ]
 
 

--- a/Source/WebKit/Scripts/webkit/tests/Makefile
+++ b/Source/WebKit/Scripts/webkit/tests/Makefile
@@ -10,6 +10,7 @@ TESTS = \
     TestWithStreamBatched \
     TestWithStreamBuffer \
     TestWithCVPixelBuffer \
+    TestWithStreamServerConnectionHandle \
 #
 
 all:

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -136,6 +136,7 @@
 #include "TestWithStreamBatchedMessages.h" // NOLINT
 #include "TestWithStreamBufferMessages.h" // NOLINT
 #include "TestWithCVPixelBufferMessages.h" // NOLINT
+#include "TestWithStreamServerConnectionHandleMessages.h" // NOLINT
 
 namespace IPC {
 
@@ -322,6 +323,8 @@ std::optional<JSC::JSValue> jsValueForArguments(JSC::JSGlobalObject* globalObjec
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
         return jsValueForDecodedMessage<MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer>(globalObject, decoder);
 #endif
+    case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
+        return jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(globalObject, decoder);
     default:
         break;
     }
@@ -923,6 +926,10 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
     case MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBuffer:
         return Vector<ArgumentDescription> { };
 #endif
+    case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
+        return Vector<ArgumentDescription> {
+            { "handle", "IPC::StreamServerConnection::Handle", nullptr, false },
+        };
     default:
         break;
     }

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -75,6 +75,7 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "TestWithSemaphore_SendSemaphore", ReceiverName::TestWithSemaphore, false, false },
     { "TestWithStreamBatched_SendString", ReceiverName::TestWithStreamBatched, true, false },
     { "TestWithStreamBuffer_SendStreamBuffer", ReceiverName::TestWithStreamBuffer, false, false },
+    { "TestWithStreamServerConnectionHandle_SendStreamServerConnection", ReceiverName::TestWithStreamServerConnectionHandle, false, false },
     { "TestWithStream_CallWithIdentifier", ReceiverName::TestWithStream, true, false },
 #if PLATFORM(COCOA)
     { "TestWithStream_SendMachSendRight", ReceiverName::TestWithStream, true, false },

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -38,11 +38,12 @@ enum class ReceiverName : uint8_t {
     , TestWithStream = 6
     , TestWithStreamBatched = 7
     , TestWithStreamBuffer = 8
-    , TestWithSuperclass = 9
-    , TestWithoutAttributes = 10
-    , IPC = 11
-    , AsyncReply = 12
-    , Invalid = 13
+    , TestWithStreamServerConnectionHandle = 9
+    , TestWithSuperclass = 10
+    , TestWithoutAttributes = 11
+    , IPC = 12
+    , AsyncReply = 13
+    , Invalid = 14
 };
 
 enum class MessageName : uint16_t {
@@ -93,6 +94,7 @@ enum class MessageName : uint16_t {
     TestWithSemaphore_SendSemaphore,
     TestWithStreamBatched_SendString,
     TestWithStreamBuffer_SendStreamBuffer,
+    TestWithStreamServerConnectionHandle_SendStreamServerConnection,
     TestWithStream_CallWithIdentifier,
 #if PLATFORM(COCOA)
     TestWithStream_SendMachSendRight,

--- a/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h
@@ -56,9 +56,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -77,9 +77,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithCVPixelBuffer_ReceiveCVPixelBufferReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RetainPtr<CVPixelBufferRef>>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h
@@ -53,9 +53,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -72,9 +72,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithImageData_ReceiveImageDataReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<RefPtr<WebCore::ImageData>>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h
@@ -74,9 +74,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -96,9 +96,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -119,9 +119,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -142,9 +142,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -165,9 +165,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -187,9 +187,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -203,9 +203,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithLegacyReceiver_Close; }
     static constexpr bool isSync = false;
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -224,9 +224,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -245,9 +245,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -266,9 +266,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -290,9 +290,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -314,9 +314,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -338,9 +338,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -361,9 +361,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -379,9 +379,9 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -400,9 +400,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -421,9 +421,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -442,9 +442,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -464,9 +464,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -490,9 +490,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -513,9 +513,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -536,9 +536,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h
@@ -52,9 +52,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -71,9 +71,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSemaphore_ReceiveSemaphoreReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<IPC::Semaphore>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h
@@ -54,9 +54,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h
@@ -54,9 +54,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h
@@ -55,9 +55,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -82,9 +82,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -108,9 +108,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -130,9 +130,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithStream_CallWithIdentifierReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -154,9 +154,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -177,9 +177,9 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<MachSendRight>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -205,9 +205,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
@@ -1,0 +1,26 @@
+# Copyright (C) 2020 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Tests Stream receiver attribute.
+messages -> TestWithStreamServerConnectionHandle  {
+    void SendStreamServerConnection(IPC::StreamServerConnection::Handle handle)
+}

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessageReceiver.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TestWithStreamServerConnectionHandle.h"
+
+#include "Decoder.h" // NOLINT
+#include "HandleMessage.h" // NOLINT
+#include "StreamServerConnection.h" // NOLINT
+#include "TestWithStreamServerConnectionHandleMessages.h" // NOLINT
+
+#if ENABLE(IPC_TESTING_API)
+#include "JSIPCBinding.h"
+#endif
+
+namespace WebKit {
+
+void TestWithStreamServerConnectionHandle::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    Ref protectedThis { *this };
+    if (decoder.messageName() == Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::name())
+        return IPC::handleMessage<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection>(connection, decoder, this, &TestWithStreamServerConnectionHandle::sendStreamServerConnection);
+    UNUSED_PARAM(connection);
+    UNUSED_PARAM(decoder);
+#if ENABLE(IPC_TESTING_API)
+    if (connection.ignoreInvalidMessageForTesting())
+        return;
+#endif // ENABLE(IPC_TESTING_API)
+    ASSERT_NOT_REACHED_WITH_MESSAGE("Unhandled message %s to %" PRIu64, IPC::description(decoder.messageName()), decoder.destinationID());
+}
+
+} // namespace WebKit
+
+#if ENABLE(IPC_TESTING_API)
+
+namespace IPC {
+
+template<> std::optional<JSC::JSValue> jsValueForDecodedMessage<MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection>(JSC::JSGlobalObject* globalObject, Decoder& decoder)
+{
+    return jsValueForDecodedArguments<Messages::TestWithStreamServerConnectionHandle::SendStreamServerConnection::Arguments>(globalObject, decoder);
+}
+
+}
+
+#endif
+

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
@@ -27,29 +27,28 @@
 #include "ArgumentCoders.h"
 #include "Connection.h"
 #include "MessageNames.h"
+#include "StreamServerConnection.h"
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
-#include <wtf/text/WTFString.h>
 
 
 namespace Messages {
-namespace TestWithIfMessage {
+namespace TestWithStreamServerConnectionHandle {
 
 static inline IPC::ReceiverName messageReceiverName()
 {
-    return IPC::ReceiverName::TestWithIfMessage;
+    return IPC::ReceiverName::TestWithStreamServerConnectionHandle;
 }
 
-#if PLATFORM(COCOA)
-class LoadURL {
+class SendStreamServerConnection {
 public:
-    using Arguments = std::tuple<String>;
+    using Arguments = std::tuple<IPC::StreamServerConnection::Handle>;
 
-    static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
+    static IPC::MessageName name() { return IPC::MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection; }
     static constexpr bool isSync = false;
 
-    explicit LoadURL(const String& url)
-        : m_arguments(url)
+    explicit SendStreamServerConnection(IPC::StreamServerConnection::Handle&& handle)
+        : m_arguments(WTFMove(handle))
     {
     }
 
@@ -59,32 +58,8 @@ public:
     }
 
 private:
-    std::tuple<const String&> m_arguments;
+    std::tuple<IPC::StreamServerConnection::Handle&&> m_arguments;
 };
-#endif
 
-#if PLATFORM(GTK)
-class LoadURL {
-public:
-    using Arguments = std::tuple<String, int64_t>;
-
-    static IPC::MessageName name() { return IPC::MessageName::TestWithIfMessage_LoadURL; }
-    static constexpr bool isSync = false;
-
-    LoadURL(const String& url, int64_t value)
-        : m_arguments(url, value)
-    {
-    }
-
-    auto&& arguments()
-    {
-        return WTFMove(m_arguments);
-    }
-
-private:
-    std::tuple<const String&, int64_t> m_arguments;
-};
-#endif
-
-} // namespace TestWithIfMessage
+} // namespace TestWithStreamServerConnectionHandle
 } // namespace Messages

--- a/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h
@@ -57,9 +57,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -82,9 +82,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -103,9 +103,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithNoArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -124,9 +124,9 @@ public:
     static IPC::MessageName asyncMessageReplyName() { return IPC::MessageName::TestWithSuperclass_TestAsyncMessageWithMultipleArgumentsReply; }
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<bool, uint64_t>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -150,9 +150,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -174,9 +174,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -197,9 +197,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h
@@ -74,9 +74,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -96,9 +96,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -119,9 +119,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -142,9 +142,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -165,9 +165,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -187,9 +187,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -203,9 +203,9 @@ public:
     static IPC::MessageName name() { return IPC::MessageName::TestWithoutAttributes_Close; }
     static constexpr bool isSync = false;
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -224,9 +224,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -245,9 +245,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -266,9 +266,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -290,9 +290,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -314,9 +314,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -338,9 +338,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -361,9 +361,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -379,9 +379,9 @@ public:
 
     static constexpr auto callbackThread = WTF::CompletionHandlerCallThread::ConstructionThread;
     using ReplyArguments = std::tuple<>;
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -400,9 +400,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -421,9 +421,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -442,9 +442,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -464,9 +464,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -490,9 +490,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -513,9 +513,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:
@@ -536,9 +536,9 @@ public:
     {
     }
 
-    const auto& arguments() const
+    auto&& arguments()
     {
-        return m_arguments;
+        return WTFMove(m_arguments);
     }
 
 private:

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -112,7 +112,6 @@ RemoteGraphicsContextGLProxy::RemoteGraphicsContextGLProxy(IPC::Connection& conn
 void RemoteGraphicsContextGLProxy::initializeIPC(IPC::StreamServerConnection::Handle&& serverConnectionHandle, RemoteRenderingBackendProxy& renderingBackend)
 {
     m_connection->send(Messages::GPUConnectionToWebProcess::CreateGraphicsContextGL(contextAttributes(), m_graphicsContextGLIdentifier, renderingBackend.ensureBackendCreated(), WTFMove(serverConnectionHandle)), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
-    serverConnectionHandle = { }; // FIXME(https://bugs.webkit.org/show_bug.cgi?id=257528): Support real rvalue semantics for send
     m_streamConnection->open(*this, renderingBackend.dispatcher());
     // TODO: We must wait until initialized, because at the moment we cannot receive IPC messages
     // during wait while in synchronous stream send. Should be fixed as part of https://bugs.webkit.org/show_bug.cgi?id=217211.

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -124,7 +124,7 @@ public:
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCConnectionHandle* toWrapped(JSContextRef, JSValueRef);
 
-    void encode(IPC::Encoder& encoder) const { encoder << m_handle; }
+    void encode(IPC::Encoder& encoder) { encoder << WTFMove(m_handle); }
 
 private:
     JSIPCConnectionHandle(IPC::Connection::Handle&& handle)
@@ -243,7 +243,7 @@ public:
     }
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCStreamServerConnectionHandle* toWrapped(JSContextRef, JSValueRef);
-    void encode(IPC::Encoder& encoder) const { encoder << m_handle; }
+    void encode(IPC::Encoder& encoder) { encoder << WTFMove(m_handle); }
 private:
     JSIPCStreamServerConnectionHandle(IPC::StreamServerConnection::Handle&& handle)
         : m_handle { WTFMove(handle) }


### PR DESCRIPTION
#### 74200f5b920190e9e8b38e95a41583447b7463cb
<pre>
Support move-only types in IPC messages.in, and use it for StreamServerConnection::Handle.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257528">https://bugs.webkit.org/show_bug.cgi?id=257528</a>

Reviewed by Kimmo Kinnunen.

Adds basic support to messages.py for creating rvalue references for types that are move only, and using WTFMove.

Makes StreamServerConnection::Handle move-only, since we never want to copy these (and the underlying connection state depends on their lifetime).

* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::Handle::encode):
(IPC::StreamServerConnection::Handle::decode):
(IPC::StreamServerConnection::Handle::encode const): Deleted.
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
(function_parameter_type):
(arguments_constructor_name):
(message_to_struct_declaration):
* Source/WebKit/Scripts/webkit/tests/TestWithCVPixelBufferMessages.h:
(Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::arguments):
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::arguments):
(Messages::TestWithCVPixelBuffer::SendCVPixelBuffer::arguments const): Deleted.
(Messages::TestWithCVPixelBuffer::ReceiveCVPixelBuffer::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithIfMessageMessages.h:
(Messages::TestWithIfMessage::LoadURL::arguments):
(Messages::TestWithIfMessage::LoadURL::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithImageDataMessages.h:
(Messages::TestWithImageData::SendImageData::arguments):
(Messages::TestWithImageData::ReceiveImageData::arguments):
(Messages::TestWithImageData::SendImageData::arguments const): Deleted.
(Messages::TestWithImageData::ReceiveImageData::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithLegacyReceiverMessages.h:
(Messages::TestWithLegacyReceiver::LoadURL::arguments):
(Messages::TestWithLegacyReceiver::LoadSomething::arguments):
(Messages::TestWithLegacyReceiver::TouchEvent::arguments):
(Messages::TestWithLegacyReceiver::AddEvent::arguments):
(Messages::TestWithLegacyReceiver::LoadSomethingElse::arguments):
(Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::arguments):
(Messages::TestWithLegacyReceiver::Close::arguments):
(Messages::TestWithLegacyReceiver::PreferencesDidChange::arguments):
(Messages::TestWithLegacyReceiver::SendDoubleAndFloat::arguments):
(Messages::TestWithLegacyReceiver::SendInts::arguments):
(Messages::TestWithLegacyReceiver::CreatePlugin::arguments):
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::arguments):
(Messages::TestWithLegacyReceiver::GetPlugins::GetPlugins):
(Messages::TestWithLegacyReceiver::GetPlugins::arguments):
(Messages::TestWithLegacyReceiver::GetPluginProcessConnection::arguments):
(Messages::TestWithLegacyReceiver::TestMultipleAttributes::arguments):
(Messages::TestWithLegacyReceiver::TestParameterAttributes::arguments):
(Messages::TestWithLegacyReceiver::TemplateTest::arguments):
(Messages::TestWithLegacyReceiver::SetVideoLayerID::arguments):
(Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::arguments):
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::arguments):
(Messages::TestWithLegacyReceiver::DeprecatedOperation::arguments):
(Messages::TestWithLegacyReceiver::ExperimentalOperation::arguments):
(Messages::TestWithLegacyReceiver::LoadURL::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::LoadSomething::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::TouchEvent::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::AddEvent::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::LoadSomethingElse::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::DidReceivePolicyDecision::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::Close::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::PreferencesDidChange::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::SendDoubleAndFloat::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::SendInts::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::CreatePlugin::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::RunJavaScriptAlert::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::GetPlugins::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::GetPluginProcessConnection::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::TestMultipleAttributes::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::TestParameterAttributes::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::TemplateTest::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::SetVideoLayerID::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::DidCreateWebProcessConnection::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::InterpretKeyEvent::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::DeprecatedOperation::arguments const): Deleted.
(Messages::TestWithLegacyReceiver::ExperimentalOperation::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithSemaphoreMessages.h:
(Messages::TestWithSemaphore::SendSemaphore::arguments):
(Messages::TestWithSemaphore::ReceiveSemaphore::arguments):
(Messages::TestWithSemaphore::SendSemaphore::arguments const): Deleted.
(Messages::TestWithSemaphore::ReceiveSemaphore::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBatchedMessages.h:
(Messages::TestWithStreamBatched::SendString::arguments):
(Messages::TestWithStreamBatched::SendString::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamBufferMessages.h:
(Messages::TestWithStreamBuffer::SendStreamBuffer::arguments):
(Messages::TestWithStreamBuffer::SendStreamBuffer::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithStreamMessages.h:
(Messages::TestWithStream::SendString::arguments):
(Messages::TestWithStream::SendStringAsync::arguments):
(Messages::TestWithStream::SendStringSync::arguments):
(Messages::TestWithStream::CallWithIdentifier::arguments):
(Messages::TestWithStream::SendMachSendRight::arguments):
(Messages::TestWithStream::ReceiveMachSendRight::arguments):
(Messages::TestWithStream::SendAndReceiveMachSendRight::arguments):
(Messages::TestWithStream::SendString::arguments const): Deleted.
(Messages::TestWithStream::SendStringAsync::arguments const): Deleted.
(Messages::TestWithStream::SendStringSync::arguments const): Deleted.
(Messages::TestWithStream::CallWithIdentifier::arguments const): Deleted.
(Messages::TestWithStream::SendMachSendRight::arguments const): Deleted.
(Messages::TestWithStream::ReceiveMachSendRight::arguments const): Deleted.
(Messages::TestWithStream::SendAndReceiveMachSendRight::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithSuperclassMessages.h:
(Messages::TestWithSuperclass::LoadURL::arguments):
(Messages::TestWithSuperclass::TestAsyncMessage::arguments):
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::arguments):
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::arguments):
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::arguments):
(Messages::TestWithSuperclass::TestSyncMessage::arguments):
(Messages::TestWithSuperclass::TestSynchronousMessage::TestSynchronousMessage):
(Messages::TestWithSuperclass::TestSynchronousMessage::arguments):
(Messages::TestWithSuperclass::LoadURL::arguments const): Deleted.
(Messages::TestWithSuperclass::TestAsyncMessage::arguments const): Deleted.
(Messages::TestWithSuperclass::TestAsyncMessageWithNoArguments::arguments const): Deleted.
(Messages::TestWithSuperclass::TestAsyncMessageWithMultipleArguments::arguments const): Deleted.
(Messages::TestWithSuperclass::TestAsyncMessageWithConnection::arguments const): Deleted.
(Messages::TestWithSuperclass::TestSyncMessage::arguments const): Deleted.
(Messages::TestWithSuperclass::TestSynchronousMessage::arguments const): Deleted.
* Source/WebKit/Scripts/webkit/tests/TestWithoutAttributesMessages.h:
(Messages::TestWithoutAttributes::LoadURL::arguments):
(Messages::TestWithoutAttributes::LoadSomething::arguments):
(Messages::TestWithoutAttributes::TouchEvent::arguments):
(Messages::TestWithoutAttributes::AddEvent::arguments):
(Messages::TestWithoutAttributes::LoadSomethingElse::arguments):
(Messages::TestWithoutAttributes::DidReceivePolicyDecision::arguments):
(Messages::TestWithoutAttributes::Close::arguments):
(Messages::TestWithoutAttributes::PreferencesDidChange::arguments):
(Messages::TestWithoutAttributes::SendDoubleAndFloat::arguments):
(Messages::TestWithoutAttributes::SendInts::arguments):
(Messages::TestWithoutAttributes::CreatePlugin::arguments):
(Messages::TestWithoutAttributes::RunJavaScriptAlert::arguments):
(Messages::TestWithoutAttributes::GetPlugins::GetPlugins):
(Messages::TestWithoutAttributes::GetPlugins::arguments):
(Messages::TestWithoutAttributes::GetPluginProcessConnection::arguments):
(Messages::TestWithoutAttributes::TestMultipleAttributes::arguments):
(Messages::TestWithoutAttributes::TestParameterAttributes::arguments):
(Messages::TestWithoutAttributes::TemplateTest::arguments):
(Messages::TestWithoutAttributes::SetVideoLayerID::arguments):
(Messages::TestWithoutAttributes::DidCreateWebProcessConnection::arguments):
(Messages::TestWithoutAttributes::InterpretKeyEvent::arguments):
(Messages::TestWithoutAttributes::DeprecatedOperation::arguments):
(Messages::TestWithoutAttributes::ExperimentalOperation::arguments):
(Messages::TestWithoutAttributes::LoadURL::arguments const): Deleted.
(Messages::TestWithoutAttributes::LoadSomething::arguments const): Deleted.
(Messages::TestWithoutAttributes::TouchEvent::arguments const): Deleted.
(Messages::TestWithoutAttributes::AddEvent::arguments const): Deleted.
(Messages::TestWithoutAttributes::LoadSomethingElse::arguments const): Deleted.
(Messages::TestWithoutAttributes::DidReceivePolicyDecision::arguments const): Deleted.
(Messages::TestWithoutAttributes::Close::arguments const): Deleted.
(Messages::TestWithoutAttributes::PreferencesDidChange::arguments const): Deleted.
(Messages::TestWithoutAttributes::SendDoubleAndFloat::arguments const): Deleted.
(Messages::TestWithoutAttributes::SendInts::arguments const): Deleted.
(Messages::TestWithoutAttributes::CreatePlugin::arguments const): Deleted.
(Messages::TestWithoutAttributes::RunJavaScriptAlert::arguments const): Deleted.
(Messages::TestWithoutAttributes::GetPlugins::arguments const): Deleted.
(Messages::TestWithoutAttributes::GetPluginProcessConnection::arguments const): Deleted.
(Messages::TestWithoutAttributes::TestMultipleAttributes::arguments const): Deleted.
(Messages::TestWithoutAttributes::TestParameterAttributes::arguments const): Deleted.
(Messages::TestWithoutAttributes::TemplateTest::arguments const): Deleted.
(Messages::TestWithoutAttributes::SetVideoLayerID::arguments const): Deleted.
(Messages::TestWithoutAttributes::DidCreateWebProcessConnection::arguments const): Deleted.
(Messages::TestWithoutAttributes::InterpretKeyEvent::arguments const): Deleted.
(Messages::TestWithoutAttributes::DeprecatedOperation::arguments const): Deleted.
(Messages::TestWithoutAttributes::ExperimentalOperation::arguments const): Deleted.
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCConnectionHandle::encode):
(WebKit::IPCTestingAPI::JSIPCStreamServerConnectionHandle::encode):
(WebKit::IPCTestingAPI::JSIPCConnectionHandle::encode const): Deleted.
(WebKit::IPCTestingAPI::JSIPCStreamServerConnectionHandle::encode const): Deleted.

Canonical link: <a href="https://commits.webkit.org/264848@main">https://commits.webkit.org/264848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f2aba4144f65de13836d00070cc6cb13a605a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8847 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11693 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8993 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10658 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/8972 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7288 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15586 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7604 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8239 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11573 "6 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7110 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9014 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7980 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2150 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12191 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9249 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8472 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2269 "Passed tests") | 
<!--EWS-Status-Bubble-End-->