### PR TITLE
[Curl] Remove download-related code in CurlRequest

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -32,8 +32,6 @@
 #include "CurlResponse.h"
 #include "ProtectionSpace.h"
 #include "ResourceRequest.h"
-#include <wtf/FileSystem.h>
-#include <wtf/MessageQueue.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Noncopyable.h>
 
@@ -85,10 +83,6 @@ public:
     // Processing for DidReceiveResponse
     WEBCORE_EXPORT void completeDidReceiveResponse();
 
-    // Download
-    void enableDownloadToFile();
-    const String& getDownloadedFilePath();
-
 private:
     enum class Action {
         None,
@@ -137,11 +131,6 @@ private:
 
     NetworkLoadMetrics networkLoadMetrics();
 
-    // Download
-    void writeDataToDownloadFileIfEnabled(const FragmentedSharedBuffer&);
-    void closeDownloadFile();
-    void cleanupDownloadFile();
-
     // Callback functions for curl
     static size_t willSendDataCallback(char*, size_t, size_t, void*);
     static size_t didReceiveHeaderCallback(char*, size_t, size_t, void*);
@@ -172,11 +161,6 @@ private:
     bool m_didReturnFromNotify { false };
     Action m_actionAfterInvoke { Action::None };
     CURLcode m_finishedResultCode { CURLE_OK };
-
-    Lock m_downloadMutex;
-    bool m_isEnabledDownloadToFile { false };
-    String m_downloadFilePath;
-    FileSystem::PlatformFileHandle m_downloadFileHandle { FileSystem::invalidPlatformFileHandle };
 
     bool m_captureExtraMetrics;
     HTTPHeaderMap m_requestHeaders;


### PR DESCRIPTION
#### 3d96d2e0cc608ad4d77d7e5214ed2dc82838d02f
<pre>
[Curl] Remove download-related code in CurlRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=257591">https://bugs.webkit.org/show_bug.cgi?id=257591</a>

Reviewed by Fujii Hironori.

CurlDownload has been removed so download-related code in CurlRequest
is no longer needed.

* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didReceiveData):
(WebCore::CurlRequest::didCancelTransfer):
(WebCore::CurlRequest::finalizeTransfer):
(WebCore::CurlRequest::enableDownloadToFile): Deleted.
(WebCore::CurlRequest::getDownloadedFilePath): Deleted.
(WebCore::CurlRequest::writeDataToDownloadFileIfEnabled): Deleted.
(WebCore::CurlRequest::closeDownloadFile): Deleted.
(WebCore::CurlRequest::cleanupDownloadFile): Deleted.
* Source/WebCore/platform/network/curl/CurlRequest.h:

Canonical link: <a href="https://commits.webkit.org/264779@main">https://commits.webkit.org/264779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65836f1410682fd31fdc43e78405c15786f39f56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8863 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/11484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8746 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10414 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7862 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15394 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11975 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1016 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->