### PR TITLE
[iOS] Add a layout test to verify that the selection is hidden while overflow scrolling

### DIFF
--- a/LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container-expected.txt
+++ b/LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container-expected.txt
@@ -1,0 +1,14 @@
+Select me
+This test verifies that selection rects are hidden when scrolling an overflow scrollable container. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS Waited for initial selection to appear
+PASS Scrolled down without ending touch
+PASS Waited for selection to disappear
+PASS Scrolled back up and ending touch
+PASS Waited for selection to reappear
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container.html
+++ b/LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+.scroller {
+    overflow-y: scroll;
+    width: 100%;
+    height: 400px;
+    font-size: 80px;
+    border: 1px solid tomato;
+    padding-top: 200px;
+}
+
+.tall-content {
+    height: 5000px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that selection rects are hidden when scrolling an overflow scrollable container. To manually test, select the text below and scroll the red box; the selection should hide when scrolling and reappear when scrolling ends.")
+    if (!window.testRunner)
+        return;
+
+    await UIHelper.longPressElement(document.getElementById("target"));
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Waited for initial selection to appear");
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(150, 300)
+        .move(150, 100, 0.2)
+        .wait(0.1)
+        .takeResult());
+    testPassed("Scrolled down without ending touch");
+    await UIHelper.waitForSelectionToDisappear();
+    testPassed("Waited for selection to disappear");
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .wait(0.1)
+        .move(150, 300, 0.2)
+        .end(150, 300)
+        .takeResult());
+    testPassed("Scrolled back up and ending touch");
+    await UIHelper.waitForSelectionToAppear();
+    testPassed("Waited for selection to reappear");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="scroller">
+        <span id="target">Select</span> me
+        <div class="tall-content"></div>
+    </div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>


### PR DESCRIPTION
#### 657bb1cf041be1aa55071483efbcd5cf15831374
<pre>
[iOS] Add a layout test to verify that the selection is hidden while overflow scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=257679">https://bugs.webkit.org/show_bug.cgi?id=257679</a>
rdar://110147727

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

Add a layout test to verify that scrolling a text selection inside an overflow container temporarily
hides the selection highlight view.

* LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container-expected.txt: Added.
* LayoutTests/editing/selection/ios/hide-selection-when-scrolling-overflow-container.html: Added.

Canonical link: <a href="https://commits.webkit.org/264896@main">https://commits.webkit.org/264896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a589d34ae0f98b58e1f8996338259fd3e1b09283

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9472 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11786 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10100 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10778 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15681 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8504 "5 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11668 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7215 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->