### PR TITLE
Implement white-space-collapse & text-wrap as longhands of white-space

### DIFF
--- a/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt
@@ -202,7 +202,6 @@ unicode-bidi: normal;
 vector-effect: none;
 vertical-align: baseline;
 visibility: visible;
-white-space: normal;
 widows: auto;
 width: 784px;
 will-change: auto;

--- a/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
+++ b/LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt
@@ -201,7 +201,6 @@ unicode-bidi: normal
 vector-effect: none
 vertical-align: baseline
 visibility: visible
-white-space: normal
 widows: auto
 width: 50%
 will-change: auto

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -344,7 +344,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -316,6 +316,7 @@ PASS text-shadow
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position
+PASS text-wrap
 PASS top
 PASS touch-action
 PASS transform
@@ -331,7 +332,7 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html
@@ -327,6 +327,7 @@
   text-transform: lowercase;
   text-underline-offset: 123px;
   text-underline-position: under;
+  text-wrap: nowrap;
   top: 123px;
   touch-action: none;
   transform: scale(-1);
@@ -343,7 +344,8 @@
   vector-effect: non-scaling-stroke;
   vertical-align: 123px;
   visibility: collapse;
-  white-space: nowrap;
+  white-space-collapse: preserve;
+  white-space-trim: discard-inner;
   widows: 123;
   width: 123px;
   will-change: height;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-text-wrap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-text-wrap-expected.txt
@@ -1,7 +1,7 @@
 
 PASS `text-wrap: balance` should be set
 PASS `text-wrap` should not be affected by previous `white-space`
-FAIL `white-space` should overwrite previous `text-wrap` assert_equals: expected "wrap" but got "balance"
+PASS `white-space` should overwrite previous `text-wrap`
 PASS `text-wrap` should not be affected by `white-space` on the parent
-FAIL `white-space` should overwrite `text-wrap` on the parent assert_equals: expected "wrap" but got "balance"
+PASS `white-space` should overwrite `text-wrap` on the parent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -1,38 +1,114 @@
 
