### PR TITLE
Rename LazyLineBreakIterator to CachedTextBreakIteratorFactory

### DIFF
--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -220,10 +220,7 @@ WTF_EXPORT_PRIVATE UBreakIterator* sentenceBreakIterator(StringView);
 
 WTF_EXPORT_PRIVATE bool isWordTextBreak(UBreakIterator*);
 
-// FIXME: This should be named "CachedTextBreakIteratorFactory" or "CachedTextBreakIteratorContext".
-// The purpose of this class is to hold the parameters of the CachedTextBreakIterator() constructor,
-// so we can create one lazily when it's needed.
-class LazyLineBreakIterator {
+class CachedLineBreakIteratorFactory {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     class PriorContext {
@@ -283,9 +280,9 @@ public:
         std::array<UChar, Length> m_priorContext;
     };
 
-    LazyLineBreakIterator() = default;
+    CachedLineBreakIteratorFactory() = default;
 
-    explicit LazyLineBreakIterator(StringView stringView, const AtomString& locale = AtomString(), LineBreakIteratorMode mode = LineBreakIteratorMode::Default)
+    explicit CachedLineBreakIteratorFactory(StringView stringView, const AtomString& locale = AtomString(), LineBreakIteratorMode mode = LineBreakIteratorMode::Default)
         : m_stringView(stringView)
         , m_locale(locale)
         , m_mode(mode)
@@ -369,7 +366,7 @@ WTF_EXPORT_PRIVATE unsigned numCodeUnitsInGraphemeClusters(StringView, unsigned)
 }
 
 using WTF::CachedTextBreakIterator;
-using WTF::LazyLineBreakIterator;
+using WTF::CachedLineBreakIteratorFactory;
 using WTF::LineBreakIteratorMode;
 using WTF::NonSharedCharacterBreakIterator;
 using WTF::TextBreakIterator;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -312,26 +312,26 @@ TextUtil::WordBreakLeft TextUtil::breakWord(const InlineTextBox& inlineTextBox, 
     return leftSide;
 }
 
-unsigned TextUtil::findNextBreakablePosition(LazyLineBreakIterator& lineBreakIterator, unsigned startPosition, const RenderStyle& style)
+unsigned TextUtil::findNextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition, const RenderStyle& style)
 {
     auto keepAllWordsForCJK = style.wordBreak() == WordBreak::KeepAll;
     auto breakNBSP = style.autoWrap() && style.nbspMode() == NBSPMode::Space;
 
     if (keepAllWordsForCJK) {
         if (breakNBSP)
-            return nextBreakablePositionKeepingAllWords(lineBreakIterator, startPosition);
-        return nextBreakablePositionKeepingAllWordsIgnoringNBSP(lineBreakIterator, startPosition);
+            return nextBreakablePositionKeepingAllWords(lineBreakIteratorFactory, startPosition);
+        return nextBreakablePositionKeepingAllWordsIgnoringNBSP(lineBreakIteratorFactory, startPosition);
     }
 
-    if (lineBreakIterator.mode() == LineBreakIteratorMode::Default) {
+    if (lineBreakIteratorFactory.mode() == LineBreakIteratorMode::Default) {
         if (breakNBSP)
-            return WebCore::nextBreakablePosition(lineBreakIterator, startPosition);
-        return nextBreakablePositionIgnoringNBSP(lineBreakIterator, startPosition);
+            return WebCore::nextBreakablePosition(lineBreakIteratorFactory, startPosition);
+        return nextBreakablePositionIgnoringNBSP(lineBreakIteratorFactory, startPosition);
     }
 
     if (breakNBSP)
-        return nextBreakablePositionWithoutShortcut(lineBreakIterator, startPosition);
-    return nextBreakablePositionIgnoringNBSPWithoutShortcut(lineBreakIterator, startPosition);
+        return nextBreakablePositionWithoutShortcut(lineBreakIteratorFactory, startPosition);
+    return nextBreakablePositionIgnoringNBSPWithoutShortcut(lineBreakIteratorFactory, startPosition);
 }
 
 bool TextUtil::shouldPreserveSpacesAndTabs(const Box& layoutBox)

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,7 +68,7 @@ public:
     static WordBreakLeft breakWord(const InlineTextBox&, size_t start, size_t length, InlineLayoutUnit width, InlineLayoutUnit availableWidth, InlineLayoutUnit contentLogicalLeft, const FontCascade&);
     static WordBreakLeft breakWord(const InlineTextItem&, const FontCascade&, InlineLayoutUnit textWidth, InlineLayoutUnit availableWidth, InlineLayoutUnit contentLogicalLeft);
 
-    static unsigned findNextBreakablePosition(LazyLineBreakIterator&, unsigned startPosition, const RenderStyle&);
+    static unsigned findNextBreakablePosition(CachedLineBreakIteratorFactory&, unsigned startPosition, const RenderStyle&);
     static LineBreakIteratorMode lineBreakIteratorMode(LineBreak);
 
     static bool shouldPreserveSpacesAndTabs(const Box&);
@@ -94,5 +94,5 @@ public:
     static bool canUseSimplifiedTextMeasuring(StringView, const RenderStyle& style, const RenderStyle* firstLineStyle);
 };
 
