### PR TITLE
[WebGPU] Delete some unnecessary methods from WebGPUExt.h

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		1C5ACAEA273A560D0095F8D5 /* TextureView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextureView.mm; sourceTree = "<group>"; };
 		1C9F7CDD29762F51006B5BE9 /* PresentationContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PresentationContext.mm; sourceTree = "<group>"; };
 		1C9F7CDE29762F51006B5BE9 /* PresentationContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PresentationContext.h; sourceTree = "<group>"; };
+		1CA7CDB12A2B284A0094071F /* WebGPUInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUInternal.h; sourceTree = "<group>"; };
 		1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CBD2E922977DAC900BBF52C /* PresentationContextCoreAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PresentationContextCoreAnimation.h; sourceTree = "<group>"; };
 		1CBD2E932977DAC900BBF52C /* PresentationContextCoreAnimation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PresentationContextCoreAnimation.mm; sourceTree = "<group>"; };
@@ -534,6 +535,7 @@
 				1CEBD7E62716AFBA00A5254D /* WebGPU.h */,
 				1CC0C8C9273A7D8900D0B481 /* WebGPU.modulemap */,
 				1C5ACAD2273A4C860095F8D5 /* WebGPUExt.h */,
+				1CA7CDB12A2B284A0094071F /* WebGPUInternal.h */,
 			);
 			path = WebGPU;
 			sourceTree = "<group>";

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -35,15 +35,6 @@ extern "C" {
 
 typedef struct WGPUExternalTextureImpl* WGPUExternalTexture;
 
-typedef void (^WGPUBufferMapBlockCallback)(WGPUBufferMapAsyncStatus status);
-typedef void (^WGPUCompilationInfoBlockCallback)(WGPUCompilationInfoRequestStatus status, WGPUCompilationInfo const * compilationInfo);
-typedef void (^WGPUCreateComputePipelineAsyncBlockCallback)(WGPUCreatePipelineAsyncStatus status, WGPUComputePipeline pipeline, char const * message);
-typedef void (^WGPUCreateRenderPipelineAsyncBlockCallback)(WGPUCreatePipelineAsyncStatus status, WGPURenderPipeline pipeline, char const * message);
-typedef void (^WGPUErrorBlockCallback)(WGPUErrorType type, char const * message);
-typedef void (^WGPUQueueWorkDoneBlockCallback)(WGPUQueueWorkDoneStatus status);
-typedef void (^WGPURequestAdapterBlockCallback)(WGPURequestAdapterStatus status, WGPUAdapter adapter, char const * message);
-typedef void (^WGPURequestDeviceBlockCallback)(WGPURequestDeviceStatus status, WGPUDevice device, char const * message);
-typedef void (^WGPURequestInvalidDeviceBlockCallback)(WGPUDevice device);
 typedef void (^WGPUWorkItem)(void);
 typedef void (^WGPUScheduleWorkBlock)(WGPUWorkItem workItem);
 
@@ -108,32 +99,9 @@ typedef struct WGPUExternalTextureDescriptor {
 
 #if !defined(WGPU_SKIP_PROCS)
 
-typedef void (*WGPUProcBindGroupLayoutSetLabel)(WGPUBindGroupLayout bindGroupLayout, char const * label);
-typedef void (*WGPUProcBindGroupSetLabel)(WGPUBindGroup bindGroup, char const * label);
-typedef void (*WGPUProcBufferSetLabel)(WGPUBuffer buffer, char const * label);
-typedef void (*WGPUProcCommandBufferSetLabel)(WGPUCommandBuffer commandBuffer, char const * label);
-typedef void (*WGPUProcCommandEncoderSetLabel)(WGPUCommandEncoder commandEncoder, char const * label);
-typedef void (*WGPUProcComputePassEncoderSetLabel)(WGPUComputePassEncoder computePassEncoder, char const * label);
-typedef void (*WGPUProcDeviceSetLabel)(WGPUDevice queue, char const * label);
-typedef void (*WGPUProcPipelineLayoutSetLabel)(WGPUPipelineLayout pipelineLayout, char const * label);
-typedef void (*WGPUProcQuerySetSetLabel)(WGPUQuerySet querySet, char const * label);
-typedef void (*WGPUProcQueueSetLabel)(WGPUQueue queue, char const * label);
-typedef void (*WGPUProcRenderBundleEncoderSetLabel)(WGPURenderBundleEncoder renderBundleEncoder, char const * label);
 typedef void (*WGPUProcRenderBundleSetLabel)(WGPURenderBundle renderBundle, char const * label);
-typedef void (*WGPUProcRenderPassEncoderSetLabel)(WGPURenderPassEncoder renderBundleEncoder, char const * label);
-typedef void (*WGPUProcSamplerSetLabel)(WGPUSampler sampler, char const * label);
-typedef void (*WGPUProcTextureSetLabel)(WGPUTexture sampler, char const * label);
-typedef void (*WGPUProcTextureViewSetLabel)(WGPUTextureView sampler, char const * label);
 
-typedef void (*WGPUProcAdapterRequestDeviceWithBlock)(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceBlockCallback callback);
-typedef void (*WGPUProcBufferMapAsyncWithBlock)(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapBlockCallback callback);
-typedef void (*WGPUProcDeviceCreateComputePipelineAsyncWithBlock)(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncBlockCallback callback);
-typedef void (*WGPUProcDeviceCreateRenderPipelineAsyncWithBlock)(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncBlockCallback callback);
-typedef bool (*WGPUProcDevicePopErrorScopeWithBlock)(WGPUDevice device, WGPUErrorBlockCallback callback);
-typedef void (*WGPUProcDeviceSetUncapturedErrorCallbackWithBlock)(WGPUDevice device, WGPUErrorBlockCallback callback);
-typedef void (*WGPUProcInstanceRequestAdapterWithBlock)(WGPUInstance instance, WGPURequestAdapterOptions const * options, WGPURequestAdapterBlockCallback callback);
-typedef void (*WGPUProcQueueOnSubmittedWorkDoneWithBlock)(WGPUQueue queue, uint64_t signalValue, WGPUQueueWorkDoneBlockCallback callback);
-typedef void (*WGPUProcShaderModuleGetCompilationInfoWithBlock)(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
+typedef WGPUExternalTexture (*WGPUProcDeviceImportExternalTexture)(WGPUSwapChain swapChain);
 
 // FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
 typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChain);
@@ -142,32 +110,7 @@ typedef WGPUTexture (*WGPUProcSwapChainGetCurrentTexture)(WGPUSwapChain swapChai
 
 #if !defined(WGPU_SKIP_DECLARATIONS)
 
-WGPU_EXPORT void wgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout, char const * label);
-WGPU_EXPORT void wgpuBindGroupSetLabel(WGPUBindGroup bindGroup, char const * label);
-WGPU_EXPORT void wgpuBufferSetLabel(WGPUBuffer buffer, char const * label);
-WGPU_EXPORT void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, char const * label);
-WGPU_EXPORT void wgpuCommandEncoderSetLabel(WGPUCommandEncoder commandEncoder, char const * label);
-WGPU_EXPORT void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, char const * label);
-WGPU_EXPORT void wgpuDeviceSetLabel(WGPUDevice queue, char const * label);
-WGPU_EXPORT void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, char const * label);
-WGPU_EXPORT void wgpuQuerySetSetLabel(WGPUQuerySet querySet, char const * label);
-WGPU_EXPORT void wgpuQueueSetLabel(WGPUQueue queue, char const * label);
-WGPU_EXPORT void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, char const * label);
 WGPU_EXPORT void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, char const * label);
