### PR TITLE
LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html is flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,6 +1,7 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: Screen orientation locking is not supported
 fragment
 
 FAIL Performing a fragment navigation must not abort the screen orientation change promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-FAIL Performing a fragment navigation within an iframe must not abort the lock promise promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
-FAIL Unloading an iframe by navigating it must abort the lock promise promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+FAIL Performing a fragment navigation within an iframe must not abort the lock promise promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL Unloading an iframe by navigating it must abort the lock promise promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
@@ -5,8 +5,10 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
-<p id="#fragment"></p>
-<a href="#fragment">fragment</a>
+<body>
+  <p id="fragment"></p>
+  <a href="#fragment">fragment</a>
+</body>
 <script type="module">
   import {
     attachIframe,
@@ -25,31 +27,30 @@
   }, "Performing a fragment navigation must not abort the screen orientation change");
 
   promise_test(async (t) => {
-    t.add_cleanup(makeCleanup());
-    const iframe = await attachIframe();
-    iframe.contentDocument.body.innerHTML = `
-      <p id="#fragment"></p>
-      <a href="#fragment">fragment</a>
-    `;
+    const iframe = await attachIframe({ src: "./resources/nav_iframe.html" });
+    t.add_cleanup(makeCleanup(iframe));
     await test_driver.bless("request full screen", null, iframe.contentWindow);
-    await document.documentElement.requestFullscreen();
+    await iframe.contentDocument.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
     const p = iframe.contentWindow.screen.orientation.lock(orientation);
-    await test_driver.click(iframe.contentDocument.querySelector("a"));
+    const anchor = iframe.contentDocument.querySelector("#clickme");
+    await test_driver.click(anchor);
     await p;
-    iframe.remove();
   }, "Performing a fragment navigation within an iframe must not abort the lock promise");
 
   promise_test(async (t) => {
-    t.add_cleanup(makeCleanup());
     const iframe = await attachIframe();
+    t.add_cleanup(makeCleanup(iframe));
     await test_driver.bless("request full screen", null, iframe.contentWindow);
-    await document.documentElement.requestFullscreen();
+    await iframe.contentDocument.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
     const p = iframe.contentWindow.screen.orientation.lock(orientation);
     const frameDOMException = iframe.contentWindow.DOMException;
-    iframe.contentWindow.location.href = "./resources/empty.html";
+    await new Promise((r) => {
+      iframe.addEventListener("load", r, { once: true });
+      iframe.contentWindow.location.href =
+        "./resources/empty.html?" + Math.random();
+    });
     await promise_rejects_dom(t, "AbortError", frameDOMException, p);
-    iframe.remove();
   }, "Unloading an iframe by navigating it must abort the lock promise");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/nav_iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/nav_iframe.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A Document</title>
+</head>
+<body>
+  <h1 id="section1">Section 1</h1>
+  <p>This is the content of section 1.</p>
+
+  <h2 id="section2">Section 2</h2>
+  <p>This is the content of section 2.</p>
+
+  <p>
+    <a href="#section1">Go to Section 1</a> |
+    <a id="clickme" href="#section2">Go to Section 2</a>
+  </p>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2363,7 +2363,6 @@ imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.html?101-last [ F
 imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-last [ Failure ]
 
 # webkit.org/b/246701 Flaky failure only on iOS
-imported/w3c/web-platform-tests/screen-orientation/active-lock.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,6 +1,6 @@
 fragment
 
 PASS Performing a fragment navigation must not abort the screen orientation change
-FAIL Performing a fragment navigation within an iframe must not abort the lock promise promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
-FAIL Unloading an iframe by navigating it must abort the lock promise promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+PASS Performing a fragment navigation within an iframe must not abort the lock promise
+FAIL Unloading an iframe by navigating it must abort the lock promise assert_unreached: Should have rejected: undefined Reached unreachable code
 


### PR DESCRIPTION
#### fa92eae15591c20501300a3ee2f002a78dc0ba0a
<pre>
LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=257630">https://bugs.webkit.org/show_bug.cgi?id=257630</a>
rdar://110148837

Reviewed by Tim Nguyen.

Fixed flakiness by loading an actual html file.
Also fixed some incorrect id values.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/nav_iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
(export.async attachIframe):
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:

Canonical link: <a href="https://commits.webkit.org/264925@main">https://commits.webkit.org/264925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b821a2db593fea0159acd9d641d1307588f969

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8721 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10542 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15490 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11467 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7018 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7891 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2217 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12087 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->