### PR TITLE
Remaining page height should never be 0

### DIFF
--- a/LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash-expected.txt
+++ b/LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash-expected.txt
@@ -1,0 +1,4 @@
+PASS if no crash or assertion failure.
+
+
+

--- a/LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash.html
+++ b/LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<p>PASS if no crash or assertion failure.</p>
+<div style="-webkit-columns:3; column-fill:auto; height:600px;">
+    <div style="height:12345678987654321px;"></div>
+    <div style="-webkit-columns:3;">
+        <div style="height:10000px;"></div>
+        <br>
+    </div>
+</div>

--- a/LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash-expected.txt
+++ b/LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash-expected.txt
@@ -1,0 +1,3 @@
+
+PASS No crash or assertion failure.
+

--- a/LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash.html
+++ b/LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<div style="columns:2; column-fill:auto; height:20px;">
+    <div style="columns:2;">
+        <div style="height:40px;"></div>
+        <div style="columns:1; height:0; column-fill:auto;">
+            <div></div>
+        </div>
+    </div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+    test(() => { }, "No crash or assertion failure.");
+</script>

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -420,6 +420,12 @@ LayoutUnit RenderFragmentedFlow::pageRemainingLogicalHeightForOffset(LayoutUnit 
         // If IncludePageBoundary is set, the line exactly on the top edge of a
         // fragment will act as being part of the previous fragment.
         remainingHeight = intMod(remainingHeight, pageLogicalHeight);
+    } else if (!remainingHeight) {
+        // When pageBoundaryRule is IncludePageBoundary, we shouldn't just return 0 if there's no
+        // space left, because in that case we're at a column boundary, in which case we should
+        // return the amount of space remaining in the *next* column. Note that the page height
+        // itself may be 0, though.
+        remainingHeight = pageLogicalHeight;
     }
     return remainingHeight;
 }


### PR DESCRIPTION
#### d0421adf295943e06d4bba1254d6dc86f36d8c9d
<pre>
Remaining page height should never be 0

<a href="https://bugs.webkit.org/show_bug.cgi?id=257087">https://bugs.webkit.org/show_bug.cgi?id=257087</a>
rdar://problem/109929893

Reviewed by Alan Baradlay.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/3e04625f97ad0ae12a02e5f4b4d1e40973d01d29">https://chromium.googlesource.com/chromium/src.git/+/3e04625f97ad0ae12a02e5f4b4d1e40973d01d29</a> &amp; <a href="https://chromium.googlesource.com/chromium/src.git/+/2fa8cb1b82fe741f526a5009f17b03158349e681">https://chromium.googlesource.com/chromium/src.git/+/2fa8cb1b82fe741f526a5009f17b03158349e681</a>

This patch covers the case where if &apos;LayoutUnit&apos; reaches infinity, it just uses &apos;pageLogicalHeight&apos; as &apos;remainingHeight&apos;.

* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(RenderFragmentedFlow::pageRemainingLogicalHeightForOffset): Add &apos;else if&apos; case
* LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash.html: Add Test Case
* LayoutTests/fast/multicol/zero-height-inner-multicol-at-boundary-crash-expected.txt: Add Test Case Expectation
* LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash.html: Add Test Case
* LayoutTests/fast/multicol/infinitely-tall-content-in-outer-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264857@main">https://commits.webkit.org/264857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c71f957fd3923ebd904b4077bea75278d04a193a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9173 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11720 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10023 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10697 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15617 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11604 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7145 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2152 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->