### PR TITLE
Make SharedMemory::Handle IPC encoding consume the object, and change all wrapping classes to expect to be moved.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -492,7 +492,7 @@ static std::optional<ImageBufferBackendHandle> handleFromBuffer(ImageBuffer& buf
     return std::nullopt;
 }
 
-void RemoteRenderingBackend::prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(const Vector<PrepareBackingStoreBuffersOutputData>&)>&& completionHandler)
+void RemoteRenderingBackend::prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(Vector<PrepareBackingStoreBuffersOutputData>&&)>&& completionHandler)
 {
     Vector<PrepareBackingStoreBuffersOutputData> outputData;
     outputData.resizeToFit(swapBuffersInput.size());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -142,7 +142,7 @@ private:
     void finalizeRenderingUpdate(RenderingUpdateID);
     void markSurfacesVolatile(MarkSurfacesAsVolatileRequestIdentifier, const Vector<WebCore::RenderingResourceIdentifier>&);
 #if PLATFORM(COCOA)
-    void prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(const Vector<PrepareBackingStoreBuffersOutputData>&)>&&);
+    void prepareBuffersForDisplay(Vector<PrepareBackingStoreBuffersInputData> swapBuffersInput, CompletionHandler<void(Vector<PrepareBackingStoreBuffersOutputData>&&)>&&);
 #endif
     
     // Received messages translated to use QualifiedRenderingResourceIdentifier.

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1496,12 +1496,12 @@ void NetworkResourceLoader::tryStoreAsCacheEntry()
         return;
     }
     LOADER_RELEASE_LOG("tryStoreAsCacheEntry: Storing entry in HTTP disk cache");
-    m_cache->store(m_networkLoad->currentRequest(), m_response, m_privateRelayed, m_bufferedDataForCache.take(), [loader = Ref { *this }](auto& mappedBody) mutable {
+    m_cache->store(m_networkLoad->currentRequest(), m_response, m_privateRelayed, m_bufferedDataForCache.take(), [loader = Ref { *this }](auto&& mappedBody) mutable {
 #if ENABLE(SHAREABLE_RESOURCE)
         if (mappedBody.shareableResourceHandle.isNull())
             return;
         LOG(NetworkCache, "(NetworkProcess) sending DidCacheResource");
-        loader->send(Messages::NetworkProcessConnection::DidCacheResource(loader->originalRequest(), mappedBody.shareableResourceHandle));
+        loader->send(Messages::NetworkProcessConnection::DidCacheResource(loader->originalRequest(), WTFMove(mappedBody.shareableResourceHandle)));
 #endif
     });
 }
@@ -1615,7 +1615,7 @@ void NetworkResourceLoader::sendResultForCacheEntry(std::unique_ptr<NetworkCache
             return;
         }
 #endif
-        send(Messages::WebResourceLoader::DidReceiveResource(entry->shareableResourceHandle()));
+        send(Messages::WebResourceLoader::DidReceiveResource(WTFMove(entry->shareableResourceHandle())));
         return;
     }
 #endif

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp
@@ -87,7 +87,7 @@ void WebSWOriginStore::sendStoreHandle(WebSWServerConnection& connection)
     auto handle = m_store.createSharedMemoryHandle();
     if (!handle)
         return;
-    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(*handle));
+    connection.send(Messages::WebSWClientConnection::SetSWOriginTableSharedMemory(WTFMove(*handle)));
 }
 
 void WebSWOriginStore::didInvalidateSharedMemory()

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -465,7 +465,7 @@ std::unique_ptr<Entry> Cache::makeRedirectEntry(const WebCore::ResourceRequest& 
     return makeUnique<Entry>(makeCacheKey(request), response, WTFMove(cachedRedirectRequest), WebCore::collectVaryingRequestHeaders(networkProcess().storageSession(m_sessionID), request, response));
 }
 
