### PR TITLE
Correct serialization of Selectors

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt
@@ -8,4 +8,6 @@ PASS Values of CSSImportRule attributes
 PASS CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]
 PASS CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]
 PASS StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]
+FAIL Existence and writability of CSSImportRule supportsText attribute assert_idl_attribute: property "supportsText" not found in prototype chain
+FAIL Value of CSSImportRule supportsText attribute assert_equals: expected (string) "(display: flex) or (display: block)" but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html
@@ -15,6 +15,7 @@
         @import url("support/a-green.css");
         @import url("support/a-green.css") screen;
         @import url("support/a-green.css") all;
+        @import url("support/a-green") supports((display: flex) or (display: block));
         @page { background-color: red; }
     </style>
 </head>
@@ -22,13 +23,14 @@
     <div id="log"></div>
 
     <script type="text/javascript">
-        var styleSheet, ruleList, rule, ruleWithMedia, ruleWithMediaAll;
+        var styleSheet, ruleList, rule, ruleWithMedia, ruleWithMediaAll, ruleWithSupports;
         setup(function() {
             styleSheet = document.getElementById("styleElement").sheet;
             ruleList = styleSheet.cssRules;
             rule = ruleList[0];
             ruleWithMedia = ruleList[1];
             ruleWithMediaAll = ruleList[2];
+            ruleWithSupports = ruleList[3];
         });
 
         test(function() {
@@ -36,6 +38,8 @@
             assert_true(rule instanceof CSSImportRule);
             assert_true(ruleWithMedia instanceof CSSRule);
             assert_true(ruleWithMedia instanceof CSSImportRule);
+            assert_true(ruleWithSupports instanceof CSSRule);
+            assert_true(ruleWithSupports instanceof CSSImportRule);
         }, "CSSRule and CSSImportRule types");
 
         test(function() {
@@ -66,6 +70,7 @@
             assert_equals(rule.cssText, '@import url("support/a-green.css");');
             assert_equals(ruleWithMedia.cssText, '@import url("support/a-green.css") screen;');
             assert_equals(ruleWithMediaAll.cssText, '@import url("support/a-green.css") all;');
+            assert_equals(ruleWithSupports.cssText, '@import url("support/a-green") supports((display: flex) or (display: block));');
             assert_equals(rule.parentRule, null);
             assert_true(rule.parentStyleSheet instanceof CSSStyleSheet);
         }, "Values of CSSRule attributes");
@@ -94,7 +99,7 @@
         }, "CSSImportRule : MediaList mediaText attribute should be updated due to [PutForwards]");
 
         test(function() {
-            var ruleWithPage = ruleList[3];
+            var ruleWithPage = ruleList[4];
             ruleWithPage.style = "margin-top: 10px;"
             assert_equals(ruleWithPage.style.cssText, "margin-top: 10px;");
         }, "CSSStyleDeclaration cssText attribute should be updated due to [PutForwards]");
@@ -103,6 +108,15 @@
             styleSheet.media = "screen";
             assert_equals(styleSheet.media.mediaText, "screen");
         }, "StyleSheet : MediaList mediaText attribute should be updated due to [PutForwards]");
+
+        test(function() {
+            assert_idl_attribute(ruleWithSupports, "supportsText");
+            assert_readonly(ruleWithSupports, "supportsText");
+        }, "Existence and writability of CSSImportRule supportsText attribute");
+
+        test(function() {
+            assert_equals(ruleWithSupports.supportsText, "(display: flex) or (display: block)");
+        }, "Value of CSSImportRule supportsText attribute");
     </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt
@@ -11,10 +11,15 @@ PASS single pseudo (simple) selector "nth-last-child" which accepts arguments in
 PASS single pseudo (simple) selector "nth-of-child" which accepts arguments in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector ":nth-last-of-type" which accepts arguments in the sequence of simple selectors that is not a universal selector
 PASS single pseudo (simple) selector ":not" which accepts arguments in the sequence of simple selectors that is not a universal selector
