### PR TITLE
[WGSL] Variables initializer shouldn't be a reference

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -226,6 +226,11 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
         result = resolve(*variable.maybeTypeName());
     if (variable.maybeInitializer()) {
         auto* initializerType = infer(*variable.maybeInitializer());
+        if (auto* reference = std::get_if<Types::Reference>(initializerType)) {
+            initializerType = reference->element;
+            variable.maybeInitializer()->m_inferredType = initializerType;
+        }
+
         if (!result)
             result = initializerType;
         else if (unify(result, initializerType))

--- a/Source/WebGPU/WGSL/tests/valid/var-initialization-with-var.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/var-initialization-with-var.wgsl
@@ -1,0 +1,15 @@
+// RUN: %metal main 2>&1 | %check
+
+fn f(x: f32) { }
+
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK: float local\d+ = 1
+  var a = 1.0;
+  // CHECK: float local\d+ = local\d
+  var b = a;
+  // CHECK: local\d+ = 0
+  b = 0.0;
+  // CHECK: f\(local\d+\)
+  _ = f(b);
+}


### PR DESCRIPTION
#### e90fdfdcdf8ca3d871a80896ba5e635b83c172e4
<pre>
[WGSL] Variables initializer shouldn&apos;t be a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=257601">https://bugs.webkit.org/show_bug.cgi?id=257601</a>
rdar://110105334

Reviewed by Mike Wyrzykowski.

When initializing a variable, the value used to initialize it should be unpacked
if it&apos;s a reference. E.g.:

var a = 0;
var b = a;
b = 1;

The above program should not change the value of `a`, and references to `b` should
have type `ref&lt;i32&gt;`, not `ref&lt;ref&lt;i32&gt;&gt;`. In order to fix that, when we infer the
type of a variable initializer (which doesn&apos;t have an explicit type annotation), if
the is a reference (as it would be for `a` in the example above, which would have type
`ref&lt;i32&gt;`), we should use the referenced type instead (i.e. `i32` in this example)

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):

Canonical link: <a href="https://commits.webkit.org/264860@main">https://commits.webkit.org/264860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3d86545702d9514808a005fc6f2e6aa4db02903

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8904 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10060 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10736 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7355 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15647 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8464 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11635 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8056 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2157 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->