### PR TITLE
Make IPC::Connection::Handle move-only.

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -43,6 +43,7 @@
 #include <wtf/threads/BinarySemaphore.h>
 
 #if PLATFORM(COCOA)
+#include "ArgumentCodersDarwin.h"
 #include "MachMessage.h"
 #include "WKCrashReporter.h"
 #endif
@@ -1444,5 +1445,23 @@ std::optional<Connection::ConnectionIdentifierPair> Connection::createConnection
     return std::nullopt;
 }
 #endif
+
+void Connection::Handle::encode(Encoder& encoder)
+{
+    encoder << WTFMove(handle);
+}
+
+std::optional<Connection::Handle> Connection::Handle::decode(Decoder& decoder)
+{
+#if USE(UNIX_DOMAIN_SOCKETS)
+    auto handle = decoder.decode<UnixFileDescriptor>();
+#elif OS(WINDOWS)
+    auto handle = decoder.decode<Win32Handle>();
+#elif OS(DARWIN)
+    auto handle = decoder.decode<MachSendRight>();
+#endif
+    return handle;
+}
+
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -134,6 +134,7 @@ def surround_in_condition(string, condition):
 
 def types_that_must_be_moved():
     return [
+        'IPC::Connection::Handle',
         'IPC::StreamServerConnection::Handle',
         'Vector<WebKit::SharedMemory::Handle>',
         'WebKit::ConsumerSharedCARingBuffer::Handle',

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -323,7 +323,7 @@ void NetworkProcessProxy::getNetworkProcessConnection(WebProcessProxy& webProces
         reply(NetworkProcessConnectionInfo { WTFMove(*identifier), cookieAcceptPolicy });
         UNUSED_VARIABLE(this);
 #elif OS(DARWIN)
-        MESSAGE_CHECK(MACH_PORT_VALID(identifier->sendRight()));
+        MESSAGE_CHECK(*identifier);
         reply(NetworkProcessConnectionInfo { WTFMove(*identifier) , cookieAcceptPolicy, connection()->getAuditToken() });
 #else
         notImplemented();

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -118,7 +118,7 @@ RefPtr<GPUProcessConnection> GPUProcessConnection::create(IPC::Connection& paren
     if (!connectionIdentifiers)
         return nullptr;
 
-    parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(connectionIdentifiers->client, getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    parentConnection.send(Messages::WebProcessProxy::CreateGPUProcessConnection(WTFMove(connectionIdentifiers->client), getGPUProcessConnectionParameters()), 0, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 
     auto instance = adoptRef(*new GPUProcessConnection(WTFMove(connectionIdentifiers->server)));
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -101,7 +101,7 @@ void WebInspectorUI::updateConnection()
     m_backendConnection = IPC::Connection::createServerConnection(connectionIdentifiers->server);
     m_backendConnection->open(*this);
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetFrontendConnection(connectionIdentifiers->client), m_inspectedPageIdentifier);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::SetFrontendConnection(WTFMove(connectionIdentifiers->client)), m_inspectedPageIdentifier);
 }
 
 void WebInspectorUI::windowObjectCleared()

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h
@@ -37,9 +37,9 @@ struct NetworkProcessConnectionInfo {
     std::optional<audit_token_t> auditToken;
 #endif
 
-    void encode(IPC::Encoder& encoder) const
+    void encode(IPC::Encoder& encoder)
     {
-        encoder << connection;
+        encoder << WTFMove(connection);
         encoder << cookieAcceptPolicy;
 #if HAVE(AUDIT_TOKEN)
         encoder << auditToken;

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp
@@ -50,7 +50,7 @@ void ConnectionTestBase::setupBase()
         return;
     }
     m_connections[0].connection = IPC::Connection::createServerConnection(WTFMove(identifiers->server));
-    m_connections[1].connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { identifiers->client.leakSendRight() });
+    m_connections[1].connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(identifiers->client) });
 }
 
 void ConnectionTestBase::teardownBase()


### PR DESCRIPTION
#### b44aa50aceaea3c7b7e4cf783c43ed93e4a4047d
<pre>
Make IPC::Connection::Handle move-only.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257579">https://bugs.webkit.org/show_bug.cgi?id=257579</a>

Reviewed by Dan Glastonbury.

Connection::Handle represents a way to construct the remote end of a connection, and its lifetime controls disconnection messages being sent to the local end.

We shouldn&apos;t ever want to copy these, only one remote end can be constructed.
t show
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::Handle::encode):
(IPC::Connection::Handle::decode):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Handle::Handle):
(IPC::Connection::Handle::operator bool const):
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::Identifier::operator bool const):
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getNetworkProcessConnection):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::create):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::updateConnection):
* Source/WebKit/WebProcess/Network/NetworkProcessConnectionInfo.h:
(WebKit::NetworkProcessConnectionInfo::encode):
(WebKit::NetworkProcessConnectionInfo::encode const): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::MockTestMessageWithConnection::arguments):
(TestWebKitAPI::MockTestMessageWithConnection::MockTestMessageWithConnection):
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.cpp:
(TestWebKitAPI::ConnectionTestBase::setupBase):

Canonical link: <a href="https://commits.webkit.org/264928@main">https://commits.webkit.org/264928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d7cb1ad3af20787d99cc08b7bd4ef8020099ed6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10828 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11957 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10268 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10984 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9295 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15837 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11836 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7357 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8248 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2218 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->