-}
-}
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -85,13 +85,13 @@ inline bool needsLineBreakIterator(UChar character)
 
 // When in non-loose mode, we can use the ASCII shortcut table.
 template<typename CharacterType, NonBreakingSpaceBehavior nonBreakingSpaceBehavior, CanUseShortcut canUseShortcut>
-inline unsigned nextBreakablePosition(LazyLineBreakIterator& lazyBreakIterator, const CharacterType* string, unsigned length, unsigned startPosition)
+inline unsigned nextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, const CharacterType* string, unsigned length, unsigned startPosition)
 {
     std::optional<unsigned> nextBreak;
 
-    CharacterType lastLastCharacter = startPosition > 1 ? string[startPosition - 2] : static_cast<CharacterType>(lazyBreakIterator.priorContext().secondToLastCharacter());
-    CharacterType lastCharacter = startPosition > 0 ? string[startPosition - 1] : static_cast<CharacterType>(lazyBreakIterator.priorContext().lastCharacter());
-    unsigned priorContextLength = lazyBreakIterator.priorContext().length();
+    CharacterType lastLastCharacter = startPosition > 1 ? string[startPosition - 2] : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().secondToLastCharacter());
+    CharacterType lastCharacter = startPosition > 0 ? string[startPosition - 1] : static_cast<CharacterType>(lineBreakIteratorFactory.priorContext().lastCharacter());
+    unsigned priorContextLength = lineBreakIteratorFactory.priorContext().length();
     for (unsigned i = startPosition; i < length; i++) {
         CharacterType character = string[i];
 
@@ -102,7 +102,7 @@ inline unsigned nextBreakablePosition(LazyLineBreakIterator& lazyBreakIterator, 
             if (!nextBreak || nextBreak.value() < i) {
                 // Don't break if positioned at start of primary context and there is no prior context.
                 if (i || priorContextLength) {
-                    auto& breakIterator = lazyBreakIterator.get();
+                    auto& breakIterator = lineBreakIteratorFactory.get();
                     nextBreak = breakIterator.following(i - 1);
                 }
             }
@@ -133,57 +133,57 @@ inline unsigned nextBreakablePositionKeepingAllWords(const CharacterType* string
     return length;
 }
 
-inline unsigned nextBreakablePositionKeepingAllWords(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition)
+inline unsigned nextBreakablePositionKeepingAllWords(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = lazyBreakIterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
         return nextBreakablePositionKeepingAllWords<LChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak>(stringView.characters8(), stringView.length(), startPosition);
     return nextBreakablePositionKeepingAllWords<UChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak>(stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePositionKeepingAllWordsIgnoringNBSP(LazyLineBreakIterator& iterator, unsigned startPosition)
+inline unsigned nextBreakablePositionKeepingAllWordsIgnoringNBSP(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = iterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
         return nextBreakablePositionKeepingAllWords<LChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace>(stringView.characters8(), stringView.length(), startPosition);
     return nextBreakablePositionKeepingAllWords<UChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace>(stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePosition(LazyLineBreakIterator& iterator, unsigned startPosition)
+inline unsigned nextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = iterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
-        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::Yes>(iterator, stringView.characters8(), stringView.length(), startPosition);
-    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::Yes>(iterator, stringView.characters16(), stringView.length(), startPosition);
+        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::Yes>(lineBreakIteratorFactory, stringView.characters8(), stringView.length(), startPosition);
+    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::Yes>(lineBreakIteratorFactory, stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePositionIgnoringNBSP(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition)
+inline unsigned nextBreakablePositionIgnoringNBSP(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = lazyBreakIterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
-        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::Yes>(lazyBreakIterator, stringView.characters8(), stringView.length(), startPosition);
-    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::Yes>(lazyBreakIterator, stringView.characters16(), stringView.length(), startPosition);
+        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::Yes>(lineBreakIteratorFactory, stringView.characters8(), stringView.length(), startPosition);
+    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::Yes>(lineBreakIteratorFactory, stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePositionWithoutShortcut(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition)
+inline unsigned nextBreakablePositionWithoutShortcut(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = lazyBreakIterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
-        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::No>(lazyBreakIterator, stringView.characters8(), stringView.length(), startPosition);
-    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::No>(lazyBreakIterator, stringView.characters16(), stringView.length(), startPosition);
+        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::No>(lineBreakIteratorFactory, stringView.characters8(), stringView.length(), startPosition);
+    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::TreatNonBreakingSpaceAsBreak, CanUseShortcut::No>(lineBreakIteratorFactory, stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePositionIgnoringNBSPWithoutShortcut(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition)
+inline unsigned nextBreakablePositionIgnoringNBSPWithoutShortcut(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = lazyBreakIterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     if (stringView.is8Bit())
-        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::No>(lazyBreakIterator, stringView.characters8(), stringView.length(), startPosition);
-    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::No>(lazyBreakIterator, stringView.characters16(), stringView.length(), startPosition);
+        return nextBreakablePosition<LChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::No>(lineBreakIteratorFactory, stringView.characters8(), stringView.length(), startPosition);
+    return nextBreakablePosition<UChar, NonBreakingSpaceBehavior::IgnoreNonBreakingSpace, CanUseShortcut::No>(lineBreakIteratorFactory, stringView.characters16(), stringView.length(), startPosition);
 }
 
-inline unsigned nextBreakablePositionBreakCharacter(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition)
+inline unsigned nextBreakablePositionBreakCharacter(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition)
 {
-    auto stringView = lazyBreakIterator.stringView();
+    auto stringView = lineBreakIteratorFactory.stringView();
     ASSERT(startPosition <= stringView.length());
     // FIXME: Can/Should we implement this using a Shared Iterator (performance issue)
     // https://bugs.webkit.org/show_bug.cgi?id=197876
@@ -192,28 +192,28 @@ inline unsigned nextBreakablePositionBreakCharacter(LazyLineBreakIterator& lazyB
     return next.value_or(stringView.length());
 }
 
-inline bool isBreakable(LazyLineBreakIterator& lazyBreakIterator, unsigned startPosition, std::optional<unsigned>& nextBreakable, bool breakNBSP, bool canUseShortcut, bool keepAllWords, bool breakAnywhere)
+inline bool isBreakable(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition, std::optional<unsigned>& nextBreakable, bool breakNBSP, bool canUseShortcut, bool keepAllWords, bool breakAnywhere)
 {
     if (nextBreakable && nextBreakable.value() >= startPosition)
         return startPosition == nextBreakable;
 
     if (breakAnywhere)
-        nextBreakable = nextBreakablePositionBreakCharacter(lazyBreakIterator, startPosition);
+        nextBreakable = nextBreakablePositionBreakCharacter(lineBreakIteratorFactory, startPosition);
     else if (keepAllWords) {
         if (breakNBSP)
-            nextBreakable = nextBreakablePositionKeepingAllWords(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePositionKeepingAllWords(lineBreakIteratorFactory, startPosition);
         else
-            nextBreakable = nextBreakablePositionKeepingAllWordsIgnoringNBSP(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePositionKeepingAllWordsIgnoringNBSP(lineBreakIteratorFactory, startPosition);
     } else if (!canUseShortcut) {
         if (breakNBSP)
-            nextBreakable = nextBreakablePositionWithoutShortcut(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePositionWithoutShortcut(lineBreakIteratorFactory, startPosition);
         else
-            nextBreakable = nextBreakablePositionIgnoringNBSPWithoutShortcut(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePositionIgnoringNBSPWithoutShortcut(lineBreakIteratorFactory, startPosition);
     } else {
         if (breakNBSP)
-            nextBreakable = nextBreakablePosition(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePosition(lineBreakIteratorFactory, startPosition);
         else
-            nextBreakable = nextBreakablePositionIgnoringNBSP(lazyBreakIterator, startPosition);
+            nextBreakable = nextBreakablePositionIgnoringNBSP(lineBreakIteratorFactory, startPosition);
     }
     return startPosition == nextBreakable;
 }

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -1426,8 +1426,8 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, 
 
         WordMeasurements wordMeasurements;
         end = lineBreaker.nextLineBreak(resolver, layoutState.lineInfo(), renderTextInfo, lastFloatFromPreviousLine, consecutiveHyphenatedLines, wordMeasurements);
-        m_flow.cachePriorCharactersIfNeeded(renderTextInfo.lineBreakIterator);
-        renderTextInfo.lineBreakIterator.priorContext().reset();
+        m_flow.cachePriorCharactersIfNeeded(renderTextInfo.lineBreakIteratorFactory);
+        renderTextInfo.lineBreakIteratorFactory.priorContext().reset();
         if (resolver.position().atEnd()) {
             // FIXME: We shouldn't be creating any runs in nextLineBreak to begin with!
             // Once BidiRunList is separated from BidiResolver this will not be needed.

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2007 David Smith (catfish.man@gmail.com)
- * Copyright (C) 2003-2013,  Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -462,7 +462,7 @@ protected:
 
     virtual void computeColumnCountAndWidth();
 
-    virtual void cachePriorCharactersIfNeeded(const LazyLineBreakIterator&) {};
+    virtual void cachePriorCharactersIfNeeded(const CachedLineBreakIteratorFactory&) { }
 
 protected:
     // Called to lay out the legend for a fieldset or the ruby text of a ruby run. Also used by multi-column layout to handle

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -88,11 +88,11 @@ void RenderRubyBase::adjustInlineDirectionLineBounds(int expansionOpportunityCou
     logicalWidth -= inset;
 }
 
-void RenderRubyBase::cachePriorCharactersIfNeeded(const LazyLineBreakIterator& lineBreakIterator)
+void RenderRubyBase::cachePriorCharactersIfNeeded(const CachedLineBreakIteratorFactory& lineBreakIteratorFactory)
 {
     auto* run = rubyRun();
     if (run)
-        run->setCachedPriorCharacters(lineBreakIterator.priorContext().lastCharacter(), lineBreakIterator.priorContext().secondToLastCharacter());
+        run->setCachedPriorCharacters(lineBreakIteratorFactory.priorContext().lastCharacter(), lineBreakIteratorFactory.priorContext().secondToLastCharacter());
 }
 
 bool RenderRubyBase::isEmptyOrHasInFlowContent() const

--- a/Source/WebCore/rendering/RenderRubyBase.h
+++ b/Source/WebCore/rendering/RenderRubyBase.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -57,7 +58,7 @@ public:
         m_isAfterExpansion = true;
     }
     
-    void cachePriorCharactersIfNeeded(const LazyLineBreakIterator&) override;
+    void cachePriorCharactersIfNeeded(const CachedLineBreakIteratorFactory&) override;
 
     bool isEmptyOrHasInFlowContent() const;
 

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -276,17 +276,17 @@ std::pair<float, float> RenderRubyRun::startAndEndOverhang(bool forFirstLine) co
     return { std::min(startOverhang, halfWidthOfFontSize), std::min(endOverhang, halfWidthOfFontSize) };
 }
 
-void RenderRubyRun::updatePriorContextFromCachedBreakIterator(LazyLineBreakIterator& iterator) const
+void RenderRubyRun::updatePriorContextFromCachedBreakIterator(CachedLineBreakIteratorFactory& lineBreakIteratorFactory) const
 {
-    iterator.priorContext().set({ m_secondToLastCharacter, m_lastCharacter });
+    lineBreakIteratorFactory.priorContext().set({ m_secondToLastCharacter, m_lastCharacter });
 }
 
-bool RenderRubyRun::canBreakBefore(const LazyLineBreakIterator& iterator) const
+bool RenderRubyRun::canBreakBefore(const CachedLineBreakIteratorFactory& lineBreakIteratorFactory) const
 {
     RenderRubyText* rubyText = this->rubyText();
     if (!rubyText)
         return true;
-    return rubyText->canBreakBefore(iterator);
+    return rubyText->canBreakBefore(lineBreakIteratorFactory);
 }
 
 std::pair<LayoutUnit, LayoutUnit> RenderRubyRun::annotationsAboveAndBelow() const

--- a/Source/WebCore/rendering/RenderRubyRun.h
+++ b/Source/WebCore/rendering/RenderRubyRun.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -63,13 +64,13 @@ public:
 
     static RenderPtr<RenderRubyRun> staticCreateRubyRun(const RenderObject* parentRuby);
     
-    void updatePriorContextFromCachedBreakIterator(LazyLineBreakIterator&) const;
+    void updatePriorContextFromCachedBreakIterator(CachedLineBreakIteratorFactory&) const;
     void setCachedPriorCharacters(UChar last, UChar secondToLast)
     {
         m_lastCharacter = last;
         m_secondToLastCharacter = secondToLast;
     }
-    bool canBreakBefore(const LazyLineBreakIterator&) const;
+    bool canBreakBefore(const CachedLineBreakIteratorFactory&) const;
 
     std::pair<LayoutUnit, LayoutUnit> annotationsAboveAndBelow() const;
 

--- a/Source/WebCore/rendering/RenderRubyText.cpp
+++ b/Source/WebCore/rendering/RenderRubyText.cpp
@@ -94,14 +94,14 @@ bool RenderRubyText::avoidsFloats() const
     return true;
 }
 
-bool RenderRubyText::canBreakBefore(const LazyLineBreakIterator& iterator) const
+bool RenderRubyText::canBreakBefore(const CachedLineBreakIteratorFactory& lineBreakIteratorFactory) const
 {
     // FIXME: It would be nice to improve this so that it isn't just hard-coded, but lookahead in this
     // case is particularly problematic.
 
-    if (!iterator.priorContext().length())
+    if (!lineBreakIteratorFactory.priorContext().length())
         return true;
-    UChar ch = iterator.priorContext().lastCharacter();
+    UChar ch = lineBreakIteratorFactory.priorContext().lastCharacter();
     ULineBreak lineBreak = (ULineBreak)u_getIntPropertyValue(ch, UCHAR_LINE_BREAK);
     // UNICODE LINE BREAKING ALGORITHM
     // http://www.unicode.org/reports/tr14/

--- a/Source/WebCore/rendering/RenderRubyText.h
+++ b/Source/WebCore/rendering/RenderRubyText.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -46,7 +47,7 @@ public:
     
     RenderRubyRun* rubyRun() const;
     
-    bool canBreakBefore(const LazyLineBreakIterator&) const;
+    bool canBreakBefore(const CachedLineBreakIteratorFactory&) const;
    
 private:
     ASCIILiteral renderName() const override { return "RenderRubyText"_s; }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1130,7 +1130,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, HashSet<const Fo
     auto& string = text();
     unsigned length = string.length();
     auto iteratorMode = mapLineBreakToIteratorMode(style.lineBreak());
-    LazyLineBreakIterator breakIterator(string, style.computedLocale(), iteratorMode);
+    CachedLineBreakIteratorFactory lineBreakIteratorFactory(string, style.computedLocale(), iteratorMode);
     bool needsWordSpacing = false;
     bool ignoringSpaces = false;
     bool isSpace = false;
@@ -1212,7 +1212,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, HashSet<const Fo
             continue;
         }
 
-        bool hasBreak = breakAll || isBreakable(breakIterator, i, nextBreakable, breakNBSP, canUseLineBreakShortcut, keepAllWords, breakAnywhere);
+        bool hasBreak = breakAll || isBreakable(lineBreakIteratorFactory, i, nextBreakable, breakNBSP, canUseLineBreakShortcut, keepAllWords, breakAnywhere);
         bool betweenWords = true;
         unsigned j = i;
         while (c != '\n' && !isSpaceAccordingToStyle(c, style) && c != '\t' && (c != softHyphen || style.hyphens() == Hyphens::None)) {
@@ -1223,7 +1223,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, HashSet<const Fo
             c = string[j];
             if (U_IS_LEAD(previousCharacter) && U_IS_TRAIL(c))
                 continue;
-            if (isBreakable(breakIterator, j, nextBreakable, breakNBSP, canUseLineBreakShortcut, keepAllWords, breakAnywhere) && characterAt(j - 1) != softHyphen)
+            if (isBreakable(lineBreakIteratorFactory, j, nextBreakable, breakNBSP, canUseLineBreakShortcut, keepAllWords, breakAnywhere) && characterAt(j - 1) != softHyphen)
                 break;
             if (breakAll) {
                 // FIXME: This code is ultra wrong.

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2017 Apple Inc. All right reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All right reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  * Copyright (C) 2013 ChangSeok Oh <shivamidow@gmail.com>
  * Copyright (C) 2013 Adobe Systems Inc. All right reserved.
@@ -36,7 +36,7 @@ class TextLayout;
 struct RenderTextInfo {
     RenderText* text { nullptr };
     std::unique_ptr<TextLayout, TextLayoutDeleter> layout;
-    LazyLineBreakIterator lineBreakIterator;
+    CachedLineBreakIteratorFactory lineBreakIteratorFactory;
     const FontCascade* font { nullptr };
 };
 

--- a/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -90,8 +90,8 @@ int WebKitGetLastLineBreakInBuffer(UChar *characters, int position, int length)
 {
     unsigned lastBreakPos = position;
     unsigned breakPos = 0;
-    LazyLineBreakIterator breakIterator(StringView(characters, length));
-    while (static_cast<int>(breakPos = nextBreakablePosition(breakIterator, breakPos)) < position)
+    CachedLineBreakIteratorFactory lineBreakIteratorFactory(StringView(characters, length));
+    while (static_cast<int>(breakPos = nextBreakablePosition(lineBreakIteratorFactory, breakPos)) < position)
         lastBreakPos = breakPos++;
     return static_cast<int>(lastBreakPos) < position ? lastBreakPos : INT_MAX;
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -167,13 +167,13 @@ TEST(WTF_TextBreakIterator, Behaviors)
     }
 }
 
-TEST(WTF_TextBreakIterator, LazyLineBreakIteratorPriorContext)
+TEST(WTF_TextBreakIterator, CachedLineBreakIteratorFactoryPriorContext)
 {
-    LazyLineBreakIterator::PriorContext priorContext;
+    CachedLineBreakIteratorFactory::PriorContext priorContext;
     EXPECT_EQ(0U, priorContext.length());
     priorContext.set({ 'a', 'b' });
     EXPECT_EQ(2U, priorContext.length());
-    LazyLineBreakIterator::PriorContext priorContext2;
+    CachedLineBreakIteratorFactory::PriorContext priorContext2;
     EXPECT_FALSE(priorContext == priorContext2);
     priorContext2.set({ 'a', 'b' });
     EXPECT_TRUE(priorContext == priorContext2);


### PR DESCRIPTION
#### 522c36c64af3fa1b643f3f5c7458571b96b5af9b
<pre>
Rename LazyLineBreakIterator to CachedTextBreakIteratorFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=257696">https://bugs.webkit.org/show_bug.cgi?id=257696</a>
rdar://110237360

Reviewed by Cameron McCormack.

LazyLineBreakIterator isn&apos;t actually an iterator. It&apos;s really just a class that holds all the parameters
necessary to create an iterator. We use it so that we can populate these parameters at the top of layout
code, but if it turns out we don&apos;t actually need an iterator (e.g. the element is empty or something)
we don&apos;t actually create the iterator until we need to. Therefore, it really should be called a factory,
rather than an iterator itself.

* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::CachedTextBreakIteratorFactory::CachedTextBreakIteratorFactory):
(WTF::LazyLineBreakIterator::PriorContext::PriorContext): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::lastCharacter const): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::secondToLastCharacter const): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::set): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::update): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::reset): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::length const): Deleted.
(WTF::LazyLineBreakIterator::PriorContext::characters const): Deleted.
(WTF::LazyLineBreakIterator::LazyLineBreakIterator): Deleted.
(WTF::LazyLineBreakIterator::stringView const): Deleted.
(WTF::LazyLineBreakIterator::mode const): Deleted.
(WTF::LazyLineBreakIterator::get): Deleted.
(WTF::LazyLineBreakIterator::resetStringAndReleaseIterator): Deleted.
(WTF::LazyLineBreakIterator::priorContext const): Deleted.
(WTF::LazyLineBreakIterator::priorContext): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::moveToNextBreakablePosition):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::endsWithSoftWrapOpportunity):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::findNextBreakablePosition):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
* Source/WebCore/rendering/BreakLines.h:
(WebCore::nextBreakablePosition):
(WebCore::nextBreakablePositionKeepingAllWords):
(WebCore::nextBreakablePositionKeepingAllWordsIgnoringNBSP):
(WebCore::nextBreakablePositionIgnoringNBSP):
(WebCore::nextBreakablePositionWithoutShortcut):
(WebCore::nextBreakablePositionIgnoringNBSPWithoutShortcut):
(WebCore::nextBreakablePositionBreakCharacter):
(WebCore::isBreakable):
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::cachePriorCharactersIfNeeded):
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::cachePriorCharactersIfNeeded):
* Source/WebCore/rendering/RenderRubyBase.h:
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::updatePriorContextFromCachedBreakIterator const):
(WebCore::RenderRubyRun::canBreakBefore const):
* Source/WebCore/rendering/RenderRubyRun.h:
* Source/WebCore/rendering/RenderRubyText.cpp:
(WebCore::RenderRubyText::canBreakBefore const):
* Source/WebCore/rendering/RenderRubyText.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::computePreferredLogicalWidths):
* Source/WebCore/rendering/line/LineBreaker.h:
* Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm:
(WebKitGetLastLineBreakInBuffer):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264858@main">https://commits.webkit.org/264858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39fc340dcbee341bfcf0658212d78589e55ea9a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10040 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10716 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15632 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7659 "Found 1 jsc stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11620 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8547 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9071 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8037 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2153 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12248 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9306 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8529 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2278 "Passed tests") | 
<!--EWS-Status-Bubble-End-->