-PASS Can set 'white-space' to CSS-wide keywords: initial
-PASS Can set 'white-space' to CSS-wide keywords: inherit
-PASS Can set 'white-space' to CSS-wide keywords: unset
-PASS Can set 'white-space' to CSS-wide keywords: revert
-PASS Can set 'white-space' to var() references:  var(--A)
-PASS Can set 'white-space' to the 'normal' keyword: normal
-PASS Can set 'white-space' to the 'pre' keyword: pre
-PASS Can set 'white-space' to the 'nowrap' keyword: nowrap
-PASS Can set 'white-space' to the 'pre-wrap' keyword: pre-wrap
-PASS Can set 'white-space' to the 'pre-line' keyword: pre-line
-PASS Setting 'white-space' to a length: 0px throws TypeError
-PASS Setting 'white-space' to a length: -3.14em throws TypeError
-PASS Setting 'white-space' to a length: 3.14cm throws TypeError
-PASS Setting 'white-space' to a length: calc(0px + 0em) throws TypeError
-PASS Setting 'white-space' to a percent: 0% throws TypeError
-PASS Setting 'white-space' to a percent: -3.14% throws TypeError
-PASS Setting 'white-space' to a percent: 3.14% throws TypeError
-PASS Setting 'white-space' to a percent: calc(0% + 0%) throws TypeError
-PASS Setting 'white-space' to a time: 0s throws TypeError
-PASS Setting 'white-space' to a time: -3.14ms throws TypeError
-PASS Setting 'white-space' to a time: 3.14s throws TypeError
-PASS Setting 'white-space' to a time: calc(0s + 0ms) throws TypeError
-PASS Setting 'white-space' to an angle: 0deg throws TypeError
-PASS Setting 'white-space' to an angle: 3.14rad throws TypeError
-PASS Setting 'white-space' to an angle: -3.14deg throws TypeError
-PASS Setting 'white-space' to an angle: calc(0rad + 0deg) throws TypeError
-PASS Setting 'white-space' to a flexible length: 0fr throws TypeError
-PASS Setting 'white-space' to a flexible length: 1fr throws TypeError
-PASS Setting 'white-space' to a flexible length: -3.14fr throws TypeError
-PASS Setting 'white-space' to a number: 0 throws TypeError
-PASS Setting 'white-space' to a number: -3.14 throws TypeError
-PASS Setting 'white-space' to a number: 3.14 throws TypeError
-PASS Setting 'white-space' to a number: calc(2 + 3) throws TypeError
-PASS Setting 'white-space' to a transform: translate(50%, 50%) throws TypeError
-PASS Setting 'white-space' to a transform: perspective(10em) throws TypeError
-PASS Setting 'white-space' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'white-space-collapse' to CSS-wide keywords: initial
+PASS Can set 'white-space-collapse' to CSS-wide keywords: inherit
+PASS Can set 'white-space-collapse' to CSS-wide keywords: unset
+PASS Can set 'white-space-collapse' to CSS-wide keywords: revert
+PASS Can set 'white-space-collapse' to var() references:  var(--A)
+PASS Can set 'white-space-collapse' to the 'collapse' keyword: collapse
+PASS Can set 'white-space-collapse' to the 'discard' keyword: discard
+PASS Can set 'white-space-collapse' to the 'preserve' keyword: preserve
+PASS Can set 'white-space-collapse' to the 'preserve-breaks' keyword: preserve-breaks
+PASS Can set 'white-space-collapse' to the 'preserve-spaces' keyword: preserve-spaces
+PASS Can set 'white-space-collapse' to the 'break-spaces' keyword: break-spaces
+PASS Setting 'white-space-collapse' to a length: 0px throws TypeError
+PASS Setting 'white-space-collapse' to a length: -3.14em throws TypeError
+PASS Setting 'white-space-collapse' to a length: 3.14cm throws TypeError
+PASS Setting 'white-space-collapse' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'white-space-collapse' to a percent: 0% throws TypeError
+PASS Setting 'white-space-collapse' to a percent: -3.14% throws TypeError
+PASS Setting 'white-space-collapse' to a percent: 3.14% throws TypeError
+PASS Setting 'white-space-collapse' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'white-space-collapse' to a time: 0s throws TypeError
+PASS Setting 'white-space-collapse' to a time: -3.14ms throws TypeError
+PASS Setting 'white-space-collapse' to a time: 3.14s throws TypeError
+PASS Setting 'white-space-collapse' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'white-space-collapse' to an angle: 0deg throws TypeError
+PASS Setting 'white-space-collapse' to an angle: 3.14rad throws TypeError
+PASS Setting 'white-space-collapse' to an angle: -3.14deg throws TypeError
+PASS Setting 'white-space-collapse' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'white-space-collapse' to a flexible length: 0fr throws TypeError
+PASS Setting 'white-space-collapse' to a flexible length: 1fr throws TypeError
+PASS Setting 'white-space-collapse' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'white-space-collapse' to a number: 0 throws TypeError
+PASS Setting 'white-space-collapse' to a number: -3.14 throws TypeError
+PASS Setting 'white-space-collapse' to a number: 3.14 throws TypeError
+PASS Setting 'white-space-collapse' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'white-space-collapse' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'white-space-collapse' to a transform: perspective(10em) throws TypeError
+PASS Setting 'white-space-collapse' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+PASS Can set 'text-wrap' to CSS-wide keywords: initial
+PASS Can set 'text-wrap' to CSS-wide keywords: inherit
+PASS Can set 'text-wrap' to CSS-wide keywords: unset
+PASS Can set 'text-wrap' to CSS-wide keywords: revert
+PASS Can set 'text-wrap' to var() references:  var(--A)
+PASS Can set 'text-wrap' to the 'wrap' keyword: wrap
+PASS Can set 'text-wrap' to the 'nowrap' keyword: nowrap
+PASS Can set 'text-wrap' to the 'balance' keyword: balance
+PASS Can set 'text-wrap' to the 'stable' keyword: stable
+PASS Can set 'text-wrap' to the 'pretty' keyword: pretty
+PASS Setting 'text-wrap' to a length: 0px throws TypeError
+PASS Setting 'text-wrap' to a length: -3.14em throws TypeError
+PASS Setting 'text-wrap' to a length: 3.14cm throws TypeError
+PASS Setting 'text-wrap' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'text-wrap' to a percent: 0% throws TypeError
+PASS Setting 'text-wrap' to a percent: -3.14% throws TypeError
+PASS Setting 'text-wrap' to a percent: 3.14% throws TypeError
+PASS Setting 'text-wrap' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'text-wrap' to a time: 0s throws TypeError
+PASS Setting 'text-wrap' to a time: -3.14ms throws TypeError
+PASS Setting 'text-wrap' to a time: 3.14s throws TypeError
+PASS Setting 'text-wrap' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'text-wrap' to an angle: 0deg throws TypeError
+PASS Setting 'text-wrap' to an angle: 3.14rad throws TypeError
+PASS Setting 'text-wrap' to an angle: -3.14deg throws TypeError
+PASS Setting 'text-wrap' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'text-wrap' to a flexible length: 0fr throws TypeError
+PASS Setting 'text-wrap' to a flexible length: 1fr throws TypeError
+PASS Setting 'text-wrap' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'text-wrap' to a number: 0 throws TypeError
+PASS Setting 'text-wrap' to a number: -3.14 throws TypeError
+PASS Setting 'text-wrap' to a number: 3.14 throws TypeError
+PASS Setting 'text-wrap' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'text-wrap' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'text-wrap' to a transform: perspective(10em) throws TypeError
+PASS Setting 'text-wrap' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL Can set 'white-space-trim' to CSS-wide keywords: initial Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to CSS-wide keywords: inherit Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to CSS-wide keywords: unset Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to CSS-wide keywords: revert Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to var() references:  var(--A) Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to the 'none' keyword: none Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to the 'discard-before' keyword: discard-before Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to the 'discard-after' keyword: discard-after Invalid property white-space-trim
+FAIL Can set 'white-space-trim' to the 'discard-inner' keyword: discard-inner Invalid property white-space-trim
+PASS Setting 'white-space-trim' to a length: 0px throws TypeError
+PASS Setting 'white-space-trim' to a length: -3.14em throws TypeError
+PASS Setting 'white-space-trim' to a length: 3.14cm throws TypeError
+PASS Setting 'white-space-trim' to a length: calc(0px + 0em) throws TypeError
+PASS Setting 'white-space-trim' to a percent: 0% throws TypeError
+PASS Setting 'white-space-trim' to a percent: -3.14% throws TypeError
+PASS Setting 'white-space-trim' to a percent: 3.14% throws TypeError
+PASS Setting 'white-space-trim' to a percent: calc(0% + 0%) throws TypeError
+PASS Setting 'white-space-trim' to a time: 0s throws TypeError
+PASS Setting 'white-space-trim' to a time: -3.14ms throws TypeError
+PASS Setting 'white-space-trim' to a time: 3.14s throws TypeError
+PASS Setting 'white-space-trim' to a time: calc(0s + 0ms) throws TypeError
+PASS Setting 'white-space-trim' to an angle: 0deg throws TypeError
+PASS Setting 'white-space-trim' to an angle: 3.14rad throws TypeError
+PASS Setting 'white-space-trim' to an angle: -3.14deg throws TypeError
+PASS Setting 'white-space-trim' to an angle: calc(0rad + 0deg) throws TypeError
+PASS Setting 'white-space-trim' to a flexible length: 0fr throws TypeError
+PASS Setting 'white-space-trim' to a flexible length: 1fr throws TypeError
+PASS Setting 'white-space-trim' to a flexible length: -3.14fr throws TypeError
+PASS Setting 'white-space-trim' to a number: 0 throws TypeError
+PASS Setting 'white-space-trim' to a number: -3.14 throws TypeError
+PASS Setting 'white-space-trim' to a number: 3.14 throws TypeError
+PASS Setting 'white-space-trim' to a number: calc(2 + 3) throws TypeError
+PASS Setting 'white-space-trim' to a transform: translate(50%, 50%) throws TypeError
+PASS Setting 'white-space-trim' to a transform: perspective(10em) throws TypeError
+PASS Setting 'white-space-trim' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
+FAIL 'white-space-trim' does not support 'discard-before discard-after' Invalid property white-space-trim
+FAIL 'white-space-trim' does not support 'discard-before discard-inner' Invalid property white-space-trim
+FAIL 'white-space-trim' does not support 'discard-after discard-inner' Invalid property white-space-trim
+FAIL 'white-space-trim' does not support 'discard-before discard-after discard-inner' Invalid property white-space-trim
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space.html
@@ -13,12 +13,35 @@
 <script>
 'use strict';
 
