### PR TITLE
Make sure ImageData objects are shared when doing structured cloning

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/without-ports/028-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/without-ports/028-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Cloning objects, preserving sharing #2 assert_equals: expected object "[object ImageData]" but got object "[object ImageData]"
+PASS Cloning objects, preserving sharing #2
 


### PR DESCRIPTION
#### dd1484feba3d6e44d5ac12d9a6162d47582781d4
<pre>
Make sure ImageData objects are shared when doing structured cloning
<a href="https://bugs.webkit.org/show_bug.cgi?id=257626">https://bugs.webkit.org/show_bug.cgi?id=257626</a>

Reviewed by Darin Adler.

Make sure ImageData objects are shared when doing structured cloning so that
if you send the same ImageData object is present multiple times in the
object being serialized, the object identity is preserved after deserializing.

* LayoutTests/imported/w3c/web-platform-tests/webmessaging/without-ports/028-expected.txt:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneSerializer::writeImageDataIndex):
(WebCore::CloneDeserializer::readImageDataIndex):
(WebCore::CloneDeserializer::readTerminal):

Canonical link: <a href="https://commits.webkit.org/264824@main">https://commits.webkit.org/264824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf6bc130931ddaccac8b5e1741f3f66e8f47f71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11584 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9879 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10537 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15489 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11466 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8608 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7869 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2120 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->