### PR TITLE
Add content-visibility perf tests

### DIFF
--- a/PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,94 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div elements below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto.html
@@ -1,0 +1,87 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div elements below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-container-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/div-container-width-changes-scrolling.html
@@ -1,0 +1,90 @@
+<!doctype HTML>
+
+<!--
+This test creates a container div with 10,000 non-trivial div children.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+     spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-container-width-changes.html
+++ b/PerformanceTests/ContentVisibility/div-container-width-changes.html
@@ -1,0 +1,82 @@
+<!doctype HTML>
+
+<!--
+This test creates a container div with 10,000 non-trivial div children.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,93 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div elements below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto.html
@@ -1,0 +1,89 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div elements below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-item-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/div-item-width-changes-scrolling.html
@@ -1,0 +1,90 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div children.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+     spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/div-item-width-changes.html
+++ b/PerformanceTests/ContentVisibility/div-item-width-changes.html
@@ -1,0 +1,82 @@
+<!doctype HTML>
+
+<!--
+This test creates a div container with 10,000 non-trivial div children.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/fieldset-container-width-changes.html
+++ b/PerformanceTests/ContentVisibility/fieldset-container-width-changes.html
@@ -1,0 +1,88 @@
+<!doctype HTML>
+
+<!--
+This test creates a fieldset with 10,000 non-trivial items. It locks the
+container and adjusts its width continuously. If content-visibility is properly
+optimized, then the width adjustments are very quick (< one frame). Otherwise,
+the layout recalculation leaks into the children element and the width
+adjustments are slow.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  border: 1px solid black;
+  background: lightblue;
+  overflow: auto;
+}
+.item {
+  display: inline-block;
+  overflow: auto;
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 150px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<fieldset id=container><legend>legend</legend></fieldset>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = "";}
+});
+
+requestAnimationFrame(runTest);
+</script>

--- a/PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,96 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the flex container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto.html
@@ -1,0 +1,89 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-container-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/flex-container-width-changes-scrolling.html
@@ -1,0 +1,94 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the flex container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+     spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-container-width-changes.html
+++ b/PerformanceTests/ContentVisibility/flex-container-width-changes.html
@@ -1,0 +1,84 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,95 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the flex container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto.html
@@ -1,0 +1,89 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-item-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/flex-item-width-changes-scrolling.html
@@ -1,0 +1,94 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items below the viewport.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the flex container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/flex-item-width-changes.html
+++ b/PerformanceTests/ContentVisibility/flex-item-width-changes.html
@@ -1,0 +1,84 @@
+<!doctype HTML>
+
+<!--
+This test creates a flex box with 10,000 non-trivial items.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,95 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the grid container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto.html
@@ -1,0 +1,88 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts its width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-container-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/grid-container-width-changes-scrolling.html
@@ -1,0 +1,93 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the grid
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+     spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-container-width-changes.html
+++ b/PerformanceTests/ContentVisibility/grid-container-width-changes.html
@@ -1,0 +1,83 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items.
+It sets content-visibility: hidden on the container and adjusts the container width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div style="position: relative; width: 90%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["400px", "500px"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("container").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto-scrolling.html
+++ b/PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto-scrolling.html
@@ -1,0 +1,94 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the grid container
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto.html
+++ b/PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto.html
@@ -1,0 +1,88 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: auto on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: auto;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; spacer.style.height = "0px"; },
+  iterationCount: 5
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-item-width-changes-scrolling.html
+++ b/PerformanceTests/ContentVisibility/grid-item-width-changes-scrolling.html
@@ -1,0 +1,93 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items below the viewport.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+On a certain iteration it sets spacer height to zero, thus causing the grid
+to render in the viewport.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+#spacer {
+  height: 200vh;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=spacer></div>
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+let currentIteration = 0;
+function runTest() {
+  currentIteration++;
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  if (currentIteration == 3)
+    spacer.style.height = "0px";
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>

--- a/PerformanceTests/ContentVisibility/grid-item-width-changes.html
+++ b/PerformanceTests/ContentVisibility/grid-item-width-changes.html
@@ -1,0 +1,83 @@
+<!doctype HTML>
+
+<!--
+This test creates a grid with 10,000 non-trivial items.
+It sets content-visibility: hidden on the container and adjusts one item width continuously.
+-->
+
+<style>
+#container {
+  content-visibility: hidden;
+
+  width: 500px;
+  height: 500px;
+  display: grid;
+  border: 1px solid black;
+  background: lightblue;
+}
+.item {
+  background: blue;
+  margin: 1px;
+  width: 10%;
+  height: 10%;
+}
+</style>
+
+<template id="item_template">
+<div class="item">
+  <div id="target" style="position: relative; width: 80%;">
+    relpos
+    <div style="position: absolute; top: 1px; left: 1%">
+      abspos
+    </div>
+  </div>
+  <div style="position: absolute; top: 1px; left: 1%">
+    abspos
+  </div>
+  lorem ipsum dolor sit amet
+</div>
+</template>
+
+<div id=container></div>
+
+<script src="../resources/runner.js"></script>
+<script>
+function construct(n) {
+  const specimen = document.importNode(document.getElementById("item_template").content, true).firstElementChild;
+  const container = document.getElementById("container");
+  for (let i = 0; i < n; ++i) {
+    const clone = specimen.cloneNode(true);
+    container.appendChild(clone);
+  }
+}
+
+construct(10000);
+
+let widths = ["90%", "95%"];
+let width_index = 0;
+function changeStyle() {
+  document.getElementById("target").style.width = widths[width_index];
+  width_index = 1 - width_index;
+}
+
+let testDone = false;
+let startTime;
+function runTest() {
+  if (startTime)
+    PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+  if (testDone)
+    return;
+
+  startTime = PerfTestRunner.now();
+
+  changeStyle();
+  requestAnimationFrame(runTest);
+}
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+  unit: 'ms',
+  done: () => { testDone = true; container.innerHTML = ""; }
+});
+requestAnimationFrame(runTest);
+
+</script>


