### PR TITLE
Avoid looking up WebKit's NSBundle by identifier

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -75,8 +75,7 @@ void NetworkProcess::platformInitializeNetworkProcess(const NetworkProcessCreati
 
 void NetworkProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)
 {
-    // Need to overide the default, because service has a different bundle ID.
-    auto webKitBundle = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"];
+    auto webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
 
     sandboxParameters.setOverrideSandboxProfilePath(makeString(String([webKitBundle resourcePath]), "/com.apple.WebKit.NetworkProcess.sb"));
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -224,7 +224,7 @@ int XPCServiceMain(int, const char**)
         }
 #endif
         auto webKitBundleVersion = String::fromLatin1(xpc_dictionary_get_string(bootstrap.get(), "WebKitBundleVersion"));
-        String expectedBundleVersion = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"].infoDictionary[(__bridge NSString *)kCFBundleVersionKey];
+        String expectedBundleVersion = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")].infoDictionary[(__bridge NSString *)kCFBundleVersionKey];
         if (!webKitBundleVersion.isNull() && !expectedBundleVersion.isNull() && webKitBundleVersion != expectedBundleVersion) {
             auto errorMessage = makeString("WebKit framework version mismatch: ", webKitBundleVersion, " != ", expectedBundleVersion);
             logAndSetCrashLogMessage(errorMessage.utf8().data());

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -525,7 +525,7 @@ static bool tryApplyCachedSandbox(const SandboxInfo& info)
 
 static inline const NSBundle *webKit2Bundle()
 {
-    const static NSBundle *bundle = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"];
+    const static NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
     return bundle;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/LegacyBundleForClass.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/LegacyBundleForClass.mm
@@ -34,7 +34,7 @@
 @implementation className (WKFoundationSupport) \
 + (NSBundle *)bundleForClass \
 { \
-    return [NSBundle bundleWithIdentifier:@"com.apple.WebKit"]; \
+    return [NSBundle bundleForClass:NSClassFromString(@"WKWebView")]; \
 } \
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/WKSafeBrowsingWarning.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKSafeBrowsingWarning.mm
@@ -110,7 +110,7 @@ static WebCore::CocoaColor *colorForItem(WarningItem item, ViewType *warning)
 
     auto colorNamed = [] (NSString *name) -> WebCore::CocoaColor * {
 #if HAVE(SAFE_BROWSING)
-        return [NSColor colorNamed:name bundle:[NSBundle bundleWithIdentifier:@"com.apple.WebKit"]];
+        return [NSColor colorNamed:name bundle:[NSBundle bundleForClass:NSClassFromString(@"WKWebView")]];
 #else
         ASSERT_NOT_REACHED();
         return nil;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -79,7 +79,7 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& WebProcessProxy::platform
 {
     static NeverDestroyed<MemoryCompactLookupOnlyRobinHoodHashSet<String>> platformPathsWithAssumedReadAccess(std::initializer_list<String> {
         [NSBundle bundleWithIdentifier:@"com.apple.WebCore"].resourcePath.stringByStandardizingPath,
-        [NSBundle bundleWithIdentifier:@"com.apple.WebKit"].resourcePath.stringByStandardizingPath
+        [NSBundle bundleForClass:NSClassFromString(@"WKWebView")].resourcePath.stringByStandardizingPath
     });
 
     return platformPathsWithAssumedReadAccess;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -123,7 +123,7 @@ void ProcessLauncher::launchProcess()
     }
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    xpc_dictionary_set_string(initializationMessage.get(), "WebKitBundleVersion", [[NSBundle bundleWithIdentifier:@"com.apple.WebKit"].infoDictionary[(__bridge NSString *)kCFBundleVersionKey] UTF8String]);
+    xpc_dictionary_set_string(initializationMessage.get(), "WebKitBundleVersion", [[NSBundle bundleForClass:NSClassFromString(@"WKWebView")].infoDictionary[(__bridge NSString *)kCFBundleVersionKey] UTF8String]);
 #endif
     xpc_connection_set_bootstrap(m_xpcConnection.get(), initializationMessage.get());
 
@@ -188,7 +188,7 @@ void ProcessLauncher::launchProcess()
         xpc_dictionary_set_bool(bootstrapMessage.get(), "disable-logging", disableLogging);
     }
 
-    bool isWebKitDevelopmentBuild = ![[[[NSBundle bundleWithIdentifier:@"com.apple.WebKit"] bundlePath] stringByDeletingLastPathComponent] hasPrefix:FileSystem::systemDirectoryPath()];
+    bool isWebKitDevelopmentBuild = ![[[[NSBundle bundleForClass:NSClassFromString(@"WKWebView")] bundlePath] stringByDeletingLastPathComponent] hasPrefix:FileSystem::systemDirectoryPath()];
     if (isWebKitDevelopmentBuild) {
         xpc_dictionary_set_fd(bootstrapMessage.get(), "stdout", STDOUT_FILENO);
         xpc_dictionary_set_fd(bootstrapMessage.get(), "stderr", STDERR_FILENO);

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -802,8 +802,7 @@ RetainPtr<CFDataRef> WebProcess::sourceApplicationAuditData() const
 void WebProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)
 {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-    // Need to override the default, because service has a different bundle ID.
-    auto webKitBundle = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"];
+    auto webKitBundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
 
 #if defined(USE_VORBIS_AUDIOCOMPONENT_WORKAROUND)
     // We need to initialize the Vorbis decoder before the sandbox gets setup; this is a one off action.

--- a/Source/WebKit/webpushd/WebPushDaemonMain.mm
+++ b/Source/WebKit/webpushd/WebPushDaemonMain.mm
@@ -78,7 +78,7 @@ namespace WebKit {
 static void applySandbox()
 {
 #if PLATFORM(MAC)
-    NSBundle *bundle = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"];
+    NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
     auto profilePath = makeString(String([bundle resourcePath]), "/com.apple.WebKit.webpushd.mac.sb"_s);
     if (FileSystem::fileExists(profilePath)) {
         AuxiliaryProcess::applySandboxProfileForDaemon(profilePath, "com.apple.webkit.webpushd"_s);


### PR DESCRIPTION
#### d355b67319be743fa225a00028bffd4ee50a75e4
<pre>
Avoid looking up WebKit&apos;s NSBundle by identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=257588">https://bugs.webkit.org/show_bug.cgi?id=257588</a>
rdar://109729179

Reviewed by Chris Dumez.

Some WebKit code that looks up WebKit&apos;s NSBundle does so by finding the bundle associated with the
WKWebView class, but most such code does so by looking up the WebKit bundle by its identifier. The
latter approach has a fundamental weakness that the &quot;com.apple.WebKit&quot; NSBundle technically isn&apos;t
guaranteed to be a singleton, with one &quot;correct&quot; answer. A process that links a non-system WebKit
has the potential to be sabotaged if stray code in the OS attempts to load the NSBundle at the path
&quot;/System/Library/Frameworks/WebKit.framework&quot; explicitly. NSBundle is happy to return an instance
that can be used to access resources in that system WebKit.framework bundle, and that bundle will
become the result if one looks up the NSBundle for the identifier &quot;com.apple.WebKit&quot;. This can have
the awful consequence that web processes will crash on launch due to an alleged mismatch between
the WebKit version observed by the ProcessLauncher and the version observed by the Web Process.

Add hardening to protect against this snafu by reworking all NSBundle lookups to operate based on
+bundleForClass:, like the GPUProcess and `WebProcessProxy::shouldAllowNonValidInjectedCode()`
have been doing. This ensures these call sites will find the NSBundle for the One True WebKit,
since only *one* DYLD image will be loaded into the process even if code tries to dlopen
/S/L/F/WebKit.framework/WebKit.

* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::initializeSandbox):
    Remove a comment that doesn&apos;t seem very clear or explain much of what&apos;s happening. Presumably
    this comment might have dated back to a time when this file was compiled into the Network
    Process target directly (in which case it would have been true that WebKit.framework is a
    &quot;different&quot; bundle relative to this code), but that is no longer the case.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceMain):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::webKit2Bundle):
* Source/WebKit/UIProcess/API/Cocoa/LegacyBundleForClass.mm:
* Source/WebKit/UIProcess/Cocoa/WKSafeBrowsingWarning.mm:
(colorForItem):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::platformPathsWithAssumedReadAccess):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::initializeSandbox):
    Ditto NetworkProcess::initializeSandbox().
* Source/WebKit/webpushd/WebPushDaemonMain.mm:
(WebKit::applySandbox):

Canonical link: <a href="https://commits.webkit.org/264801@main">https://commits.webkit.org/264801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4873ba3530c870dffbacbbd0f26b29cbc858cc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9766 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10413 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7066 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6929 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7763 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->