-runPropertyTests('white-space', [
-  { syntax: 'normal'},
-  { syntax: 'pre' },
-  { syntax: 'nowrap' },
-  { syntax: 'pre-wrap' },
-  { syntax: 'pre-line' },
+runPropertyTests('white-space-collapse', [
+  { syntax: 'collapse'},
+  { syntax: 'discard' },
+  { syntax: 'preserve' },
+  { syntax: 'preserve-breaks' },
+  { syntax: 'preserve-spaces' },
+  { syntax: 'break-spaces' },
 ]);
+
+runPropertyTests('text-wrap', [
+  { syntax: 'wrap'},
+  { syntax: 'nowrap' },
+  { syntax: 'balance' },
+  { syntax: 'stable' },
+  { syntax: 'pretty' },
+]);
+
+runPropertyTests('white-space-trim', [
+  { syntax: 'none'},
+  { syntax: 'discard-before' },
+  { syntax: 'discard-after' },
+  { syntax: 'discard-inner' },
+]);
+
+runUnsupportedPropertyTests('white-space-trim', [
+  'discard-before discard-after',
+  'discard-before discard-inner',
+  'discard-after discard-inner',
+  'discard-before discard-after discard-inner'
+])
 
 </script>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -344,7 +344,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -344,7 +344,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -344,7 +344,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -343,7 +343,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -315,6 +315,7 @@ PASS text-shadow
 PASS text-transform
 PASS text-underline-offset
 PASS text-underline-position
+PASS text-wrap
 PASS top
 PASS touch-action
 PASS transform
@@ -330,7 +331,7 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -344,7 +344,6 @@ PASS unicode-bidi
 PASS vector-effect
 PASS vertical-align
 PASS visibility
-PASS white-space
 PASS white-space-collapse
 PASS widows
 PASS width

--- a/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
+++ b/LayoutTests/svg/css/getComputedStyle-basic-expected.txt
@@ -402,8 +402,6 @@ rect: style.getPropertyValue(vertical-align) : baseline
 rect: style.getPropertyCSSValue(vertical-align) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(visibility) : visible
 rect: style.getPropertyCSSValue(visibility) : [object CSSPrimitiveValue]
-rect: style.getPropertyValue(white-space) : normal
-rect: style.getPropertyCSSValue(white-space) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(widows) : auto
 rect: style.getPropertyCSSValue(widows) : [object CSSPrimitiveValue]
 rect: style.getPropertyValue(width) : 100px
@@ -908,8 +906,6 @@ g: style.getPropertyValue(vertical-align) : baseline
 g: style.getPropertyCSSValue(vertical-align) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(visibility) : visible
 g: style.getPropertyCSSValue(visibility) : [object CSSPrimitiveValue]
-g: style.getPropertyValue(white-space) : normal
-g: style.getPropertyCSSValue(white-space) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(widows) : auto
 g: style.getPropertyCSSValue(widows) : [object CSSPrimitiveValue]
 g: style.getPropertyValue(width) : auto

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3644,7 +3644,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<TextWrap>(CSSPropertyTextWrap, &RenderStyle::textWrap, &RenderStyle::setTextWrap),
         new DiscretePropertyWrapper<TransformBox>(CSSPropertyTransformBox, &RenderStyle::transformBox, &RenderStyle::setTransformBox),
         new DiscretePropertyWrapper<TransformStyle3D>(CSSPropertyTransformStyle, &RenderStyle::transformStyle3D, &RenderStyle::setTransformStyle3D),
-        new DiscretePropertyWrapper<WhiteSpace>(CSSPropertyWhiteSpace, &RenderStyle::whiteSpace, &RenderStyle::setWhiteSpace),
         new DiscretePropertyWrapper<WordBreak>(CSSPropertyWordBreak, &RenderStyle::wordBreak, &RenderStyle::setWordBreak),
         new DiscretePropertyWrapper<OverflowAnchor>(CSSPropertyOverflowAnchor, &RenderStyle::overflowAnchor, &RenderStyle::setOverflowAnchor),
         new DiscretePropertyWrapper<TextSpacingTrim>(CSSPropertyTextSpacingTrim, &RenderStyle::textSpacingTrim, &RenderStyle::setTextSpacingTrim),
@@ -3741,7 +3740,8 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         CSSPropertyTextEmphasis,
         CSSPropertyFontVariant,
         CSSPropertyFontSynthesis,
-        CSSPropertyContainIntrinsicSize
+        CSSPropertyContainIntrinsicSize,
+        CSSPropertyWhiteSpace
     };
     const unsigned animatableShorthandPropertiesCount = std::size(animatableShorthandProperties);
 

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -95,6 +95,8 @@ ExceptionOr<void> CSSComputedStyleDeclaration::setCssText(const String&)
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#Notes
 RefPtr<CSSValue> CSSComputedStyleDeclaration::getPropertyCSSValue(CSSPropertyID propertyID, ComputedStyleExtractor::UpdateLayout updateLayout) const
 {
+    if (!isExposed(propertyID, settings()))
+        return nullptr;
     return ComputedStyleExtractor(m_element.ptr(), m_allowVisitedStyle, m_pseudoElementSpecifier).propertyValue(propertyID, updateLayout);
 }
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1347,48 +1347,6 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
-constexpr CSSValueID toCSSValueID(WhiteSpace e)
-{
-    switch (e) {
-    case WhiteSpace::Normal:
-        return CSSValueNormal;
-    case WhiteSpace::Pre:
-        return CSSValuePre;
-    case WhiteSpace::PreWrap:
-        return CSSValuePreWrap;
-    case WhiteSpace::PreLine:
-        return CSSValuePreLine;
-    case WhiteSpace::NoWrap:
-        return CSSValueNowrap;
-    case WhiteSpace::BreakSpaces:
-        return CSSValueBreakSpaces;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return CSSValueInvalid;
-}
-
-template<> constexpr WhiteSpace fromCSSValueID(CSSValueID valueID)
-{
-    switch (valueID) {
-    case CSSValueNowrap:
-        return WhiteSpace::NoWrap;
-    case CSSValuePre:
-        return WhiteSpace::Pre;
-    case CSSValuePreWrap:
-        return WhiteSpace::PreWrap;
-    case CSSValuePreLine:
-        return WhiteSpace::PreLine;
-    case CSSValueNormal:
-        return WhiteSpace::Normal;
-    case CSSValueBreakSpaces:
-        return WhiteSpace::BreakSpaces;
-    default:
-        break;
-    }
-    ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
-    return WhiteSpace::Normal;
-}
-
 #define TYPE WhiteSpaceCollapse
 #define FOR_EACH(CASE) CASE(Collapse) CASE(Discard) CASE(Preserve) CASE(PreserveBreaks) CASE(PreserveSpaces) CASE(BreakSpaces)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6048,20 +6048,15 @@
         },
         "white-space": {
             "inherited": true,
-            "values": [
-                "normal",
-                "pre",
-                "pre-wrap",
-                "pre-line",
-                "nowrap",
-                "break-spaces"
-            ],
             "codegen-properties": {
-                "parser-grammar": "<<values>>"
+                "longhands": [
+                    "white-space-collapse",
+                    "text-wrap"
+                ]
             },
             "specification": {
-                "category": "css-22",
-                "url": "https://www.w3.org/TR/CSS22/text.html#propdef-white-space"
+                "category": "css-text",
+                "url": "https://www.w3.org/TR/css-text-4/#white-space-property"
             }
         },
         "white-space-collapse": {

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -102,6 +102,7 @@ private:
     Ref<CSSValue> getMaskShorthandValue();
     Ref<CSSValueList> getCSSPropertyValuesForGridShorthand(const StylePropertyShorthand&);
     Ref<CSSValue> fontVariantShorthandValue();
+    RefPtr<CSSValue> whiteSpaceShorthandValue(const RenderStyle&);
 
     RefPtr<Element> m_element;
     PseudoId m_pseudoElementSpecifier;

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -121,6 +121,7 @@ private:
     String serializeGridTemplate() const;
     String serializeOffset() const;
     String serializePageBreak() const;
+    String serializeWhiteSpace() const;
 
     StylePropertyShorthand m_shorthand;
     RefPtr<CSSValue> m_longhandValues[maxShorthandLength];
@@ -382,6 +383,8 @@ String ShorthandSerializer::serialize()
     case CSSPropertyWebkitColumnBreakAfter:
     case CSSPropertyWebkitColumnBreakBefore:
         return serializeColumnBreak();
+    case CSSPropertyWhiteSpace:
+        return serializeWhiteSpace();
     default:
         ASSERT_NOT_REACHED();
         return String();
@@ -1162,6 +1165,26 @@ String ShorthandSerializer::serializePageBreak() const
     default:
         return String();
     }
+}
+
+String ShorthandSerializer::serializeWhiteSpace() const
+{
+    auto whiteSpaceCollapse = longhandValueID(0);
+    auto textWrap = longhandValueID(1);
+    if (whiteSpaceCollapse == CSSValueBreakSpaces && textWrap == CSSValueWrap)
+        return nameString(CSSValueBreakSpaces);
+    if (whiteSpaceCollapse == CSSValueCollapse && textWrap == CSSValueWrap)
+        return nameString(CSSValueNormal);
+    if (whiteSpaceCollapse == CSSValueCollapse && textWrap == CSSValueNowrap)
+        return nameString(CSSValueNowrap);
+    if (whiteSpaceCollapse == CSSValuePreserve && textWrap == CSSValueNowrap)
+        return nameString(CSSValuePre);
+    if (whiteSpaceCollapse == CSSValuePreserveBreaks && textWrap == CSSValueWrap)
+        return nameString(CSSValuePreLine);
+    if (whiteSpaceCollapse == CSSValuePreserve && textWrap == CSSValueWrap)
+        return nameString(CSSValuePreWrap);
+
+    return String();
 }
 
 String serializeShorthandValue(const StyleProperties& properties, CSSPropertyID shorthand)

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -66,6 +66,9 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 #endif
     }
 
