### PR TITLE
[GTK] Make it possible to change the GL API at runtime

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -94,11 +94,16 @@ public:
     virtual Type type() const = 0;
 
 #if USE(EGL)
+    enum class OpenGLAPI {
+        OpenGL,
+        OpenGLES,
+    };
+    static OpenGLAPI glAPI();
+    static EGLenum eglAPI();
+
     WEBCORE_EXPORT GLContext* sharingGLContext();
     void clearSharingGLContext();
-#endif
 
-#if USE(EGL)
     EGLDisplay eglDisplay() const;
     bool eglCheckVersion(int major, int minor) const;
 

--- a/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
@@ -46,11 +46,15 @@ GstGLContext* PlatformDisplay::gstGLContext() const
     if (!m_gstGLContext) {
         if (auto* gstDisplay = gstGLDisplay()) {
             if (auto* context = const_cast<PlatformDisplay*>(this)->sharingGLContext()) {
-#if USE(OPENGL_ES)
-                GstGLAPI glAPI = GST_GL_API_GLES2;
-#elif USE(OPENGL)
-                GstGLAPI glAPI = GST_GL_API_OPENGL;
-#endif
+                GstGLAPI glAPI;
+                switch (PlatformDisplay::glAPI()) {
+                case PlatformDisplay::OpenGLAPI::OpenGLES:
+                    glAPI = GST_GL_API_GLES2;
+                    break;
+                case PlatformDisplay::OpenGLAPI::OpenGL:
+                    glAPI = GST_GL_API_OPENGL;
+                    break;
+                }
                 m_gstGLContext = adoptGRef(gst_gl_context_new_wrapped(gstDisplay, reinterpret_cast<guintptr>(context->platformContext()), GST_GL_PLATFORM_EGL, glAPI));
             }
         }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp
@@ -28,6 +28,7 @@
 
 #if USE(TEXTURE_MAPPER_GL)
 
+#include "PlatformDisplay.h"
 #include "TextureMapperGLHeaders.h"
 #include <mutex>
 #include <wtf/ThreadSpecific.h>
@@ -51,17 +52,21 @@ const TextureMapperContextAttributes& TextureMapperContextAttributes::get()
     auto& attributes = *threadSpecificAttributes();
     if (!attributes.initialized) {
         attributes.initialized = true;
-#if USE(OPENGL_ES)
-        attributes.isGLES2Compliant = true;
+        switch (PlatformDisplay::glAPI()) {
+        case PlatformDisplay::OpenGLAPI::OpenGLES: {
+            attributes.isGLES2Compliant = true;
 
-        auto extensionsString = String::fromLatin1(reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)));
-        attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot"_s);
-        attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage"_s);
-#else
-        attributes.isGLES2Compliant = false;
-        attributes.supportsNPOTTextures = true;
-        attributes.supportsUnpackSubimage = true;
-#endif
+            auto extensionsString = String::fromLatin1(reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS)));
+            attributes.supportsNPOTTextures = extensionsString.contains("GL_OES_texture_npot"_s);
+            attributes.supportsUnpackSubimage = extensionsString.contains("GL_EXT_unpack_subimage"_s);
+            break;
+        }
+        case PlatformDisplay::OpenGLAPI::OpenGL:
+            attributes.isGLES2Compliant = false;
+            attributes.supportsNPOTTextures = true;
+            attributes.supportsUnpackSubimage = true;
+            break;
+        }
     }
     return attributes;
 }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -128,8 +128,8 @@ TextureMapperGLData::~TextureMapperGLData()
     for (auto& entry : m_vbos)
         glDeleteBuffers(1, &entry.value);
 
-#if !USE(OPENGL_ES)
-    if (GLContext::current()->version() >= 320 && m_vao)
+#if USE(OPENGL)
+    if (PlatformDisplay::glAPI() == PlatformDisplay::OpenGLAPI::OpenGL && GLContext::current()->version() >= 320 && m_vao)
         glDeleteVertexArrays(1, &m_vao);
 #endif
 }