-std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& responseData, Function<void(MappedBody&)>&& completionHandler)
+std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& response, PrivateRelayed privateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&& responseData, Function<void(MappedBody&&)>&& completionHandler)
 {
     ASSERT(responseData);
 
@@ -495,7 +495,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
             mappedBody.shareableResource = ShareableResource::create(sharedMemory.releaseNonNull(), 0, bodyData.size());
             if (!mappedBody.shareableResource) {
                 if (completionHandler)
-                    completionHandler(mappedBody);
+                    completionHandler(WTFMove(mappedBody));
                 return;
             }
             if (auto handle = mappedBody.shareableResource->createHandle())
@@ -503,7 +503,7 @@ std::unique_ptr<Entry> Cache::store(const WebCore::ResourceRequest& request, con
         }
 #endif
         if (completionHandler)
-            completionHandler(mappedBody);
+            completionHandler(WTFMove(mappedBody));
         LOG(NetworkCache, "(NetworkProcess) stored");
     });
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -168,7 +168,7 @@ public:
     };
     using RetrieveCompletionHandler = Function<void(std::unique_ptr<Entry>, const RetrieveInfo&)>;
     void retrieve(const WebCore::ResourceRequest&, const GlobalFrameID&, std::optional<NavigatingToAppBoundDomain>, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, RetrieveCompletionHandler&&);
-    std::unique_ptr<Entry> store(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, PrivateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&&, Function<void(MappedBody&)>&& = nullptr);
+    std::unique_ptr<Entry> store(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, PrivateRelayed, RefPtr<WebCore::FragmentedSharedBuffer>&&, Function<void(MappedBody&&)>&& = nullptr);
     std::unique_ptr<Entry> storeRedirect(const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, const WebCore::ResourceRequest& redirectRequest, std::optional<Seconds> maxAgeCap);
     std::unique_ptr<Entry> update(const WebCore::ResourceRequest&, const Entry&, const WebCore::ResourceResponse& validatingResponse, PrivateRelayed);
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
@@ -142,7 +142,7 @@ void SpeculativeLoad::didFinishLoading(const WebCore::NetworkLoadMetrics&)
     if (m_didComplete)
         return;
     if (!m_cacheEntry && m_bufferedDataForCache) {
-        m_cacheEntry = m_cache->store(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.get(), [](auto& mappedBody) { });
+        m_cacheEntry = m_cache->store(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.get(), [](auto&& mappedBody) { });
         // Create a synthetic cache entry if we can't store.
         if (!m_cacheEntry && isStatusCodeCacheableByDefault(m_response.httpStatusCode()))
             m_cacheEntry = m_cache->makeEntry(m_originalRequest, m_response, m_privateRelayed, m_bufferedDataForCache.take());

--- a/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
+++ b/Source/WebKit/Platform/IPC/SharedBufferReference.cpp
@@ -54,7 +54,7 @@ void SharedBufferReference::encode(Encoder& encoder) const
         if (auto memoryHandle = sharedMemoryBuffer->createHandle(SharedMemory::Protection::ReadOnly))
             handle = WTFMove(*memoryHandle);
     }
-    encoder << handle;
+    encoder << WTFMove(handle);
 #endif
 }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -48,9 +48,9 @@ StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
     return { WTFMove(*handle) };
 }
 
