### PR TITLE
Exiting fullscreen should abort screen orientation pending promises

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,4 +1,7 @@
 
-FAIL fullscreen and orientation support promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-PASS Iframe can't itself know if it's parent is fullscreen when changing orientation
+
+PASS Fully unlocking the screen orientation causes a pending lock to be aborted
+FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+PASS Exiting fullscreen causes a pending lock to be aborted
+PASS Exiting fullscreen from an iframe causes a pending lock to be aborted
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
@@ -33,13 +33,38 @@
     const lockPromise = iframeWindow.screen.orientation.lock(
       getOppositeOrientation()
     );
+    await document.exitFullscreen();
+    const frameDOMException = iframe.contentWindow.DOMException;
+    await promise_rejects_dom(t, "AbortError", frameDOMException, lockPromise);
+  }, "Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted");
+
+  promise_test(async (t) => {
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+    const { orientation } = screen;
+    const oppositeOrientation = getOppositeOrientation();
+    const lockPromise = orientation.lock(oppositeOrientation);
     const fsExitPromise = document.exitFullscreen();
+    await promise_rejects_dom(t, "AbortError", lockPromise);
+    await fsExitPromise;
+  }, "Exiting fullscreen causes a pending lock to be aborted");
+
+  promise_test(async (t) => {
+    const iframe = await attachIframe();
+    t.add_cleanup(makeCleanup(iframe));
+    const iframeWindow = iframe.contentWindow;
+    await test_driver.bless("request full screen", null, iframeWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
+    const lockPromise = iframeWindow.screen.orientation.lock(
+      getOppositeOrientation()
+    );
+    const fsExitPromise = iframe.contentDocument.exitFullscreen();
     await promise_rejects_dom(
       t,
-      "SecurityError",
+      "AbortError",
       iframeWindow.DOMException,
       lockPromise
     );
     await fsExitPromise;
-  }, "Iframe can't itself know if it's parent is fullscreen when changing orientation");
+  }, "Exiting fullscreen from an iframe causes a pending lock to be aborted");
 </script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,4 +1,7 @@
 
-PASS fullscreen and orientation support
-PASS Iframe can't itself know if it's parent is fullscreen when changing orientation
+
+PASS Fully unlocking the screen orientation causes a pending lock to be aborted
+FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+PASS Exiting fullscreen causes a pending lock to be aborted
+PASS Exiting fullscreen from an iframe causes a pending lock to be aborted
 


### PR DESCRIPTION
#### c454d31677690e9a95f76c6e5ca37391e9336bb2
<pre>
Exiting fullscreen should abort screen orientation pending promises
<a href="https://bugs.webkit.org/show_bug.cgi?id=257638">https://bugs.webkit.org/show_bug.cgi?id=257638</a>
rdar://110153261

Reviewed by NOBODY (OOPS!).

Adds support for rejecting any pending orientation promise the orientation manager might be holding.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::exitFullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c454d31677690e9a95f76c6e5ca37391e9336bb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11743 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10722 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7342 "4 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8149 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15637 "2 flakes 127 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8451 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8297 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11625 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8787 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7167 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8043 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8056 "Exiting early after 10 failures. 10 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->