### PR TITLE
[LBSE] REGRESSION: Transform repainting/relayout broken

### DIFF
--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -132,11 +132,15 @@ AffineTransform* SVGGraphicsElement::ensureSupplementalTransform()
 
 void SVGGraphicsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGTests::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
+    // Updating the SVG transform baseVal needs to happen before calling attributeChanged().
+    // attributeChanged() invokes svgAttributeChanged(), which calls RenderLayerModelObjects
+    // repaintOrRelayoutAfterSVGTransformChange() method, if LBSE is activated. To determine
+    // if the SVG transform changed, m_transform has to be updated before.
     if (name == SVGNames::transformAttr)
         m_transform->baseVal()->parse(newValue);
+
+    SVGTests::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)


### PR DESCRIPTION
#### ab79bc420356129cadfc6533d9f223f687856cc3
<pre>
[LBSE] REGRESSION: Transform repainting/relayout broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=257692">https://bugs.webkit.org/show_bug.cgi?id=257692</a>

Reviewed by NOBODY (OOPS!).

Dynamically changing e.g. the &apos;transform&apos; attribute, has no effect
in LBSE anymore, since 46ecab837eb9d6d766ba877abc8796c87d85df95.

The order of the attributeChanged() / m_transform-&gt;baseVal()-&gt;parse(...) calls
was swapped, which had no effect in the legacy SVG engine, but breaks in LBSE.
Restore the previous order and fix the issue.

Fixes 13 test failures when LBSE is activated:
 - svg/carto.net/tabgroup.svg
 - svg/repaint/foreign-object-repainting-after-modifying-container-transform.html
 - svg/repaint/foreign-object-repainting-after-modifying-transform.html
 - svg/repaint/image-repainting-after-modifying-container-transform.html
 - svg/repaint/image-repainting-after-modifying-transform.html
 - svg/repaint/inner-svg-repainting-after-modifying-container-transform.html
 - svg/repaint/inner-svg-repainting-after-modifying-transform.html
 - svg/repaint/shape-repainting-after-modifying-container-transform.html
 - svg/repaint/shape-repainting-after-modifying-transform.html
 - svg/repaint/text-repainting-after-modifying-container-transform.html
 - svg/repaint/text-repainting-after-modifying-transform.html
 - svg/repaint/mask-clip-target-transform.svg
 - svg/text/text-rescale.html

* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::attributeChanged): Update SVGTransform before calling attributeChanged().
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab79bc420356129cadfc6533d9f223f687856cc3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11731 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10709 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15627 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7191 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->