### PR TITLE
[CMake] Unify GStreamer sources

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -408,6 +408,8 @@ void GStreamerDataChannelHandler::postTask(Function<void()>&& function)
     ScriptExecutionContext::postTaskTo(m_contextIdentifier, WTFMove(function));
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1613,4 +1613,6 @@ struct LogArgument<WebCore::RTCStatsLogger> {
 }; // namespace WTF
 #endif // !RELEASE_LOG_DISABLED
 
+#undef GST_CAT_DEFAULT
+
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -384,6 +384,8 @@ bool GStreamerPeerConnectionBackend::isNegotiationNeeded(uint32_t eventId) const
     return m_endpoint->isNegotiationNeeded(eventId);
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -203,6 +203,8 @@ std::unique_ptr<RTCDtlsTransportBackend> GStreamerRtpSenderBackend::dtlsTranspor
     return makeUnique<GStreamerDtlsTransportBackend>(WTFMove(transport));
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -153,6 +153,8 @@ ExceptionOr<void> GStreamerRtpTransceiverBackend::setCodecPreferences(const Vect
     return { };
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
@@ -100,6 +100,8 @@ void GStreamerSctpTransportBackend::stateChanged()
     });
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -472,6 +472,8 @@ void GStreamerStatsCollector::getStats(CollectorCallback&& callback, GstPad* pad
     }, holder, reinterpret_cast<GDestroyNotify>(destroyCallbackHolder)));
 }
 
-}; // namespace WebCore
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
 
 #endif // ENABLE(WEB_RTC) && USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -591,6 +591,8 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
     return caps;
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -77,9 +77,9 @@ platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp
-platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
-platform/graphics/gbm/GraphicsContextGLFallback.cpp
-platform/graphics/gbm/GraphicsContextGLGBM.cpp
+platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp @no-unify
+platform/graphics/gbm/GraphicsContextGLFallback.cpp @no-unify
+platform/graphics/gbm/GraphicsContextGLGBM.cpp @no-unify
 platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp @no-unify
 platform/graphics/gbm/PlatformDisplayGBM.cpp @no-unify
 
@@ -88,8 +88,6 @@ platform/graphics/gtk/DisplayRefreshMonitorGtk.cpp
 platform/graphics/gtk/GdkCairoUtilities.cpp
 platform/graphics/gtk/ImageGtk.cpp
 platform/graphics/gtk/SystemFontDatabaseGTK.cpp
-
-platform/graphics/gstreamer/ImageGStreamerCairo.cpp
 
 platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -73,10 +73,10 @@ platform/graphics/egl/GLContextLibWPE.cpp
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp
-platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
-platform/graphics/gbm/GraphicsContextGLFallback.cpp
-platform/graphics/gbm/GraphicsContextGLGBM.cpp
-platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
+platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp @no-unify
+platform/graphics/gbm/GraphicsContextGLFallback.cpp @no-unify
+platform/graphics/gbm/GraphicsContextGLGBM.cpp @no-unify
+platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp @no-unify
 
 platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/platform/GStreamer.cmake
+++ b/Source/WebCore/platform/GStreamer.cmake
@@ -8,103 +8,8 @@ if (ENABLE_VIDEO OR ENABLE_WEB_AUDIO)
         "${WEBCORE_DIR}/platform/mediarecorder/gstreamer"
     )
 
-    list(APPEND WebCore_SOURCES
-        Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
-        Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
-        Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerRtpTransformBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
-        Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
-        Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
-
-        Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
-
-        platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
-        platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
-        platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
-        platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
-        platform/graphics/gstreamer/GRefPtrGStreamer.cpp
-        platform/graphics/gstreamer/GStreamerAudioMixer.cpp
-        platform/graphics/gstreamer/GStreamerCommon.cpp
-        platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
-        platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
-        platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp
-        platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
-        platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
-        platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
-        platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
-        platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
-        platform/graphics/gstreamer/MediaSampleGStreamer.cpp
-        platform/graphics/gstreamer/TextCombinerGStreamer.cpp
-        platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
-        platform/graphics/gstreamer/TextSinkGStreamer.cpp
-        platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
-        platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
-        platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
-        platform/graphics/gstreamer/VideoFrameGStreamer.cpp
-        platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
-        platform/graphics/gstreamer/VideoSinkGStreamer.cpp
-        platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
-        platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
-        platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
-
-        platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
-        platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
-
-        platform/graphics/gstreamer/mse/AppendPipeline.cpp
-        platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
-        platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
-        platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
-        platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
-        platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
-        platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
-        platform/graphics/gstreamer/mse/TrackQueue.cpp
-        platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
-
-        platform/gstreamer/GStreamerCodecUtilities.cpp
-        platform/gstreamer/GStreamerElementHarness.cpp
-        platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
-        platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
-        platform/gstreamer/WebKitFliteSourceGStreamer.cpp
-
-        platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
-
-        platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
-        platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
-        platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
-        platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
-        platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.cpp
-        platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
-        platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
-        platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
-        platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
-
-        platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
-        platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
-        platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
-        platform/mediastream/gstreamer/GStreamerCapturer.cpp
-        platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
-        platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
-        platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
-        platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
-        platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
-        platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
-        platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
-        platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeMediaSourceCenterGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
-        platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+    list(APPEND WebCore_UNIFIED_SOURCE_LIST_FILES
+        "platform/SourcesGStreamer.txt"
     )
 
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
@@ -184,17 +89,12 @@ if (ENABLE_VIDEO)
         )
     endif ()
 
