### PR TITLE
Fix PS build following 264739@main

### DIFF
--- a/Source/WebCore/Modules/highlight/Highlight.h
+++ b/Source/WebCore/Modules/highlight/Highlight.h
@@ -32,7 +32,6 @@
 
 namespace WebCore {
 
-class AbstractRange;
 class CSSStyleDeclaration;
 class DOMSetAdapter;
 class PropertySetCSSStyleDeclaration;
@@ -63,7 +62,7 @@ private:
 
 class Highlight : public RefCounted<Highlight> {
 public:
-    WEBCORE_EXPORT static Ref<Highlight> create(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&&);
+    WEBCORE_EXPORT static Ref<Highlight> create(FixedVector<std::reference_wrapper<AbstractRange>>&&);
     void clearFromSetLike();
     bool addToSetLike(AbstractRange&);
     bool removeFromSetLike(const AbstractRange&);
@@ -81,7 +80,7 @@ public:
 
     // FIXME: Add WEBCORE_EXPORT CSSStyleDeclaration& style();
 private:
-    explicit Highlight(FixedVector<std::reference_wrapper<WebCore::AbstractRange>>&&);
+    explicit Highlight(FixedVector<std::reference_wrapper<AbstractRange>>&&);
 
     Vector<Ref<HighlightRangeData>> m_rangesData;
     Type m_type { Type::Highlight };

--- a/Source/WebCore/Modules/highlight/HighlightRegister.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegister.cpp
@@ -74,7 +74,7 @@ void HighlightRegister::addAnnotationHighlightWithRange(Ref<StaticRange>&& value
     if (m_map.contains(annotationHighlightKey()))
         m_map.get(annotationHighlightKey())->addToSetLike(value);
     else
-        setFromMapLike(annotationHighlightKey(), Highlight::create({ WTFMove(value) }));
+        setFromMapLike(annotationHighlightKey(), Highlight::create(FixedVector<std::reference_wrapper<AbstractRange>> { WTFMove(value) }));
 }
 
 }


### PR DESCRIPTION
#### 0de6e36e1db7e181d3eccb00a704bd00f2f4f7f9
<pre>
Fix PS build following 264739@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=257586">https://bugs.webkit.org/show_bug.cgi?id=257586</a>

Unreviewed build fix.

* Source/WebCore/Modules/highlight/Highlight.h:
* Source/WebCore/Modules/highlight/HighlightRegister.cpp:
(WebCore::HighlightRegister::addAnnotationHighlightWithRange):
Make type conversion explicit.

Canonical link: <a href="https://commits.webkit.org/264774@main">https://commits.webkit.org/264774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef371d87f2bc81a3f89c2ad6bdb272f9403896a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8607 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11475 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8735 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10403 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7059 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7851 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8483 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7753 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11964 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1013 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->