-FAIL escaped character in attribute name assert_equals: expected "[ns\\:foo]" but got "[ns:foo]"
-FAIL escaped character as code point in attribute name assert_equals: expected "[\\30 zonk]" but got "[0zonk]"
-FAIL escaped character (@) in attribute name assert_equals: expected "[\\@]" but got "[@]"
-FAIL escaped character in attribute name with any namespace assert_equals: expected "[*|ns\\:foo]" but got "[*|ns:foo]"
-FAIL escaped character in attribute prefix assert_equals: expected "[ns\\:odd|foo]" but got "[ns:odd|foo]"
-FAIL escaped character in both attribute prefix and name assert_equals: expected "[ns\\:odd|odd\\:name]" but got "[ns:odd|odd:name]"
+PASS escaped character in attribute name
+PASS escaped character as code point in attribute name
+PASS escaped character (@) in attribute name
+PASS escaped character in attribute name with any namespace
+PASS escaped character in attribute prefix
+PASS escaped character in both attribute prefix and name
+PASS escaped character (\) in element name
+PASS escaped character (\) in element name with any namespace without default
+PASS escaped character (\) in element name with any namespace with default
+PASS escaped character (\) in element name with no namespace
+PASS escaped character (*) in element prefix
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html
@@ -97,7 +97,7 @@
                 assert_selector_serializes_to(' :not(  :hover   ) ', ':not(:hover)');
             }, 'single pseudo (simple) selector ":not" which accepts arguments in the sequence of simple selectors that is not a universal selector')
 
-            var escaped_ns_rule = "@namespace ns\\:odd url(ns);";
+            const escaped_ns_rule = "@namespace ns\\:odd url(ns);";
             test(function() {
                 assert_selector_serializes_to("[ns\\:foo]", "[ns\\:foo]");
             }, "escaped character in attribute name");
@@ -116,6 +116,26 @@
             test(function() {
                 assert_selector_serializes_to(escaped_ns_rule + "[ns\\:odd|odd\\:name]", "[ns\\:odd|odd\\:name]");
             }, "escaped character in both attribute prefix and name");
+
+            test(() => {
+              assert_selector_serializes_to("\\\\", "\\\\");
+            }, "escaped character (\\) in element name");
+            test(() => {
+              assert_selector_serializes_to("*|\\\\", "\\\\");
+            }, "escaped character (\\) in element name with any namespace without default");
+            test(() => {
+              assert_selector_serializes_to("@namespace 'blah'; *|\\\\", "*|\\\\");
+            }, "escaped character (\\) in element name with any namespace with default");
+            test(() => {
+              assert_selector_serializes_to("|\\\\", "|\\\\");
+            }, "escaped character (\\) in element name with no namespace");
+
+            const element_escaped_ns_rule = "@namespace x\\* 'blah';";            
+            test(() => {
+              assert_selector_serializes_to(element_escaped_ns_rule + "x\\*|test", "x\\*|test");
+            }, "escaped character (*) in element prefix");
+
+            // TODO: https://github.com/w3c/csswg-drafts/issues/8911
         </script>
     </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/xml-stylesheet-pi-in-doctype.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>xml-stylesheet processing instruction in doctype internal subset</title>
-    <link rel="help" href="https://w3c.github.io/csswg-drafts/cssom/#prolog"/>
+    <link rel="help" href="https://drafts.csswg.org/cssom/#prolog"/>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>


### PR DESCRIPTION
#### 892935d504cf4b301a232d0b4399b5ac97f67900
<pre>
Correct serialization of Selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=184604">https://bugs.webkit.org/show_bug.cgi?id=184604</a>
rdar://97092572

Reviewed by Antti Koivisto and Tim Nguyen.

We did not use serializeIdentifier for qualified name prefixes and
local names. E.g., x:x was not serialized as x\:x. This was previously
attempted, but it would do the wrong thing for * and thus backed out.
So now we do not escape when prefix or local name is *.

The only edge case remaining is whether the * and \* inputs should mean
the same thing. <a href="https://github.com/w3c/csswg-drafts/issues/8911">https://github.com/w3c/csswg-drafts/issues/8911</a> will
eventually address this.

Meanwhile this seems like a solid improvement.

Also synchronize web-platform-tests/css/cssom up to upstream commit
57c5006103146974adb3af50d325c3b6ce7153d0 for real this time.
264934@main missed a couple changes.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssimportrule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorSerialize.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/xml-stylesheet-pi-in-doctype.xhtml:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::serializeIdentifierOrStar):
(WebCore::CSSSelector::selectorText const):

Canonical link: <a href="https://commits.webkit.org/264980@main">https://commits.webkit.org/264980@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc5402768d1f6c7817c479d37a5374208de2ba7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10408 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11157 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15960 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12005 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7462 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8424 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2262 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->