### PR TITLE
REGRESSION(257658@main): Unable to exit fullscreen from video controls on bleacherreport.com

### DIFF
--- a/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document-expected.html
+++ b/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<style>
+    #test {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="test"></div>
+</html>

--- a/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document.html
+++ b/LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<style>
+    #test {
+        background-color: green;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<div id="test"></div>
+<script>
+document.addEventListener("webkitfullscreenchange", () => {
+    test.style.backgroundColor = "red";
+});
+document.addEventListener("fullscreenchange", () => {
+    if (document.fullscreenElement)
+        document.exitFullscreen();
+    else
+        document.documentElement.classList.remove("reftest-wait");
+});
+if (window.internals) {
+    internals.withUserGesture(() => {
+        test.requestFullscreen();
+    });
+}
+</script>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -618,12 +618,14 @@ void FullscreenManager::dispatchEventForNode(Node& node, EventType eventType)
 {
     bool supportsUnprefixedAPI = document().settings().unprefixedFullscreenAPIEnabled();
     switch (eventType) {
-    case EventType::Change:
+    case EventType::Change: {
         if (supportsUnprefixedAPI)
             node.dispatchEvent(Event::create(eventNames().fullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
-        if (!supportsUnprefixedAPI || !node.hasEventListeners(eventNames().fullscreenchangeEvent))
+        bool shouldEmitUnprefixed = !(node.hasEventListeners(eventNames().webkitfullscreenchangeEvent) && node.hasEventListeners(eventNames().fullscreenchangeEvent)) && !(node.document().hasEventListeners(eventNames().webkitfullscreenchangeEvent) && node.document().hasEventListeners(eventNames().fullscreenchangeEvent));
+        if (!supportsUnprefixedAPI || shouldEmitUnprefixed)
             node.dispatchEvent(Event::create(eventNames().webkitfullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         break;
+    }
     case EventType::Error:
         if (supportsUnprefixedAPI)
             node.dispatchEvent(Event::create(eventNames().fullscreenerrorEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));


### PR DESCRIPTION
#### fced3c93326628b5ee97b8aee317e8596c9ec9f8
<pre>
REGRESSION(257658@main): Unable to exit fullscreen from video controls on bleacherreport.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=257616">https://bugs.webkit.org/show_bug.cgi?id=257616</a>
rdar://109373298

Reviewed by Jer Noble.

The website was using an event listener for both prefixed &amp; unprefixed APIs on the document object, causing the
library&apos;s event listener to fire twice and wrongly track the fullscreen state.

To fix this, extend the check from 260651@main to cover document event listners as well.

* LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document-expected.html: Added.
* LayoutTests/fullscreen/event-listener-prefixed-unprefixed-document.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::dispatchEventForNode):

Canonical link: <a href="https://commits.webkit.org/264814@main">https://commits.webkit.org/264814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ee59ae46ceb71935cb9ae800dddd144dbd4891

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11552 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9838 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10492 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15454 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8258 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7833 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2110 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->