### PR TITLE
[Curl] Remove suspend/pause-related code in CurlRequest.

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -48,11 +48,6 @@ class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequest
     WTF_MAKE_NONCOPYABLE(CurlRequest);
 
 public:
-    enum class ShouldSuspend : bool {
-        No = false,
-        Yes = true
-    };
-
     enum class EnableMultipart : bool {
         No = false,
         Yes = true
@@ -63,9 +58,9 @@ public:
         Extended
     };
 
-    static Ref<CurlRequest> create(const ResourceRequest& request, CurlRequestClient& client, ShouldSuspend shouldSuspend = ShouldSuspend::No, EnableMultipart enableMultipart = EnableMultipart::No, CaptureNetworkLoadMetrics captureMetrics = CaptureNetworkLoadMetrics::Basic)
+    static Ref<CurlRequest> create(const ResourceRequest& request, CurlRequestClient& client, EnableMultipart enableMultipart = EnableMultipart::No, CaptureNetworkLoadMetrics captureMetrics = CaptureNetworkLoadMetrics::Basic)
     {
-        return adoptRef(*new CurlRequest(request, &client, shouldSuspend, enableMultipart, captureMetrics));
+        return adoptRef(*new CurlRequest(request, &client, enableMultipart, captureMetrics));
     }
 
     virtual ~CurlRequest();
@@ -76,10 +71,8 @@ public:
     bool isServerTrustEvaluationDisabled() { return m_shouldDisableServerTrustEvaluation; }
     void disableServerTrustEvaluation() { m_shouldDisableServerTrustEvaluation = true; }
 
-    WEBCORE_EXPORT void start();
-    WEBCORE_EXPORT void cancel();
-    WEBCORE_EXPORT void suspend();
     WEBCORE_EXPORT void resume();
+    WEBCORE_EXPORT void cancel();
 
     const ResourceRequest& resourceRequest() const { return m_request; }
     bool isCancelled();
@@ -104,7 +97,7 @@ private:
         FinishTransfer
     };
 
-    WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, ShouldSuspend, EnableMultipart, CaptureNetworkLoadMetrics);
+    WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, EnableMultipart, CaptureNetworkLoadMetrics);
 
     void retain() override { ref(); }
     void release() override { deref(); }
@@ -127,7 +120,6 @@ private:
     void didCompleteTransfer(CURLcode) override;
     void didCancelTransfer() override;
     void finalizeTransfer();
-    void invokeCancel();
 
     int didReceiveDebugInfo(curl_infotype, char*, size_t);
 
@@ -142,12 +134,6 @@ private:
     bool needToInvokeDidCancelTransfer() const { return m_didNotifyResponse && !m_didReturnFromNotify && m_actionAfterInvoke == Action::FinishTransfer; }
     void invokeDidReceiveResponseForFile(const URL&);
     void invokeDidReceiveResponse(const CurlResponse&, Action);
-    void setRequestPaused(bool);
-    void setCallbackPaused(bool);
-    void pausedStatusChanged();
-    bool shouldBePaused() const { return m_isPausedOfRequest || m_isPausedOfCallback; };
-    void updateHandlePauseState(bool);
-    bool isHandlePaused() const;
 
     NetworkLoadMetrics networkLoadMetrics();
 
@@ -175,32 +161,17 @@ private:
     bool m_shouldDisableServerTrustEvaluation { false };
     bool m_enableMultipart { false };
 
-    enum class StartState : uint8_t { StartSuspended, WaitingForStart, DidStart };
-    StartState m_startState;
-    
     std::unique_ptr<CurlHandle> m_curlHandle;
     CurlFormDataStream m_formDataStream;
     std::unique_ptr<CurlMultipartHandle> m_multipartHandle;
 
     CurlResponse m_response;
+    bool m_didStartTransfer { false };
     bool m_didReceiveResponse { false };
     bool m_didNotifyResponse { false };
     bool m_didReturnFromNotify { false };
     Action m_actionAfterInvoke { Action::None };
     CURLcode m_finishedResultCode { CURLE_OK };
