### PR TITLE
Add WKViewCreateWPE for PlayStation

### DIFF
--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
@@ -56,7 +56,20 @@ WKCursorType toWKCursorType(const WebCore::Cursor& cursor)
 
 WKViewRef WKViewCreate(WKPageConfigurationRef configuration)
 {
+#if USE(WPE_BACKEND_PLAYSTATION)
+    RELEASE_ASSERT_WITH_MESSAGE(false, "API unavailable with WPE Backend PlayStation");
+#else
     return WebKit::toAPI(WebKit::PlayStationWebView::create(*WebKit::toImpl(configuration)).leakRef());
+#endif
+}
+
+WKViewRef WKViewCreateWPE(struct wpe_view_backend* backend, WKPageConfigurationRef configuration)
+{
+#if USE(WPE_BACKEND_PLAYSTATION)
+    return WebKit::toAPI(WebKit::PlayStationWebView::create(backend, *WebKit::toImpl(configuration)).leakRef());
+#else
+    RELEASE_ASSERT_WITH_MESSAGE(false, "API unavailable without WPE Backend PlayStation");
+#endif
 }
 
 WKPageRef WKViewGetPage(WKViewRef view)

--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.h
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.h
@@ -31,7 +31,10 @@
 extern "C" {
 #endif
 
+struct wpe_view_backend;
+
 WK_EXPORT WKViewRef WKViewCreate(WKPageConfigurationRef configuration);
+WK_EXPORT WKViewRef WKViewCreateWPE(struct wpe_view_backend*, WKPageConfigurationRef);
 
 WK_EXPORT void WKViewSetViewClient(WKViewRef, const WKViewClientBase*);
 

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -349,7 +349,7 @@ void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, cons
 #if USE(WPE_RENDERER)
 UnixFileDescriptor PageClientImpl::hostFileDescriptor()
 {
-    return UnixFileDescriptor { 1, UnixFileDescriptor::Adopt };
+    return UnixFileDescriptor { wpe_view_backend_get_renderer_host_fd(m_view.backend()), UnixFileDescriptor::Adopt };
 }
 #endif
 

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -30,7 +30,33 @@
 #include "DrawingAreaProxyCoordinatedGraphics.h"
 #include "WebProcessPool.h"
 
+#if USE(WPE_BACKEND_PLAYSTATION)
+#include <wpe/playstation.h>
+#endif
+
 namespace WebKit {
+
+#if USE(WPE_BACKEND_PLAYSTATION)
+
+RefPtr<PlayStationWebView> PlayStationWebView::create(struct wpe_view_backend* backend, const API::PageConfiguration& configuration)
+{
+    return adoptRef(*new PlayStationWebView(backend, configuration));
+}
+
+PlayStationWebView::PlayStationWebView(struct wpe_view_backend* backend, const API::PageConfiguration& conf)
+    : m_pageClient(makeUnique<PageClientImpl>(*this))
+    , m_viewStateFlags { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow }
+    , m_backend(backend)
+{
+    auto configuration = conf.copy();
+    auto* pool = configuration->processPool();
+    m_page = pool->createWebPage(*m_pageClient, WTFMove(configuration));
+
+    wpe_view_backend_initialize(m_backend);
+    m_page->initializeWebPage();
+}
+
+#else
 
 RefPtr<PlayStationWebView> PlayStationWebView::create(const API::PageConfiguration& configuration)
 {
@@ -47,6 +73,8 @@ PlayStationWebView::PlayStationWebView(const API::PageConfiguration& conf)
 
     m_page->initializeWebPage();
 }
+
+#endif // USE(WPE_BACKEND_PLAYSTATION)
 
 PlayStationWebView::~PlayStationWebView()
 {

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
@@ -36,7 +36,11 @@ namespace WebKit {
 class PlayStationWebView : public API::ObjectImpl<API::Object::Type::View> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+#if USE(WPE_BACKEND_PLAYSTATION)
+    static RefPtr<PlayStationWebView> create(struct wpe_view_backend*, const API::PageConfiguration&);
+#else
     static RefPtr<PlayStationWebView> create(const API::PageConfiguration&);
+#endif
     virtual ~PlayStationWebView();
 
     void setClient(std::unique_ptr<API::ViewClient>&&);
@@ -48,6 +52,10 @@ public:
 
     void setViewState(OptionSet<WebCore::ActivityState>);
     OptionSet<WebCore::ActivityState> viewState() const { return m_viewStateFlags; }
+
+#if USE(WPE_BACKEND_PLAYSTATION)
+    struct wpe_view_backend* backend() { return m_backend; }
+#endif
 
 #if ENABLE(FULLSCREEN_API)
     void willEnterFullScreen();
@@ -70,7 +78,11 @@ public:
     void setCursor(const WebCore::Cursor&);
 
 private:
+#if USE(WPE_BACKEND_PLAYSTATION)
+    PlayStationWebView(struct wpe_view_backend*, const API::PageConfiguration&);
+#else
     PlayStationWebView(const API::PageConfiguration&);
+#endif
 
     std::unique_ptr<API::ViewClient> m_client;
     std::unique_ptr<WebKit::PageClientImpl> m_pageClient;
@@ -78,6 +90,9 @@ private:
     OptionSet<WebCore::ActivityState> m_viewStateFlags;
 
     WebCore::IntSize m_viewSize;
+#if USE(WPE_BACKEND_PLAYSTATION)
+    struct wpe_view_backend* m_backend;
+#endif
 #if ENABLE(FULLSCREEN_API)
     bool m_isFullScreen { false };
 #endif

--- a/Tools/MiniBrowser/playstation/CMakeLists.txt
+++ b/Tools/MiniBrowser/playstation/CMakeLists.txt
@@ -22,6 +22,11 @@ set(MiniBrowser_LIBRARIES
 )
 set(MiniBrowser_FRAMEWORKS WebKit)
 
+if (USE_WPE_BACKEND_PLAYSTATION)
+    set(MiniBrowser_DEFINITIONS USE_WPE_BACKEND_PLAYSTATION)
+    list(APPEND MiniBrowser_LIBRARIES WebKit::WPEToolingBackends)
+endif ()
+
 WEBKIT_EXECUTABLE_DECLARE(MiniBrowser)
 WEBKIT_EXECUTABLE(MiniBrowser)
 

--- a/Tools/MiniBrowser/playstation/WebViewWindow.cpp
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.cpp
@@ -40,6 +40,10 @@
 #include <toolkitten/Cursor.h>
 #include <toolkitten/MessageDialog.h>
 
+#if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
+#include <WPEToolingBackends/HeadlessViewBackend.h>
+#endif
+
 using namespace toolkitten;
 
 inline WebViewWindow* toWebView(const void* clientInfo)
@@ -84,7 +88,12 @@ WebViewWindow::WebViewWindow(WKPageConfigurationRef configuration, Client&& wind
     WKPreferencesSetAcceleratedCompositingEnabled(m_preferences.get(), false);
     WKPreferencesSetFullScreenEnabled(m_preferences.get(), true);
 
+#if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
+    m_window = std::make_unique<WPEToolingBackends::HeadlessViewBackend>(1920, 1080);
+    m_view = WKViewCreateWPE(m_window->backend(), configuration);
+#else
     m_view = WKViewCreate(configuration);
+#endif
     m_context->addWindow(this);
 
     WKViewClientV0 viewClient {

--- a/Tools/MiniBrowser/playstation/WebViewWindow.h
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.h
@@ -31,6 +31,12 @@
 #include <memory>
 #include <toolkitten/Widget.h>
 
+#if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
+namespace WPEToolingBackends {
+class HeadlessViewBackend;
+}
+#endif
+
 class WebViewWindow final : public toolkitten::Widget {
 public:
     struct Client {
@@ -83,6 +89,10 @@ private:
     WKRetainPtr<WKViewRef> m_view;
     std::shared_ptr<WebContext> m_context;
     WKRetainPtr<WKPreferencesRef> m_preferences;
+
+#if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
+    std::unique_ptr<WPEToolingBackends::HeadlessViewBackend> m_window;
+#endif
 
     Client m_client;
 


### PR DESCRIPTION
#### 0054d6405e19aafc6d5592bffd6f9aa707b008b0
<pre>
Add WKViewCreateWPE for PlayStation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257660">https://bugs.webkit.org/show_bug.cgi?id=257660</a>

Reviewed by Fujii Hironori.

Add `WKViewCreateWPE` so a `wpe_view_backend` can be passed into the
underlying `PlayStationWebView`. This is only relevant when
`USE(WPE_BACKEND_PLAYSTATION)` is `ON`.

* Source/WebKit/UIProcess/API/C/playstation/WKView.cpp:
(WKViewCreate):
(WKViewCreateWPE):
* Source/WebKit/UIProcess/API/C/playstation/WKView.h:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::hostFileDescriptor):
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::PlayStationWebView::create):
(WebKit::PlayStationWebView::PlayStationWebView):
(WebKit::m_backend):
* Source/WebKit/UIProcess/playstation/PlayStationWebView.h:
(WebKit::PlayStationWebView::backend):
* Tools/MiniBrowser/playstation/CMakeLists.txt:
* Tools/MiniBrowser/playstation/WebViewWindow.cpp:
(WebViewWindow::WebViewWindow):
* Tools/MiniBrowser/playstation/WebViewWindow.h:

Canonical link: <a href="https://commits.webkit.org/264877@main">https://commits.webkit.org/264877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0aa4c943827f78fb8d6fba46b74143236000068

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8997 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10650 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9005 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/11272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/9253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/11809 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9143 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/11272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10809 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/11272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/11272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/8869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/9253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1038 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/8619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->