### PR TITLE
[GStreamer] Create and activate the GstGLContext in the compositing thread

### DIFF
--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -45,6 +45,8 @@ editing/gtk/WebContentReaderGtk.cpp
 
 loader/soup/ResourceLoaderSoup.cpp
 
+page/gstreamer/PageGStreamer.cpp @no-unify
+
 page/gtk/DragControllerGtk.cpp
 
 page/linux/ResourceUsageOverlayLinux.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -48,6 +48,8 @@ loader/soup/ResourceLoaderSoup.cpp
 page/linux/ResourceUsageOverlayLinux.cpp
 page/linux/ResourceUsageThreadLinux.cpp
 
+page/gstreamer/PageGStreamer.cpp @no-unify
+
 page/scrolling/nicosia/ScrollingCoordinatorNicosia.cpp
 page/scrolling/nicosia/ScrollingStateNodeNicosia.cpp
 page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7816,6 +7816,17 @@ void HTMLMediaElement::mediaPlayerGetRawCookies(const URL& url, MediaPlayerClien
 
 #endif
 
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+GstGLContext* HTMLMediaElement::mediaPlayerGstGLContext() const
+{
+    auto* page = document().page();
+    if (!page)
+        return nullptr;
+
+    return page->gstGLContext();
+}
+#endif
+
 void HTMLMediaElement::mediaPlayerEngineFailedToLoad() const
 {
     if (!m_player)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -802,6 +802,10 @@ private:
     void mediaPlayerGetRawCookies(const URL&, MediaPlayerClient::GetRawCookiesCallback&&) const final;
 #endif
 
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+    GstGLContext* mediaPlayerGstGLContext() const final;
+#endif
+
     void mediaPlayerEngineFailedToLoad() const final;
 
     double mediaPlayerRequestedPlaybackRate() const final;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -85,6 +85,15 @@
 #include "DeviceOrientationUpdateProvider.h"
 #endif
 
+#if USE(COORDINATED_GRAPHICS)
+#include <wtf/RunLoop.h>
+#if ENABLE(VIDEO) && USE(GSTREAMER_GL)
+#include "GRefPtrGStreamer.h"
+
+typedef struct _GstGLContext GstGLContext;
+#endif
+#endif
+
 namespace JSC {
 class Debugger;
 }
@@ -1054,6 +1063,20 @@ public:
     const WeakHashSet<LocalFrame>& rootFrames() const { return m_rootFrames; }
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
 
+#if USE(COORDINATED_GRAPHICS)
+    void setCompositingRunLoop(RunLoop* runLoop)
+    {
+        m_compositingRunLoop = runLoop;
+#if ENABLE(VIDEO) && USE(GSTREAMER_GL)
+        m_gstGLContext = nullptr;
+#endif
+    }
+    RunLoop* compositingRunLoop() const { return m_compositingRunLoop.get(); }
+#if ENABLE(VIDEO) && USE(GSTREAMER_GL)
+    GstGLContext* gstGLContext();
+#endif
+#endif
+
 private:
     struct Navigation {
         RegistrableDomain domain;
@@ -1426,6 +1449,13 @@ private:
     Ref<BadgeClient> m_badgeClient;
 
     HashMap<RegistrableDomain, uint64_t> m_noiseInjectionHashSalts;
+
+#if USE(COORDINATED_GRAPHICS)
+    RefPtr<RunLoop> m_compositingRunLoop;
+#if ENABLE(VIDEO) && USE(GSTREAMER_GL)
+    GRefPtr<GstGLContext> m_gstGLContext;
+#endif
+#endif
 };
 
 inline PageGroup& Page::group()

--- a/Source/WebCore/page/gstreamer/PageGStreamer.cpp
+++ b/Source/WebCore/page/gstreamer/PageGStreamer.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (C) 2023 Igalia, S.L
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "config.h"
+#include "Page.h"
+
+#if ENABLE(VIDEO) && USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+#include "GLContext.h"
+#include "PlatformDisplay.h"
+#include <epoxy/egl.h>
+#define GST_USE_UNSTABLE_API
+#include <gst/gl/gl.h>
+#undef GST_USE_UNSTABLE_API
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
+#define GST_CAT_DEFAULT webkit_media_player_debug
+
+namespace WebCore {
+
+#if USE(EGL)
+static GstGLAPI queryGstGLAPI()
+{
+    switch (eglQueryAPI()) {
+    case EGL_OPENGL_API:
+        return GST_GL_API_OPENGL;
+    case EGL_OPENGL_ES_API:
+        return GST_GL_API_GLES2;
+    default:
+        break;
+    }
+
+    return GST_GL_API_NONE;
+}
+#endif
+
+GstGLContext* Page::gstGLContext()
+{
+#if USE(EGL)
+    if (m_gstGLContext)
+        return m_gstGLContext.get();
+
+    if (!m_compositingRunLoop)
+        return nullptr;
+
+    auto* gstGLDisplay = PlatformDisplay::sharedDisplayForCompositing().gstGLDisplay();
+    if (!gstGLDisplay)
+        return nullptr;
+
+    GRefPtr<GstGLContext> gstGLContext;
+    BinarySemaphore semaphore;
+    m_compositingRunLoop->dispatch([&semaphore, gstGLDisplay, &gstGLContext]() {
+        if (auto* context = GLContext::current()) {
+            GstGLAPI glAPI = queryGstGLAPI();
+            if (glAPI != GST_GL_API_NONE) {
+                gstGLContext = adoptGRef(gst_gl_context_new_wrapped(gstGLDisplay, reinterpret_cast<guintptr>(context->platformContext()), GST_GL_PLATFORM_EGL, glAPI));
+                if (gst_gl_context_activate(gstGLContext.get(), TRUE)) {
+                    GUniqueOutPtr<GError> error;
+                    if (!gst_gl_context_fill_info(gstGLContext.get(), &error.outPtr()))
+                        GST_WARNING("Failed to fill in GStreamer context: %s", error->message);
+                } else
+                    GST_WARNING("Failed to activate GStreamer context %" GST_PTR_FORMAT, gstGLContext.get());
+            }
+        }
+        semaphore.signal();
+    });
+    semaphore.wait();
+
+    if (!gstGLContext)
+        return nullptr;
+
+    m_gstGLContext = WTFMove(gstGLContext);
+    return m_gstGLContext.get();
+#else
+    return nullptr;
+#endif
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(VIDEO) && USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1629,6 +1629,13 @@ void MediaPlayer::simulateAudioInterruption()
 
     m_private->simulateAudioInterruption();
 }
+
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+GstGLContext* MediaPlayer::gstGLContext()
+{
+    return client().mediaPlayerGstGLContext();
+}
+#endif
 #endif
 
 void MediaPlayer::beginSimulatedHDCPError()

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -58,6 +58,10 @@ OBJC_CLASS NSArray;
 typedef struct __CVBuffer* CVPixelBufferRef;
 #endif
 
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+typedef struct _GstGLContext GstGLContext;
+#endif
+
 namespace WTF {
 class MachSendRight;
 }
@@ -289,6 +293,10 @@ public:
 
 #if PLATFORM(COCOA)
     virtual void mediaPlayerOnNewVideoFrameMetadata(VideoFrameMetadata&&, RetainPtr<CVPixelBufferRef>&&) { }
+#endif
+
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+    virtual GstGLContext* mediaPlayerGstGLContext() const { return nullptr; }
 #endif
 
     virtual bool mediaPlayerPrefersSandboxedParsing() const { return false; }
@@ -619,6 +627,9 @@ public:
 
 #if USE(GSTREAMER)
     void simulateAudioInterruption();
+#if USE(COORDINATED_GRAPHICS) && USE(GSTREAMER_GL)
+    GstGLContext* gstGLContext();
+#endif
 #endif
 
     void beginSimulatedHDCPError();

--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -351,7 +351,6 @@ void PlatformDisplay::terminateEGLDisplay()
 {
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLDisplay = nullptr;
-    m_gstGLContext = nullptr;
 #endif
     clearSharingGLContext();
     ASSERT(m_eglDisplayInitialized);

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -51,7 +51,6 @@ typedef struct _GdkDisplay GdkDisplay;
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
 #include "GRefPtrGStreamer.h"
 
-typedef struct _GstGLContext GstGLContext;
 typedef struct _GstGLDisplay GstGLDisplay;
 #endif // ENABLE(VIDEO) && USE(GSTREAMER_GL)
 
@@ -125,7 +124,6 @@ public:
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     GstGLDisplay* gstGLDisplay() const;
-    GstGLContext* gstGLContext() const;
 #endif
 
 #if USE(LCMS)
@@ -189,10 +187,7 @@ private:
 #endif
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
-    bool tryEnsureGstGLContext() const;
-
     mutable GRefPtr<GstGLDisplay> m_gstGLDisplay;
-    mutable GRefPtr<GstGLContext> m_gstGLContext;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -81,7 +81,9 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
 
     m_compositor = ThreadedCompositor::create(*this, *this, m_displayID, scaledSize, scaleFactor, paintFlags);
     m_layerTreeContext.contextID = m_surface->surfaceID();
-    m_surface->didCreateCompositingRunLoop(m_compositor->compositingRunLoop());
+    auto& compositingRunLoop = m_compositor->compositingRunLoop();
+    m_surface->didCreateCompositingRunLoop(compositingRunLoop);
+    m_webPage.corePage()->setCompositingRunLoop(&compositingRunLoop);
 
     didChangeViewport();
 }
@@ -91,6 +93,7 @@ LayerTreeHost::~LayerTreeHost()
     cancelPendingLayerFlush();
 
     m_surface->willDestroyCompositingRunLoop();
+    m_webPage.corePage()->setCompositingRunLoop(nullptr);
     m_coordinator.invalidate();
     m_compositor->invalidate();
     m_surface = nullptr;


### PR DESCRIPTION
#### b29369ca29f1e05208abcdc133c055f309209691
<pre>
[GStreamer] Create and activate the GstGLContext in the compositing thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=257599">https://bugs.webkit.org/show_bug.cgi?id=257599</a>

Reviewed by NOBODY (OOPS!).

We currently create the GstGLContext wrapping the sharing context and
it&apos;s activated in the main thread. That means, among other things, that
gst sends all GL operations on the context to the main thread. Another
side effect is that the sharing context is made current in the main
thread and remains forever. This patch creates the GstGLContext wrapping
the compositing GL context and activated in the compositing thread,
ensuring all GL operations happen in the compositing thread.

* Source/WebCore/SourcesGTK.txt: Add PageGStreamer.cpp to compilation.
* Source/WebCore/SourcesWPE.txt: Ditto.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerGstGLContext const): Get the GstGLContext from the Page.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::setCompositingRunLoop): Set the compositing RunLoop and reset the GstGLContext.
(WebCore::Page::compositingRunLoop const): Get the compositing RunLoop.
* Source/WebCore/page/gstreamer/PageGStreamer.cpp: Added.
(WebCore::queryGstGLAPI): Helper to get the GstGLAPI of the current GL context.
(WebCore::Page::gstGLContext): Get or create the GstGLContext.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::gstGLContext): Ask the client for the GstGLContext.
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerGstGLContext const):
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::terminateEGLDisplay): Remove GstGLContext from PlatformDisplay.
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webkit_gl_video_sink_class_init): Remove change_state, since the context is now set by
MediaPlayerPrivateGStreamer on needs-context message.
(webKitGLVideoSinkProbePlatform): Remove the check of GstGLDisplay.
(requestGLContext): Deleted.
(setGLContext): Deleted.
(webKitGLVideoSinkChangeState): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleNeedContextMessage): Handle GL display and context messages.
(WebCore::MediaPlayerPrivateGStreamer::createVideoSinkGL): Check we have a GstGLContext.
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::PlatformDisplay::gstGLDisplay const): Simplify to just get or create the GstGLDisplay.
(createGstGLDisplay): Deleted.
(PlatformDisplay::tryEnsureGstGLContext const): Deleted.
(PlatformDisplay::gstGLDisplay const): Deleted.
(PlatformDisplay::gstGLContext const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost): Set the compositing run loop on the page.
(WebKit::LayerTreeHost::~LayerTreeHost): Reset the compositing run loop on the page.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b29369ca29f1e05208abcdc133c055f309209691

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8630 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11500 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9784 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10435 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7882 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15414 "1 flakes 114 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11375 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8515 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->