-    if (USE_GSTREAMER_GL)
-        if (NOT USE_GSTREAMER_FULL)
-            list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
-                ${GSTREAMER_GL_INCLUDE_DIRS}
-            )
-            list(APPEND WebCore_LIBRARIES
-                ${GSTREAMER_GL_LIBRARIES}
-            )
-        endif ()
-        list(APPEND WebCore_SOURCES
-            platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+    if (USE_GSTREAMER_GL AND NOT USE_GSTREAMER_FULL)
+        list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+            ${GSTREAMER_GL_INCLUDE_DIRS}
+        )
+        list(APPEND WebCore_LIBRARIES
+            ${GSTREAMER_GL_LIBRARIES}
         )
     endif ()
 
@@ -230,14 +130,6 @@ if (ENABLE_WEB_AUDIO)
         "${WEBCORE_DIR}/platform/audio/gstreamer"
     )
 
-    list(APPEND WebCore_SOURCES
-        platform/audio/gstreamer/AudioDestinationGStreamer.cpp
-        platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
-        platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
-        platform/audio/gstreamer/FFTFrameGStreamer.cpp
-        platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
-    )
-
     if (NOT USE_GSTREAMER_FULL)
         list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
             ${GSTREAMER_AUDIO_INCLUDE_DIRS}
@@ -250,30 +142,12 @@ if (ENABLE_WEB_AUDIO)
     endif ()
 endif ()
 
-if (ENABLE_ENCRYPTED_MEDIA)
-    list(APPEND WebCore_SOURCES
-        platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp
+if (ENABLE_ENCRYPTED_MEDIA AND ENABLE_THUNDER)
+    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+        ${THUNDER_INCLUDE_DIRS}
     )
 
-    if (ENABLE_THUNDER)
-        list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
-            ${THUNDER_INCLUDE_DIRS}
-        )
-
-        list(APPEND WebCore_LIBRARIES
-            ${THUNDER_LIBRARIES}
-        )
-
-        list(APPEND WebCore_SOURCES
-            platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
-            platform/graphics/gstreamer/eme/CDMThunder.cpp
-            platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
-        )
-    endif ()
-endif ()
-
-if (USE_CAIRO)
-    list(APPEND WebCore_SOURCES
-        platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+    list(APPEND WebCore_LIBRARIES
+        ${THUNDER_LIBRARIES}
     )
 endif ()

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -1,0 +1,131 @@
+// Copyright (C) 2023 Igalia S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpReceiverTransformBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpSenderTransformBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+Modules/mediastream/gstreamer/GStreamerRtpTransformBackend.cpp
+Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
+Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+
+Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+
+platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+platform/audio/gstreamer/FFTFrameGStreamer.cpp
+platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp @no-unify
+
+platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/GRefPtrGStreamer.cpp
+platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+platform/graphics/gstreamer/GStreamerCommon.cpp
+platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+platform/graphics/gstreamer/GStreamerVideoFrameHolder.cpp @no-unify
+platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
+platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+platform/graphics/gstreamer/ImageGStreamerCairo.cpp
+platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+platform/graphics/gstreamer/MediaEngineConfigurationFactoryGStreamer.cpp
+platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+platform/graphics/gstreamer/TextCombinerGStreamer.cpp @no-unify
+platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp @no-unify
+platform/graphics/gstreamer/TextSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+platform/graphics/gstreamer/VideoSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp @no-unify
+platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp @no-unify
+
+platform/graphics/gstreamer/eme/CDMFactoryGStreamer.cpp
+platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+platform/graphics/gstreamer/eme/CDMThunder.cpp
+platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp @no-unify
+
+platform/graphics/gstreamer/mse/AppendPipeline.cpp
+platform/graphics/gstreamer/mse/GStreamerMediaDescription.cpp
+platform/graphics/gstreamer/mse/GStreamerRegistryScannerMSE.cpp
+platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
+platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+platform/graphics/gstreamer/mse/TrackQueue.cpp
+platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp @no-unify
+
+platform/gstreamer/GStreamerCodecUtilities.cpp
+platform/gstreamer/GStreamerElementHarness.cpp
+platform/gstreamer/PlatformSpeechSynthesizerGStreamer.cpp
+platform/gstreamer/VideoEncoderPrivateGStreamer.cpp @no-unify
+platform/gstreamer/WebKitFliteSourceGStreamer.cpp @no-unify
+
+platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+
+platform/mediastream/libwebrtc/gstreamer/GStreamerVideoCommon.cpp
+platform/mediastream/libwebrtc/gstreamer/GStreamerVideoDecoderFactory.cpp
+platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+platform/mediastream/libwebrtc/gstreamer/GStreamerVideoFrameLibWebRTC.cpp
+platform/mediastream/libwebrtc/gstreamer/LibWebRTCProviderGStreamer.cpp
+platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
+platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.cpp
+platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingVideoSourceLibWebRTC.cpp
+
+platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+platform/mediastream/gstreamer/GStreamerCapturer.cpp
+platform/mediastream/gstreamer/GStreamerDTMFSenderBackend.cpp
+platform/mediastream/gstreamer/GStreamerDisplayCaptureDeviceManager.cpp
+platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp @no-unify
+platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeMediaSourceCenterGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_audio_destination_debug);
 #define GST_CAT_DEFAULT webkit_audio_destination_debug
 