-
-    bool m_isPausedOfRequest { false };
-    bool m_isPausedOfCallback { false };
-    Lock m_pauseStateMutex;
-    // Following `m_isHandlePaused` is actual paused state of CurlHandle. It's required because pause
-    // request coming from main thread has a time lag until it invokes and receive callback can
-    // change the state by returning a special value. So that is must be managed by this flag.
-    // Unfortunately libcurl doesn't have an interface to check the state.
-    // There's also no need to protect this flag by the mutex because it is and MUST BE accessed only
-    // within worker thread. The access must be using accessor to detect irregular usage.
-    // [TODO] When libcurl is updated to fetch paused state, remove this state variable and
-    // setter/getter above.
-    bool m_isHandlePaused { false };
 
     Lock m_downloadMutex;
     bool m_isEnabledDownloadToFile { false };

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -90,7 +90,6 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
         m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
         m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
     }
-    m_curlRequest->start();
 }
 
 NetworkDataTaskCurl::~NetworkDataTaskCurl()
@@ -145,7 +144,7 @@ Ref<CurlRequest> NetworkDataTaskCurl::createCurlRequest(ResourceRequest&& reques
     // Creates a CurlRequest in suspended state.
     // Then, NetworkDataTaskCurl::resume() will be called and communication resumes.
     const auto captureMetrics = shouldCaptureExtraNetworkLoadMetrics() ? CurlRequest::CaptureNetworkLoadMetrics::Extended : CurlRequest::CaptureNetworkLoadMetrics::Basic;
-    return CurlRequest::create(request, *this, CurlRequest::ShouldSuspend::Yes, CurlRequest::EnableMultipart::No, captureMetrics);
+    return CurlRequest::create(request, *this, CurlRequest::EnableMultipart::No, captureMetrics);
 }
 
 void NetworkDataTaskCurl::curlDidSendData(CurlRequest&, unsigned long long totalBytesSent, unsigned long long totalBytesExpectedToSend)
@@ -397,7 +396,6 @@ void NetworkDataTaskCurl::willPerformHTTPRedirection()
             m_curlRequest->setUserPass(m_initialCredential.user(), m_initialCredential.password());
             m_curlRequest->setAuthenticationScheme(ProtectionSpace::AuthenticationScheme::HTTPBasic);
         }
-        m_curlRequest->start();
 
         if (m_state != State::Suspended) {
             m_state = State::Suspended;
@@ -517,7 +515,6 @@ void NetworkDataTaskCurl::restartWithCredential(const ProtectionSpace& protectio
     m_curlRequest->setUserPass(credential.user(), credential.password());
     if (shouldDisableServerTrustEvaluation)
         m_curlRequest->disableServerTrustEvaluation();
-    m_curlRequest->start();
 
     if (m_state != State::Suspended) {
         m_state = State::Suspended;


### PR DESCRIPTION
#### e671a9a3e20ab0ffa1246c3d69feec02d0f4e07b
<pre>
[Curl] Remove suspend/pause-related code in CurlRequest.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257578">https://bugs.webkit.org/show_bug.cgi?id=257578</a>

Reviewed by Fujii Hironori.

WinCairo WK1 was removed. As a result, most of the suspend/pause-related
controls in CurlRequest are no longer needed.

* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::CurlRequest):
(WebCore::CurlRequest::resume):
(WebCore::CurlRequest::cancel):
(WebCore::CurlRequest::setupTransfer):
(WebCore::CurlRequest::didReceiveData):
(WebCore::CurlRequest::completeDidReceiveResponse):
(WebCore::CurlRequest::start): Deleted.
(WebCore::CurlRequest::suspend): Deleted.
(WebCore::CurlRequest::setRequestPaused): Deleted.
(WebCore::CurlRequest::setCallbackPaused): Deleted.
(WebCore::CurlRequest::invokeCancel): Deleted.
(WebCore::CurlRequest::pausedStatusChanged): Deleted.
(WebCore::CurlRequest::updateHandlePauseState): Deleted.
(WebCore::CurlRequest::isHandlePaused const): Deleted.
* Source/WebCore/platform/network/curl/CurlRequest.h:
(WebCore::CurlRequest::create):
(WebCore::CurlRequest::shouldBePaused const): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::NetworkDataTaskCurl):
(WebKit::NetworkDataTaskCurl::createCurlRequest):
(WebKit::NetworkDataTaskCurl::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCurl::restartWithCredential):

Canonical link: <a href="https://commits.webkit.org/264773@main">https://commits.webkit.org/264773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50fcfe5223803636f4abf3cdfc50557013acb688

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11461 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9746 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7839 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11332 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8467 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7738 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2083 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->