### PR TITLE
Select with multiple enabled does not consistently fire OnChange

### DIFF
--- a/LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside-expected.txt
+++ b/LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside-expected.txt
@@ -1,0 +1,9 @@
+should dispatch change event when mouse is released outside.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside.html
+++ b/LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<select id="listBoxSelect" size="5" multiple="multiple">
+<option value="option 1">Option 1</option>
+<option value="option 2">Option 2</option>
+<option value="option 3">Option 3</option>
+<option value="option 4">Option 4</option>
+<option value="option 5">Option 5</option>
+</select>
+<script>
+description('should dispatch change event when mouse is released outside.');
+jsTestIsAsync = true;
+var select = document.getElementById('listBoxSelect');
+select.onchange = function() {
+    testPassed('A change event was dispatched.');
+}
+
+window.onload = function()
+{
+    if (!window.eventSender)
+        debug('Select listbox using mouse and release the mouse pointer outside the listbox. The test passes if "A change event was dispatched." is printed.');
+    else {   
+        var x = select.offsetLeft + 7;
+        var y = select.offsetTop + 7;
+        eventSender.dragMode = false;
+        eventSender.mouseMoveTo(x, y);
+        eventSender.mouseDown();
+        eventSender.mouseMoveTo(x, y + 20);
+        eventSender.mouseMoveTo(x, y + 600);
+        eventSender.mouseUp(); 
+        setTimeout(HorizontalTest, 100);
+    }
+}
+function HorizontalTest()
+{
+    var x = select.offsetLeft + 7;
+    var y = select.offsetTop + 7;
+    eventSender.dragMode = false;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseMoveTo(x + 20, y);
+    eventSender.mouseMoveTo(x + 600, y);
+    eventSender.mouseUp();
+    finishJSTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3937,6 +3937,7 @@ imported/w3c/web-platform-tests/css/css-writing-modes/forms/color-input-appearan
 # <select> are always menulists on iOS, regardless of multiple/size attributes, these tests assume the listbox appearance that desktop platforms have.
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-multiple-scrolling.optional.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/select-size-scrolling-and-sizing.optional.html [ Failure ]
+fast/forms/select/multiselect-in-listbox-mouse-release-outside.html [ Skip ]
 
 # To investigate: might need to relax the tests, or adapt native thumb appearance.
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/range-input-vertical-ltr-painting.html [ ImageOnlyFailure ]

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
  * Copyright (C) 2012 Digia Plc. and/or its subsidiary(-ies)
  *
@@ -34,6 +35,7 @@
 #include "LocalFrameView.h"
 #include "Page.h"
 #include "RenderBox.h"
+#include "RenderListBox.h"
 #include "RenderView.h"
 #include "ScrollView.h"
 #include "Settings.h"
@@ -75,6 +77,8 @@ void AutoscrollController::startAutoscrollForSelection(RenderObject* renderer)
     if (m_autoscrollTimer.isActive())
         return;
     auto* scrollable = RenderBox::findAutoscrollable(renderer);
+    if (!scrollable)
+        scrollable = renderer->isListBox() ? downcast<RenderListBox>(renderer) : nullptr;
     if (!scrollable)
         return;
     m_autoscrollType = AutoscrollForSelection;


### PR DESCRIPTION
#### 066cf30607d538a2f7766f4acf615fb0a9118a4c
<pre>
Select with multiple enabled does not consistently fire OnChange

<a href="https://bugs.webkit.org/show_bug.cgi?id=257565">https://bugs.webkit.org/show_bug.cgi?id=257565</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=164563

This patch adds logic for the case, when the listbox is scrollable to
fire &apos;onChange&apos; event when the selection is dropped outside of &apos;listbox&apos;.

* Source/WebCore/page/AutoscrollController.cpp:
(AutoscrollController::startAutoscrollForSelection): As above
* LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside.html: Add Test Case
* LayoutTests/fast/forms/select/multiselect-in-listbox-mouse-release-outside-expected.txt: Add Test Case Expectation
* LayoutTests/platform/ios/TestExpectations: &apos;iOS&apos; exception due to lack of &apos;listbox&apos; appearance

Canonical link: <a href="https://commits.webkit.org/264873@main">https://commits.webkit.org/264873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb72ac1fb7a93dbdba7bc1379d0db13a6a2c27b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11566 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10504 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7858 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2168 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->