### PR TITLE
Add support to generate-serializers to generate serializers that take an rvalue.

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -61,6 +61,8 @@ namespace Namespace { class ConditionalCommonClass; }
 #endif
 namespace Namespace { class CommonClass; }
 namespace Namespace { class AnotherCommonClass; }
+namespace WebCore { class MoveOnlyBaseClass; }
+namespace WebCore { class MoveOnlyDerivedClass; }
 
 namespace IPC {
 
@@ -152,6 +154,16 @@ template<> struct ArgumentCoder<Namespace::CommonClass> {
 template<> struct ArgumentCoder<Namespace::AnotherCommonClass> {
     static void encode(Encoder&, const Namespace::AnotherCommonClass&);
     static std::optional<Ref<Namespace::AnotherCommonClass>> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::MoveOnlyBaseClass> {
+    static void encode(Encoder&, WebCore::MoveOnlyBaseClass&&);
+    static std::optional<WebCore::MoveOnlyBaseClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebCore::MoveOnlyDerivedClass> {
+    static void encode(Encoder&, WebCore::MoveOnlyDerivedClass&&);
+    static std::optional<WebCore::MoveOnlyDerivedClass> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -45,6 +45,8 @@
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
 #include <WebCore/InheritsFrom.h>
+#include <WebCore/MoveOnlyBaseClass.h>
+#include <WebCore/MoveOnlyDerivedClass.h>
 #include <WebCore/TimingFunction.h>
 #include <wtf/CreateUsingClass.h>
 #include <wtf/Seconds.h>
@@ -195,6 +197,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "int"_s,
                 "value"_s
+            }
+        } },
+        { "WebCore::MoveOnlyBaseClass"_s, {
+            { "std::variant<WebCore::MoveOnlyDerivedClass>"_s, "subclasses"_s }
+        } },
+        { "WebCore::MoveOnlyDerivedClass"_s, {
+            {
+                "std::optional<int>"_s,
+                "firstMember"_s
+            }, {
+                "int"_s,
+                "secondMember"_s
             }
         } },
         { "WebCore::SharedStringHash"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -156,3 +156,12 @@ headers: "CommonHeader.h"
     int value;
     [NotSerialized] double notSerialized;
 }
+
+[RValue] class WebCore::MoveOnlyBaseClass subclasses {
+    WebCore::MoveOnlyDerivedClass,
+}
+
+[RValue] class WebCore::MoveOnlyDerivedClass {
+    [Nullable] int firstMember;
+    int secondMember;
+}


### PR DESCRIPTION
#### 6b8b65111faf678fc9449fc862065c59309ff134
<pre>
Add support to generate-serializers to generate serializers that take an rvalue.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257581">https://bugs.webkit.org/show_bug.cgi?id=257581</a>

Reviewed by Alex Christensen.

Some types are move-only and should be consumed by serialization. This adds support
for generate encode functions that take an rvalue and can move the contents.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(argument_coder_declarations):
(encode_type):
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyBaseClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyBaseClass&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::decode):
(WTF::void&gt;):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/264912@main">https://commits.webkit.org/264912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88cc7036c702a2079b1a00ca0dc2fd76006ca2a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8899 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11732 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10711 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9024 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7331 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15629 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8286 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11617 "11 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7156 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8032 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->