### PR TITLE
REGRESSION(264795@main) media/video-object-fit.html test is failing

### DIFF
--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -318,14 +318,16 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
     _videoGravity = videoGravity;
 
     MediaPlayerEnums::VideoGravity gravity = MediaPlayerEnums::VideoGravity::ResizeAspect;
-    if (videoGravity == AVLayerVideoGravityResize)
+    if ([videoGravity isEqualToString:AVLayerVideoGravityResize])
         gravity = MediaPlayerEnums::VideoGravity::Resize;
-    if (videoGravity == AVLayerVideoGravityResizeAspect)
+    else if ([videoGravity isEqualToString:AVLayerVideoGravityResizeAspect])
         gravity = MediaPlayerEnums::VideoGravity::ResizeAspect;
-    else if (videoGravity == AVLayerVideoGravityResizeAspectFill)
+    else if ([videoGravity isEqualToString:AVLayerVideoGravityResizeAspectFill])
         gravity = MediaPlayerEnums::VideoGravity::ResizeAspectFill;
     else
         ASSERT_NOT_REACHED();
+
+    OBJC_INFO_LOG(OBJC_LOGIDENTIFIER, videoGravity.UTF8String);
 
     if (_fullscreenModel)
         _fullscreenModel->setVideoLayerGravity(gravity);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -32,6 +32,7 @@
 #include "GraphicsContext.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "LayoutRect.h"
+#include "MediaPlayerEnums.h"
 #include "RotateTransformOperation.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
@@ -419,6 +420,24 @@ void GraphicsLayer::setMaskLayer(RefPtr<GraphicsLayer>&& layer)
     }
     
     m_maskLayer = WTFMove(layer);
+}
+
+MediaPlayerVideoGravity GraphicsLayer::videoGravity() const
+{
+#if USE(CA)
+    return m_videoGravity;
+#else
+    return MediaPlayerVideoGravity::ResizeAspect;
+#endif
+}
+
+void GraphicsLayer::setVideoGravity(MediaPlayerVideoGravity gravity)
+{
+#if USE(CA)
+    m_videoGravity = gravity;
+#else
+    UNUSED_PARAM(gravity);
+#endif
 }
 
 Path GraphicsLayer::shapeLayerPath() const

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -35,6 +35,7 @@
 #include "GraphicsLayerClient.h"
 #include "HTMLMediaElementIdentifier.h"
 #include "LayerHostingContextIdentifier.h"
+#include "MediaPlayerEnums.h"
 #include "Path.h"
 #include "PlatformLayer.h"
 #include "PlatformLayerIdentifier.h"
@@ -499,6 +500,10 @@ public:
     bool contentsRectClipsDescendants() const { return m_contentsRectClipsDescendants; }
     virtual void setContentsRectClipsDescendants(bool b) { m_contentsRectClipsDescendants = b; }
 
+    // Used to lay out video contents within a video layer.
+    MediaPlayerVideoGravity videoGravity() const;
+    WEBCORE_EXPORT virtual void setVideoGravity(MediaPlayerVideoGravity);
+
     Path shapeLayerPath() const;
     WEBCORE_EXPORT virtual void setShapeLayerPath(const Path&);
 
@@ -816,6 +821,7 @@ protected:
 
     EventRegion m_eventRegion;
 #if USE(CA)
+    MediaPlayerVideoGravity m_videoGravity { MediaPlayerVideoGravity::ResizeAspect };
     WindRule m_shapeLayerWindRule { WindRule::NonZero };
     Path m_shapeLayerPath;
 #endif

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -1963,6 +1963,22 @@ String convertEnumerationToString(MediaPlayer::SupportsType enumerationValue)
     return values[static_cast<size_t>(enumerationValue)];
 }
 
