### PR TITLE
bugs.webkit.org internal server error when limiting search by 1 month

### DIFF
--- a/Websites/bugs.webkit.org/Bugzilla/Search.pm
+++ b/Websites/bugs.webkit.org/Bugzilla/Search.pm
@@ -2217,7 +2217,20 @@ sub SqlifyDate {
         my ($sec, $min, $hour, $mday, $month, $year, $wday)  = localtime($date);
         if ($sign && $sign eq '+') { $amount = -$amount; }
         $startof = 1 if $amount == 0;
-        if ($unit eq 'w') {                  # convert weeks to days
+# WEBKIT_CHANGES: Fixed invalid date returns on some occasions.
+        if ($unit eq 'm') {
+            $month -= $amount;
+            $year += floor($month/12);
+            $month %= 12;
+            if ($startof) {
+                return sprintf("%4d-%02d-01 00:00:00", $year+1900, $month+1);
+            }
+            else {
+                $amount = 31*$amount;
+                $unit = 'd';
+            }
+        }
+        elsif ($unit eq 'w') {                  # convert weeks to days
             $amount = 7*$amount;
             $amount += $wday if $startof;
             $unit = 'd';
@@ -2237,18 +2250,6 @@ sub SqlifyDate {
             else {
                 return sprintf("%4d-%02d-%02d %02d:%02d:%02d", 
                                $year+1900-$amount, $month+1, $mday, $hour, $min, $sec);
-            }
-        }
-        elsif ($unit eq 'm') {
-            $month -= $amount;
-            $year += floor($month/12);
-            $month %= 12;
-            if ($startof) {
-                return sprintf("%4d-%02d-01 00:00:00", $year+1900, $month+1);
-            }
-            else {
-                return sprintf("%4d-%02d-%02d %02d:%02d:%02d", 
-                               $year+1900, $month+1, $mday, $hour, $min, $sec);
             }
         }
         elsif ($unit eq 'h') {


### PR DESCRIPTION
#### 48759ded673b7c57b5f8bf04104bb7508098ea56
<pre>
bugs.webkit.org internal server error when limiting search by 1 month
<a href="https://bugs.webkit.org/show_bug.cgi?id=257546">https://bugs.webkit.org/show_bug.cgi?id=257546</a>
rdar://110075621

Reviewed by Alexey Proskuryakov.

Fixed SqlifyDate function in Bugzilla/Search.pm such that it multiplies month by 31 days and returns valid date.
Previously it would change only the month and keep the day of the month the same, causing invalid dates to be
returned depending on certain dates and how far to go back to.

* Websites/bugs.webkit.org/Bugzilla/Search.pm:
(SqlifyDate):

Canonical link: <a href="https://commits.webkit.org/264820@main">https://commits.webkit.org/264820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1dfaecd74a73f0c5b4274024244e62f575755ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8605 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11472 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9757 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10401 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7057 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15384 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2116 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->