+    propertySettings.cssTextWrapEnabled = true;
+    propertySettings.cssWhiteSpaceCollapseEnabled = true;
+
     StaticCSSValuePool::init();
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -142,6 +142,8 @@ private:
     bool consumeContainerShorthand(bool important);
     bool consumeContainIntrinsicSizeShorthand(bool important);
 
+    bool consumeWhiteSpaceShorthand(bool important);
+
 private:
     // Inputs:
     CSSParserTokenRange m_range;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2210,7 +2210,8 @@ RenderStyle HTMLInputElement::createInnerTextStyle(const RenderStyle& style)
     textBlockStyle.inheritFrom(style);
     adjustInnerTextStyle(style, textBlockStyle);
 
-    textBlockStyle.setWhiteSpace(WhiteSpace::Pre);
+    textBlockStyle.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
+    textBlockStyle.setTextWrap(TextWrap::NoWrap);
     textBlockStyle.setOverflowWrap(OverflowWrap::Normal);
     textBlockStyle.setOverflowX(Overflow::Hidden);
     textBlockStyle.setOverflowY(Overflow::Hidden);

--- a/Source/WebCore/html/HTMLPreElement.cpp
+++ b/Source/WebCore/html/HTMLPreElement.cpp
@@ -54,9 +54,10 @@ bool HTMLPreElement::hasPresentationalHintsForAttribute(const QualifiedName& nam
 
 void HTMLPreElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == wrapAttr)