-WGPU_EXPORT void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderBundleEncoder, char const * label);
-WGPU_EXPORT void wgpuSamplerSetLabel(WGPUSampler sampler, char const * label);
-WGPU_EXPORT void wgpuTextureSetLabel(WGPUTexture sampler, char const * label);
-WGPU_EXPORT void wgpuTextureViewSetLabel(WGPUTextureView sampler, char const * label);
-
-WGPU_EXPORT void wgpuAdapterRequestDeviceWithBlock(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor, WGPURequestDeviceBlockCallback callback);
-WGPU_EXPORT void wgpuBufferMapAsyncWithBlock(WGPUBuffer buffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapBlockCallback callback);
-WGPU_EXPORT void wgpuDeviceCreateComputePipelineAsyncWithBlock(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncBlockCallback callback);
-WGPU_EXPORT void wgpuDeviceCreateRenderPipelineAsyncWithBlock(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncBlockCallback callback);
-WGPU_EXPORT void wgpuDevicePopErrorScopeWithBlock(WGPUDevice device, WGPUErrorBlockCallback callback);
-WGPU_EXPORT void wgpuDeviceSetUncapturedErrorCallbackWithBlock(WGPUDevice device, WGPUErrorBlockCallback callback);
-WGPU_EXPORT void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPURequestAdapterOptions const * options, WGPURequestAdapterBlockCallback callback);
-WGPU_EXPORT void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue queue, WGPUQueueWorkDoneBlockCallback callback);
-WGPU_EXPORT void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule shaderModule, WGPUCompilationInfoBlockCallback callback);
 
 // FIXME: https://github.com/webgpu-native/webgpu-headers/issues/89 is about moving this from WebGPUExt.h to WebGPU.h
 WGPU_EXPORT WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain);