-void StreamConnectionBuffer::Handle::encode(Encoder& encoder) const
+void StreamConnectionBuffer::Handle::encode(Encoder& encoder) &&
 {
-    encoder << memory;
+    encoder << WTFMove(memory);
 }
 
 std::optional<StreamConnectionBuffer::Handle> StreamConnectionBuffer::Handle::decode(Decoder& decoder)

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -76,7 +76,7 @@ public:
 
     struct Handle {
         WebKit::SharedMemory::Handle memory;
-        void encode(Encoder&) const;
+        void encode(Encoder&) &&;
         static std::optional<Handle> decode(Decoder&);
     };
     Handle createHandle();

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -165,7 +165,7 @@ void StreamServerConnection::sendAsyncReply(AsyncReplyID asyncReplyID, Arguments
 
 inline void StreamServerConnection::Handle::encode(Encoder& encoder) &&
 {
-    encoder << WTFMove(outOfStreamConnection) << buffer;
+    encoder << WTFMove(outOfStreamConnection) << WTFMove(buffer);
 }
 
 inline std::optional<StreamServerConnection::Handle> StreamServerConnection::Handle::decode(Decoder& decoder)

--- a/Source/WebKit/Platform/SharedMemory.cpp
+++ b/Source/WebKit/Platform/SharedMemory.cpp
@@ -89,12 +89,6 @@ void SharedMemoryHandle::setOwnershipOfMemory(const ProcessIdentity&, MemoryLedg
 
 namespace IPC {
 
-void ArgumentCoder<WebKit::SharedMemoryHandle>::encode(Encoder& encoder, const WebKit::SharedMemoryHandle& handle)
-{
-    encoder << WTFMove(handle.m_handle);
-    encoder << handle.m_size;
-}
-
 void ArgumentCoder<WebKit::SharedMemoryHandle>::encode(Encoder& encoder, WebKit::SharedMemoryHandle&& handle)
 {
     encoder << WTFMove(handle.m_handle);

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -96,7 +96,7 @@ private:
     friend class IPC::Connection;
 #endif
 
-    mutable Type m_handle;
+    Type m_handle;
     size_t m_size { 0 };
 };
 
@@ -166,7 +166,6 @@ private:
 namespace IPC {
 
 template<> struct ArgumentCoder<WebKit::SharedMemoryHandle, void> {
-    static void encode(Encoder&, const WebKit::SharedMemoryHandle&);
     static void encode(Encoder&, WebKit::SharedMemoryHandle&&);
     static std::optional<WebKit::SharedMemoryHandle> decode(Decoder&);
 };

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -133,9 +133,16 @@ def surround_in_condition(string, condition):
 
 
 def types_that_must_be_moved():
-    return frozenset([
+    return [
         'IPC::StreamServerConnection::Handle',
-    ])
+        'Vector<WebKit::SharedMemory::Handle>',
+        'WebKit::ConsumerSharedCARingBuffer::Handle',
+        'WebKit::ImageBufferBackendHandle',
+        'WebKit::ShareableBitmap::Handle',
+        'WebKit::ShareableResource::Handle',
+        'WebKit::SharedMemory::Handle',
+        'WebKit::UpdateInfo',
+    ]
 
 
 def function_parameter_type(type, kind):
@@ -399,7 +406,7 @@ def types_that_cannot_be_forward_declared():
         'WebKit::WCContentBufferIdentifier',
         'WebKit::WebExtensionEventListenerType',
         'WebKit::XRDeviceIdentifier',
-    ] + serialized_identifiers())
+    ] + serialized_identifiers() + types_that_must_be_moved())
 
 
 def conditions_for_header(header):

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -50,7 +50,7 @@ public:
         SharedMemory::Handle memory;
         size_t frameCount;
         void takeOwnershipOfMemory(MemoryLedger ledger) { memory.takeOwnershipOfMemory(ledger); }
-        template <typename Encoder> void encode(Encoder&) const;
+        template <typename Encoder> void encode(Encoder&) &&;
         template <typename Decoder> static std::optional<Handle> decode(Decoder&);
     };
     // FIXME: Remove this deprecated constructor.
@@ -75,9 +75,9 @@ protected:
 };
 
 template <typename Encoder>
-void ConsumerSharedCARingBuffer::Handle::encode(Encoder& encoder) const
+void ConsumerSharedCARingBuffer::Handle::encode(Encoder& encoder) &&
 {
-    encoder << memory << frameCount;
+    encoder << WTFMove(memory) << frameCount;
 }
 
 template <typename Decoder>

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -126,7 +126,7 @@ void ContextMenuContextData::encode(IPC::Encoder& encoder) const
         if (auto imageHandle = m_controlledImage->createHandle(SharedMemory::Protection::ReadOnly))
             handle = WTFMove(*imageHandle);
     }
-    encoder << handle;
+    encoder << WTFMove(handle);
     encoder << m_controlledSelectionData;
     encoder << m_selectedTelephoneNumbers;
     encoder << m_selectionIsEditable;
@@ -142,14 +142,14 @@ void ContextMenuContextData::encode(IPC::Encoder& encoder) const
         if (auto imageHandle = m_potentialQRCodeNodeSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly))
             potentialQRCodeNodeSnapshotImageHandle = WTFMove(*imageHandle);
     }
-    encoder << potentialQRCodeNodeSnapshotImageHandle;
+    encoder << WTFMove(potentialQRCodeNodeSnapshotImageHandle);
 
     ShareableBitmap::Handle potentialQRCodeViewportSnapshotImageHandle;
     if (m_potentialQRCodeViewportSnapshotImage) {
         if (auto imageHandle = m_potentialQRCodeViewportSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly))
             potentialQRCodeViewportSnapshotImageHandle = WTFMove(*imageHandle);
     }
-    encoder << potentialQRCodeViewportSnapshotImageHandle;
+    encoder << WTFMove(potentialQRCodeViewportSnapshotImageHandle);
 #endif
 }
 

--- a/Source/WebKit/Shared/ShareableBitmap.serialization.in
+++ b/Source/WebKit/Shared/ShareableBitmap.serialization.in
@@ -33,7 +33,7 @@ header: "ShareableBitmap.h"
 #endif
 }
 
