### PR TITLE
ThreadSafeObjectHeap should be part of IPC

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -212,7 +212,7 @@ public:
 
     void lowMemoryHandler(WTF::Critical, WTF::Synchronous);
 
-    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>>& serializedImageBufferHeap() { return m_remoteSerializedImageBufferObjectHeap; }
+    IPC::ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>>& serializedImageBufferHeap() { return m_remoteSerializedImageBufferObjectHeap; }
 
 #if ENABLE(WEBGL)
     void releaseGraphicsContextGLForTesting(GraphicsContextGLIdentifier);
@@ -361,7 +361,7 @@ private:
     using RemoteGraphicsContextGLMap = HashMap<GraphicsContextGLIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteGraphicsContextGL>>;
     RemoteGraphicsContextGLMap m_remoteGraphicsContextGLMap;
 #endif
-    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>> m_remoteSerializedImageBufferObjectHeap;
+    IPC::ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>> m_remoteSerializedImageBufferObjectHeap;
     using RemoteGPUMap = HashMap<WebGPUIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteGPU>>;
     RemoteGPUMap m_remoteGPUMap;
 #if ENABLE(ENCRYPTED_MEDIA)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -75,7 +75,7 @@ private:
     void createPixelConformerIfNeeded();
 
     const Ref<IPC::Connection> m_connection;
-    ThreadSafeObjectHeap<RemoteVideoFrameIdentifier, RefPtr<WebCore::VideoFrame>> m_heap;
+    IPC::ThreadSafeObjectHeap<RemoteVideoFrameIdentifier, RefPtr<WebCore::VideoFrame>> m_heap;
 #if PLATFORM(COCOA)
     SharedVideoFrameWriter m_sharedVideoFrameWriter;
     SharedVideoFrameReader m_sharedVideoFrameReader;

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
@@ -33,7 +33,7 @@
 #include <wtf/Noncopyable.h>
 #include <wtf/ObjectIdentifier.h>
 