--- a/Source/WebGPU/WebGPU/WebGPUInternal.h
+++ b/Source/WebGPU/WebGPU/WebGPUInternal.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (^WGPUBufferMapBlockCallback)(WGPUBufferMapAsyncStatus);
+typedef void (^WGPUCompilationInfoBlockCallback)(WGPUCompilationInfoRequestStatus, const WGPUCompilationInfo* compilationInfo);
+typedef void (^WGPUCreateComputePipelineAsyncBlockCallback)(WGPUCreatePipelineAsyncStatus, WGPUComputePipeline pipeline, const char* message);
+typedef void (^WGPUCreateRenderPipelineAsyncBlockCallback)(WGPUCreatePipelineAsyncStatus, WGPURenderPipeline pipeline, const char* message);
+typedef void (^WGPUErrorBlockCallback)(WGPUErrorType, const char* message);
+typedef void (^WGPUQueueWorkDoneBlockCallback)(WGPUQueueWorkDoneStatus);
+typedef void (^WGPURequestAdapterBlockCallback)(WGPURequestAdapterStatus, WGPUAdapter adapter, const char* message);
+typedef void (^WGPURequestDeviceBlockCallback)(WGPURequestDeviceStatus, WGPUDevice device, const char* message);
+typedef void (^WGPURequestInvalidDeviceBlockCallback)(WGPUDevice);
+
+#if !defined(WGPU_SKIP_PROCS)
+
+typedef void (*WGPUProcAdapterRequestDeviceWithBlock)(WGPUAdapter, const WGPUDeviceDescriptor*, WGPURequestDeviceBlockCallback);
+typedef void (*WGPUProcBufferMapAsyncWithBlock)(WGPUBuffer, WGPUMapModeFlags mode, size_t offset, size_t size, WGPUBufferMapBlockCallback);
+typedef void (*WGPUProcDeviceCreateComputePipelineAsyncWithBlock)(WGPUDevice, const WGPUComputePipelineDescriptor* descriptor, WGPUCreateComputePipelineAsyncBlockCallback);
+typedef void (*WGPUProcDeviceCreateRenderPipelineAsyncWithBlock)(WGPUDevice, const WGPURenderPipelineDescriptor* descriptor, WGPUCreateRenderPipelineAsyncBlockCallback);
+typedef bool (*WGPUProcDevicePopErrorScopeWithBlock)(WGPUDevice, WGPUErrorBlockCallback);
+typedef void (*WGPUProcDeviceSetUncapturedErrorCallbackWithBlock)(WGPUDevice, WGPUErrorBlockCallback);
+typedef void (*WGPUProcInstanceRequestAdapterWithBlock)(WGPUInstance, const WGPURequestAdapterOptions*, WGPURequestAdapterBlockCallback);
+typedef void (*WGPUProcQueueOnSubmittedWorkDoneWithBlock)(WGPUQueue, WGPUQueueWorkDoneBlockCallback);
+typedef void (*WGPUProcShaderModuleGetCompilationInfoWithBlock)(WGPUShaderModule, WGPUCompilationInfoBlockCallback);
+
+#endif // !defined(WGPU_SKIP_PROCS)
+
+#if !defined(WGPU_SKIP_DECLARATIONS)
+
+void wgpuAdapterRequestDeviceWithBlock(WGPUAdapter, const WGPUDeviceDescriptor*, WGPURequestDeviceBlockCallback);
+void wgpuBufferMapAsyncWithBlock(WGPUBuffer, WGPUMapModeFlags, size_t offset, size_t, WGPUBufferMapBlockCallback);
+void wgpuDeviceCreateComputePipelineAsyncWithBlock(WGPUDevice, const WGPUComputePipelineDescriptor*, WGPUCreateComputePipelineAsyncBlockCallback);
+void wgpuDeviceCreateRenderPipelineAsyncWithBlock(WGPUDevice, const WGPURenderPipelineDescriptor*, WGPUCreateRenderPipelineAsyncBlockCallback);
+void wgpuDevicePopErrorScopeWithBlock(WGPUDevice, WGPUErrorBlockCallback);
+void wgpuDeviceSetUncapturedErrorCallbackWithBlock(WGPUDevice, WGPUErrorBlockCallback);
+void wgpuInstanceRequestAdapterWithBlock(WGPUInstance, const WGPURequestAdapterOptions*, WGPURequestAdapterBlockCallback);
+void wgpuQueueOnSubmittedWorkDoneWithBlock(WGPUQueue, WGPUQueueWorkDoneBlockCallback);
+void wgpuShaderModuleGetCompilationInfoWithBlock(WGPUShaderModule, WGPUCompilationInfoBlockCallback);
+
+#endif // !defined(WGPU_SKIP_DECLARATIONS)
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/Source/WebGPU/WebGPU/config.h
+++ b/Source/WebGPU/WebGPU/config.h
@@ -27,6 +27,7 @@
 
 #include "WebGPU.h"
 #include "WebGPUExt.h"
