### PR TITLE
[JSC] delete operator shouldn't perform TDZ checks

### DIFF
--- a/JSTests/ChakraCore/test/LetConst/tdz1.baseline-jsc
+++ b/JSTests/ChakraCore/test/LetConst/tdz1.baseline-jsc
@@ -4,7 +4,7 @@ ReferenceError: Cannot access uninitialized variable.
 local x
 ReferenceError: Cannot access uninitialized variable.
 a is a string
-ReferenceError: Cannot access uninitialized variable.
+did not delete a
 did not delete a
 ReferenceError: Cannot access uninitialized variable.
 ReferenceError: Cannot access uninitialized variable.

--- a/JSTests/stress/const-not-strict-mode.js
+++ b/JSTests/stress/const-not-strict-mode.js
@@ -9,18 +9,6 @@ function assert(cond) {
 }
 noInline(assert);
 
-function shouldThrowTDZ(func) {
-    var hasThrown = false;
-    try {
-        func();
-    } catch(e) {
-        if (e.name.indexOf("ReferenceError") !== -1)
-            hasThrown = true;
-    }
-    assert(hasThrown);
-}
-noInline(shouldThrowTDZ);
-
 
 // Tests
 
@@ -28,19 +16,21 @@ noInline(shouldThrowTDZ);
 const NUM_LOOPS = 1000;
 
 ;(function() {
-function foo() {
+function foo(i) {
     delete x;
-    const x = 20;
+    const x = i;
+    assert(x === i);
 }
-function bar() {
+function bar(i) {
     delete x;
-    const x = 20;
+    const x = i;
     function capX() { return x; }
+    assert(x === i);
 }
 
 for (var i = 0; i < NUM_LOOPS; i++) {
-    shouldThrowTDZ(foo);
-    shouldThrowTDZ(bar);
+    foo(i);
+    bar(i);
 }
 
 })();

--- a/JSTests/stress/lexical-let-not-strict-mode.js
+++ b/JSTests/stress/lexical-let-not-strict-mode.js
@@ -9,33 +9,23 @@ function assert(cond) {
 }
 noInline(assert);
 
-function shouldThrowTDZ(func) {
-    var hasThrown = false;
-    try {
-        func();
-    } catch(e) {
-        if (e.name.indexOf("ReferenceError") !== -1)
-            hasThrown = true;
-    }
-    assert(hasThrown);
-}
-noInline(shouldThrowTDZ);
-
 ;(function() {
 
-function foo() {
+function foo(i) {
     delete x;
-    let x;
+    let x = i;
+    assert(x === i);
 }
-function bar() {
+function bar(i) {
     delete x;
-    let x;
+    let x = i;
     function capX() { return x; }
+    assert(capX() === i);
 }
 
 for (var i = 0; i < 1000; i++) {
-    shouldThrowTDZ(foo);
-    shouldThrowTDZ(bar);
+    foo(i);
+    bar(i);
 }
 
 })();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -2669,14 +2669,11 @@ RegisterID* PostfixNode::emitBytecode(BytecodeGenerator& generator, RegisterID* 
 RegisterID* DeleteResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     Variable var = generator.variable(m_ident);
-    if (var.local()) {
-        generator.emitTDZCheckIfNecessary(var, var.local(), nullptr);
+    if (var.local())
         return generator.emitLoad(generator.finalDestination(dst), false);
-    }
 
     generator.emitExpressionInfo(divot(), divotStart(), divotEnd());
     RefPtr<RegisterID> base = generator.emitResolveScope(dst, var);
-    generator.emitTDZCheckIfNecessary(var, nullptr, base.get());
     return generator.emitDeleteById(generator.finalDestination(dst, base.get()), base.get(), m_ident);
 }
 


### PR DESCRIPTION
#### fca15e410aef3a78d5f573612079c4692ac54faa
<pre>
[JSC] delete operator shouldn&apos;t perform TDZ checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257697">https://bugs.webkit.org/show_bug.cgi?id=257697</a>
&lt;rdar://problem/110237888&gt;

Reviewed by Yusuke Suzuki.

ReferenceError for an uninitialized binding is being originated in GetBindingValue [1], yet delete
operator [2] calls into DeleteBinding instead, which is a no-op [3] in case of a lexical binding.

This change removes TDZ check and calls into JSSymbolTableObject::deleteProperty() instead,
which does nothing but returning `false` that is being ignored by del_by_id opcode in sloppy mode,
precluding a runtime error from being thrown for code like `delete foo; let foo`.

As for the strict mode, TDZ check isn&apos;t even reached because a SyntaxError is thrown for any binding
that could possibly end up being unitialized [4].

In no way this change affects WithStatement since it can&apos;t produce a value deemed as
uninitialized binding (an empty JSValue).

Aligns JSC with V8 and SpiderMonkey.

[1]: <a href="https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s">https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s</a> (step 2)
[2]: <a href="https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation">https://tc39.es/ecma262/#sec-delete-operator-runtime-semantics-evaluation</a> (step 5.c)
[3]: <a href="https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n">https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n</a> (step 2)
[4]: <a href="https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors">https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors</a>

* JSTests/ChakraCore/test/LetConst/tdz1.baseline-jsc:
* JSTests/stress/const-not-strict-mode.js:
* JSTests/stress/lexical-let-not-strict-mode.js:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::DeleteResolveNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/265212@main">https://commits.webkit.org/265212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f2133923422dd74d410b25261d9dea4b1cfe745

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10290 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/10527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/10793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/11936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/12521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/10477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/11936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10447 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/12521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/10793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/12322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/12521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/10793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/12322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/8697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/12521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/10793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/12322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/9766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/10477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/10423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/10793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/10423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/10707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1149 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/9760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->