### PR TITLE
[run-benchmarks] The browser benchmark runner harness should be able to specify MotionMark subtests to run

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -151,9 +151,12 @@ class BenchmarkRunner(object):
                 _log.info('Start the iteration {current_iteration} of {iterations} for current benchmark'.format(current_iteration=iteration, iterations=count))
                 try:
                     self._browser_driver.prepare_env(self._config)
-
                     if 'entry_point' in self._plan:
-                        result = self._run_one_test(web_root, self._plan['entry_point'], iteration)
+                        if 'subtest_entry_point' in self._plan and self._subtests:
+                            entry_point = self._plan['subtest_entry_point']
+                        else:
+                            entry_point = self._plan['entry_point']
+                        result = self._run_one_test(web_root, entry_point, iteration)
                         debug_outputs.append(result.pop('debugOutput', None))
                         assert(result)
                         results.append(result)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -1,6 +1,10 @@
+import logging
+
 from abc import ABCMeta, abstractmethod
 from webkitpy.benchmark_runner.utils import get_driver_binary_path
 from contextlib import contextmanager
+
+_log = logging.getLogger(__name__)
 
 
 class BrowserDriver(object):
@@ -52,7 +56,8 @@ class BrowserDriver(object):
         yield
 
     @contextmanager
-    def profile(self, timeout):
+    def profile(self, output_path, profile_filename, timeout=300):
+        _log.error('The --profile option was specified, but an empty context was called. This run will not be profiled.')
         yield
 
     @property

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark.patch
@@ -1,5 +1,66 @@
+diff --git a/resources/debug-runner/motionmark.js b/resources/debug-runner/motionmark.js
+index c1a97359c895..65352e531eed 100644
+--- a/resources/debug-runner/motionmark.js
++++ b/resources/debug-runner/motionmark.js
+@@ -511,6 +511,37 @@ window.suitesManager =
+         return suites;
+     },
+ 
++    constructSuitesFromURLParameters: function(urlParameterString) {
++        var urlParams = new URLSearchParams(urlParameterString);
++        var suiteNames = urlParams.getAll("suite-name");
++        var testNames = urlParams.getAll("test-name");
++        var suites = [];
++        for (var i = 0; i < suiteNames.length; i++) {
++            var suiteName = decodeURIComponent(suiteNames[i]);
++            var testName = decodeURIComponent(testNames[i]);
++            var suiteRegExp = new RegExp(suiteName.toLowerCase(), "i");
++            var testRegExp = new RegExp(testName.toLowerCase(), "i");
++            var test = [];
++            for (var j = 0; j < Suites.length; ++j) {
++                var suite = Suites[j];
++                if (!Utilities.stripUnwantedCharactersForURL(suite.name.toLowerCase()).match(suiteRegExp))
++                    continue;
++                var test;
++                for (var k = 0; k < suite.tests.length; ++k) {
++                    suiteTest = suite.tests[k];
++                    if (Utilities.stripUnwantedCharactersForURL(suiteTest.name.toLowerCase()).match(testRegExp)) {
++                        test = suiteTest;
++                        break;
++                    }
++                }
++                if (!test)
++                    continue;
++                suites.push(new Suite(suiteName, [test]));
++            };
++        }
++        return suites;
++    },
++
+     updateLocalStorageFromJSON: function(results)
+     {
+         for (var suiteName in results[Strings.json.results.tests]) {
+@@ -622,16 +653,12 @@ Utilities.extendObject(window.benchmarkController, {
+ 
+     startBenchmarkImmediatelyIfEncoded: function()
+     {
+-        benchmarkController.options = Utilities.convertQueryStringToObject(location.search);
+-        if (!benchmarkController.options)
+-            return false;
+-
+-        benchmarkController.suites = suitesManager.suitesFromQueryString(benchmarkController.options["suite-name"], benchmarkController.options["test-name"]);
++        benchmarkController.suites = suitesManager.constructSuitesFromURLParameters(location.search)
+         if (!benchmarkController.suites.length)
+             return false;
+ 
+         setTimeout(function() {
+-            this._startBenchmark(benchmarkController.suites, benchmarkController.options, "running-test");
++            this._startBenchmark(benchmarkController.suites, this.benchmarkDefaultParameters, "running-test");
+         }.bind(this), 0);
+         return true;
+     },
 diff --git a/resources/runner/motionmark.js b/resources/runner/motionmark.js
-index d45155e..b10635a 100644
+index ccd7132c90b1..f97712db3024 100644
 --- a/resources/runner/motionmark.js
 +++ b/resources/runner/motionmark.js
 @@ -411,6 +411,62 @@ window.benchmarkRunnerClient = {
@@ -47,30 +108,34 @@ index d45155e..b10635a 100644
 +
 +    didFinishLastIteration: function()
 +    {
-+        // submit result to server
-+        var results = JSON.stringify(this._computeResultsReports());
-+        var xhr = new XMLHttpRequest();
-+        xhr.open("POST", "/report");
-+        xhr.setRequestHeader("Content-type", "application/json");
-+        xhr.setRequestHeader("Content-length", results.length);
-+        xhr.setRequestHeader("Connection", "close");
-+        xhr.onreadystatechange = function() {
-+            if (xhr.readyState == XMLHttpRequest.DONE && xhr.status == 200) {
-+                closeRequest = new XMLHttpRequest();
-+                closeRequest.open("GET", "/shutdown");
-+                closeRequest.send()
-+            }
-+        }
-+        xhr.send(results);
++       // Submit result to server
++       var results = JSON.stringify(this._computeResultsReports());
++       var xhr = new XMLHttpRequest();
++       xhr.open("POST", "/report");
++       xhr.setRequestHeader("Content-type", "application/json");
++       xhr.setRequestHeader("Content-length", results.length);
++       xhr.setRequestHeader("Connection", "close");
++       xhr.onreadystatechange = function() {
++           if (xhr.readyState == XMLHttpRequest.DONE && xhr.status == 200) {
++               closeRequest = new XMLHttpRequest();
++               closeRequest.open("GET", "/shutdown");
++               closeRequest.send()
++           }
++       }
++       xhr.send(results);
      }
  };
  
-@@ -652,4 +708,7 @@ window.benchmarkController = {
+@@ -657,4 +713,11 @@ window.benchmarkController = {
      }
  };
  
 -window.addEventListener("load", function() { benchmarkController.initialize(); });
-+window.addEventListener("load", function() {
-+    setTimeout(benchmarkController.startBenchmark.bind(benchmarkController), 3000);
-+    benchmarkController.initialize();
-+});
++if (window.location.href.includes("developer.html")) {
++    window.addEventListener("load", function() { benchmarkController.initialize(); });
++} else {
++    window.addEventListener("load", function() {
++        setTimeout(benchmarkController.startBenchmark.bind(benchmarkController), 3000);
++        benchmarkController.initialize();
++    });
++}

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
@@ -6,6 +6,7 @@
     "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
     "entry_point": "index.html",
+    "subtest_entry_point": "developer.html",
     "config": {
         "orientation": "landscape"
     },
@@ -152,6 +153,100 @@
             {"path": "tests/text/design-6.js", "mode": "100644", "type": "blob"},
             {"path": "tests/text/design.html", "mode": "100644", "type": "blob"},
             {"path": "tests/text/design.js", "mode": "100644", "type": "blob"}
+        ]
+    },
+    "subtest_url_format": "suite-name=${SUITE}&test-name=${TEST}",
+    "subtests": {
+        "MotionMark": [
+            "Multiply",
+            "CanvasArcs",
+            "Leaves",
+            "Paths",
+            "CanvasLines",
+            "Images",
+            "Design",
+            "Suits"
+        ],
+        "HTMLSuite": [
+            "CSSBouncingCircles",
+            "CSSBouncingClippedRects",
+            "CSSBouncingGradientCircles",
+            "CSSBouncingBlendCircles",
+            "CSSBouncingFilterCircles",
+            "CSSBouncingSVGimages",
+            "CSSBouncingTaggedImages",
+            "Focus20",
+            "DOMParticlesSVGMasks",
+            "CompositedTransforms"
+        ],
+        "CanvasSuite": [
+            "CanvasBouncingClippedRects",
+            "CanvasBouncingGradientCircles",
+            "CanvasBouncingSVGImages",
+            "CanvasBouncingPNGImages",
+            "StrokeShapes",
+            "FillShapes",
+            "CanvasPutGetImageData"
+        ],
+        "SVGSuite": [
+            "SVGBouncingCircles",
+            "SVGBouncingClippedRects",
+            "SVGBouncingGradientCircles",
+            "SVGBouncingSVGImages",
+            "SVGBouncingPNGiImages"
+        ],
+        "LeavesSuite": [
+            "TranslateonlyLeaves",
+            "TranslateScaleLeaves",
+            "TranslateOpacityLeaves"
+        ],
+        "MultiplySuite": [
+            "MultiplyCSSOpacityOnly",
+            "MultiplyCSSDisplayOnly",
+            "MultiplyCSSVisibilityOnly"
+        ],
+        "TextSuite": [
+            "DesignLatinOnly12Items",
+            "DesignCJKOnly12Items",
+            "DesignRTLandComplexScriptsOnly12Items",
+            "DesignLatinOnly6Items",
+            "DesignCJKOnly6Items",
+            "DesignRTLAndComplexScriptsOnly6Items"
+        ],
+        "SuitsSuite": [
+            "SuitsClipOnly",
+            "SuitsShapeOnly",
+            "SuitsClipShapeRotation",
+            "SuitsClipShapeGradient",
+            "SuitsStatic"
+        ],
+        "3DGraphics": [
+            "TrianglesWebGL",
+            "TrianglesWebGPU"
+        ],
+        "BasicCanvasPathSuite": [
+            "CanvasLineSegmentsButtCaps",
+            "CanvasLineSegmentsRoundCaps",
+            "CanvasLineSegmentsSquareCaps",
+            "CanvasLinePathBevelJoin",
+            "CanvasLinePathRoundJoin",
+            "CanvasLinePathMiterJoin",
+            "CanvasLinePathWithDashPattern",
+            "CanvasQuadraticSegments",
+            "CanvasQuadraticPath",
+            "CanvasBezierSegments",
+            "CanvasBezierPath",
+            "CanvasArcToSegments",
+            "CanvasArcSegments",
+            "CanvasRects",
+            "CanvasEllipses",
+            "CanvasLinePathFill",
+            "CanvasQuadraticPathFill",
+            "CanvasBezierPathFill",
+            "CanvasArcToSegmentsFill",
+            "CanvasArcSegmentsFill",
+            "CanvasRectsFill",
+            "CanvasEllipsesFill"
         ]
     }
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -48,7 +48,6 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         return result
 
     def _construct_subtest_url(self, subtests):
-        print(subtests)
         if not subtests or not isinstance(subtests, collections.abc.Mapping if sys.version_info >= (3, 10) else collections.Mapping) or 'subtest_url_format' not in self._plan:
             return ''
         subtest_url = ''
@@ -63,6 +62,8 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         try:
             self._http_server_driver.serve(web_root)
             url = urljoin(self._http_server_driver.base_url(), self._plan_name + '/' + test_file + self._construct_subtest_url(self._subtests))
+            if '?' not in url:
+                url = url.replace('&', '?', 1)
             if enable_profiling:
                 context = self._browser_driver.profile(self._profile_output_dir, profile_filename)
             else:


### PR DESCRIPTION
#### 653b530b9ffd3f4440fc6636b2da3c011633215f
<pre>
[run-benchmarks] The browser benchmark runner harness should be able to specify MotionMark subtests to run
<a href="https://bugs.webkit.org/show_bug.cgi?id=257663">https://bugs.webkit.org/show_bug.cgi?id=257663</a>
rdar://110187208

Reviewed by Dewei Zhu.

This patch adds support for MotionMark subtests in run-benchmarks, similar to the support already included for JetStream2.

Subtests can be listed with the `--list-subtests` flag, and come in the form {SUITE}/{TEST}. MotionMark&apos;s default run (without any subtests specified) contains just the MotionMark suite in order, but the test plan includes all the other debug suites and tests as well for running separately.

To run subtests, use the --subtests flag and specify a list of subtests (as listed in --list-subtests), separated by spaces. The runner will run only those subtests in each iteration, and report on only those results.

Also, some more under-the hood improvements:
 - Added a new field to the plan, &apos;subtest_entry_point&apos;, that changes the entry point of the test if --subtests is specified.
 - Changes to webserver/motionmark.patch include not auto-loading the benchmark if `developer.html` is loaded in (because the debug runner already starts tests automatically if encoded), and extending the debug runner to accept multiple suites and tests as arguments.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner._run_benchmark):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.profile): Fixed a bug where using the --profile flag would crash the benchmark harness, and added logging to note when the placeholder context is being called.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark.patch:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/264906@main">https://commits.webkit.org/264906@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15ae7b3021be43c67aeb121b603fda918c1492f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8972 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9264 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11823 "1 flakes 96 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10130 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10821 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9133 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15715 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11703 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7242 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8125 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->