-[CustomHeader] class WebKit::ShareableBitmapHandle {
+[CustomHeader, RValue] class WebKit::ShareableBitmapHandle {
     WebKit::SharedMemoryHandle m_handle;
     [Validator='!m_configuration->sizeInBytes().hasOverflowed() && m_handle->size() >= m_configuration->sizeInBytes()'] WebKit::ShareableBitmapConfiguration m_configuration;
 }

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -37,9 +37,9 @@ using namespace WebCore;
 
 ShareableResourceHandle::ShareableResourceHandle() = default;
 
-void ShareableResourceHandle::encode(IPC::Encoder& encoder) const
+void ShareableResourceHandle::encode(IPC::Encoder& encoder) &&
 {
-    encoder << m_handle;
+    encoder << WTFMove(m_handle);
     encoder << m_offset;
     encoder << m_size;
 }

--- a/Source/WebKit/Shared/ShareableResource.h
+++ b/Source/WebKit/Shared/ShareableResource.h
@@ -47,7 +47,7 @@ public:
     bool isNull() const { return m_handle.isNull(); }
     unsigned size() const { return m_size; }
 
-    void encode(IPC::Encoder&) const;
+    void encode(IPC::Encoder&) &&;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, ShareableResourceHandle&);
 
     RefPtr<WebCore::SharedBuffer> tryWrapInSharedBuffer() &&;

--- a/Source/WebKit/Shared/UpdateInfo.cpp
+++ b/Source/WebKit/Shared/UpdateInfo.cpp
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-void UpdateInfo::encode(IPC::Encoder& encoder) const
+void UpdateInfo::encode(IPC::Encoder& encoder) &&
 {
     encoder << viewSize;
     encoder << deviceScaleFactor;
@@ -41,7 +41,7 @@ void UpdateInfo::encode(IPC::Encoder& encoder) const
     encoder << updateRectBounds;
     encoder << updateRects;
     encoder << updateScaleFactor;
-    encoder << bitmapHandle;
+    encoder << WTFMove(bitmapHandle);
     encoder << bitmapOffset;
 }
 

--- a/Source/WebKit/Shared/UpdateInfo.h
+++ b/Source/WebKit/Shared/UpdateInfo.h
@@ -47,7 +47,7 @@ public:
     UpdateInfo(UpdateInfo&&) = default;
     UpdateInfo& operator=(UpdateInfo&&) = default;
 
-    void encode(IPC::Encoder&) const;
+    void encode(IPC::Encoder&) &&;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, UpdateInfo&);
 
     // The size of the web view.

--- a/Source/WebKit/Shared/UserData.cpp
+++ b/Source/WebKit/Shared/UserData.cpp
@@ -214,7 +214,7 @@ void UserData::encode(IPC::Encoder& encoder, const API::Object& object)
         // Initial true indicates a bitmap was allocated and is shareable.
         encoder << true;
         encoder << image.parameters();
-        encoder << handle;
+        encoder << WTFMove(handle);
         break;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1438,7 +1438,7 @@ void ArgumentCoder<WebCore::ScriptBuffer>::encode(Encoder& encoder, const WebCor
     bool isShareableResourceHandle = !handle.isNull();
     encoder << isShareableResourceHandle;
     if (isShareableResourceHandle) {
-        encoder << handle;
+        encoder << WTFMove(handle);
         return;
     }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -665,7 +665,7 @@ bool WebPageProxy::updateIconForDirectory(NSFileWrapper *fileWrapper, const Stri
     auto handle = convertedImage->createHandle();
     if (!handle)
         return false;
-    send(Messages::WebPage::UpdateAttachmentIcon(identifier, *handle, iconSize));
+    send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTFMove(*handle), iconSize));
     return true;
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11366,7 +11366,7 @@ void WebPageProxy::requestAttachmentIcon(const String& identifier, const String&
                 handle = WTFMove(*iconHandle);
 #endif
 
-        send(Messages::WebPage::UpdateAttachmentIcon(identifier, handle, size));
+        send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTFMove(handle), size));
     };
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -924,7 +924,7 @@ void WebAutomationSessionProxy::takeScreenshot(WebCore::PageIdentifier pageID, s
     snapshotRectForScreenshot(pageID, frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, [pageID, frameID, callbackID] (std::optional<String> errorString, WebCore::IntRect&& rect) {
         ShareableBitmap::Handle handle;
         if (errorString) {
-            WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, handle, *errorString), 0);
+            WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, WTFMove(handle), *errorString), 0);
             return;
         }
 