-        style.setProperty(CSSPropertyWhiteSpace, CSSValuePreWrap);
-    else
+    if (name == wrapAttr) {
+        style.setProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+        style.setProperty(CSSPropertyTextWrap, CSSValueWrap);
+    } else
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
 }
 

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -109,7 +109,8 @@ void HTMLTableCellElement::collectPresentationalHintsForAttribute(const Qualifie
 {
     switch (name.nodeName()) {
     case AttributeNames::nowrapAttr:
-        addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValueNowrap);
+        addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpaceCollapse, CSSValueCollapse);
+        addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrap, CSSValueNowrap);
         break;
     case AttributeNames::widthAttr:
         // width="0" is not allowed for compatibility with WinIE.

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -134,10 +134,12 @@ void HTMLTextAreaElement::collectPresentationalHintsForAttribute(const Qualified
 {
     if (name == wrapAttr) {
         if (m_wrap != NoWrap) {
-            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValuePreWrap);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrap, CSSValueWrap);
             addPropertyToPresentationalHintStyle(style, CSSPropertyOverflowWrap, CSSValueBreakWord);
         } else {
-            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValuePre);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrap, CSSValueNowrap);
             addPropertyToPresentationalHintStyle(style, CSSPropertyOverflowWrap, CSSValueNormal);
         }
     } else

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -152,7 +152,8 @@ void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
     if (cue->backgroundColor().isValid())
         setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForHTML(cue->backgroundColor()));
     setInlineStyleProperty(CSSPropertyWritingMode, cue->getCSSWritingMode(), false);
