### PR TITLE
[Cocoa] Sometimes a YouTube video is incorrectly sized, and doesn't respond to window resize

### DIFF
--- a/Source/WebCore/platform/graphics/FloatPoint.cpp
+++ b/Source/WebCore/platform/graphics/FloatPoint.cpp
@@ -95,4 +95,19 @@ TextStream& operator<<(TextStream& ts, const FloatPoint& p)
     return ts << "(" << TextStream::FormatNumberRespectingIntegers(p.x()) << "," << TextStream::FormatNumberRespectingIntegers(p.y()) << ")";
 }
 
+Ref<JSON::Object> FloatPoint::toJSONObject() const
+{
+    auto object = JSON::Object::create();
+
+    object->setDouble("x"_s, m_x);
+    object->setDouble("y"_s, m_y);
+
+    return object;
+}
+
+String FloatPoint::toJSONString() const
+{
+    return toJSONObject()->toJSONString();
+}
+
 }

--- a/Source/WebCore/platform/graphics/FloatPoint.h
+++ b/Source/WebCore/platform/graphics/FloatPoint.h
@@ -193,6 +193,9 @@ public:
     WEBCORE_EXPORT FloatPoint matrixTransform(const TransformationMatrix&) const;
     WEBCORE_EXPORT FloatPoint matrixTransform(const AffineTransform&) const;
 
+    WEBCORE_EXPORT String toJSONString() const;
+    WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
+
 private:
     float m_x { 0 };
     float m_y { 0 };
@@ -307,3 +310,15 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FloatPoint&);
 
 }
 
+namespace WTF {
+
+template<typename Type> struct LogArgument;
+template <>
+struct LogArgument<WebCore::FloatPoint> {
+    static String toString(const WebCore::FloatPoint& point)
+    {
+        return point.toJSONString();
+    }
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/graphics/FloatRect.cpp
+++ b/Source/WebCore/platform/graphics/FloatRect.cpp
@@ -281,4 +281,19 @@ TextStream& operator<<(TextStream& ts, const FloatRect &r)
     return ts << r.location() << " " << r.size();
 }
 
+Ref<JSON::Object> FloatRect::toJSONObject() const
+{
+    auto object = JSON::Object::create();
+
+    object->setObject("location"_s, m_location.toJSONObject());
+    object->setObject("size"_s, m_size.toJSONObject());
+
+    return object;
+}
+
+String FloatRect::toJSONString() const
+{
+    return toJSONObject()->toJSONString();
+}
+
 }

--- a/Source/WebCore/platform/graphics/FloatRect.h
+++ b/Source/WebCore/platform/graphics/FloatRect.h
@@ -239,6 +239,9 @@ public:
     static FloatRect infiniteRect();
     bool isInfinite() const;
 
+    WEBCORE_EXPORT String toJSONString() const;
+    WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
+
 private:
     FloatPoint m_location;
     FloatSize m_size;
@@ -322,3 +325,16 @@ WEBCORE_EXPORT id makeNSArrayElement(const FloatRect&);
 #endif
 
 }
+
+namespace WTF {
+
+template<typename Type> struct LogArgument;
+template <>
+struct LogArgument<WebCore::FloatRect> {
+    static String toString(const WebCore::FloatRect& rect)
+    {
+        return rect.toJSONString();
+    }
+};
+
+} // namespace WTF

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -63,7 +63,7 @@ PlatformLayer* VideoLayerManagerObjC::videoInlineLayer() const
 
 void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, FloatSize contentSize)
 {
-    ALWAYS_LOG(LOGIDENTIFIER, contentSize.width(), ", ", contentSize.height());
+    ALWAYS_LOG(LOGIDENTIFIER, contentSize);
 
     m_videoLayer = videoLayer;
     [m_videoLayer web_disableAllActions];

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -220,7 +220,7 @@ void VideoFullscreenModelContext::requestFullscreenMode(HTMLMediaElementEnums::V
 
 void VideoFullscreenModelContext::setVideoLayerFrame(WebCore::FloatRect frame)
 {
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, frame.size());
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, frame);
     if (m_manager)
         m_manager->setVideoLayerFrame(m_contextId, frame);
 }


### PR DESCRIPTION
#### ae406cb584f994b3ec3b5b6801573329422d9596
<pre>
[Cocoa] Sometimes a YouTube video is incorrectly sized, and doesn&apos;t respond to window resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=257628">https://bugs.webkit.org/show_bug.cgi?id=257628</a>
rdar://109754524

Reviewed by Simon Fraser.

`-[WebAVPlayerLayer layoutSublayers]` will calculate a `targetVideoFrame` based on the current
videoLayer&apos;s bounds, the videoDimensions, and gravity. If this value matches the current video
frame, it bails out early without making any changes.

However, it doesn&apos;t save `targetVideoFrame` to `_targetVideoFrame`. If the gravity, videoDimensions,
or even the videoLayer&apos;s bounds change, and there&apos;s an existing pending call to `-resolveBounds`,
an incorrent frame will be set on the videoLayer (whatever the last successful call to
`-layoutSublayers` generated).

Rather than create a local `targetVideoFrame`, just save the results of calling
`-calculateTargetVideoFrame` to the `_targetVideoFrame` ivar. This ensures that subsequent calls to
`-resolveBounds` operate on the correct values.

Extensive drive-by fix: In investigating this bug, there were a number of times where logging which
included a frame&apos;s location would have been useful. But FloatPoint and FloatRect don&apos;t have logging
methods to convert their values to a String (only FloatSize does). So this patch adds those missing
logging methods and converts existing logging to log the whole rect.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer layoutSublayers]):
(-[WebAVPlayerLayer resolveBounds]):
* Source/WebCore/platform/graphics/FloatPoint.cpp:
(WebCore::FloatPoint::toJSONObject const):
(WebCore::FloatPoint::toJSONString const):
* Source/WebCore/platform/graphics/FloatPoint.h:
(WTF::LogArgument&lt;WebCore::FloatPoint&gt;::toString):
* Source/WebCore/platform/graphics/FloatRect.cpp:
(WebCore::FloatRect::toJSONObject const):
(WebCore::FloatRect::toJSONString const):
* Source/WebCore/platform/graphics/FloatRect.h:
(WTF::LogArgument&lt;WebCore::FloatRect&gt;::toString):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setVideoLayer):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::setVideoLayerFrame):

Canonical link: <a href="https://commits.webkit.org/264832@main">https://commits.webkit.org/264832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db8728b04b31c259d3037ba7cd3ba7481502345b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8853 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9870 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10522 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15483 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7858 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2126 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->