@@ -164,8 +164,8 @@ GLuint TextureMapperGLData::getStaticVBO(GLenum target, GLsizeiptr size, const v
 
 GLuint TextureMapperGLData::getVAO()
 {
-#if !USE(OPENGL_ES)
-    if (GLContext::current()->version() >= 320 && !m_vao)
+#if USE(OPENGL)
+    if (PlatformDisplay::glAPI() == PlatformDisplay::OpenGLAPI::OpenGL && GLContext::current()->version() >= 320 && !m_vao)
         glGenVertexArrays(1, &m_vao);
 #endif
 
@@ -212,8 +212,8 @@ void TextureMapperGL::beginPainting(PaintFlags flags, BitmapTexture* surface)
     data().PaintFlags = flags;
     bindSurface(surface);
 
-#if !USE(OPENGL_ES)
-    if (GLContext::current()->version() >= 320) {
+#if USE(OPENGL)
+    if (PlatformDisplay::glAPI() == PlatformDisplay::OpenGLAPI::OpenGL && GLContext::current()->version() >= 320) {
         glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &data().previousVAO);
         glBindVertexArray(data().getVAO());
     }
@@ -240,8 +240,8 @@ void TextureMapperGL::endPainting()
     else
         glDisable(GL_DEPTH_TEST);
 
-#if !USE(OPENGL_ES)
-    if (GLContext::current()->version() >= 320)
+#if USE(OPENGL)
+    if (PlatformDisplay::glAPI() == PlatformDisplay::OpenGLAPI::OpenGL && GLContext::current()->version() >= 320)
         glBindVertexArray(data().previousVAO);
 #endif
 }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -437,9 +437,8 @@ void AcceleratedBackingStoreDMABuf::ensureGLContext()
     if (!m_gdkGLContext)
         g_error("GDK is not able to create a GL context: %s.", error->message);
 
-#if USE(OPENGL_ES)
-    gdk_gl_context_set_use_es(m_gdkGLContext.get(), TRUE);
-#endif
+    if (WebCore::PlatformDisplay::glAPI() == WebCore::PlatformDisplay::OpenGLAPI::OpenGLES)
+        gdk_gl_context_set_use_es(m_gdkGLContext.get(), TRUE);
 
     if (!gdk_gl_context_realize(m_gdkGLContext.get(), &error.outPtr()))
         g_error("GDK failed to realize the GL context: %s.", error->message);


### PR DESCRIPTION
#### 98202654e06bb690a6bf7afd096ec8ead5f5aaca
<pre>
[GTK] Make it possible to change the GL API at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=257648">https://bugs.webkit.org/show_bug.cgi?id=257648</a>

Reviewed by NOBODY (OOPS!).

Right now it&apos;s a buildtime option, USE(OPENGL) and USE(OPENGL_ES) are
mutually exclusive. Since OpenGL is the default, we sometimes break
OPENGL_ES build by mistake, or even rendering since it&apos;s untested.
Making it possible to decide the API at runtime allows to easily test
both cases without having to recompile.

The public build option ENABLE_GLES2 is kept for compatibility and now
it just changes the default API to OpenGL ES.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::glAPI):
(WebCore::PlatformDisplay::eglAPI):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::glAPIName):
(WebCore::GLContext::getEGLConfig):
(WebCore::GLContext::create):
(WebCore::GLContext::createOffscreen):
(WebCore::GLContext::createSharing):
(WebCore::GLContext::createContextForEGLVersion):
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::PlatformDisplay::gstGLContext const):
* Source/WebCore/platform/graphics/texmap/TextureMapperContextAttributes.cpp:
(WebCore::TextureMapperContextAttributes::get):
* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::TextureMapperGLData::~TextureMapperGLData):
(WebCore::TextureMapperGLData::getVAO):
(WebCore::TextureMapperGL::beginPainting):
(WebCore::TextureMapperGL::endPainting):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::create):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::openGLAPI):
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::ensureGLContext):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreWayland.cpp:
(WebKit::isEGLImageAvailable):
(WebKit::tryInitializeEGL):
(WebKit::AcceleratedBackingStoreWayland::ensureGLContext):
* Source/cmake/OptionsGTK.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98202654e06bb690a6bf7afd096ec8ead5f5aaca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11627 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15532 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7547 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8173 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11510 "6 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7058 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8946 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7918 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2135 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12130 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9180 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8404 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2257 "Passed tests") | 
<!--EWS-Status-Bubble-End-->