### PR TITLE
Web Inspector: REGRESSION(?): Storage: arrow key movement sometimes skips items

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.js
@@ -174,9 +174,8 @@ WI.DOMStorageContentView = class DOMStorageContentView extends WI.ContentView
                 this._dataGrid.appendChild(node);
             }
 
-            this._sortDataGrid();
             this._dataGrid.addPlaceholderNode();
-            this._dataGrid.updateLayout();
+            this._sortDataGrid();
         }.bind(this));
     }
 


### PR DESCRIPTION
#### ba617a2832c014b8ccfef7fbd21db69a0fcdc47d
<pre>
Web Inspector: REGRESSION(?): Storage: arrow key movement sometimes skips items
<a href="https://bugs.webkit.org/show_bug.cgi?id=257608">https://bugs.webkit.org/show_bug.cgi?id=257608</a>

Reviewed by Patrick Angle.

`WI.DataGrid` has two different ways of managing the state of its children:
- `_children` represents the &quot;original&quot; order of children before any sorting happens.
- `_rows` contains the visual ordering of children after sorting and whatnot.

The logic that calculates the `previousSibling`/`nextSibling` for each `WI.DataGridNode` happens in two different places:
1. `WI.DataGridNode.prototype._recalculateSiblings`, which is called by `WI.DataGrid.prototype.insertChild`.
2. `WI.DataGrid.prototype._sortNodesCallback`, specifically after sorting has finished.

(1) uses `_children` and (2) uses `_rows`, which can lead to issues if the caller doesn&apos;t sort the `WI.DataGrid` *after* adding any new `WI.DataGridNode` as in that case the item before it in `_children` might not actually be the item before it in `_rows`.

Imagine we have a `WI.DataGrid` with two children added in reverse alphabetical order but sorted alphabetically:

    _children:
        b { previous: a, next: _ }
        a { previous: _, next: b }

    _rows:
        a { previous: _, next: b }
        b { previous: a, next: _ }

If we now added another `WI.DataGridNode` for &quot;z&quot; *without* sorting, we&apos;d end up with this:

    _children:
        b { previous: a, next: _ }
        a { previous: _, next: z }
        z { previous: a, next: _ }

    _rows:
        a { previous: _, next: z }
        b { previous: a, next: _ }
        z { previous: a, next: _ }

Which would cause the user to skip over &quot;b&quot; when pressing the down arrow key if &quot;a&quot; is selected.

I am somewhat doubtful that this is an issue elsewhere in Web Inspector as `WI.PlaceholderDataGridNode` is not used anywhere else (and `WI.DataGrid` is sorta unofficially softly deprecated in favor of `WI.Table`).

* Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.js:
(WI.DOMStorageContentView.prototype._populate):
Always sort *after* adding `WI.DataGridNode`, not before.

Canonical link: <a href="https://commits.webkit.org/264823@main">https://commits.webkit.org/264823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63c1e2ff2f81ace63a93c545ec0666b2c2659723

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8667 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11534 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9863 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10470 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8236 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11407 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6972 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7819 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->