+#include "WebGPUInternal.h"
 
 #include <Metal/Metal.h>
 


### PR DESCRIPTION
#### 5b9c48e708e7ffa2da29b615e9e78e92d2fc0370
<pre>
[WebGPU] Delete some unnecessary methods from WebGPUExt.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=257673">https://bugs.webkit.org/show_bug.cgi?id=257673</a>
rdar://110201177

Reviewed by Mike Wyrzykowski.

The more custom stuff in WebGPUExt.h we have, the more difficult it will be to
swap in and out different WebGPU implementations. We generally want to minimize
the contents of WebGPUExt.h as much as possible.

This patch deletes the fooWithBlock() functions from being exported, in favor of
just using the common function pointer + userdata paradigm instead. This patch
doesn&apos;t actually delete the implementation of the fooWithBlock() functions,
because they will probably be useful while implementing
<a href="https://github.com/WebKit/WebKit/pull/13849.">https://github.com/WebKit/WebKit/pull/13849.</a> This patch therefore moves their
declaration to a WebGPUInternal.h file, which is not exported.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp:
(PAL::WebGPU::requestDeviceCallback):
(PAL::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUBufferImpl.cpp:
(PAL::WebGPU::mapAsyncCallback):
(PAL::WebGPU::BufferImpl::mapAsync):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::createComputePipelineAsyncCallback):
(PAL::WebGPU::DeviceImpl::createComputePipelineAsync):
(PAL::WebGPU::createRenderPipelineAsyncCallback):
(PAL::WebGPU::DeviceImpl::createRenderPipelineAsync):
(PAL::WebGPU::popErrorScopeCallback):
(PAL::WebGPU::DeviceImpl::popErrorScope):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUImpl.cpp:
(PAL::WebGPU::requestAdapterCallback):
(PAL::WebGPU::GPUImpl::requestAdapter):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUQueueImpl.cpp:
(PAL::WebGPU::onSubmittedWorkDoneCallback):
(PAL::WebGPU::QueueImpl::onSubmittedWorkDone):
* Source/WebGPU/WebGPU/Adapter.mm:
(wgpuAdapterRequestDevice):
(wgpuAdapterRequestDeviceWithBlock): Deleted.
* Source/WebGPU/WebGPU/Buffer.mm:
(wgpuBufferMapAsyncWithBlock): Deleted.
* Source/WebGPU/WebGPU/Device.mm:
(wgpuDeviceCreateComputePipelineAsyncWithBlock): Deleted.
(wgpuDeviceCreateRenderPipelineAsyncWithBlock): Deleted.
(wgpuDevicePopErrorScopeWithBlock): Deleted.
(wgpuDeviceSetUncapturedErrorCallbackWithBlock): Deleted.
* Source/WebGPU/WebGPU/Instance.mm:
(wgpuInstanceRequestAdapter):
(wgpuInstanceRequestAdapterWithBlock): Deleted.
* Source/WebGPU/WebGPU/Queue.mm:
(wgpuQueueOnSubmittedWorkDoneWithBlock): Deleted.
* Source/WebGPU/WebGPU/ShaderModule.mm:
(wgpuShaderModuleGetCompilationInfoWithBlock): Deleted.
* Source/WebGPU/WebGPU/WebGPUExt.h:

Canonical link: <a href="https://commits.webkit.org/264893@main">https://commits.webkit.org/264893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b44208beb420023298505e2180d70d859e42d7b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11847 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10157 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10848 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7452 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8561 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8906 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8151 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2184 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->