### PR TITLE
[buildbot] Add watchos to test-result-archive

### DIFF
--- a/Tools/CISupport/test-result-archive
+++ b/Tools/CISupport/test-result-archive
@@ -59,7 +59,7 @@ def compress_spindumps(layoutTestResultsDir):
                     gzip_file(root, name)
 
 def archive_test_results(configuration, platform, layoutTestResultsDir):
-    assert platform in ('mac', 'win', 'gtk', 'wincairo', 'ios', 'wpe')
+    assert platform in ('mac', 'win', 'gtk', 'wincairo', 'ios', 'watchos', 'wpe')
 
     try:
         os.unlink(archiveFile)
@@ -76,7 +76,7 @@ def archive_test_results(configuration, platform, layoutTestResultsDir):
 
     open(os.path.join(layoutTestResultsDir, '.placeholder'), 'w').close()
 
-    if platform in ('mac', 'ios'):
+    if platform in ('mac', 'ios', 'watchos'):
         compress_spindumps(layoutTestResultsDir)
         if subprocess.call(["ditto", "-c", "-k", "--sequesterRsrc", "--zlibCompressionLevel", "2", layoutTestResultsDir, archiveFile]):
             return 1


### PR DESCRIPTION
#### 61ab9d41944ce4dbd4b9518c8ab078f78b298da3
<pre>
[buildbot] Add watchos to test-result-archive
<a href="https://bugs.webkit.org/show_bug.cgi?id=257603">https://bugs.webkit.org/show_bug.cgi?id=257603</a>
rdar://110114331

Reviewed by Ryan Haddad.

* Tools/CISupport/test-result-archive: Add watchos.

Canonical link: <a href="https://commits.webkit.org/264800@main">https://commits.webkit.org/264800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c96a505b703386975eeb7570da831aed4a3aafc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11515 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9804 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10453 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7898 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6958 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12014 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1022 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->