### PR TITLE
workers/opaque-origin.html WPT is failing in WebKit only

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/workers/opaque-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/opaque-origin-expected.txt
@@ -1,9 +1,9 @@
 
 
 PASS Worker has an opaque origin.
-FAIL Worker can read its own blobs. assert_equals: expected (string) "from worker" but got (object) null
-FAIL Worker can read its owners blobs. assert_equals: expected (string) "from page" but got (object) null
-FAIL Worker can XHR fetch a blob. assert_equals: expected "from page" but got ""
-FAIL Worker can fetch a blob. promise_test: Unhandled rejection with value: object "TypeError: Load failed"
+PASS Worker can read its own blobs.
+PASS Worker can read its owners blobs.
+PASS Worker can XHR fetch a blob.
+PASS Worker can fetch a blob.
 PASS Worker can access BroadcastChannel
 

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -60,7 +60,7 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
         return nullptr;
 
     for (const auto* document : Document::allDocuments()) {
-        if (&document->securityOrigin() == &blobOrigin)
+        if (document->securityOrigin().isSameOriginAs(blobOrigin))
             return document;
     }
     return nullptr;

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -290,7 +290,8 @@ bool SecurityOrigin::canRequest(const URL& url, const OriginAccessPatterns& patt
     if (m_universalAccess)
         return true;
 
-    if (getCachedOrigin(url) == this)
+    auto cachedOriginForURL = getCachedOrigin(url);
+    if (cachedOriginForURL && isSameOriginAs(*cachedOriginForURL))
         return true;
 
     if (isOpaque())


### PR DESCRIPTION
#### cf4c6bcca8bdcea58e4e38f59512f9d6a15c7d48
<pre>
workers/opaque-origin.html WPT is failing in WebKit only
<a href="https://bugs.webkit.org/show_bug.cgi?id=257573">https://bugs.webkit.org/show_bug.cgi?id=257573</a>

Reviewed by Darin Adler.

ThreadableBlobRegistry was storing Blob URL opaque origins in per thread storage.
As a result, if a context with an opaque origin creates a worker, the worker
and the context won&apos;t be able to access each other&apos;s blobs. As a matter of fact,
the worker won&apos;t even be able to load the blobs it created since we hop to the
main thread to do the loading.

To address the issue, ThreadableBlobRegistry now stores origins in a global map,
that is always accessed on the main thread. Also tweak SecurityOrigin::canRequest()
and another call site so that it doesn&apos;t only do a pointer check for cached blob
origins. This is important since the origins get isolated-copied across threads.

* LayoutTests/imported/w3c/web-platform-tests/workers/opaque-origin-expected.txt:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::unregisterBlobURLOriginIfNecessary):
(WebCore::ThreadableBlobRegistry::registerBlobURL):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::getCachedOrigin):
(WebCore::originMap): Deleted.
(WebCore::blobURLReferencesMap): Deleted.
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::canRequest const):

Canonical link: <a href="https://commits.webkit.org/264799@main">https://commits.webkit.org/264799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3247da1064252c9b68ff440c65415cbb26cc7e4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10298 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11518 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9808 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10455 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7903 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8227 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6961 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7805 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2103 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8276 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->