### PR TITLE
Fix scrollbar-gutter stable in vertical writing modes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt
@@ -19,14 +19,14 @@ PASS overflow scroll, scrollbar-gutter auto
 PASS overflow visible, scrollbar-gutter auto
 PASS overflow hidden, scrollbar-gutter auto
 PASS overflow clip, scrollbar-gutter auto
-FAIL overflow auto, scrollbar-gutter stable assert_greater_than: content height expected a number greater than 200 but got 200
+PASS overflow auto, scrollbar-gutter stable
 PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
-FAIL overflow hidden, scrollbar-gutter stable assert_greater_than: content height expected a number greater than 200 but got 200
+PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_greater_than: content height expected a number greater than 200 but got 200
+FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_greater_than: content height expected a number greater than 200 but got 200
+FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt
@@ -19,14 +19,14 @@ PASS overflow scroll, scrollbar-gutter auto
 PASS overflow visible, scrollbar-gutter auto
 PASS overflow hidden, scrollbar-gutter auto
 PASS overflow clip, scrollbar-gutter auto
-FAIL overflow auto, scrollbar-gutter stable assert_greater_than: content height expected a number greater than 200 but got 200
+PASS overflow auto, scrollbar-gutter stable
 PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
-FAIL overflow hidden, scrollbar-gutter stable assert_greater_than: content height expected a number greater than 200 but got 200
+PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_greater_than: content height expected a number greater than 200 but got 200
+FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_greater_than: content height expected a number greater than 200 but got 200
+FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -879,7 +879,8 @@ bool RenderBox::includeVerticalScrollbarSize() const
 bool RenderBox::includeHorizontalScrollbarSize() const
 {
     return hasNonVisibleOverflow() && layer() && !layer()->hasOverlayScrollbars()
-        && (style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Auto);
+        && (style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Auto
+            || (style().overflowX() == Overflow::Hidden && !style().scrollbarGutter().isAuto));
 }
 
 int RenderBox::verticalScrollbarWidth() const
@@ -887,7 +888,7 @@ int RenderBox::verticalScrollbarWidth() const
     auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (!scrollableArea)
         return 0;
-    return includeVerticalScrollbarSize() ? scrollableArea->verticalScrollbarWidth() : 0;
+    return includeVerticalScrollbarSize() ? scrollableArea->verticalScrollbarWidth(IgnoreOverlayScrollbarSize, isHorizontalWritingMode()) : 0;
 }
 
 int RenderBox::horizontalScrollbarHeight() const
@@ -895,7 +896,7 @@ int RenderBox::horizontalScrollbarHeight() const
     auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (!scrollableArea)
         return 0;
-    return includeHorizontalScrollbarSize() ? scrollableArea->horizontalScrollbarHeight() : 0;
+    return includeHorizontalScrollbarSize() ? scrollableArea->horizontalScrollbarHeight(IgnoreOverlayScrollbarSize, isHorizontalWritingMode()) : 0;
 }
 
 int RenderBox::intrinsicScrollbarLogicalWidth() const
@@ -2142,8 +2143,8 @@ LayoutRect RenderBox::overflowClipRect(const LayoutPoint& location, RenderFragme
     // Subtract out scrollbars if we have them.
     if (auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr) {
         if (shouldPlaceVerticalScrollbarOnLeft())
-            clipRect.move(scrollableArea->verticalScrollbarWidth(relevancy), 0);
-        clipRect.contract(scrollableArea->verticalScrollbarWidth(relevancy), scrollableArea->horizontalScrollbarHeight(relevancy));
+            clipRect.move(scrollableArea->verticalScrollbarWidth(relevancy, isHorizontalWritingMode()), 0);
+        clipRect.contract(scrollableArea->verticalScrollbarWidth(relevancy, isHorizontalWritingMode()), scrollableArea->horizontalScrollbarHeight(relevancy, isHorizontalWritingMode()));
     }
 
     return clipRect;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -595,7 +595,7 @@ FloatRect RenderBoxModelObject::constrainingRectForStickyPosition() const
 
         float scrollbarOffset = 0;
         if (enclosingClippingBox.hasLayer() && enclosingClippingBox.shouldPlaceVerticalScrollbarOnLeft() && scrollableArea)
-            scrollbarOffset = scrollableArea->verticalScrollbarWidth(IgnoreOverlayScrollbarSize);
+            scrollbarOffset = scrollableArea->verticalScrollbarWidth(IgnoreOverlayScrollbarSize, isHorizontalWritingMode());
 
         constrainingRect.setLocation(FloatPoint(scrollOffset.x() + scrollbarOffset, scrollOffset.y()));
         return constrainingRect;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -119,8 +119,8 @@ public:
     // Returns true when there is actually scrollable overflow (requires layout to be up-to-date).
     bool hasCompositedScrollableOverflow() const { return m_hasCompositedScrollableOverflow; }
 
-    int verticalScrollbarWidth(OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize) const;
-    int horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize) const;
+    int verticalScrollbarWidth(OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
+    int horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy = IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
 
     bool hasOverflowControls() const;
     bool hitTestOverflowControls(HitTestResult&, const IntPoint& localPoint);


### PR DESCRIPTION
#### 0f6bd1d186405f2134662981c82a0857f353b5e2
<pre>
Fix scrollbar-gutter stable in vertical writing modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257605">https://bugs.webkit.org/show_bug.cgi?id=257605</a>

Reviewed by Simon Fraser.

Stable scrollbar gutters on non-viewports now correctly account for vertical writing modes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::includeHorizontalScrollbarSize const):
(WebCore::RenderBox::verticalScrollbarWidth const):
(WebCore::RenderBox::horizontalScrollbarHeight const):
(WebCore::RenderBox::overflowClipRect const):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::constrainingRectForStickyPosition const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::verticalScrollbarWidth const):
(WebCore::RenderLayerScrollableArea::horizontalScrollbarHeight const):
(WebCore::RenderLayerScrollableArea::computeScrollOrigin):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/264937@main">https://commits.webkit.org/264937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58f635f8d7921e7e0e302362a04527f8a832db9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10545 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9147 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11725 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10704 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15622 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11610 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8025 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2230 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->