### PR TITLE
[Filters] Loop through the SVGFilter unique effects instead of traversing the whole graph when possible

### DIFF
--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -221,10 +221,8 @@ OptionSet<FilterRenderingMode> SVGFilter::supportedFilterRenderingModes() const
 {
     OptionSet<FilterRenderingMode> modes = allFilterRenderingModes;
 
-    for (auto& term : m_expression) {
-        auto& effect = m_effects[term.index];
+    for (auto& effect : m_effects)
         modes = modes & effect->supportedFilterRenderingModes();
-    }
 
     ASSERT(modes);
     return modes;
@@ -232,15 +230,14 @@ OptionSet<FilterRenderingMode> SVGFilter::supportedFilterRenderingModes() const
 
 FilterEffectVector SVGFilter::effectsOfType(FilterFunction::Type filterType) const
 {
-    HashSet<Ref<FilterEffect>> effects;
+    FilterEffectVector effects;
 
-    for (auto& term : m_expression) {
-        auto& effect = m_effects[term.index];
+    for (auto& effect : m_effects) {
         if (effect->filterType() == filterType)
-            effects.add(effect);
+            effects.append(effect);
     }
 
-    return copyToVector(effects);
+    return effects;
 }
 
 FilterResults& SVGFilter::ensureResults(const FilterResultsCreator& resultsCreator)
@@ -277,6 +274,7 @@ RefPtr<FilterImage> SVGFilter::apply(const Filter&, FilterImage& sourceImage, Fi
 RefPtr<FilterImage> SVGFilter::apply(FilterImage* sourceImage, FilterResults& results)
 {
     ASSERT(!m_expression.isEmpty());
+    ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::Software));
 
     FilterImageVector stack;
 


### PR DESCRIPTION
#### d9fab762ebfd9b0ea04a566f37a8588342e1f1fa
<pre>
[Filters] Loop through the SVGFilter unique effects instead of traversing the whole graph when possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=257612">https://bugs.webkit.org/show_bug.cgi?id=257612</a>
rdar://110125903

Reviewed by Cameron McCormack.

It is efficient for SVGFilter to loop through its unique effects vector instead
of traversing the whole graph through the SVGFilterExpression when possible.

This a left over from 263886@main which made SVGFilterExpression own indices to
the vector of unique effects.

* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::supportedFilterRenderingModes const):
(WebCore::SVGFilter::effectsOfType const):
(WebCore::SVGFilter::apply):

Canonical link: <a href="https://commits.webkit.org/264813@main">https://commits.webkit.org/264813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fece0dd141ed2c0002b908d8d084a11968bc734

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11545 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8817 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9829 "1 flakes 3 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10484 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15449 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6980 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2113 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->