@@ -939,12 +939,12 @@ void WebAutomationSessionProxy::takeScreenshot(WebCore::PageIdentifier pageID, s
         RefPtr<WebImage> image = page->scaledSnapshotWithOptions(snapshotRect, 1, SnapshotOptionsShareable);
         if (!image) {
             String screenshotErrorType = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::ScreenshotError);
-            WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, handle, screenshotErrorType), 0);
+            WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, WTFMove(handle), screenshotErrorType), 0);
             return;
         }
 
         handle = image->createHandle(SharedMemory::Protection::ReadOnly);
-        WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, handle, { }), 0);
+        WebProcess::singleton().parentProcessConnection()->send(Messages::WebAutomationSession::DidTakeScreenshot(callbackID, WTFMove(handle), { }), 0);
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
@@ -30,7 +30,7 @@ header: "PrepareBackingStoreBuffersData.h"
     bool hasEmptyDirtyRegion;
 };
 
-[CustomHeader] struct WebKit::PrepareBackingStoreBuffersOutputData {
+[CustomHeader, RValue] struct WebKit::PrepareBackingStoreBuffersOutputData {
     WebKit::BufferIdentifierSet bufferSet;
     std::optional<WebKit::ImageBufferBackendHandle> frontBufferHandle;
     WebKit::SwapBuffersDisplayRequirement displayRequirement;

--- a/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp
@@ -79,7 +79,7 @@ void WebDragClient::startDrag(DragItem item, DataTransfer& dataTransfer, LocalFr
 
     m_page->willStartDrag();
 
-    m_page->send(Messages::WebPageProxy::StartDrag(dataTransfer.pasteboard().selectionData(), dataTransfer.sourceOperationMask(), handle, dataTransfer.dragLocation()));
+    m_page->send(Messages::WebPageProxy::StartDrag(dataTransfer.pasteboard().selectionData(), dataTransfer.sourceOperationMask(), WTFMove(handle), dataTransfer.dragLocation()));
 }
 
 }; // namespace WebKit.

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -108,7 +108,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer&, LocalFrame& fram
         return;
 
     m_page->willStartDrag();
-    m_page->send(Messages::WebPageProxy::StartDrag(dragItem, *handle));
+    m_page->send(Messages::WebPageProxy::StartDrag(dragItem, WTFMove(*handle)));
 }
 
 void WebDragClient::didConcludeEditDrag()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -427,7 +427,7 @@ void DrawingAreaCoordinatedGraphics::updateGeometry(const IntSize& size, Complet
         updateInfo.deviceScaleFactor = m_webPage.corePage()->deviceScaleFactor();
         display(updateInfo);
         if (!m_layerTreeHost)
-            send(Messages::DrawingAreaProxy::Update(0, updateInfo));
+            send(Messages::DrawingAreaProxy::Update(0, WTFMove(updateInfo)));
     }
 
     completionHandler();
@@ -657,12 +657,12 @@ void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
     // Send along a complete update of the page so we can paint the contents right after we exit the
     // accelerated compositing mode, eliminiating flicker.
     if (m_compositingAccordingToProxyMessages) {
-        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, updateInfo));
+        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, WTFMove(updateInfo)));
         m_compositingAccordingToProxyMessages = false;
     } else {
         // If we left accelerated compositing mode before we sent an EnterAcceleratedCompositingMode message to the
         // UI process, we still need to let it know about the new contents, so send an Update message.
-        send(Messages::DrawingAreaProxy::Update(0, updateInfo));
+        send(Messages::DrawingAreaProxy::Update(0, WTFMove(updateInfo)));
     }
 }
 
@@ -714,10 +714,10 @@ void DrawingAreaCoordinatedGraphics::display()
     }
 
     if (m_compositingAccordingToProxyMessages) {
-        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, updateInfo));
+        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, WTFMove(updateInfo)));
         m_compositingAccordingToProxyMessages = false;
     } else
-        send(Messages::DrawingAreaProxy::Update(0, updateInfo));
+        send(Messages::DrawingAreaProxy::Update(0, WTFMove(updateInfo)));
     m_isWaitingForDidUpdate = true;
     m_scheduledWhileWaitingForDidUpdate = false;
 }

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -371,7 +371,7 @@ void FindController::getImageForFindMatch(uint32_t matchIndex)
     if (handle.isNull())
         return;
 
