### PR TITLE
LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html is flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html
@@ -9,28 +9,45 @@
   import {
     attachIframe,
     getOppositeOrientation,
+    makeCleanup,
   } from "./resources/orientation-utils.js";
 
   promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    screen.orientation.addEventListener(
-      "change",
-      async () => {
-        await screen.orientation.lock(getOppositeOrientation());
-      },
-      { once: true }
-    );
-    await screen.orientation.lock(getOppositeOrientation());
+
+    const eventPromise = new Promise((res, rej) => {
+      screen.orientation.addEventListener(
+        "change",
+        () => {
+          screen.orientation
+            .lock(getOppositeOrientation())
+            .then(res)
+            .catch(rej);
+        },
+        { once: true }
+      );
+    });
+    const lockPromise = screen.orientation.lock(getOppositeOrientation());
+    await Promise.all([eventPromise, lockPromise]);
   }, "Re-locking the screen orientation after a change event fires must not abort");
 
   promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    screen.orientation.onchange = async () => {
-      screen.orientation.onchange = null;
-      screen.orientation.unlock();
-    };
-    await screen.orientation.lock(getOppositeOrientation());
+    const eventPromise = new Promise((res) => {
+      screen.orientation.addEventListener(
+        "change",
+        () => {
+          screen.orientation.unlock();
+          res();
+        },
+        { once: true }
+      );
+    });
+    const lockPromise = screen.orientation.lock(getOppositeOrientation());
+    await Promise.all([eventPromise, lockPromise]);
   }, "Unlocking the screen orientation after a change event must not abort");
 </script>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2364,7 +2364,6 @@ imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker.html?101-l
 
 # webkit.org/b/246701 Flaky failure only on iOS
 imported/w3c/web-platform-tests/screen-orientation/event-before-promise.html [ Pass Failure ]
-imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Pass Failure ]
 imported/w3c/web-platform-tests/screen-orientation/onchange-event.html [ Pass Failure ]
 


### PR DESCRIPTION
#### df5c46999eb344972288ba06dae8137e42243154
<pre>
LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=257637">https://bugs.webkit.org/show_bug.cgi?id=257637</a>
rdar://110152655

Reviewed by Tim Nguyen.

Added some promises that actually wait for the events, which fixes things as far
as flakiness is concerned.

 * LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html:
 * LayoutTests/platform/ios-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/264936@main">https://commits.webkit.org/264936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0d9fe1215bd5a0e512169eb54dbcfc6c88045fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11944 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10255 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10968 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15829 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7349 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->