-namespace WebKit {
+namespace IPC {
 
 // Type for the key in mapping from object identifier references to object state.
 template<typename T>
@@ -193,21 +193,21 @@ template<typename T> inline void add(Hasher& hasher, ObjectIdentifierReference<T
 }
 
 template<typename T>
-TextStream& operator<<(TextStream& ts, const WebKit::ObjectIdentifierReference<T>& reference)
+TextStream& operator<<(TextStream& ts, const IPC::ObjectIdentifierReference<T>& reference)
 {
     ts << "ObjectIdentifierReference(" << reference.identifier() << ", " << reference.version() << ")";
     return ts;
 }
 
 template<typename T>
-TextStream& operator<<(TextStream& ts, const WebKit::ObjectIdentifierReadReference<T>& reference)
+TextStream& operator<<(TextStream& ts, const IPC::ObjectIdentifierReadReference<T>& reference)
 {
     ts << "ObjectIdentifierReadReference(" << reference.identifier() << ", " << reference.version() << ")";
     return ts;
 }
 
 template<typename T>
-TextStream& operator<<(TextStream& ts, const WebKit::ObjectIdentifierWriteReference<T>& reference)
+TextStream& operator<<(TextStream& ts, const IPC::ObjectIdentifierWriteReference<T>& reference)
 {
     ts << "ObjectIdentifierWriteReference(" << reference.identifier() << ", " << reference.version() << ", " << reference.pendingReads() << ")";
     return ts;
@@ -217,16 +217,16 @@ TextStream& operator<<(TextStream& ts, const WebKit::ObjectIdentifierWriteRefere
 
 namespace WTF {
 
-template<typename T> struct HashTraits<WebKit::ObjectIdentifierReference<T>> : SimpleClassHashTraits<WebKit::ObjectIdentifierReference<T>> {
+template<typename T> struct HashTraits<IPC::ObjectIdentifierReference<T>> : SimpleClassHashTraits<IPC::ObjectIdentifierReference<T>> {
     static constexpr bool emptyValueIsZero = HashTraits<T>::emptyValueIsZero;
 };
 
-template<typename T> struct DefaultHash<WebKit::ObjectIdentifierReference<T>> {
-    static unsigned hash(const WebKit::ObjectIdentifierReference<T>& reference)
+template<typename T> struct DefaultHash<IPC::ObjectIdentifierReference<T>> {
+    static unsigned hash(const IPC::ObjectIdentifierReference<T>& reference)
     {
         return computeHash(reference);
     }
-    static bool equal(const WebKit::ObjectIdentifierReference<T>& a, const WebKit::ObjectIdentifierReference<T>& b)
+    static bool equal(const IPC::ObjectIdentifierReference<T>& a, const IPC::ObjectIdentifierReference<T>& b)
     {
         return a == b;
     }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4478,10 +4478,10 @@
 		3AC6E5242A1C59AE0059F092 /* RemoteGraphicsContextGLInitializationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLInitializationState.h; sourceTree = "<group>"; };
 		3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginQuotaManager.cpp; sourceTree = "<group>"; };
 		3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginQuotaManager.h; sourceTree = "<group>"; };
-		3AF5B4712A244FDC004C3D4D /* RemoteGraphicsContextGLMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RemoteGraphicsContextGLMessages.h; path = RemoteGraphicsContextGLMessages.h; sourceTree = "<group>"; };
-		3AF5B4722A244FDC004C3D4D /* RemoteGraphicsContextGLMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteGraphicsContextGLMessageReceiver.cpp; path = RemoteGraphicsContextGLMessageReceiver.cpp; sourceTree = "<group>"; };
-		3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RemoteGraphicsContextGLProxyMessages.h; path = RemoteGraphicsContextGLProxyMessages.h; sourceTree = "<group>"; };
-		3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteGraphicsContextGLProxyMessageReceiver.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		3AF5B4712A244FDC004C3D4D /* RemoteGraphicsContextGLMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLMessages.h; sourceTree = "<group>"; };
+		3AF5B4722A244FDC004C3D4D /* RemoteGraphicsContextGLMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLMessageReceiver.cpp; sourceTree = "<group>"; };
+		3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLProxyMessages.h; sourceTree = "<group>"; };
+		3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteGraphicsContextGLProxyMessageReceiver.cpp; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
 		3F418EF51887BD97002795FD /* VideoFullscreenManagerMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VideoFullscreenManagerMessageReceiver.cpp; sourceTree = "<group>"; };
 		3F418EF61887BD97002795FD /* VideoFullscreenManagerMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VideoFullscreenManagerMessages.h; sourceTree = "<group>"; };
@@ -8039,7 +8039,6 @@
 				86D1970829AE4E930083B077 /* NetworkProcessConnectionParameters.h */,
 				86D1970729AE4E8A0083B077 /* NetworkProcessConnectionParameters.serialization.in */,
 				5CD748B523C8EB190092A9B5 /* NetworkResourceLoadIdentifier.h */,
-				7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */,
 				5CE77805297CB484000BA9CF /* PALArgumentCoders.serialization.in */,
 				8657EE3928EDB8C500FF9B40 /* Pasteboard.serialization.in */,
 				7AFBD36E21E546E3005DBACB /* PersistencyUtils.cpp */,
@@ -8098,7 +8097,6 @@
 				86DD518B28EF028500DF2A58 /* TextFlags.serialization.in */,
 				86890B81294B6FD900DB95CE /* TextRecognitionResult.serialization.in */,
 				F4A7CE842667EB4E00228685 /* TextRecognitionUpdateResult.h */,
-				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				2FD43B921FA006A30083F51C /* TouchBarMenuData.cpp */,
 				2FD43B911FA006A10083F51C /* TouchBarMenuData.h */,
 				2F809DD51FBD1BC9005FE63A /* TouchBarMenuItemData.cpp */,
@@ -8496,6 +8494,7 @@
 				1AAB0377185A7C6A00EDF501 /* MessageSender.cpp */,
 				1AAB0378185A7C6A00EDF501 /* MessageSender.h */,
 				93A7081029BE7D2F006CAA2D /* MessageSenderInlines.h */,
+				7B5A3DC527AE501A006C6F97 /* ObjectIdentifierReferenceTracker.h */,
 				7BE9326227F5C75A00D5FEFB /* ReceiverMatcher.h */,
 				7BAB110F25DD02B2008FC479 /* ScopedActiveMessageReceiveQueue.h */,
 				2DC18001D90DDD15FC6991A9 /* SharedBufferReference.cpp */,
@@ -8514,6 +8513,7 @@
 				7B73123725CC8524003B2796 /* StreamServerConnection.cpp */,
 				7B73123825CC8524003B2796 /* StreamServerConnection.h */,
 				7BE5134A29768F0E00814F18 /* StreamServerConnectionBuffer.h */,
+				7BE37F6F27B1475F007A6CD3 /* ThreadSafeObjectHeap.h */,
 				F48570A22644BEC400C05F71 /* Timeout.h */,
 				7BDD9DDB28D205C6004CDF48 /* WorkQueueMessageReceiver.h */,
 			);
@@ -13398,14 +13398,14 @@
 				1C55A57C275457C500EB7E95 /* RemoteDeviceMessages.h */,
 				1C55A57E275457C500EB7E95 /* RemoteExternalTextureMessageReceiver.cpp */,
 				1C55A57A275457C500EB7E95 /* RemoteExternalTextureMessages.h */,
-				3AF5B4722A244FDC004C3D4D /* RemoteGraphicsContextGLMessageReceiver.cpp */,
-				3AF5B4712A244FDC004C3D4D /* RemoteGraphicsContextGLMessages.h */,
-				3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */,
-				3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */,
 				1C55A59D275457CA00EB7E95 /* RemoteGPUMessageReceiver.cpp */,
 				1C55A58F275457C800EB7E95 /* RemoteGPUMessages.h */,
 				1CDDFC7D2755866D00C93C62 /* RemoteGPUProxyMessageReceiver.cpp */,
 				1CDDFC7E2755866D00C93C62 /* RemoteGPUProxyMessages.h */,
+				3AF5B4722A244FDC004C3D4D /* RemoteGraphicsContextGLMessageReceiver.cpp */,
+				3AF5B4712A244FDC004C3D4D /* RemoteGraphicsContextGLMessages.h */,
+				3AF5B4742A244FDD004C3D4D /* RemoteGraphicsContextGLProxyMessageReceiver.cpp */,
+				3AF5B4732A244FDC004C3D4D /* RemoteGraphicsContextGLProxyMessages.h */,
 				1D47659B25CE74AD007AF312 /* RemoteImageDecoderAVFManagerMessageReceiver.cpp */,
 				1D47659925CE74AC007AF312 /* RemoteImageDecoderAVFManagerMessages.h */,
 				1D47658F25CCCE92007AF312 /* RemoteImageDecoderAVFProxyMessageReceiver.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h
@@ -34,10 +34,10 @@ namespace WebKit {
 
 enum RemoteSerializedImageBufferIdentifierType { };
 using RemoteSerializedImageBufferIdentifier = AtomicObjectIdentifier<RemoteSerializedImageBufferIdentifierType>;
-using RemoteSerializedImageBufferReadReference = ObjectIdentifierReadReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferWriteReference = ObjectIdentifierWriteReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferReference = ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferReferenceTracker = ObjectIdentifierReferenceTracker<RemoteSerializedImageBufferIdentifier>;
+using RemoteSerializedImageBufferReadReference = IPC::ObjectIdentifierReadReference<RemoteSerializedImageBufferIdentifier>;
+using RemoteSerializedImageBufferWriteReference = IPC::ObjectIdentifierWriteReference<RemoteSerializedImageBufferIdentifier>;
+using RemoteSerializedImageBufferReference = IPC::ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>;
+using RemoteSerializedImageBufferReferenceTracker = IPC::ObjectIdentifierReferenceTracker<RemoteSerializedImageBufferIdentifier>;
 
 
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h
@@ -34,10 +34,10 @@ namespace WebKit {
 
 enum RemoteVideoFrameIdentifierType { };
 using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>;
-using RemoteVideoFrameReadReference = ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameWriteReference = ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameReference = ObjectIdentifierReference<RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameReferenceTracker = ObjectIdentifierReferenceTracker<RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReadReference = IPC::ObjectIdentifierReadReference<RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReference = IPC::ObjectIdentifierReference<RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReferenceTracker = IPC::ObjectIdentifierReferenceTracker<RemoteVideoFrameIdentifier>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxyIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxyIdentifier.h
@@ -32,10 +32,10 @@
 
 namespace WebKit {
 
-using RemoteVideoFrameReadReference = ObjectIdentifierReadReference<WebCore::RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameWriteReference = ObjectIdentifierWriteReference<WebCore::RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameReference = ObjectIdentifierReference<WebCore::RemoteVideoFrameIdentifier>;
-using RemoteVideoFrameReferenceTracker = ObjectIdentifierReferenceTracker<WebCore::RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReadReference = IPC::ObjectIdentifierReadReference<WebCore::RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameWriteReference = IPC::ObjectIdentifierWriteReference<WebCore::RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReference = IPC::ObjectIdentifierReference<WebCore::RemoteVideoFrameIdentifier>;
+using RemoteVideoFrameReferenceTracker = IPC::ObjectIdentifierReferenceTracker<WebCore::RemoteVideoFrameIdentifier>;
 
 } // namespace WebKit
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 		7B2950E22972AFDE008CC225 /* StreamConnectionEncoderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */; };
 		7B397C0628BE0EAD00239202 /* ConnectionTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */; };
 		7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7C83E0391D0A602700FEBCF3 /* UtilitiesCocoa.mm */; };
+		7B52E86C2A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */; };
 		7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */; };
 		7B6FF89728C22D9400CA76B0 /* WebKit.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 2B648DBA28C1C1F700791F2B /* WebKit.framework */; };
 		7B7392E928F849EC007297FC /* MessageSenderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392E128F849EC007297FC /* MessageSenderTests.cpp */; };
