### PR TITLE
[Curl] Simplify event handling in CurlRequest::invokeDidReceiveResponse()

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -84,13 +84,6 @@ public:
     WEBCORE_EXPORT void completeDidReceiveResponse();
 
 private:
-    enum class Action {
-        None,
-        ReceiveData,
-        StartTransfer,
-        FinishTransfer
-    };
-
     WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, EnableMultipart, CaptureNetworkLoadMetrics);
 
     void retain() override { ref(); }
@@ -125,9 +118,9 @@ private:
 
     // Processing for DidReceiveResponse
     bool needToInvokeDidReceiveResponse() const { return m_didReceiveResponse && !m_didNotifyResponse; }
-    bool needToInvokeDidCancelTransfer() const { return m_didNotifyResponse && !m_didReturnFromNotify && m_actionAfterInvoke == Action::FinishTransfer; }
+    bool needToInvokeDidCancelTransfer() const { return m_didNotifyResponse && !m_didReturnFromNotify && m_mustInvokeCancelTransfer; }
     void invokeDidReceiveResponseForFile(const URL&);
-    void invokeDidReceiveResponse(const CurlResponse&, Action);
+    void invokeDidReceiveResponse(const CurlResponse&, Function<void()>&& completionHandler = { });
 
     NetworkLoadMetrics networkLoadMetrics();
 
@@ -159,8 +152,8 @@ private:
     bool m_didReceiveResponse { false };
     bool m_didNotifyResponse { false };
     bool m_didReturnFromNotify { false };
-    Action m_actionAfterInvoke { Action::None };
-    CURLcode m_finishedResultCode { CURLE_OK };
+    bool m_mustInvokeCancelTransfer { false };
+    Function<void()> m_responseCompletionHandler;
 
     bool m_captureExtraMetrics;
     HTTPHeaderMap m_requestHeaders;


### PR DESCRIPTION
#### ed79ff00223f7816b5a60598863a8587a1d1801a
<pre>
[Curl] Simplify event handling in CurlRequest::invokeDidReceiveResponse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257639">https://bugs.webkit.org/show_bug.cgi?id=257639</a>

Reviewed by Fujii Hironori.

Replacing the argument of invokeDidReceiveResponse from Action
to Function makes the subsequent processing easier to understand.

* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didReceiveData):
(WebCore::CurlRequest::didReceiveHeaderFromMultipart):
(WebCore::CurlRequest::didCompleteTransfer):
(WebCore::CurlRequest::invokeDidReceiveResponseForFile):
(WebCore::CurlRequest::invokeDidReceiveResponse):
(WebCore::CurlRequest::completeDidReceiveResponse):
* Source/WebCore/platform/network/curl/CurlRequest.h:
(WebCore::CurlRequest::needToInvokeDidCancelTransfer const):
(WebCore::CurlRequest::invokeDidReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/264827@main">https://commits.webkit.org/264827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09cc4f65509afcfd844939349ee4d440469484bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11607 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8899 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9905 "2 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10563 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15507 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8312 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11485 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7036 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12107 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1030 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->