### PR TITLE
[GStreamer] Do not activate and fill the gst GL context

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -254,6 +254,9 @@ GLContext* PlatformDisplay::sharingGLContext()
 
 void PlatformDisplay::clearSharingGLContext()
 {
+#if ENABLE(VIDEO) && USE(GSTREAMER_GL)
+    m_gstGLContext = nullptr;
+#endif
     m_sharingGLContext = nullptr;
 }
 #endif
@@ -351,7 +354,6 @@ void PlatformDisplay::terminateEGLDisplay()
 {
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
     m_gstGLDisplay = nullptr;
-    m_gstGLContext = nullptr;
 #endif
     clearSharingGLContext();
     ASSERT(m_eglDisplayInitialized);

--- a/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
@@ -20,24 +20,8 @@
 #include "config.h"
 #include "PlatformDisplay.h"
 
-#include "GStreamerCommon.h"
-
-#if USE(EGL)
 #include "GLContext.h"
-#endif
-
-#if PLATFORM(X11)
-#include "PlatformDisplayX11.h"
-#endif
-
-#if PLATFORM(WAYLAND)
-#include "PlatformDisplayWayland.h"
-#endif
-
-#if USE(WPE_RENDERER)
-#include "PlatformDisplayLibWPE.h"
-#endif
-
+#include "GStreamerCommon.h"
 #define GST_USE_UNSTABLE_API
 #include <gst/gl/gl.h>
 #if USE(EGL) && GST_GL_HAVE_PLATFORM_EGL
@@ -45,72 +29,34 @@
 #endif
 #undef GST_USE_UNSTABLE_API
 
-GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
-#define GST_CAT_DEFAULT webkit_media_player_debug
-
-using namespace WebCore;
-
-static GstGLDisplay* createGstGLDisplay(const PlatformDisplay& sharedDisplay)
-{
-#if USE(EGL)
-    return GST_GL_DISPLAY(gst_gl_display_egl_new_with_egl_display(sharedDisplay.eglDisplay()));
-#else
-    return nullptr;
-#endif
-}
-
-bool PlatformDisplay::tryEnsureGstGLContext() const
-{
-    if (m_gstGLDisplay && m_gstGLContext)
-        return true;
-
-#if USE(OPENGL_ES)
-    GstGLAPI glAPI = GST_GL_API_GLES2;
-#elif USE(OPENGL)
-    GstGLAPI glAPI = GST_GL_API_OPENGL;
-#else
-    return false;
-#endif
-
-    auto* sharedContext = const_cast<PlatformDisplay*>(this)->sharingGLContext();
-    if (!sharedContext)
-        return false;
-
-    GCGLContext contextHandle = sharedContext->platformContext();
-    if (!contextHandle)
-        return false;
-
-    m_gstGLDisplay = adoptGRef(createGstGLDisplay(*this));
-    if (!m_gstGLDisplay)
-        return false;
-
-    m_gstGLContext = adoptGRef(gst_gl_context_new_wrapped(m_gstGLDisplay.get(), reinterpret_cast<guintptr>(contextHandle), GST_GL_PLATFORM_EGL, glAPI));
-
-    // Activate and fill the GStreamer wrapped context with the Webkit's shared one.
-    auto* previousActiveContext = GLContext::current();
-    sharedContext->makeContextCurrent();
-    if (gst_gl_context_activate(m_gstGLContext.get(), TRUE)) {
-        GUniqueOutPtr<GError> error;
-        if (!gst_gl_context_fill_info(m_gstGLContext.get(), &error.outPtr()))
-            GST_WARNING("Failed to fill in GStreamer context: %s", error->message);
-    } else
-        GST_WARNING("Failed to activate GStreamer context %" GST_PTR_FORMAT, m_gstGLContext.get());
-    if (previousActiveContext)
-        previousActiveContext->makeContextCurrent();
-
-    return true;
-}
+namespace WebCore {
 
 GstGLDisplay* PlatformDisplay::gstGLDisplay() const
 {
-    if (!tryEnsureGstGLContext())
-        return nullptr;
+#if USE(EGL)
+    if (!m_gstGLDisplay)
+        m_gstGLDisplay = adoptGRef(GST_GL_DISPLAY(gst_gl_display_egl_new_with_egl_display(eglDisplay())));
+#endif
     return m_gstGLDisplay.get();
 }
 
 GstGLContext* PlatformDisplay::gstGLContext() const
 {
-    if (!tryEnsureGstGLContext())
-        return nullptr;
+#if USE(EGL)
+    if (!m_gstGLContext) {
+        if (auto* gstDisplay = gstGLDisplay()) {
+            if (auto* context = const_cast<PlatformDisplay*>(this)->sharingGLContext()) {
+#if USE(OPENGL_ES)
+                GstGLAPI glAPI = GST_GL_API_GLES2;
+#elif USE(OPENGL)
+                GstGLAPI glAPI = GST_GL_API_OPENGL;
+#endif
+                m_gstGLContext = adoptGRef(gst_gl_context_new_wrapped(gstDisplay, reinterpret_cast<guintptr>(context->platformContext()), GST_GL_PLATFORM_EGL, glAPI));
+            }
+        }
+    }
+#endif
     return m_gstGLContext.get();
 }
+
+} // namespace WebCore


### PR DESCRIPTION
#### d4b48c26573684c9cb7b5612f92b7c4f4b9fc784
<pre>
[GStreamer] Do not activate and fill the gst GL context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257599">https://bugs.webkit.org/show_bug.cgi?id=257599</a>

Reviewed by Miguel Gomez.

It&apos;s only used as a sharing context, so it doesn&apos;t need to be activated
and filled. This way we avoid making the sharing context the current
one in the main thread forever.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::clearSharingGLContext):
(WebCore::PlatformDisplay::terminateEGLDisplay):
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::PlatformDisplay::gstGLDisplay const):
(WebCore::PlatformDisplay::gstGLContext const):
(createGstGLDisplay): Deleted.
(PlatformDisplay::tryEnsureGstGLContext const): Deleted.
(PlatformDisplay::gstGLDisplay const): Deleted.
(PlatformDisplay::gstGLContext const): Deleted.

Canonical link: <a href="https://commits.webkit.org/264826@main">https://commits.webkit.org/264826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a23ee25c831b8b276a527914c02f2fb36d88c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10286 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8647 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11509 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9794 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10444 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15419 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11382 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7794 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2121 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->