-static void initializeDebugCategory()
+static void initializeAudioDestinationDebugCategory()
 {
     ensureGStreamerInitialized();
     registerWebKitGStreamerElements();
@@ -55,7 +55,7 @@ static void initializeDebugCategory()
 
 static unsigned long maximumNumberOfOutputChannels()
 {
-    initializeDebugCategory();
+    initializeAudioDestinationDebugCategory();
 
     static int count = 0;
     static std::once_flag onceFlag;
@@ -90,7 +90,7 @@ static unsigned long maximumNumberOfOutputChannels()
 
 Ref<AudioDestination> AudioDestination::create(AudioIOCallback& callback, const String&, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
 {
-    initializeDebugCategory();
+    initializeAudioDestinationDebugCategory();
     // FIXME: make use of inputDeviceId as appropriate.
 
     // FIXME: Add support for local/live audio input.
@@ -292,6 +292,8 @@ void AudioDestinationGStreamer::notifyIsPlaying(bool isPlaying)
     if (m_callback)
         m_callback->isPlayingDidChange();
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -42,7 +42,7 @@ static const float gSampleBitRate = 44100;
 GST_DEBUG_CATEGORY(webkit_audio_provider_debug);
 #define GST_CAT_DEFAULT webkit_audio_provider_debug
 
-static void initializeDebugCategory()
+static void initializeAudioSourceProviderDebugCategory()
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
@@ -86,7 +86,7 @@ static void copyGStreamerBuffersToAudioChannel(GstAdapter* adapter, AudioBus* bu
 AudioSourceProviderGStreamer::AudioSourceProviderGStreamer()
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
 {
-    initializeDebugCategory();
+    initializeAudioSourceProviderDebugCategory();
 }
 
 #if ENABLE(MEDIA_STREAM)
@@ -94,7 +94,7 @@ AudioSourceProviderGStreamer::AudioSourceProviderGStreamer(MediaStreamTrackPriva
     : m_captureSource(source)
     , m_notifier(MainThreadNotifier<MainThreadNotification>::create())
 {
-    initializeDebugCategory();
+    initializeAudioSourceProviderDebugCategory();
     registerWebKitGStreamerElements();
     const char* pipelineNamePrefix = "";
 #if USE(GSTREAMER_WEBRTC)
@@ -482,6 +482,8 @@ void AudioSourceProviderGStreamer::clearAdapters()
     for (auto& adapter : m_adapters.values())
         gst_adapter_clear(adapter.get());
 }
+
+#undef GST_CAT_DEFAULT
 
 } // WebCore
 

--- a/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp
@@ -475,4 +475,6 @@ void webkitWebAudioSourceSetDispatchToRenderThreadFunction(WebKitWebAudioSrc* sr
     src->priv->dispatchToRenderThreadFunction = WTFMove(function);
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(WEB_AUDIO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -169,6 +169,8 @@ void AudioTrackPrivateGStreamer::setEnabled(bool enabled)
         m_player->updateEnabledAudioTrack();
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -195,4 +195,6 @@ void webKitDMABufVideoSinkSetMediaPlayerPrivate(WebKitDMABufVideoSink* sink, Med
     webKitVideoSinkSetMediaPlayerPrivate(priv->appSink.get(), priv->mediaPlayerPrivate);
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -235,4 +235,6 @@ bool webKitGLVideoSinkProbePlatform()
     return isGStreamerPluginAvailable("app") && isGStreamerPluginAvailable("opengl");
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp
@@ -139,5 +139,8 @@ void GStreamerAudioMixer::unregisterProducer(const GRefPtr<GstPad>& mixerPad)
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_pipeline.get()), GST_DEBUG_GRAPH_SHOW_ALL, "audio-mixer-after-producer-unregistration");
 }
 
-}
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1019,6 +1019,8 @@ bool gstObjectHasProperty(GstPad* pad, const char* name)
     return gstObjectHasProperty(GST_OBJECT_CAST(pad), name);
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #undef IS_GST_FULL_1_18

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1091,5 +1091,8 @@ Vector<RTCRtpCapabilities::HeaderExtensionCapability> GStreamerRegistryScanner::
 
 #endif // USE(GSTREAMER_WEBRTC)
 
-}
-#endif
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -333,4 +333,6 @@ static void webkit_app_sink_with_workarounds_class_init(WebKitAppSinkWithWorkaro
     gobjectClass->constructed = webkitAppSinkWithWorkAroundsConstructed;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -104,4 +104,6 @@ void webKitVideoSinkSetMediaPlayerPrivate(GstElement* appSink, MediaPlayerPrivat
     }, player, nullptr);
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp
@@ -320,6 +320,8 @@ void ImageDecoderGStreamer::pushEncodedData(const FragmentedSharedBuffer& shared
     m_decoderHarness->flush();
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER) && ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -97,6 +97,8 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
     }
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -139,14 +139,6 @@ using namespace std;
 static const FloatSize s_holePunchDefaultFrameSize(1280, 720);
 #endif
 
-static void initializeDebugCategory()
-{
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        GST_DEBUG_CATEGORY_INIT(webkit_media_player_debug, "webkitmediaplayer", 0, "WebKit media player");
-    });
-}
-
 MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
     , m_player(player)