-    setInlineStyleProperty(CSSPropertyWhiteSpace, CSSValuePreWrap);
+    setInlineStyleProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+    setInlineStyleProperty(CSSPropertyTextWrap, CSSValueWrap);
 
     // Make sure shadow or stroke is not clipped.
     setInlineStyleProperty(CSSPropertyOverflow, CSSValueVisible);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -234,8 +234,10 @@ void VTTCueBox::applyCSSProperties(const IntSize& videoSize)
     // alignment:
     setInlineStyleProperty(CSSPropertyTextAlign, cue->getCSSAlignment());
     
-    if (!cue->snapToLines())
-        setInlineStyleProperty(CSSPropertyWhiteSpace, CSSValuePre);
+    if (!cue->snapToLines()) {
+        setInlineStyleProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+        setInlineStyleProperty(CSSPropertyTextWrap, CSSValueNowrap);
+    }
 
     // Make sure shadow or stroke is not clipped.
     setInlineStyleProperty(CSSPropertyOverflow, CSSValueVisible);

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -81,7 +81,8 @@ RenderStyle RenderListItem::computeMarkerStyle() const
     markerStyle.setFontDescription(WTFMove(fontDescription));
     markerStyle.fontCascade().update(&document().fontSelector());
     markerStyle.setUnicodeBidi(UnicodeBidi::Isolate);