@@ -2785,6 +2786,7 @@
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
 		7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionEncoderTests.cpp; sourceTree = "<group>"; };
 		7B397C0528BE0EAD00239202 /* ConnectionTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConnectionTests.cpp; sourceTree = "<group>"; };
+		7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadSafeObjectHeapTests.cpp; sourceTree = "<group>"; };
 		7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionWorkQueueTests.cpp; sourceTree = "<group>"; };
 		7B7392E128F849EC007297FC /* MessageSenderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageSenderTests.cpp; sourceTree = "<group>"; };
 		7B7392EA28F849F3007297FC /* IPCTestUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPCTestUtilities.h; sourceTree = "<group>"; };
@@ -4499,6 +4501,7 @@
 				7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */,
 				7BAA4A8F28CA14AE004CE938 /* StreamConnectionTests.cpp */,
 				7B636FC129700F0700F3670F /* StreamConnectionWorkQueueTests.cpp */,
+				7B52E8642A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp */,
 			);
 			path = IPC;
 			sourceTree = "<group>";
@@ -6090,6 +6093,7 @@
 				7BAA4A9028CA14AE004CE938 /* StreamConnectionTests.cpp in Sources */,
 				7B636FC229700F0700F3670F /* StreamConnectionWorkQueueTests.cpp in Sources */,
 				7B9FC58C28A2717D007570E7 /* TestsController.cpp in Sources */,