@@ -289,7 +281,10 @@ private:
 
 void MediaPlayerPrivateGStreamer::registerMediaEngine(MediaEngineRegistrar registrar)
 {
-    initializeDebugCategory();
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_media_player_debug, "webkitmediaplayer", 0, "WebKit media player");
+    });
     registrar(makeUnique<MediaPlayerFactoryGStreamer>());
 }
 
@@ -4384,6 +4379,8 @@ String MediaPlayerPrivateGStreamer::codecForStreamId(const String& streamId)
     return m_codecs.get(streamId);
 }
 
-}
+#undef GST_CAT_DEFAULT
 
-#endif // USE(GSTREAMER)
+} // namespace WebCore
+
+#endif //  ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp
@@ -226,4 +226,6 @@ GstElement* webkitTextCombinerNew()
     return GST_ELEMENT(g_object_new(WEBKIT_TYPE_TEXT_COMBINER, nullptr));
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp
@@ -139,4 +139,6 @@ GstElement* webkitTextSinkNew(WeakPtr<MediaPlayerPrivateGStreamer>&& player)
     return element;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -287,6 +287,8 @@ void TrackPrivateBaseGStreamer::streamChanged()
     });
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_video_decoder_debug);
 #define GST_CAT_DEFAULT webkit_video_decoder_debug
 
-static WorkQueue& gstWorkQueue()
+static WorkQueue& gstDecoderWorkQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("GStreamer VideoDecoder Queue"));
     return queue.get();