-    markerStyle.setWhiteSpace(WhiteSpace::Pre);
+    markerStyle.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
+    markerStyle.setTextWrap(TextWrap::NoWrap);
     markerStyle.setTextTransform({ });
     return markerStyle;
 }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -270,8 +270,10 @@ void RenderTheme::adjustStyle(RenderStyle& style, const Element* element, const 
             style.setPaddingBox(WTFMove(paddingBox));
 
         // Whitespace
-        if (Theme::singleton().controlRequiresPreWhiteSpace(appearance))
-            style.setWhiteSpace(WhiteSpace::Pre);
+        if (Theme::singleton().controlRequiresPreWhiteSpace(appearance)) {
+            style.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
+            style.setTextWrap(TextWrap::NoWrap);
+        }
 
         // Width / Height
         // The width and height here are affected by the zoom.

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1093,7 +1093,8 @@ void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) c
     style.setHeight(Length(LengthType::Auto));
 
     // White-space is locked to pre
-    style.setWhiteSpace(WhiteSpace::Pre);
+    style.setWhiteSpaceCollapse(WhiteSpaceCollapse::Preserve);
+    style.setTextWrap(TextWrap::NoWrap);
 
     // Set the button's vertical size.
     setSizeFromFont(style, menuListButtonSizes());

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -565,7 +565,7 @@ public:
     WEBCORE_EXPORT int computedLineHeight() const;
     int computeLineHeight(const Length&) const;
 
-    WhiteSpace whiteSpace() const { return static_cast<WhiteSpace>(m_inheritedFlags.whiteSpace); }
+    WhiteSpace whiteSpace() const;
     static constexpr bool autoWrap(WhiteSpace);
     inline bool autoWrap() const;
     static constexpr bool preserveNewline(WhiteSpace);
@@ -1215,7 +1215,6 @@ public:
     inline void setImageOrientation(ImageOrientation);
     inline void setImageRendering(ImageRendering);
 
-    void setWhiteSpace(WhiteSpace v) { m_inheritedFlags.whiteSpace = static_cast<unsigned>(v); }
     void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
     void setTextWrap(TextWrap v) { m_inheritedFlags.textWrap = static_cast<unsigned>(v); }
 
@@ -2170,10 +2169,9 @@ private:
         unsigned cursorVisibility : 1; // CursorVisibility
 #endif
         unsigned direction : 1; // TextDirection
-        unsigned whiteSpace : 3; // WhiteSpace
         unsigned whiteSpaceCollapse : 3; // WhiteSpaceCollapse
         unsigned textWrap : 3; // TextWrap
-        // 36 bits
+        // 33 bits
         unsigned borderCollapse : 1; // BorderCollapse
         unsigned boxDirection : 1; // BoxDirection
 
@@ -2183,16 +2181,16 @@ private:
         unsigned pointerEvents : 4; // PointerEvents
         unsigned insideLink : 2; // InsideLink
         unsigned insideDefaultButton : 1;
-        // 47 bits
+        // 44 bits
 
         // CSS Text Layout Module Level 3: Vertical writing support
         unsigned writingMode : 2; // WritingMode
-        // 49 bits
+        // 46 bits
 
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // 54 bits
+        // 51 bits
     };
 
     // This constructor is used to implement the replace operation.

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1307,6 +1307,7 @@ TextStream& operator<<(TextStream& ts, WhiteSpace whiteSpace)
     }
     return ts;
 }
+
 TextStream& operator<<(TextStream& ts, WhiteSpaceCollapse whiteSpaceCollapse)
 {
     switch (whiteSpaceCollapse) {

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -789,7 +789,6 @@ inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other)
         && cursorVisibility == other.cursorVisibility
 #endif
         && direction == other.direction
-        && whiteSpace == other.whiteSpace
         && whiteSpaceCollapse == other.whiteSpaceCollapse
         && textWrap == other.textWrap
         && borderCollapse == other.borderCollapse

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -83,10 +83,12 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
     case CSSPropertyTextEmphasisStyle:
     case CSSPropertyTextShadow:
     case CSSPropertyTextTransform:
+    case CSSPropertyTextWrap:
     case CSSPropertyUnicodeBidi:
     case CSSPropertyWordBreak:
     case CSSPropertyWordSpacing:
     case CSSPropertyWhiteSpace:
+    case CSSPropertyWhiteSpaceCollapse:
     case CSSPropertyAnimationDuration:
     case CSSPropertyAnimationTimingFunction:
     case CSSPropertyAnimationDelay:
@@ -139,8 +141,10 @@ bool isValidCueStyleProperty(CSSPropertyID id)
     case CSSPropertyOutlineWidth:
     case CSSPropertyVisibility:
     case CSSPropertyWhiteSpace:
+    case CSSPropertyWhiteSpaceCollapse:
     case CSSPropertyTextDecorationLine:
     case CSSPropertyTextShadow:
+    case CSSPropertyTextWrap:
     case CSSPropertyBorderStyle:
     case CSSPropertyPaintOrder:
     case CSSPropertyStrokeLinejoin:

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -452,7 +452,8 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             bool isVertical = style.marqueeDirection() == MarqueeDirection::Up || style.marqueeDirection() == MarqueeDirection::Down;
             // Make horizontal marquees not wrap.
             if (!isVertical) {
-                style.setWhiteSpace(WhiteSpace::NoWrap);
+                style.setWhiteSpaceCollapse(WhiteSpaceCollapse::Collapse);
+                style.setTextWrap(TextWrap::NoWrap);
                 style.setTextAlign(TextAlignMode::Start);
             }
             // Apparently this is the expected legacy behavior.

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -152,10 +152,13 @@ bool SVGTextContentElement::hasPresentationalHintsForAttribute(const QualifiedNa
 void SVGTextContentElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     if (name.matches(XMLNames::spaceAttr)) {
-        if (value == "preserve"_s)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValuePre);
-        else
-            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValueNowrap);
+        if (value == "preserve"_s) {
+            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrap, CSSValueNowrap);
+        } else {
+            addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpaceCollapse, CSSValueCollapse);
+            addPropertyToPresentationalHintStyle(style, CSSPropertyTextWrap, CSSValueNowrap);
+        }
         return;
     }
 


