### PR TITLE
REGRESSION (264435@main): Audio player time remainder/spent are oscillating when CSS width has been specified

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -231,7 +231,7 @@ class TimeControl extends LayoutItem
         this.scrubber.x = (() => {
             if (this._loading)
                 return this.activityIndicator.width + scrubberMargin;
-            if (this._timeLabelsDisplayOnScrubberSide && this.elapsedTimeLabel.visible)
+            if (this._timeLabelsDisplayOnScrubberSide)
                 return this.elapsedTimeLabel.width + scrubberMargin;
             return 0;
         })();


### PR DESCRIPTION
#### 9add6861de2a89ce6f9537d1dcd339b9829ac385
<pre>
REGRESSION (264435@main): Audio player time remainder/spent are oscillating when CSS width has been specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=257523">https://bugs.webkit.org/show_bug.cgi?id=257523</a>
rdar://110043258

Reviewed by Aditya Keerthi.

* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype._performIdealLayout):
When partially-reverting 264301@main in 264435@main, I re-introduced a
`this.elapsedTimeLabel.visible` which caused this flashing (because of a layout
dependency cycle). Since it is not relevant to the bug I was trying to fix
in 264435@main, remove that condition and make this logic more like the
long-standing code.

Canonical link: <a href="https://commits.webkit.org/264760@main">https://commits.webkit.org/264760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a14d4c4707c987cb2d8b303cdc25b5de35f45b71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10211 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8811 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11447 "101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9729 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10367 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7029 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/7824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8148 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8450 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11933 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1010 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8192 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->