+WTF::TextStream& operator<<(TextStream& ts, MediaPlayerEnums::VideoGravity gravity)
+{
+    switch (gravity) {
+    case MediaPlayerEnums::VideoGravity::Resize:
+        ts << "resize";
+        break;
+    case MediaPlayerEnums::VideoGravity::ResizeAspect:
+        ts << "resize-aspect";
+        break;
+    case MediaPlayerEnums::VideoGravity::ResizeAspectFill:
+        ts << "resize-aspect-fill";
+        break;
+    }
+    return ts;
+}
+
 String convertEnumerationToString(MediaPlayer::BufferingPolicy enumerationValue)
 {
     static const NeverDestroyed<String> values[] = {

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -126,6 +126,7 @@ public:
     typedef uint32_t VideoFullscreenMode;
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, MediaPlayerEnums::VideoGravity);
 WEBCORE_EXPORT String convertEnumerationToString(MediaPlayerEnums::ReadyState);
 String convertEnumerationToString(MediaPlayerEnums::NetworkState);
 String convertEnumerationToString(MediaPlayerEnums::Preload);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -974,6 +974,15 @@ void GraphicsLayerCA::setContentsRectClipsDescendants(bool contentsRectClipsDesc
     noteLayerPropertyChanged(ChildrenChanged | ContentsRectsChanged);
 }
 
+void GraphicsLayerCA::setVideoGravity(MediaPlayerVideoGravity gravity)
+{
+    if (gravity == m_videoGravity)
+        return;
+
+    GraphicsLayer::setVideoGravity(gravity);
+    noteLayerPropertyChanged(VideoGravityChanged);
+}
+
 void GraphicsLayerCA::setShapeLayerPath(const Path& path)
 {
     // FIXME: need to check for path equality. No bool Path::operator==(const Path&)!.
@@ -1310,6 +1319,7 @@ void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, 
         }
         m_contentsLayerPurpose = purpose;
         m_contentsDisplayDelegate = nullptr;
+        updateVideoGravity();
         noteSublayersChanged();
         noteLayerPropertyChanged(ContentsPlatformLayerChanged);
         return;
@@ -2038,6 +2048,9 @@ void GraphicsLayerCA::commitLayerChangesBeforeSublayers(CommitState& commitState
         updateBlendMode();
 #endif
 
+    if (m_uncommittedChanges & VideoGravityChanged)
+        updateVideoGravity();
+
     if (m_uncommittedChanges & ShapeChanged)
         updateShape();
 
@@ -2532,6 +2545,12 @@ void GraphicsLayerCA::updateBlendMode()
     }
 }
 #endif
+
+void GraphicsLayerCA::updateVideoGravity()
+{
+    if (m_contentsLayer)
+        m_contentsLayer->setVideoGravity(m_videoGravity);
+}
 
 void GraphicsLayerCA::updateShape()
 {
@@ -4333,6 +4352,7 @@ const char* GraphicsLayerCA::layerChangeAsString(LayerChange layerChange)
 #endif
 #endif
     case LayerChange::ContentsScalingFiltersChanged: return "ContentsScalingFiltersChanged";
+    case LayerChange::VideoGravityChanged: return "VideoGravityChanged";
     }
     ASSERT_NOT_REACHED();
     return "";

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -130,6 +130,8 @@ public:
     WEBCORE_EXPORT void setContentsClippingRect(const FloatRoundedRect&) override;
     WEBCORE_EXPORT void setContentsRectClipsDescendants(bool) override;
 
+    WEBCORE_EXPORT void setVideoGravity(MediaPlayerVideoGravity) override;
+
     WEBCORE_EXPORT void setShapeLayerPath(const Path&) override;
     WEBCORE_EXPORT void setShapeLayerWindRule(WindRule) override;
 
@@ -480,6 +482,7 @@ private:
     void updateBlendMode();
 #endif
 
+    void updateVideoGravity();
     void updateShape();
     void updateWindRule();
 
@@ -603,6 +606,7 @@ private:
 #endif
 #endif
         ContentsScalingFiltersChanged           = 1LLU << 43,
+        VideoGravityChanged                     = 1LLU << 44,
     };
     typedef uint64_t LayerChangeFlags;
     static const char* layerChangeAsString(LayerChange);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -56,7 +56,7 @@ class AcceleratedEffect;
 struct AcceleratedEffectValues;
 #endif
 
