### PR TITLE
REGRESSION (259167@main): [ macOS ] webaudio/audiocontext-large-samplerate.html is a flaky failure

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2704,8 +2704,6 @@ webkit.org/b/255184 [ Ventura ] transforms/3d/hit-testing/overlapping-layers-hit
 [ Ventura ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-009.html [ Pass ImageOnlyFailure ]
 [ Ventura ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-010.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/256091 [ Ventura+ ] webaudio/audiocontext-large-samplerate.html [ Pass Failure ]
-
 webkit.org/b/255788 [ Ventura+ Debug ] tiled-drawing/scrolling/scroll-snap/scroll-snap-mandatory-async-overflow.html [ Skip ]
 
 webkit.org/b/256108 media/video-audio-session-mode.html [ Failure ]

--- a/LayoutTests/webaudio/audiocontext-large-samplerate.html
+++ b/LayoutTests/webaudio/audiocontext-large-samplerate.html
@@ -8,15 +8,13 @@ jsTestIsAsync = true;
 
 context = new AudioContext({ sampleRate: 384000 });
 shouldBe("context.sampleRate", "384000");
-
+context.addEventListener("statechange", () => {
+    shouldBeEqualToString("context.state", "running");
+    finishJSTest();
+}, {once: true});
 node = new ConstantSourceNode(context, { offset: 0.5 });
 node.connect(context.destination);
 node.start();
-
-setTimeout(() => {
-    shouldBeEqualToString("context.state", "running");
-    finishJSTest();
-}, 100);
 </script>
 </body>
 </html>

--- a/LayoutTests/webaudio/audiocontext-low-samplerate.html
+++ b/LayoutTests/webaudio/audiocontext-low-samplerate.html
@@ -8,15 +8,13 @@ jsTestIsAsync = true;
 
 context = new AudioContext({ sampleRate: 3000 });
 shouldBe("context.sampleRate", "3000");
-
+context.addEventListener("statechange", () => {
+    shouldBeEqualToString("context.state", "running");
+    finishJSTest();
+}, {once: true});
 node = new ConstantSourceNode(context, { offset: 0.5 });
 node.connect(context.destination);
 node.start();
-
-setTimeout(() => {
-    shouldBeEqualToString("context.state", "running");
-    finishJSTest();
-}, 100);
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### f293387b8a8c3bcf37f2b03e0c04c09577817bf0
<pre>
REGRESSION (259167@main): [ macOS ] webaudio/audiocontext-large-samplerate.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256091">https://bugs.webkit.org/show_bug.cgi?id=256091</a>
rdar://108658391

Reviewed by Youenn Fablet.

AudioContext is slow to start if the test starts the GPU process.
The tests used setTimeout which could fire before the AudioContext
handled the start.

Use AudioContext.onstatechange to trigger the test of
AudioContext.state == &quot;running&quot;.

* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/webaudio/audiocontext-large-samplerate.html:
* LayoutTests/webaudio/audiocontext-low-samplerate.html:

Canonical link: <a href="https://commits.webkit.org/264831@main">https://commits.webkit.org/264831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/014303327ef338eb155495ac9ba5cbfcd25a383e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8761 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11623 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8919 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10584 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8021 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11503 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2124 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->