@@ -79,7 +79,7 @@ bool GStreamerVideoDecoder::create(const String& codecName, const Config& config
 
     GRefPtr<GstElement> element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     auto decoder = makeUniqueRef<GStreamerVideoDecoder>(codecName, config, WTFMove(outputCallback), WTFMove(postTaskCallback), WTFMove(element));
-    gstWorkQueue().dispatch([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
+    gstDecoderWorkQueue().dispatch([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
         auto internalDecoder = decoder->m_internalDecoder;
         internalDecoder->postTask([callback = WTFMove(callback), decoder = WTFMove(decoder)]() mutable {
             GST_DEBUG("Video decoder created");
@@ -102,14 +102,14 @@ GStreamerVideoDecoder::~GStreamerVideoDecoder()
 
 void GStreamerVideoDecoder::decode(EncodedFrame&& frame, DecodeCallback&& callback)
 {
-    gstWorkQueue().dispatch([value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
+    gstDecoderWorkQueue().dispatch([value = Vector<uint8_t> { frame.data }, isKeyFrame = frame.isKeyFrame, timestamp = frame.timestamp, duration = frame.duration, decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
         decoder->decode({ value.data(), value.size() }, isKeyFrame, timestamp, duration, WTFMove(callback));
     });
 }
 
 void GStreamerVideoDecoder::flush(Function<void()>&& callback)
 {
-    gstWorkQueue().dispatch([decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
+    gstDecoderWorkQueue().dispatch([decoder = m_internalDecoder, callback = WTFMove(callback)]() mutable {
         decoder->flush(WTFMove(callback));
     });
 }
@@ -230,6 +230,8 @@ void GStreamerInternalVideoDecoder::flush(Function<void()>&& callback)
     m_harness->flushBuffers();
     m_postTaskCallback(WTFMove(callback));
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -47,7 +47,7 @@ GST_DEBUG_CATEGORY(webkit_video_frame_debug);
 
 namespace WebCore {
 
-static void ensureDebugCategoryInitialized()
+static void ensureVideoFrameDebugCategoryInitialized()
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -73,7 +73,7 @@ private:
 
 GstSampleColorConverter& GstSampleColorConverter::singleton()
 {
-    ensureDebugCategoryInitialized();
+    ensureVideoFrameDebugCategoryInitialized();
     static NeverDestroyed<GstSampleColorConverter> sharedInstance;
     return sharedInstance;
 }
@@ -366,7 +366,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(GRefPtr<GstSample>&& sample, const Floa
     , m_sample(WTFMove(sample))
     , m_presentationSize(presentationSize)
 {
-    ensureDebugCategoryInitialized();
+    ensureVideoFrameDebugCategoryInitialized();
     ASSERT(m_sample);
     GstBuffer* buffer = gst_sample_get_buffer(m_sample.get());
     RELEASE_ASSERT(buffer);
@@ -380,7 +380,7 @@ VideoFrameGStreamer::VideoFrameGStreamer(const GRefPtr<GstSample>& sample, const
     , m_sample(sample)
     , m_presentationSize(presentationSize)
 {
-    ensureDebugCategoryInitialized();
+    ensureVideoFrameDebugCategoryInitialized();
 }
 
 static void copyPlane(uint8_t* destination, const uint8_t* source, uint64_t sourceStride, const ComputedPlaneLayout& spanPlaneLayout)
@@ -549,6 +549,8 @@ RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()
 {
     return GstSampleColorConverter::singleton().convertSampleToImage(m_sample);
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -176,4 +176,6 @@ VideoFrameMetadata webkitGstBufferGetVideoFrameMetadata(GstBuffer* buffer)
     return videoFrameMetadata;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp
@@ -321,4 +321,6 @@ GstElement* webkitVideoSinkNew()
     return GST_ELEMENT(g_object_new(WEBKIT_TYPE_VIDEO_SINK, nullptr));
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_video_track_debug);
 #define GST_CAT_DEFAULT webkit_video_track_debug
 
-static void ensureDebugCategoryInitialized()
+static void ensureVideoTrackDebugCategoryInitialized()
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -50,14 +50,14 @@ VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivat
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, WTFMove(pad), shouldHandleStreamStartEvent)
     , m_player(player)
 {
-    ensureDebugCategoryInitialized();
+    ensureVideoTrackDebugCategoryInitialized();
 }
 
 VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer> player, unsigned index, GstStream* stream)
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, stream)
     , m_player(player)
 {
-    ensureDebugCategoryInitialized();
+    ensureVideoTrackDebugCategoryInitialized();
 
     g_signal_connect_swapped(m_stream.get(), "notify::caps", G_CALLBACK(+[](VideoTrackPrivateGStreamer* track) {
         track->m_taskQueue.enqueueTask([track]() {
@@ -175,6 +175,8 @@ void VideoTrackPrivateGStreamer::setSelected(bool selected)
     if (m_player)
         m_player->updateEnabledVideoTrack();
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -334,4 +334,6 @@ GstElement* webkitAudioSinkNew()
     return sink;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -1200,4 +1200,6 @@ bool webKitSrcIsCrossOrigin(WebKitWebSrc* src, const SecurityOrigin& origin)
     return false;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -100,6 +100,8 @@ bool CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input)
     return true;
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -697,6 +697,8 @@ CDMInstanceThunder* CDMInstanceSessionThunder::cdmInstanceThunder() const
     return static_cast<CDMInstanceThunder*>(proxy.get());
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp
@@ -90,5 +90,8 @@ RefPtr<SharedBuffer> InitData::extractCencIfNeeded(RefPtr<SharedBuffer>&& unpars
     return payload;
 }
 
-}
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
 #endif // ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -515,4 +515,6 @@ static void setContext(GstElement* element, GstContext* context)
     GST_ELEMENT_CLASS(parent_class)->set_context(element, context);
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -165,4 +165,6 @@ static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* iv
     return result;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -1130,6 +1130,8 @@ static GstPadProbeReturn matroskademuxForceSegmentStartToEqualZero(GstPad*, GstP
     return GST_PAD_PROBE_OK;
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore.
 
-#endif // USE(GSTREAMER)
+#endif // ENABLE(VIDEO) && USE(GSTREAMER) && ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -401,6 +401,8 @@ bool MediaPlayerPrivateGStreamerMSE::currentMediaTimeMayProgress() const
     return m_mediaSourcePrivate->hasFutureTime(currentMediaTime(), durationMediaTime(), buffered());
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore.
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -222,5 +222,8 @@ WTFLogChannel& MediaSourcePrivateGStreamer::logChannel() const
 
 #endif
 
-}
-#endif
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
@@ -90,6 +90,8 @@ void MediaSourceTrackGStreamer::remove()
     m_isRemoved = true;
 }
 
-}
+#undef GST_CAT_DEFAULT
 
-#endif
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -380,5 +380,8 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
     return 0;
 }
 
-}
-#endif
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.cpp
@@ -161,5 +161,8 @@ GstClockTime TrackQueue::durationEnqueued() const
     return GST_BUFFER_DTS_OR_PTS(back) - GST_BUFFER_DTS_OR_PTS(front);
 }
 
-}
-#endif
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp
@@ -76,6 +76,8 @@ uint8_t GStreamerCodecUtilities::parseVP9Profile(const String& codec)
     return profile;
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -633,6 +633,8 @@ void GStreamerElementHarness::dumpGraph(const char* filenamePrefix)
 #endif
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -767,5 +767,6 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
 }
 
 #undef NUMBER_OF_THREADS
+#undef GST_CAT_DEFAULT
 
 #endif // ENABLE(VIDEO) && USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -270,4 +270,6 @@ void webKitFliteSrcSetUtterance(WebKitFliteSrc* src, const PlatformSpeechSynthes
     priv->text = text;
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(SPEECH_SYNTHESIS) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -363,6 +363,8 @@ void MediaRecorderPrivateGStreamer::notifyEOS()
     m_eosCondition.notifyAll();
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_TRANSCODER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -44,16 +44,6 @@ const static RealtimeMediaSourceCapabilities::EchoCancellation defaultEchoCancel
 GST_DEBUG_CATEGORY(webkit_audio_capture_source_debug);
 #define GST_CAT_DEFAULT webkit_audio_capture_source_debug
 
-static void initializeDebugCategory()
-{
-    ensureGStreamerInitialized();
-
-    static std::once_flag debugRegisteredFlag;
-    std::call_once(debugRegisteredFlag, [] {
-        GST_DEBUG_CATEGORY_INIT(webkit_audio_capture_source_debug, "webkitaudiocapturesource", 0, "WebKit Audio Capture Source.");
-    });
-}
-
 class GStreamerAudioCaptureSourceFactory : public AudioCaptureFactory {
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, PageIdentifier) final
@@ -99,7 +89,12 @@ GStreamerAudioCaptureSource::GStreamerAudioCaptureSource(GStreamerCaptureDevice 
     : RealtimeMediaSource(device, WTFMove(hashSalts))
     , m_capturer(makeUnique<GStreamerAudioCapturer>(device))
 {
-    initializeDebugCategory();
+    ensureGStreamerInitialized();
+
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_audio_capture_source_debug, "webkitaudiocapturesource", 0, "WebKit Audio Capture Source.");
+    });
 }
 
 GStreamerAudioCaptureSource::~GStreamerAudioCaptureSource()
@@ -212,6 +207,8 @@ void GStreamerAudioCaptureSource::setInterruptedForTesting(bool isInterrupted)
     m_capturer->setInterrupted(isInterrupted);
     RealtimeMediaSource::setInterruptedForTesting(isInterrupted);
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -40,7 +40,7 @@ static constexpr size_t s_audioCaptureSampleRate = 48000;
 GST_DEBUG_CATEGORY(webkit_audio_capturer_debug);
 #define GST_CAT_DEFAULT webkit_audio_capturer_debug
 
-static void initializeDebugCategory()
+static void initializeAudioCapturerDebugCategory()
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -51,13 +51,13 @@ static void initializeDebugCategory()
 GStreamerAudioCapturer::GStreamerAudioCapturer(GStreamerCaptureDevice device)
     : GStreamerCapturer(device, adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, s_audioCaptureSampleRate, nullptr)))
 {
-    initializeDebugCategory();
+    initializeAudioCapturerDebugCategory();
 }
 
 GStreamerAudioCapturer::GStreamerAudioCapturer()
     : GStreamerCapturer("appsrc", adoptGRef(gst_caps_new_simple("audio/x-raw", "rate", G_TYPE_INT, s_audioCaptureSampleRate, nullptr)), CaptureDevice::DeviceType::Microphone)
 {
-    initializeDebugCategory();
+    initializeAudioCapturerDebugCategory();
 }
 
 GstElement* GStreamerAudioCapturer::createConverter()
@@ -100,6 +100,8 @@ bool GStreamerAudioCapturer::setSampleRate(int sampleRate)
     g_object_set(m_capsfilter.get(), "caps", m_caps.get(), nullptr);
     return true;
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -196,6 +196,8 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
     }
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp
@@ -38,7 +38,7 @@ GST_DEBUG_CATEGORY(webkit_capturer_debug);
 
 namespace WebCore {
 
-static void initializeDebugCategory()
+static void initializeCapturerDebugCategory()
 {
     ensureGStreamerInitialized();
 
@@ -54,7 +54,7 @@ GStreamerCapturer::GStreamerCapturer(GStreamerCaptureDevice device, GRefPtr<GstC
     , m_sourceFactory(nullptr)
     , m_deviceType(device.type())
 {
-    initializeDebugCategory();
+    initializeCapturerDebugCategory();
 }
 
 GStreamerCapturer::GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps> caps, CaptureDevice::DeviceType deviceType)
@@ -63,7 +63,7 @@ GStreamerCapturer::GStreamerCapturer(const char* sourceFactory, GRefPtr<GstCaps>
     , m_sourceFactory(sourceFactory)
     , m_deviceType(deviceType)
 {
-    initializeDebugCategory();
+    initializeCapturerDebugCategory();
 }
 
 GStreamerCapturer::~GStreamerCapturer()
@@ -217,6 +217,8 @@ void GStreamerCapturer::setInterrupted(bool isInterrupted)
 {
     g_object_set(m_valve.get(), "drop", isInterrupted, nullptr);
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1025,4 +1025,6 @@ GstElement* webkitMediaStreamSrcNew()
     return GST_ELEMENT_CAST(g_object_new(webkit_media_stream_src_get_type(), nullptr));
 }
 
+#undef GST_CAT_DEFAULT
+
 #endif // ENABLE(VIDEO) && ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_video_capture_source_debug);
 #define GST_CAT_DEFAULT webkit_video_capture_source_debug
 
-static void initializeDebugCategory()
+static void initializeVideoCaptureSourceDebugCategory()
 {
     ensureGStreamerInitialized();
 
@@ -110,7 +110,7 @@ GStreamerVideoCaptureSource::GStreamerVideoCaptureSource(String&& deviceID, Atom
     , m_capturer(makeUnique<GStreamerVideoCapturer>(sourceFactory, deviceType))
     , m_deviceType(deviceType)
 {
-    initializeDebugCategory();
+    initializeVideoCaptureSourceDebugCategory();
     m_capturer->setPipewireNodeAndFD(nodeAndFd);
     m_capturer->addObserver(*this);
 }
@@ -120,7 +120,7 @@ GStreamerVideoCaptureSource::GStreamerVideoCaptureSource(GStreamerCaptureDevice 
     , m_capturer(makeUnique<GStreamerVideoCapturer>(device))
     , m_deviceType(CaptureDevice::DeviceType::Camera)
 {
-    initializeDebugCategory();
+    initializeVideoCaptureSourceDebugCategory();
     m_capturer->addObserver(*this);
 }
 
@@ -309,6 +309,8 @@ void GStreamerVideoCaptureSource::generatePresets()
 
     setSupportedPresets(WTFMove(presets));
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -30,7 +30,7 @@ GST_DEBUG_CATEGORY(webkit_video_capturer_debug);
 
 namespace WebCore {
 
-static void initializeDebugCategory()
+static void initializeVideoCapturerDebugCategory()
 {
     ensureGStreamerInitialized();
 
@@ -43,13 +43,13 @@ static void initializeDebugCategory()
 GStreamerVideoCapturer::GStreamerVideoCapturer(GStreamerCaptureDevice device)
     : GStreamerCapturer(device, adoptGRef(gst_caps_new_empty_simple("video/x-raw")))
 {
-    initializeDebugCategory();
+    initializeVideoCapturerDebugCategory();
 }
 
 GStreamerVideoCapturer::GStreamerVideoCapturer(const char* sourceFactory, CaptureDevice::DeviceType deviceType)
     : GStreamerCapturer(sourceFactory, adoptGRef(gst_caps_new_empty_simple("video/x-raw")), deviceType)
 {
-    initializeDebugCategory();
+    initializeVideoCapturerDebugCategory();
 }
 
 GstElement* GStreamerVideoCapturer::createSource()
@@ -358,6 +358,8 @@ void GStreamerVideoCapturer::reconfigure()
     GST_INFO_OBJECT(m_pipeline.get(), "Setting video capture device caps to %" GST_PTR_FORMAT, caps.get());
     g_object_set(m_videoSrcMIMETypeFilter.get(), "caps", caps.get(), nullptr);
 }
+
+#undef GST_CAT_DEFAULT
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp
@@ -61,6 +61,8 @@ void RealtimeIncomingAudioSourceGStreamer::dispatchSample(GRefPtr<GstSample>&& s
     audioSamplesAvailable(presentationTime, frames, description, 0);
 }
 
-}
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -218,6 +218,8 @@ bool RealtimeIncomingSourceGStreamer::handleUpstreamQuery(GstQuery* query, int c
     return gst_pad_peer_query(pad.get(), query);
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp
@@ -117,6 +117,8 @@ const GstStructure* RealtimeIncomingVideoSourceGStreamer::stats()
     return m_stats.get();
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -195,6 +195,8 @@ void RealtimeOutgoingAudioSourceGStreamer::linkOutgoingSource()
     g_object_set(m_inputSelector.get(), "active-pad", sinkPad.get(), nullptr);
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -240,6 +240,8 @@ void RealtimeOutgoingMediaSourceGStreamer::setSinkPad(GRefPtr<GstPad>&& pad)
     g_object_get(m_transceiver.get(), "sender", &m_sender.outPtr(), nullptr);
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -278,6 +278,8 @@ void RealtimeOutgoingVideoSourceGStreamer::flush()
     gst_element_send_event(m_outgoingSource.get(), gst_video_event_new_downstream_force_key_unit(GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, FALSE, 1));
 }
 
+#undef GST_CAT_DEFAULT
+
 } // namespace WebCore
 
 #endif // USE(GSTREAMER_WEBRTC)


### PR DESCRIPTION
#### 28b96586b4723d885bfbd29369652b81322deccd
<pre>
[CMake] Unify GStreamer sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=257562">https://bugs.webkit.org/show_bug.cgi?id=257562</a>

Reviewed by Carlos Garcia Campos.

Flag the GStreamer GObject subclasses as no-unify, undefine GST_CAT_DEFAULT at the end of each unit
to avoid warnings about its redefinition in neighbour units.

Most of the GBM are now no-unify, otherwise the epoxy include from MediaPlayerPrivateGStreamer
throws an error...

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/GStreamer.cmake:
* Source/WebCore/platform/SourcesGStreamer.txt: Added.
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::initializeAudioDestinationDebugCategory):
(WebCore::maximumNumberOfOutputChannels):
(WebCore::AudioDestination::create):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::createBusFromInMemoryAudioFile):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp:
(WebCore::initializeAudioSourceProviderDebugCategory):
(WebCore::AudioSourceProviderGStreamer::AudioSourceProviderGStreamer):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/audio/gstreamer/WebKitWebAudioSourceGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerAudioMixer.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
* Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
* Source/WebCore/platform/graphics/gstreamer/ImageDecoderGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::registerMediaEngine):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/TextCombinerGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/TextSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::gstDecoderWorkQueue):
(WebCore::GStreamerVideoDecoder::create):
(WebCore::GStreamerVideoDecoder::decode):
(WebCore::GStreamerVideoDecoder::flush):
(WebCore::gstWorkQueue): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::gstEncoderWorkQueue):
(WebCore::GStreamerVideoEncoder::create):
(WebCore::GStreamerVideoEncoder::encode):
(WebCore::GStreamerVideoEncoder::flush):
(WebCore::gstWorkQueue): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::ensureVideoFrameDebugCategoryInitialized):
(WebCore::GstSampleColorConverter::singleton):
(WebCore::VideoFrameGStreamer::VideoFrameGStreamer):
(WebCore::ensureDebugCategoryInitialized): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/VideoSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::ensureVideoTrackDebugCategoryInitialized):
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
(WebCore::ensureDebugCategoryInitialized): Deleted.
* Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/TrackQueue.cpp:
* Source/WebCore/platform/gstreamer/GStreamerCodecUtilities.cpp:
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
* Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::GStreamerAudioCaptureSource):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::initializeAudioCapturerDebugCategory):
(WebCore::GStreamerAudioCapturer::GStreamerAudioCapturer):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::initializeCapturerDebugCategory):
(WebCore::GStreamerCapturer::GStreamerCapturer):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::initializeVideoCaptureSourceDebugCategory):
(WebCore::m_deviceType):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::initializeVideoCapturerDebugCategory):
(WebCore::GStreamerVideoCapturer::GStreamerVideoCapturer):
(WebCore::initializeDebugCategory): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:

Canonical link: <a href="https://commits.webkit.org/264829@main">https://commits.webkit.org/264829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/481779bcc658dcca357c07668e612d3c2a94a84b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8756 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8914 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9919 "3 flakes 2 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10579 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8014 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11500 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7909 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->