### PR TITLE
Object replacement character (0xFFFC) generates null (0) glyph

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4471,7 +4471,6 @@ webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertic
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-srl-032.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-srl-034.xht [ ImageOnlyFailure ]
 webkit.org/b/209080 imported/w3c/web-platform-tests/css/css-writing-modes/vertical-alignment-srl-040.xht [ ImageOnlyFailure ]
-webkit.org/b/255298 imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-decorations-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/219343 imported/w3c/web-platform-tests/css/css-flexbox/flex-aspect-ratio-img-column-012.html [ ImageOnlyFailure ]
 webkit.org/b/219343 imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/text/zero-width-characters-complex-script.html
+++ b/LayoutTests/fast/text/zero-width-characters-complex-script.html
@@ -35,7 +35,6 @@ function testWithZeroWidthSpace(a, b) {
     failedCount += testChar(a, b, 0x202D);
     failedCount += testChar(a, b, 0x202E);
     failedCount += testChar(a, b, 0xFEFF);
-    failedCount += testChar(a, b, 0xFFFC);
 
     return failedCount;
 }

--- a/LayoutTests/fast/text/zero-width-characters.html
+++ b/LayoutTests/fast/text/zero-width-characters.html
@@ -11,7 +11,6 @@ function test()
     testString += String.fromCharCode(0x200E);
     testString += String.fromCharCode(0x200F);
     testString += String.fromCharCode(0xFEFF);
-    testString += String.fromCharCode(0xFFFC);
     var span = document.getElementById("characters");
     var abWidth = span.offsetWidth;
     span.firstChild.data = "a";

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis-expected-mismatch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+<style>
+.foo {
+  font-size: 100px;
+  writing-mode: vertical-lr;
+  text-combine-upright: all;
+}
+</style>
+</head>
+<body>
+This test makes sure that, when <code>text-combine-upright</code> and <code>text-emphasis</code> are used together, the emphasis mark doesn't disappear. The test passes if you see an emphasis mark to the right of the letter X below.
+<p class="foo">X</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+<link rel="mismatch" href="reference/text-combine-emphasis-notref.html">
+<style>
+.foo {
+  font-size: 100px;
+  writing-mode: vertical-lr;
+  text-combine-upright: all;
+  text-emphasis: filled;
+}
+</style>
+</head>
+<body>
+This test makes sure that, when <code>text-combine-upright</code> and <code>text-emphasis</code> are used together, the emphasis mark doesn't disappear. The test passes if you see an emphasis mark to the right of the letter X below.
+<p class="foo">X</p>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1-expected-mismatch.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+</head>
+<body>
+This test makes sure that the U+FFFC OBJECT REPLACEMENT CHARACTER doesn't get deleted. The test passes if the letter below isn't at the left edge of the green box.
+<div style="background: green; font-size: 100px; height: 300px;">e&#x0301;<span style="display: inline-block; height: 200px; width: 1px;"></span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+<link rel="mismatch" href="reference/object-replacement-1-notref.html">
+</head>
+<body>
+This test makes sure that the U+FFFC OBJECT REPLACEMENT CHARACTER doesn't get deleted. The test passes if the letter below isn't at the left edge of the green box.
+<div style="background: green; font-size: 100px; height: 300px;">&#xFFFC;e&#x0301;<span style="display: inline-block; height: 200px; width: 1px;"></span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2-expected-mismatch.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+</head>
+<body>
+This test makes sure that the U+FFFC OBJECT REPLACEMENT CHARACTER doesn't get deleted. The test passes if the letter below isn't at the left edge of the green box.
+<div style="background: green; font-size: 100px; height: 300px;">e<span style="display: inline-block; height: 200px; width: 1px;"></span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CSS Text: U+FFFC OBJECT REPLACEMENT CHARACTER presence</title>
+<link rel="author" title="Myles C. Maxfield" href="mailto:mmaxfield@apple.com">
+<link rel="help" href="https://www.w3.org/TR/css-text-3">
+<link rel="mismatch" href="reference/object-replacement-2-notref.html">
+</head>
+<body>
+This test makes sure that the U+FFFC OBJECT REPLACEMENT CHARACTER doesn't get deleted. The test passes if the letter below isn't at the left edge of the green box.
+<div style="background: green; font-size: 100px; height: 300px;">&#xFFFC;e<span style="display: inline-block; height: 200px; width: 1px;"></span></div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -263,13 +263,11 @@ public:
     {
         // https://drafts.csswg.org/css-text-3/#white-space-processing
         // "Unsupported Default_ignorable characters must be ignored for text rendering."
-        return (character == objectReplacementCharacter
-            || isControlCharacter(character)
-            || isDefaultIgnorableCodePoint(character));
+        return isControlCharacter(character) || isDefaultIgnorableCodePoint(character);
     }
     // FIXME: Callers of treatAsZeroWidthSpace() and treatAsZeroWidthSpaceInComplexScript() should probably be calling isCharacterWhoseGlyphsShouldBeDeletedForTextRendering() instead.
     static bool treatAsZeroWidthSpace(UChar32 c) { return treatAsZeroWidthSpaceInComplexScript(c) || c == zeroWidthNonJoiner || c == zeroWidthJoiner; }
-    static bool treatAsZeroWidthSpaceInComplexScript(UChar32 c) { return c < space || (c >= deleteCharacter && c < noBreakSpace) || c == softHyphen || c == zeroWidthSpace || (c >= leftToRightMark && c <= rightToLeftMark) || (c >= leftToRightEmbed && c <= rightToLeftOverride) || c == zeroWidthNoBreakSpace || c == objectReplacementCharacter; }
+    static bool treatAsZeroWidthSpaceInComplexScript(UChar32 c) { return c < space || (c >= deleteCharacter && c < noBreakSpace) || c == softHyphen || c == zeroWidthSpace || (c >= leftToRightMark && c <= rightToLeftMark) || (c >= leftToRightEmbed && c <= rightToLeftOverride) || c == zeroWidthNoBreakSpace; }
     static bool canReceiveTextEmphasis(UChar32);
 
     static inline UChar normalizeSpaces(UChar character)


### PR DESCRIPTION
#### aba48e65ac8b5a624f37a9be944e686e552d89b7
<pre>
Object replacement character (0xFFFC) generates null (0) glyph
<a href="https://bugs.webkit.org/show_bug.cgi?id=255298">https://bugs.webkit.org/show_bug.cgi?id=255298</a>
rdar://107897203

Reviewed by Cameron McCormack.

The spec doesn&apos;t say anything about the object replacement character being deleted. Neither
Chrome nor Firefox delete the object replacement character.

Tests are being upstreamed at <a href="https://github.com/web-platform-tests/wpt/pull/40391.">https://github.com/web-platform-tests/wpt/pull/40391.</a>

* LayoutTests/TestExpectations:
* LayoutTests/fast/text/zero-width-characters-complex-script.html:
* LayoutTests/fast/text/zero-width-characters.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-combine-emphasis.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/object-replacement-2.html: Added.
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering):
(WebCore::FontCascade::treatAsZeroWidthSpaceInComplexScript):

Canonical link: <a href="https://commits.webkit.org/264886@main">https://commits.webkit.org/264886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af77888ce5ed2e2e913f73e513bd3e0108bbb29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11835 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9165 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10831 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8242 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11717 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7249 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->