### PR TITLE
[WGSL] Don't pack user-defined structs

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -39,6 +39,8 @@ enum class StructureRole : uint8_t {
     ComputeInput,
     VertexOutput,
     BindGroup,
+    UserDefinedResource,
+    PackedResource,
 };
 
 class Structure final : public Declaration {

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -195,7 +195,7 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
         unsigned alignment = 0;
         unsigned size = 0;
         unsigned paddingID = 0;
-        bool shouldPack = structDecl.role() == AST::StructureRole::UserDefined;
+        bool shouldPack = structDecl.role() == AST::StructureRole::PackedResource;
         const auto& addPadding = [&](unsigned paddingSize) {
             ASSERT(shouldPack);
             m_stringBuilder.append(m_indent, "uint8_t __padding", ++paddingID, "[", String::number(paddingSize), "]; \n");
@@ -405,6 +405,8 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         case AST::StructureRole::BindGroup:
         case AST::StructureRole::UserDefined:
         case AST::StructureRole::ComputeInput:
+        case AST::StructureRole::UserDefinedResource:
+        case AST::StructureRole::PackedResource:
             return;
         case AST::StructureRole::VertexInput:
             m_stringBuilder.append("[[attribute(", *AST::extractInteger(location.location()), ")]]");
@@ -454,7 +456,7 @@ void FunctionDefinitionWriter::visit(const Type* type)
         },
         [&](const Vector& vector) {
             auto* primitive = std::get_if<Primitive>(vector.element);
-            if (primitive && m_structRole.has_value() && *m_structRole == AST::StructureRole::UserDefined) {
+            if (primitive && m_structRole.has_value() && *m_structRole == AST::StructureRole::PackedResource) {
                 switch (primitive->kind) {
                 case Types::Primitive::AbstractInt:
                 case Types::Primitive::I32:

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -1,0 +1,22 @@
+// RUN: %metal-compile main
+
+struct T {
+    x: vec3<f32>,
+    y: i32,
+}
+
+var<private> t: T;
+var<private> m: mat3x3<f32>;
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = testUnpacked();
+}
+
+fn testUnpacked() -> i32
+{
+    _ = t.x * m;
+    _ = m * t.x;
+    return 0;
+}


### PR DESCRIPTION
#### 0f12e79a9bd41fdb635555d0a08db893d4670801
<pre>
[WGSL] Don&apos;t pack user-defined structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=257653">https://bugs.webkit.org/show_bug.cgi?id=257653</a>
rdar://110175536

Reviewed by Myles C. Maxfield.

WGSL distinguishes from Metal in the representation of `vec3`. In WGSL, the size
of `vec3&lt;T&gt;` is `3 * sizeof(T)` and the alignment is `4 * sizeof(T)`. In Metal,
we translate `vec3&lt;T&gt;` to `vec&lt;T, 3&gt;`, which has both size and alignment equal
to `4 * sizeof(T)`. This difference is observable through buffers.

The implementation to pack structs was first introduced in 264243@main, by using
packed types (e.g. `packed_float3`). Originally, all structs were packed, but
packed types aren&apos;t allowed everywhere, for example on the vertex output. To fix
that, in 264277@main, I changed it so that we only pack user-defined structs, but
that is not correct either, since not all operations work on packed types. An
example is matrix multiplication: we can only multiply a matrix by `vec&lt;float, 3&gt;`,
not `packed_float3`.

To implement this correctly, we need to distinguish between a packed and unpacked
struct, and we can&apos;t modify the original struct. Packed structs are only necessary
for resources, and in that case we need to create a duplicate, packed version of the
struct. This is the first of a series of patches that implement the proper behavior.
For now, we merely set up the duplicate struct and introduce 2 new struct roles to
give us more information about packed structs. This information will be used in the
following patches to determine where we need to explicitly pack and upack values.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::packResourceStruct):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264864@main">https://commits.webkit.org/264864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfbd7dabbfdad3dc636a4cba0d48b5a844f29e1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10740 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7360 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11639 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8805 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8060 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->