-
+enum class MediaPlayerVideoGravity : uint8_t;
 
 class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main> {
     friend class PlatformCALayerCocoa;
@@ -245,7 +245,10 @@ public:
     virtual void setCornerRadius(float) = 0;
 
     virtual void setAntialiasesEdges(bool) = 0;
-    
+
+    virtual MediaPlayerVideoGravity videoGravity() const = 0;
+    virtual void setVideoGravity(MediaPlayerVideoGravity) = 0;
+
     // Only used by LayerTypeShapeLayer.
     virtual FloatRoundedRect shapeRoundedRect() const = 0;
     virtual void setShapeRoundedRect(const FloatRoundedRect&) = 0;
@@ -313,7 +316,7 @@ public:
     static CGRect frameForLayer(const PlatformLayer*);
 
     void moveToLayerPool();
-    
+
     virtual void dumpAdditionalProperties(TextStream&, OptionSet<PlatformLayerTreeAsTextFlags>);
 
 protected:

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -156,6 +156,9 @@ public:
 
     void setAntialiasesEdges(bool) override;
 
+    MediaPlayerVideoGravity videoGravity() const override;
+    void setVideoGravity(MediaPlayerVideoGravity) override;
+
     FloatRoundedRect shapeRoundedRect() const override;
     void setShapeRoundedRect(const FloatRoundedRect&) override;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -32,6 +32,7 @@
 #import "IOSurface.h"
 #import "LengthFunctions.h"
 #import "LocalCurrentGraphicsContext.h"
+#import "MediaPlayerEnumsCocoa.h"
 #import "Model.h"
 #import "PlatformCAAnimationCocoa.h"
 #import "PlatformCAFilters.h"
@@ -954,6 +955,23 @@ void PlatformCALayerCocoa::setAntialiasesEdges(bool antialiases)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [m_layer setEdgeAntialiasingMask:antialiases ? (kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge) : 0];
+    END_BLOCK_OBJC_EXCEPTIONS
+}
+
+MediaPlayerVideoGravity PlatformCALayerCocoa::videoGravity() const
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if ([m_layer respondsToSelector:@selector(videoGravity)])
+        return convertAVLayerToMediaPlayerVideoGravity([(AVPlayerLayer *)m_layer videoGravity]);
+    END_BLOCK_OBJC_EXCEPTIONS
+    return MediaPlayerVideoGravity::ResizeAspect;
+}
+
+void PlatformCALayerCocoa::setVideoGravity(MediaPlayerVideoGravity gravity)
+{
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if ([m_layer respondsToSelector:@selector(setVideoGravity:)])
+        [(AVPlayerLayer *)m_layer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(gravity)];
     END_BLOCK_OBJC_EXCEPTIONS
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "MediaPlayerEnums.h"
+
+OBJC_CLASS NSString;
+
+namespace WebCore {
+
+WEBCORE_EXPORT NSString *convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity);
+WEBCORE_EXPORT MediaPlayerVideoGravity convertAVLayerToMediaPlayerVideoGravity(NSString *);
+
+}

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaPlayerEnumsCocoa.h"
+
+#include <pal/cocoa/AVFoundationSoftLink.h>
+
+namespace WebCore {
+
+MediaPlayerVideoGravity convertAVLayerToMediaPlayerVideoGravity(NSString *gravity)
+{
+    if ([gravity isEqualToString:AVLayerVideoGravityResizeAspect])
+        return MediaPlayerVideoGravity::ResizeAspect;
+    if ([gravity isEqualToString:AVLayerVideoGravityResizeAspectFill])
+        return MediaPlayerVideoGravity::ResizeAspectFill;
+    if ([gravity isEqualToString:AVLayerVideoGravityResize])
+        return MediaPlayerVideoGravity::Resize;
+
+    return MediaPlayerVideoGravity::ResizeAspect;
+}
+
+NSString *convertMediaPlayerToAVLayerVideoGravity(MediaPlayerVideoGravity gravity)
+{
+    switch (gravity) {
+    case MediaPlayerVideoGravity::ResizeAspect:
+        return AVLayerVideoGravityResizeAspect;
+    case MediaPlayerVideoGravity::ResizeAspectFill:
+        return AVLayerVideoGravityResizeAspectFill;
+    case MediaPlayerVideoGravity::Resize:
+        return AVLayerVideoGravityResize;
+    }
+}
+
+
+}

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -572,6 +572,9 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
 #if ENABLE(CSS_COMPOSITING)
     updateBlendMode(style);
 #endif
+#if ENABLE(VIDEO)
+    updateVideoGravity(style);
+#endif
     updateContentsScalingFilters(style);
 }
 