-    m_webPage->send(Messages::WebPageProxy::DidGetImageForFindMatch(selectionSnapshot->parameters(), handle, matchIndex));
+    m_webPage->send(Messages::WebPageProxy::DidGetImageForFindMatch(selectionSnapshot->parameters(), WTFMove(handle), matchIndex));
 }
 
 void FindController::selectFindMatch(uint32_t matchIndex)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -138,12 +138,15 @@ public:
             return false;
 
         auto backendHandle = sharing->createBackendHandle(SharedMemory::Protection::ReadOnly);
-        m_connection->send(Messages::RemoteLayerTreeDrawingAreaProxy::AsyncSetLayerContents(m_layerID, backendHandle, clone->renderingResourceIdentifier()), m_drawingArea.toUInt64());
         ASSERT(std::holds_alternative<MachSendRight>(backendHandle));
 
-        Locker locker { m_surfaceLock };
-        m_surfaceSendRight = std::get<MachSendRight>(backendHandle);
-        m_surfaceIdentifier = clone->renderingResourceIdentifier();
+        {
+            Locker locker { m_surfaceLock };
+            m_surfaceSendRight = std::get<MachSendRight>(backendHandle);
+            m_surfaceIdentifier = clone->renderingResourceIdentifier();
+        }
+
+        m_connection->send(Messages::RemoteLayerTreeDrawingAreaProxy::AsyncSetLayerContents(m_layerID, WTFMove(backendHandle), clone->renderingResourceIdentifier()), m_drawingArea.toUInt64());
 
         return true;
     }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5115,7 +5115,7 @@ void WebPage::didFinishLoadForQuickLookDocumentInMainFrame(const FragmentedShare
     if (!handle)
         return;
 
-    send(Messages::WebPageProxy::DidFinishLoadForQuickLookDocumentInMainFrame(*handle));
+    send(Messages::WebPageProxy::DidFinishLoadForQuickLookDocumentInMainFrame(WTFMove(*handle)));
 }
 
 void WebPage::requestPasswordForQuickLookDocumentInMainFrame(const String& fileName, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCBackingStore.h
@@ -53,7 +53,7 @@ public:
                 if (is<ImageBufferBackendHandleSharing>(sharing))
                     handle = downcast<ImageBufferBackendHandleSharing>(*sharing).createBackendHandle();
             }
-            encoder << handle;
+            encoder << WTFMove(handle);
         }
     }
 


### PR DESCRIPTION
#### 6c8a9cf2cbd26a062624cc4f020fe598e1336a2e
<pre>
Make SharedMemory::Handle IPC encoding consume the object, and change all wrapping classes to expect to be moved.
<a href="https://bugs.webkit.org/show_bug.cgi?id=234169">https://bugs.webkit.org/show_bug.cgi?id=234169</a>
&lt;rdar://problem/86646632&gt;

Reviewed by Kimmo Kinnunen.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::prepareBuffersForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWOriginStore.cpp:
(WebKit::WebSWOriginStore::sendStoreHandle):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::store):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp:
(WebKit::NetworkCache::SpeculativeLoad::didFinishLoading):
* Source/WebKit/Platform/IPC/SharedBufferReference.cpp:
(IPC::SharedBufferReference::encode const):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::Handle::encode):
(IPC::StreamConnectionBuffer::Handle::encode const): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::Handle::encode):
* Source/WebKit/Platform/SharedMemory.cpp:
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
(WebKit::ConsumerSharedCARingBuffer::Handle::encode):
(WebKit::ConsumerSharedCARingBuffer::Handle::encode const): Deleted.
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::ContextMenuContextData::encode const):
* Source/WebKit/Shared/ShareableBitmap.serialization.in:
* Source/WebKit/Shared/ShareableResource.cpp:
(WebKit::ShareableResourceHandle::encode):
(WebKit::ShareableResourceHandle::encode const): Deleted.
* Source/WebKit/Shared/ShareableResource.h:
* Source/WebKit/Shared/UserData.cpp:
(WebKit::UserData::encode):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::ScriptBuffer&gt;::encode):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::updateIconForDirectory):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestAttachmentIcon):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::takeScreenshot):
* Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::startDrag):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::getImageForFindMatch):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:

Canonical link: <a href="https://commits.webkit.org/264922@main">https://commits.webkit.org/264922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec8cb84a84a42f35ea9049075e96fa6f57aa317a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9149 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10802 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10249 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10960 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9272 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7544 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15820 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11820 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8998 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8230 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->