### PR DESCRIPTION
#### eff0d22edb04a7bc761bc1fb0428abef8ccbb1ba
<pre>
Implement white-space-collapse &amp; text-wrap as longhands of white-space
<a href="https://bugs.webkit.org/show_bug.cgi?id=256927">https://bugs.webkit.org/show_bug.cgi?id=256927</a>
rdar://109486221

Reviewed by Tim Nguyen.

This commit lays the groundwork for future work on white-space-collapse
and text-wrap. White-space is now parsed as a shorthand property, and
the longhand values for white-space (white-space-collapse and text-wrap)
are set accordingly.

The whiteSpace value in m_inheritedFlags in RenderStyle has been removed.
The RenderStyle.whiteSpace() method still exists, but it uses the two
longhand variables above to reconstruct the original value of whiteSpace.
The setWhiteSpace method has been removed, and any existing references
to setWhiteSpace have been replaced with the corresponding calls to
setWhiteSpaceCollapse and setTextWrap.

Further work needs to be done to properly integrate the white-space-collapse
and text-wrap longhands into WebKit. Currently, this commit preserves
the original behavior of white-space processing, but it assumes that
white-space-collapse and text-wrap only take on the combinations of
values that are achievable via the shorthand values of white-space.
(Otherwise, the whiteSpace getter in RenderStyle cannot reconstruct the
&apos;original&apos; value of white-space.) Thus, the codebase must replace
existing references to RenderStyle.whiteSpace() with appropriate references
to RenderStyle.whiteSpaceCollapse() and RenderStyle.textWrap() before
individually modifying the white-space-collapse and text-wrap properties.

* LayoutTests/fast/css/getComputedStyle/computed-style-expected.txt:
* LayoutTests/fast/css/getComputedStyle/computed-style-without-renderer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-text-wrap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space.html:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/svg/css/getComputedStyle-basic-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::getPropertyCSSValue const):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::whiteSpaceShorthandValue):
(WebCore::ComputedStyleExtractor::propertyValue):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/ComputedStyleExtractor.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serialize):
(WebCore::ShorthandSerializer::serializeWhiteSpace const):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
(WebCore::CSSPropertyParser::consumeWhiteSpaceShorthand):
(WebCore::CSSPropertyParser::parseShorthand):
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::conflictsWithInlineStyleOfElement const):
(WebCore::EditingStyle::removeStyleFromRulesAndContext):
(WebCore::StyleChange::StyleChange):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::createInnerTextStyle):
* Source/WebCore/html/HTMLPreElement.cpp:
(WebCore::HTMLPreElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
(WebCore::TextTrackCueGenericBoxElement::applyCSSProperties):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties):
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::computeMarkerStyle const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustStyle):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::adjustMenuListStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::RenderStyle):
(WebCore::RenderStyle::changeRequiresLayout const):
(WebCore::RenderStyle::whiteSpace const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::whiteSpace const): Deleted.
(WebCore::RenderStyle::setWhiteSpace): Deleted.
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::InheritedFlags::operator== const):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidMarkerStyleProperty):
(WebCore::Style::isValidCueStyleProperty):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::collectPresentationalHintsForAttribute):

Canonical link: <a href="https://commits.webkit.org/265267@main">https://commits.webkit.org/265267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/494fc6bb1da365d69c3578f7d8fb7d3650771986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12065 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11371 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12463 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16697 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9589 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9331 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2504 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->