### PR TITLE
[WGSL] Use the metal compiler to validate wgslc tests

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -34,7 +34,7 @@
 #include "Constraints.h"
 #include "Types.h"
 #include "WGSLShaderModule.h"
-
+#include <wtf/HashSet.h>
 #include <wtf/SortedArrayMap.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -114,6 +114,7 @@ private:
     std::optional<AST::StageAttribute::Stage> m_entryPointStage;
     std::optional<String> m_suffix;
     unsigned m_functionConstantIndex { 0 };
+    HashSet<AST::Function*> m_visitedFunctions;
 };
 
 void FunctionDefinitionWriter::write()
@@ -140,6 +141,9 @@ void FunctionDefinitionWriter::write()
 
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
 {
+    if (!m_visitedFunctions.add(&functionDefinition).isNewEntry)
+        return;
+
     for (auto& callee : m_callGraph.callees(functionDefinition))
         visit(*callee.target);
 

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -22,5 +22,12 @@ config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 
 config.substitutions.append(('%check', '{}/bin/OutputCheck --comment=".*//" %s'.format(site.getuserbase())))
 config.substitutions.append(('%wgslc', '{} %s _ 2>&1'.format(wgslc)))
-config.substitutions.append(('%metal', '{} --dump-generated-code %s'.format(wgslc)))
 config.substitutions.append(('%not', 'eval !'))
+config.substitutions.append(('%metal-compile', (
+    "function metal_compile() {"
+    "    set -e -o pipefail;"
+    f"    {wgslc} --dump-generated-code '%s' \"$1\" > '%t.metal';"
+    "    xcrun -sdk macosx metal -c '%t.metal' -o /dev/null;"
+    "};"
+    "metal_compile ")))
+config.substitutions.append(('%metal', '{} --dump-generated-code %s'.format(wgslc)))

--- a/Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl
@@ -1,4 +1,4 @@
-// RUN: %metal main 2>&1 | %check
+// RUN: %metal-compile main
 
 fn f1(x: array<vec2<f32>, 1>) -> f32 { return x[0][0]; }
 fn f2(x: array<vec2<i32>, 1>) -> i32 { return x[0][0]; }
@@ -9,98 +9,38 @@ const global = array(vec2(0));
 fn testCallee()
 {
     // - Globals in a callee function
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: };
-    // CHECK: f1\(local\d+\)
     _ = f1(global);
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<int, 2>(0)
-    // CHECK-L: };
-    // CHECK: f2\(local\d+\)
     _ = f2(global);
 }
 
 @compute @workgroup_size(1)
 fn main() {
     // - Simple assignment promotion
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: };
     let x : array<vec2<f32>, 1> = array(vec2(0));
 
     // - Call with immediate value
-
-    // CHECK-L: f1({
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: })
     _ = f1(array(vec2(0)));
 
     // - Call with local constant
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: };
     const a = array(vec2(0));
-    // CHECK: f1\(local\d+\)
     _ = f1(a);
 
     // - Two-level nested vector promotoin
-
-    // CHECK: local\d+ = {
-    // CHECK-L: {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: }
-    // CHECK-L: };
     const b = array(array(vec2(0)));
-    // CHECK: f4\(local\d+\)
     _ = f4(b);
 
     // - Constant promoted to two types
-
     const c = array(vec2(0));
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: };
-    // CHECK: f1\(local\d+\)
     _ = f1(c);
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<int, 2>(0)
-    // CHECK-L: };
-    // CHECK: f2\(local\d+\)
     _ = f2(c);
 
     // - Global constants
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<float, 2>(0)
-    // CHECK-L: };
-    // CHECK: f1\(local\d+\)
     _ = f1(global);
-
-    // CHECK: local\d+ = {
-    // CHECK-L: vec<int, 2>(0)
-    // CHECK-L: };
-    // CHECK: f2\(local\d+\)
     _ = f2(global);
 
     {
         // - Test within a nested block
-        // CHECK: local\d+ = {
-        // CHECK-L: vec<float, 2>(0)
-        // CHECK-L: };
-        // CHECK: f1\(local\d+\)
         _ = f1(global);
-
-        // CHECK: local\d+ = {
-        // CHECK-L: vec<int, 2>(0)
-        // CHECK-L: };
-        // CHECK: f2\(local\d+\)
         _ = f2(global);
     }
 

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -131,7 +131,7 @@ static int runWGSL(const CommandLine& options)
         WGSL::AST::dumpAST(shaderModule);
 
     if (options.dumpGeneratedCode())
-        dataLog(prepareResult.msl);
+        printf("%s", prepareResult.msl.utf8().data());
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
#### 4eb67675fc202cb8b9e5a79869a5c9d3aadca10d
<pre>
[WGSL] Use the metal compiler to validate wgslc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=257652">https://bugs.webkit.org/show_bug.cgi?id=257652</a>
rdar://110174039

Reviewed by Mike Wyrzykowski and Myles C. Maxfield.

Instead of using OutputCheck and regular expressions to match the generated Metal
code, we can invoke the Metal compiler to check the code is valid.

* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/type-promotion.wgsl:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/264859@main">https://commits.webkit.org/264859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a196615b2ef20a316dd7b82a423a1d4d72c3c97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9178 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11750 "1 flakes 95 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10735 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7356 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11634 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8800 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8055 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->