+				7B52E86C2A2A1A2200A3251F /* ThreadSafeObjectHeapTests.cpp in Sources */,
 				7B397C0828BE394B00239202 /* UtilitiesCocoa.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "ThreadSafeObjectHeap.h"
+#include <atomic>
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace TestWebKitAPI {
+
+namespace {
+
+enum TestedObjectIdentifierType { };
+using TestedObjectIdentifier = AtomicObjectIdentifier<TestedObjectIdentifierType>;
+using TestedObjectReadReference = IPC::ObjectIdentifierReadReference<TestedObjectIdentifier>;
+using TestedObjectWriteReference = IPC::ObjectIdentifierWriteReference<TestedObjectIdentifier>;
+using TestedObjectReference = IPC::ObjectIdentifierReference<TestedObjectIdentifier>;
+using TestedObjectReferenceTracker = IPC::ObjectIdentifierReferenceTracker<TestedObjectIdentifier>;
+
+class TestedObject : public ThreadSafeRefCounted<TestedObject> {
+public:
+    static RefPtr<TestedObject> create(int value)
+    {
+        return adoptRef(*new TestedObject(value));
+    }
+    ~TestedObject()
+    {
+        s_instances--;
+    }
+    int value() const { return m_value; }
+    static size_t instances() { return s_instances; }
+    auto newWriteReference() { return m_referenceTracker.write(); }
+    auto newReadReference() { return m_referenceTracker.read(); }
+private:
+    TestedObject(int value)
+        : m_value(value)
+    {
+        s_instances++;
+    }
+    const int m_value;
+    TestedObjectReferenceTracker m_referenceTracker { TestedObjectIdentifier::generate() };
+    static std::atomic<size_t> s_instances;
+};
+
+std::atomic<size_t> TestedObject::s_instances;
+
+class ThreadSafeObjectHeapTest : public testing::Test {
+public:
+    void SetUp() override
+    {
+        WTF::initializeMainThread();
+    }
+    void TearDown() override
+    {
+        ASSERT_EQ(TestedObject::instances(), 0u);
+    }
+};
+
+}
+
+TEST_F(ThreadSafeObjectHeapTest, AddAndGetWorks)
+{
+    {
+        IPC::ThreadSafeObjectHeap<TestedObjectIdentifier, RefPtr<TestedObject>> heap;
+        std::optional<TestedObjectReadReference> read1;
+        {
+            auto obj1 = TestedObject::create(344);
+            heap.retire(obj1->newWriteReference(), { obj1 }, std::nullopt);
+            read1 = obj1->newReadReference();
+        }
+        EXPECT_EQ(344, heap.retire(WTFMove(*read1), 0_s)->value());
+        EXPECT_EQ(1u, TestedObject::instances());
+    }
+    EXPECT_EQ(0u, TestedObject::instances());
+}
+
+}


### PR DESCRIPTION
#### 6494a227e7790aec849cee13ebc5428072547832
<pre>
ThreadSafeObjectHeap should be part of IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=257645">https://bugs.webkit.org/show_bug.cgi?id=257645</a>
rdar://110165802

Reviewed by Antti Koivisto.

Rename WebKit::ThreadSafeObjectHeap to IPC::ThreadSafeObjectHeap.
The class is used to track IPC object references, so it is related to
IPC.
IPC/* files can be tested with unit tests, so IPC::ThreadSafeObjectHeap
is easier to improve.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::serializedImageBufferHeap):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h: Renamed from Source/WebKit/Shared/ObjectIdentifierReferenceTracker.h.
(IPC::ObjectIdentifierReference::ObjectIdentifierReference):
(IPC::ObjectIdentifierReference::identifier const):
(IPC::ObjectIdentifierReference::version const):
(IPC::ObjectIdentifierReference::operator== const):
(IPC::ObjectIdentifierReference::isHashTableDeletedValue const):
(IPC::ObjectIdentifierReference::encode const):
(IPC::ObjectIdentifierReference::decode):
(IPC::ObjectIdentifierReadReference::ObjectIdentifierReadReference):
(IPC::ObjectIdentifierReadReference::identifier const):
(IPC::ObjectIdentifierReadReference::version const):
(IPC::ObjectIdentifierReadReference::reference const):
(IPC::ObjectIdentifierReadReference::encode const):
(IPC::ObjectIdentifierReadReference::decode):
(IPC::ObjectIdentifierWriteReference::generateForAdd):
(IPC::ObjectIdentifierWriteReference::ObjectIdentifierWriteReference):
(IPC::ObjectIdentifierWriteReference::identifier const):
(IPC::ObjectIdentifierWriteReference::version const):
(IPC::ObjectIdentifierWriteReference::pendingReads const):
(IPC::ObjectIdentifierWriteReference::reference const):
(IPC::ObjectIdentifierWriteReference::retiredReference const):
(IPC::ObjectIdentifierWriteReference::encode const):
(IPC::ObjectIdentifierWriteReference::decode):
(IPC::ObjectIdentifierReferenceTracker::ObjectIdentifierReferenceTracker):
(IPC::ObjectIdentifierReferenceTracker::read const):
(IPC::ObjectIdentifierReferenceTracker::write const):
(IPC::ObjectIdentifierReferenceTracker::identifier const):
(IPC::add):
(IPC::operator&lt;&lt;):
(WTF::DefaultHash&lt;IPC::ObjectIdentifierReference&lt;T&gt;&gt;::hash):
(WTF::DefaultHash&lt;IPC::ObjectIdentifierReference&lt;T&gt;&gt;::equal):
* Source/WebKit/Platform/IPC/ThreadSafeObjectHeap.h: Renamed from Source/WebKit/Shared/ThreadSafeObjectHeap.h.
(IPC::ThreadSafeObjectHeap::ReferenceState::ReferenceState):
(IPC::HeldType&gt;::retire):
(IPC::HeldType&gt;::retireRemove):
(IPC::HeldType&gt;::clear):
(IPC::HeldType&gt;::add):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameIdentifier.h:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxyIdentifier.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp: Added.
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/264861@main">https://commits.webkit.org/264861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7553e29925d930619dda774aae10c3969c7514ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11624 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10585 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15527 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8331 "5 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11505 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7055 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7915 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2159 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->