### PR TITLE
[JSC] FTL should not load arguments twice for type check and use for non-full-64bit values

### DIFF
--- a/JSTests/stress/force-string-array-or-string.js
+++ b/JSTests/stress/force-string-array-or-string.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 //@ requireOptions("--jitPolicyScale=0")
 function foo(a0, a1) {
     try {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1215,6 +1215,11 @@ void testStoreAfterClobberExitsSideways();
 void testStoreAfterClobberDifferentWidth();
 void testStoreAfterClobberDifferentWidthSuccessor();
 void testStoreAfterClobberExitsSidewaysSuccessor();
+void testNarrowLoad();
+void testNarrowLoadClobber();
+void testNarrowLoadClobberNarrow();
+void testNarrowLoadNotClobber();
+void testNarrowLoadUpper();
 
 void testVectorOrConstants(v128_t, v128_t);
 void testVectorAndConstants(v128_t, v128_t);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -550,6 +550,11 @@ void run(const TestConfig* config)
     RUN(testStoreAfterClobberExitsSideways());
     RUN(testStoreAfterClobberDifferentWidthSuccessor());
     RUN(testStoreAfterClobberExitsSidewaysSuccessor());
+    RUN(testNarrowLoad());
+    RUN(testNarrowLoadClobber());
+    RUN(testNarrowLoadClobberNarrow());
+    RUN(testNarrowLoadNotClobber());
+    RUN(testNarrowLoadUpper());
 
     RUN(testInt32ToDoublePartialRegisterStall());
     RUN(testInt32ToDoublePartialRegisterWithoutStall());


### PR DESCRIPTION
#### 4b922ed0225742e027a5689412dca1f94c4226a1
<pre>
[JSC] FTL should not load arguments twice for type check and use for non-full-64bit values
<a href="https://bugs.webkit.org/show_bug.cgi?id=192073">https://bugs.webkit.org/show_bug.cgi?id=192073</a>
rdar://110121633

Reviewed by Mark Lam.

This patch removes redundant loads from the same address even when the access width is different.
Like,

    @y = Load64(@x)
    @z = Load32(@x)

is converted to

    @y = Load64(@x)
    @z = Trunc(@y)

if no clobbering happens between these two loads. This pattern can be seen in FTL since FTL does Int32 check
with 64bit load for an argument first and later it loads 32bit part of this Int32. Right now, we are loading
twice. This patch eliminates the second load with B3 CSE.

* Source/JavaScriptCore/b3/B3EliminateCommonSubexpressions.cpp:

Canonical link: <a href="https://commits.webkit.org/264846@main">https://commits.webkit.org/264846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b58717fc5d9f05bb6d07fae9808227ca492afa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8811 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11670 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9973 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15570 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7590 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8381 "4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11553 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8475 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7097 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8995 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7964 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2146 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12175 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9230 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1034 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8453 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2266 "Passed tests") | 
<!--EWS-Status-Bubble-End-->