### PR TITLE
Reimport css/css-scrollbars WPT tests.

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -2931,6 +2931,7 @@
         "web-platform-tests/css/css-scroll-snap/support/scroll-target-margin-001-iframe.html",
         "web-platform-tests/css/css-scroll-snap/support/scroll-target-padding-001-iframe.html",
         "web-platform-tests/css/css-scroll-snap/support/scroll-target-snap-001-iframe.html",
+        "web-platform-tests/css/css-scrollbars/input-scrollbar-color-ref.html",
         "web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001-ref.html",
         "web-platform-tests/css/css-scrollbars/scrollbar-width-paint-002-ref.html",
         "web-platform-tests/css/css-scrollbars/scrollbar-width-paint-003-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
+<input>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Reference</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
+<input>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Test: scrollbar-color shouldn't cause scrollbars in inputs</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color">
+<link rel="match" href="input-scrollbar-color-ref.html">
+<style>
+    :root {
+        scrollbar-color: red yellow;
+    }
+</style>
+<input>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing-expected.txt
@@ -1,0 +1,15 @@
+
+FAIL e.style['scrollbar-color'] = "initial" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "unset" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "revert" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "red green" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "#FF0000 #00FF00" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['scrollbar-color'] = "currentcolor currentcolor" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['scrollbar-color'] = "" should not set the property value
+PASS e.style['scrollbar-color'] = "auto auto" should not set the property value
+PASS e.style['scrollbar-color'] = "auto currentcolor" should not set the property value
+PASS e.style['scrollbar-color'] = "red" should not set the property value
+PASS e.style['scrollbar-color'] = "#FF0000" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: parsing scrollbar-color declarations</title>
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars/"/>
+<meta name="assert" content="Parsing scrollbar-color declarations">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+
+<script>
+    test_valid_value('scrollbar-color', 'initial');
+    test_valid_value('scrollbar-color', 'inherit');
+    test_valid_value('scrollbar-color', 'unset');
+    test_valid_value('scrollbar-color', 'revert');
+    test_valid_value('scrollbar-color', 'auto');
+    test_valid_value("scrollbar-color", "red green");
+    test_valid_value("scrollbar-color", "#FF0000 #00FF00", "rgb(255, 0, 0) rgb(0, 255, 0)");
+    test_valid_value("scrollbar-color", "currentcolor currentcolor");
+
+    test_invalid_value("scrollbar-color", "");
+    test_invalid_value("scrollbar-color", "auto auto");
+    test_invalid_value("scrollbar-color", "auto currentcolor");
+    test_invalid_value("scrollbar-color", "red");
+    test_invalid_value("scrollbar-color", "#FF0000");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/w3c-import.log
@@ -17,7 +17,11 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/auto-scrollbar-inline-children.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/inheritance.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/multicol-in-orthogonal-writing-mode-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-002.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-003.html
@@ -26,6 +30,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-008.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-keywords.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001-ref.html


### PR DESCRIPTION
#### 12222b2a21138d94248c76a0f49a0c09f41291f1
<pre>
Reimport css/css-scrollbars WPT tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257570">https://bugs.webkit.org/show_bug.cgi?id=257570</a>

Reviewed by Tim Nguyen.

Reimport css/css-scrollbars WPT tests, this is to get the scrollbar-color-parsing test.

WPT Commit: ceb8a99f802f1b8193ce8a611374c0991933334b

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/input-scrollbar-color.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-parsing.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/264793@main">https://commits.webkit.org/264793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00670d32c07ad1b2807e781a6f2703b53d3844f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9795 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10443 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7888 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11379 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7799 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2098 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->