### PR DESCRIPTION
#### bd32ef1d52c7fb92c3b492d22f498f7f0c0d6fde
<pre>
Add content-visibility perf tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=257704">https://bugs.webkit.org/show_bug.cgi?id=257704</a>

Reviewed by Alan Baradlay.

Add content-visibility perf tests based on chromium display_locking perf tests.
The tested scenarios are:
- a container has width toggled between predefined widths on each animation frame
- In -scolling.html additionally tests the container outside the viewport is scrolled into the viewport

The tests are repeated for both content-visibility:hidden and auto, and for containers as div, grid or flexbox.

* PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/div-container-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/div-container-width-changes-scolling.html: Added.
* PerformanceTests/ContentVisibility/div-container-width-changes.html: Added.
* PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/div-item-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/div-item-width-changes-scrolling.html: Added.
* PerformanceTests/ContentVisibility/div-item-width-changes.html: Added.
* PerformanceTests/ContentVisibility/fieldset-container-width-changes.html: Added.
* PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/flex-container-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/flex-container-width-changes-scrolling.html: Added.
* PerformanceTests/ContentVisibility/flex-container-width-changes.html: Added.
* PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/flex-item-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/flex-item-width-changes-scrolling.html: Added.
* PerformanceTests/ContentVisibility/flex-item-width-changes.html: Added.
* PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/grid-container-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/grid-container-width-changes-scrolling.html: Added.
* PerformanceTests/ContentVisibility/grid-container-width-changes.html: Added.
* PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto-scrolling.html: Added.
* PerformanceTests/ContentVisibility/grid-item-width-changes-cv-auto.html: Added.
* PerformanceTests/ContentVisibility/grid-item-width-changes-scrolling.html: Added.
* PerformanceTests/ContentVisibility/grid-item-width-changes.html: Added.

Canonical link: <a href="https://commits.webkit.org/264897@main">https://commits.webkit.org/264897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98117fb57bc3d47c8c049d219ed8e99c9332eb7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/8941 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/9229 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/9447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/10594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8921 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/11216 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/9196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/10594 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/9087 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/11216 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/9447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/11216 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/9447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/10753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/11216 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/9447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/8818 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/9196 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/9447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2190 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12285 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/8565 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->