@@ -826,6 +829,32 @@ void RenderLayerBacking::updateBlendMode(const RenderStyle& style)
 }
 #endif
 
+#if ENABLE(VIDEO)
+void RenderLayerBacking::updateVideoGravity(const RenderStyle& style)
+{
+    if (!renderer().isVideo())
+        return;
+
+    MediaPlayerVideoGravity videoGravity;
+    switch (style.objectFit()) {
+    case ObjectFit::None:
+    case ObjectFit::ScaleDown:
+        // FIXME: Add support for "None" and "ScaleDown" with video gravity modes
+        FALLTHROUGH;
+    case ObjectFit::Fill:
+        videoGravity = MediaPlayerVideoGravity::Resize;
+        break;
+    case ObjectFit::Contain:
+        videoGravity = MediaPlayerVideoGravity::ResizeAspect;
+        break;
+    case ObjectFit::Cover:
+        videoGravity = MediaPlayerVideoGravity::ResizeAspectFill;
+        break;
+    }
+    m_graphicsLayer->setVideoGravity(videoGravity);
+}
+#endif
+
 void RenderLayerBacking::updateContentsScalingFilters(const RenderStyle& style)
 {
     if (!renderer().isCanvas() || canvasCompositingStrategy(renderer()) != CanvasAsLayerContents)
@@ -1026,6 +1055,10 @@ void RenderLayerBacking::updateConfigurationAfterStyleChange()
     updateBlendMode(style);
 #endif
     updateContentsScalingFilters(style);
+
+#if ENABLE(VIDEO)
+    updateVideoGravity(style);
+#endif
 }
 
 bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAncestor)
@@ -1381,6 +1414,10 @@ void RenderLayerBacking::updateGeometry(const RenderLayer* compositedAncestor)
     updateBlendMode(style);
 #endif
     updateContentsScalingFilters(style);
+
+#if ENABLE(VIDEO)
+    updateVideoGravity(style);
+#endif
 
     ASSERT(compositedAncestor == m_owningLayer.ancestorCompositingLayer());
     LayoutRect parentGraphicsLayerRect = computeParentGraphicsLayerRect(compositedAncestor);

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -362,6 +362,9 @@ private:
 #if ENABLE(CSS_COMPOSITING)
     void updateBlendMode(const RenderStyle&);
 #endif
+#if ENABLE(VIDEO)
+    void updateVideoGravity(const RenderStyle&);
+#endif
     void updateContentsScalingFilters(const RenderStyle&);
 
     // Return the opacity value that this layer should use for compositing.

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -45,6 +45,7 @@ public:
 
 protected:
     void layout() override;
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
     void visibleInViewportStateChanged() override { }
 
@@ -57,8 +58,6 @@ private:
     bool isMedia() const final { return true; }
     bool isImage() const final { return false; }
     void paintReplaced(PaintInfo&, const LayoutPoint&) override;
-
-    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 };
 
 inline RenderMedia* HTMLMediaElement::renderer() const

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -267,7 +267,14 @@ void RenderVideo::layout()
     RenderMedia::layout();
     updatePlayer();
 }
-    
+
+void RenderVideo::styleDidChange(StyleDifference difference, const RenderStyle* oldStyle)
+{
+    RenderMedia::styleDidChange(difference, oldStyle);
+    if (!oldStyle || style().objectFit() != oldStyle->objectFit())
+        setNeedsLayout();
+}
+
 HTMLVideoElement& RenderVideo::videoElement() const
 {
     return downcast<HTMLVideoElement>(RenderMedia::mediaElement());

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -76,6 +76,7 @@ private:
     void paintReplaced(PaintInfo&, const LayoutPoint&) final;
 
     void layout() final;
+    void styleDidChange(StyleDifference, const RenderStyle* oldStyle) final;
 
     void visibleInViewportStateChanged() final;
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -69,6 +69,7 @@ header: "RemoteLayerTreeTransaction.h"
     DescendentOfSeparatedPortalChanged
 #endif
     ScrollingNodeIDChanged
+    VideoGravityChanged
 };
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -31,8 +31,10 @@
 #import "RemoteLayerTreeHost.h"
 #import "RemoteLayerTreeInteractionRegionLayers.h"
 #import <QuartzCore/QuartzCore.h>
