### PR TITLE
[iOS] Memory leak when long pressing images

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
@@ -32,6 +32,14 @@
 
 @implementation WKContextMenuElementInfo
 
+- (void)dealloc
+{
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContextMenuElementInfo.class, self))
+        return;
+    _elementInfo->API::ContextMenuElementInfo::~ContextMenuElementInfo();
+    [super dealloc];
+}
+
 - (NSURL *)linkURL
 {
     return _elementInfo->url();


### PR DESCRIPTION
#### c6de46a00a2ee92ad2fd093f3e03ebbfc4b6a9e1
<pre>
[iOS] Memory leak when long pressing images
<a href="https://bugs.webkit.org/show_bug.cgi?id=257633">https://bugs.webkit.org/show_bug.cgi?id=257633</a>
rdar://109165223

Reviewed by Megan Gardner and Wenson Hsieh.

When long pressing an image (bringing up a context menu) on iOS,
`InteractionInformationAtPosition` is sent to the UI process.

`InteractionInformationAtPosition` is used to create `WKContextMenuElementInfo`,
an API object that contains information about the element that is associated
with the context menu.

However, `WKContextMenuElementInfo` is backed by an `API::ContextMenuElementInfo`.
Like all objects conforming to `WKObject`, the backing object is stored as a
reference. Consequently, the backing object is not automatically destroyed once
`WKContextMenuElementInfo` is deallocated. Consequently, a memory leak occurs
after `WKContextMenuElementInfo` is deallocated.

To fix, implement `-[WKContextMenuElementInfo dealloc]` and explicitly destroy
the backing object.

* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm:
(-[WKContextMenuElementInfo dealloc]):

Implement `-dealloc`, matching other `WKObject`s.

Canonical link: <a href="https://commits.webkit.org/264833@main">https://commits.webkit.org/264833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/929266b22026390dfe8e80f0d325dc30055f03be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11589 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9887 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10543 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7184 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15491 "3 flakes 108 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8294 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7019 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12088 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1031 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->