+#import <WebCore/MediaPlayerEnumsCocoa.h>
 #import <WebCore/PlatformCAFilters.h>
 #import <WebCore/ScrollbarThemeMac.h>
+#import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/BlockObjCExceptions.h>
@@ -296,6 +298,13 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         // FIXME: Implement DescendentOfSeparatedPortalChanged.
     }
 #endif
+#endif
+
+#if HAVE(AVKIT)
+    if (properties.changedProperties & LayerChange::VideoGravityChanged) {
+        if ([layer respondsToSelector:@selector(setVideoGravity:)])
+            [(WebAVPlayerLayer*)layer setVideoGravity:convertMediaPlayerToAVLayerVideoGravity(properties.videoGravity)];
+    }
 #endif
 }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -38,6 +38,7 @@
 #include <WebCore/FloatSize.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/LayoutMilestone.h>
+#include <WebCore/MediaPlayerEnums.h>
 #include <WebCore/Model.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/ScrollTypes.h>
@@ -110,6 +111,7 @@ enum class LayerChange : uint64_t {
     DescendentOfSeparatedPortalChanged  = 1LLU << 42,
 #endif
 #endif
+    VideoGravityChanged                 = 1LLU << 44,
 };
 
 class RemoteLayerTreeTransaction {
@@ -204,6 +206,7 @@ public:
         WebCore::PlatformCALayer::FilterType magnificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
         WebCore::BlendMode blendMode { WebCore::BlendMode::Normal };
         WebCore::WindRule windRule { WebCore::WindRule::NonZero };
+        WebCore::MediaPlayerVideoGravity videoGravity { WebCore::MediaPlayerVideoGravity::ResizeAspect };
         bool antialiasesEdges { true };
         bool hidden { false };
         bool backingStoreAttached { true };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -158,6 +158,7 @@ RemoteLayerTreeTransaction::LayerProperties::LayerProperties(const LayerProperti
     , magnificationFilter(other.magnificationFilter)
     , blendMode(other.blendMode)
     , windRule(other.windRule)
+    , videoGravity(other.videoGravity)
     , antialiasesEdges(other.antialiasesEdges)
     , hidden(other.hidden)
     , backingStoreAttached(other.backingStoreAttached)
@@ -334,6 +335,9 @@ void RemoteLayerTreeTransaction::LayerProperties::encode(IPC::Encoder& encoder) 
         encoder << isDescendentOfSeparatedPortal;
 #endif
 #endif
+
+    if (changedProperties & LayerChange::VideoGravityChanged)
+        encoder << videoGravity;
 }
 
 bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, LayerProperties& result)
@@ -597,6 +601,11 @@ bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, 
     }
 #endif
 #endif
+
+    if (result.changedProperties & LayerChange::VideoGravityChanged) {
+        if (!decoder.decode(result.videoGravity))
+            return false;
+    }
 
     return true;
 }
@@ -1005,6 +1014,9 @@ static void dumpChangedLayers(TextStream& ts, const RemoteLayerTreeTransaction::
             ts.dumpProperty("isDescendentOfSeparatedPortal", layerProperties.isDescendentOfSeparatedPortal);
 #endif
 #endif
+
+        if (layerProperties.changedProperties & LayerChange::VideoGravityChanged)
+            ts.dumpProperty("videoGravity", layerProperties.videoGravity);
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -174,6 +174,9 @@ public:
 
     void setAntialiasesEdges(bool) override;
 
+    WebCore::MediaPlayerVideoGravity videoGravity() const override;
+    void setVideoGravity(WebCore::MediaPlayerVideoGravity) override;
+
     // FIXME: Having both shapeRoundedRect and shapePath is redundant. We could use shapePath for everything.
     WebCore::FloatRoundedRect shapeRoundedRect() const override;
     void setShapeRoundedRect(const WebCore::FloatRoundedRect&) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -169,6 +169,7 @@ void PlatformCALayerRemote::updateClonedLayerProperties(PlatformCALayerRemote& c
     clone.setBackgroundColor(backgroundColor());
     clone.setContentsScale(contentsScale());
     clone.setCornerRadius(cornerRadius());
+    clone.setVideoGravity(videoGravity());
 
     if (!m_properties.shapePath.isNull())
         clone.setShapePath(m_properties.shapePath);
@@ -876,6 +877,20 @@ void PlatformCALayerRemote::setAntialiasesEdges(bool antialiases)
 
     m_properties.antialiasesEdges = antialiases;
     m_properties.notePropertiesChanged(LayerChange::AntialiasesEdgesChanged);
+}
+
+MediaPlayerVideoGravity PlatformCALayerRemote::videoGravity() const
+{
+    return m_properties.videoGravity;
+}
+
+void PlatformCALayerRemote::setVideoGravity(MediaPlayerVideoGravity gravity)
+{
+    if (m_properties.videoGravity == gravity)
+        return;
+
+    m_properties.videoGravity = gravity;
+    m_properties.notePropertiesChanged(LayerChange::VideoGravityChanged);
 }
 
 FloatRoundedRect PlatformCALayerRemote::shapeRoundedRect() const


### PR DESCRIPTION
#### 9f0beb45c5d7c4830cd579eb68cee6564172c01c
<pre>
REGRESSION(264795@main) media/video-object-fit.html test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257604">https://bugs.webkit.org/show_bug.cgi?id=257604</a>
rdar://110117044

Reviewed by Eric Carlson.

In 264795@main, we now correctly lay out the contents of the media element when that element
recreates its media layer while in fullscreen or pip. This had the paradoxical effect of exposing
serious problems in our object-fit implementation for video elements.

The WebAVPlayerLayer class in the UI process is responsible for responding to layer-based layout
changes. These can happen both during normal page layout, and also when the video contents move
outside of the page and into fullscreen or pip. To correctly layout the video contents, it must
know what the effective videoGravity of the underlying video layer has been set to. However, this
information never leaves the WebContent process. This worked previously only accidentally.

Additionally, the RenderLayer is responsible for telling the MediaPlayer whether it should resize
respecting the underlying aspect ratio of the media, or whether it should ignore aspect ratio.
This code runs after layout, but changes to style that don&apos;t affect layout (like object-fit) are
never propogated into the media element.

And one final problem, WebAVPlayerLayer used pointer equality to check whether the passed in
string matches the values exposed by AVFoundation; it should use -isEqualToString:.

1. Notice that the object-fit style has changed in RenderVideo and push those changes into the
   MediaPlayer via updatePlayer().

2. Add a new videoGravity()/setVideoGravity() accessor to GraphicsLayer and GraphicsLayerCA, and
   to PlatformCALayer and PlatformCALayerCocoa.

3. Propogate these changes across the UIProcess boundary as part of the LayerProperties.

4. Fix WebAVPlayerLayer&apos;s -setVideoGravity: method.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setVideoGravity:]):
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::videoGravity const):
(WebCore::GraphicsLayer::setVideoGravity):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setVideoGravity):
(WebCore::GraphicsLayerCA::setContentsToVideoElement):
(WebCore::GraphicsLayerCA::commitLayerChangesBeforeSublayers):
(WebCore::GraphicsLayerCA::updateVideoGravity):
(WebCore::GraphicsLayerCA::layerChangeAsString):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::videoGravity const):
(WebCore::PlatformCALayerCocoa::setVideoGravity):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.h: Added.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerEnumsCocoa.mm: Added.
(WebCore::convertAVLayerToMediaPlayerVideoGravity):
(WebCore::convertMediaPlayerToAVLayerVideoGravity):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):
(WebCore::RenderLayerBacking::updateVideoGravity):
(WebCore::RenderLayerBacking::updateConfigurationAfterStyleChange):
(WebCore::RenderLayerBacking::updateGeometry):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::styleDidChange):
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
(WebKit::dumpChangedLayers):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::updateClonedLayerProperties const):
(WebKit::PlatformCALayerRemote::videoGravity const):
(WebKit::PlatformCALayerRemote::setVideoGravity):

Canonical link: <a href="https://commits.webkit.org/264812@main">https://commits.webkit.org/264812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86fac9a6e848672303f2f220b222217647c56340

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8929 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11548 "1 flakes 98 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9830 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10481 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7925 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15453 "1 flakes 124 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11429 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8555 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7824 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2112 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->