### PR TITLE
[Curl] Remove unused functions from CurlSSLHandle

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -323,16 +323,10 @@ const String CurlHandle::errorDescription(CURLcode errorCode)
     return String::fromLatin1(curl_easy_strerror(errorCode));
 }
 
-void CurlHandle::enableSSLForHost(const String& host)
+void CurlHandle::enableSSL()
 {
     auto& sslHandle = CurlContext::singleton().sslHandle();
-    if (auto sslClientCertificate = sslHandle.getSSLClientCertificate(host)) {
-        setSslCert(sslClientCertificate->first.utf8().data());
-        setSslCertType("P12");
-        setSslKeyPassword(sslClientCertificate->second.utf8().data());
-    }
-
-    if (sslHandle.canIgnoreAnyHTTPSCertificatesForHost(host) || sslHandle.shouldIgnoreSSLErrors()) {
+    if (sslHandle.shouldIgnoreSSLErrors()) {
         setSslVerifyPeer(CurlHandle::VerifyPeer::Disable);
         setSslVerifyHost(CurlHandle::VerifyHost::LooseNameCheck);
     } else {
@@ -414,7 +408,7 @@ void CurlHandle::setUrl(const URL& url)
     curl_easy_setopt(m_handle, CURLOPT_URL, curlUrl.string().latin1().data());
 
     if (url.protocolIs("https"_s))
-        enableSSLForHost(m_url.host().toString());
+        enableSSL();
 }
 
 void CurlHandle::appendRequestHeaders(const HTTPHeaderMap& headers)
@@ -592,21 +586,6 @@ void CurlHandle::setSslVerifyPeer(VerifyPeer verifyPeer)
 void CurlHandle::setSslVerifyHost(VerifyHost verifyHost)
 {
     curl_easy_setopt(m_handle, CURLOPT_SSL_VERIFYHOST, static_cast<long>(verifyHost));
-}
-
-void CurlHandle::setSslCert(const char* cert)
-{
-    curl_easy_setopt(m_handle, CURLOPT_SSLCERT, cert);
-}
-
-void CurlHandle::setSslCertType(const char* type)
-{
-    curl_easy_setopt(m_handle, CURLOPT_SSLCERTTYPE, type);
-}
-
-void CurlHandle::setSslKeyPassword(const char* password)
-{
-    curl_easy_setopt(m_handle, CURLOPT_KEYPASSWD, password);
 }
 
 void CurlHandle::setSslCipherList(const char* cipherList)

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -249,7 +249,7 @@ public:
     void enableShareHandle();
 
     void setUrl(const URL&);
-    void enableSSLForHost(const String&);
+    void enableSSL();
 
     void appendRequestHeaders(const HTTPHeaderMap&);
     void appendRequestHeader(const String& name, const String& value);
@@ -278,9 +278,6 @@ public:
     void setCACertBlob(void*, size_t);
     void setSslVerifyPeer(VerifyPeer);
     void setSslVerifyHost(VerifyHost);
-    void setSslCert(const char*);
-    void setSslCertType(const char*);
-    void setSslKeyPassword(const char*);
     void setSslCipherList(const char*);
     void setSslECCurves(const char*);
 

--- a/Source/WebCore/platform/network/curl/CurlSSLHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlSSLHandle.cpp
@@ -61,38 +61,6 @@ void CurlSSLHandle::clearCACertInfo()
     m_caCertInfo = std::monostate { };
 }
 
-void CurlSSLHandle::allowAnyHTTPSCertificatesForHost(const String& host)
-{
-    Locker locker { m_allowedHostsLock };
-
-    m_allowedHosts.addVoid(host);
-}
-
-bool CurlSSLHandle::canIgnoreAnyHTTPSCertificatesForHost(const String& host) const
-{
-    Locker locker { m_allowedHostsLock };
-
-    return m_allowedHosts.contains(host);
-}
-
-void CurlSSLHandle::setClientCertificateInfo(const String& hostName, const String& certificate, const String& key)
-{
-    Locker locker { m_allowedClientHostsLock };
-
-    m_allowedClientHosts.set(hostName, ClientCertificate { certificate, key });
-}
-
-std::optional<CurlSSLHandle::ClientCertificate> CurlSSLHandle::getSSLClientCertificate(const String& hostName) const
-{
-    Locker locker { m_allowedClientHostsLock };
-
-    auto it = m_allowedClientHosts.find(hostName);
-    if (it == m_allowedClientHosts.end())
-        return std::nullopt;
-
-    return it->value;
-}
-
 #if NEED_OPENSSL_THREAD_SUPPORT
 
 void CurlSSLHandle::ThreadSupport::setup()

--- a/Source/WebCore/platform/network/curl/CurlSSLHandle.h
+++ b/Source/WebCore/platform/network/curl/CurlSSLHandle.h
@@ -46,7 +46,6 @@ namespace WebCore {
 class CurlSSLHandle {
     WTF_MAKE_NONCOPYABLE(CurlSSLHandle);
     friend NeverDestroyed<CurlSSLHandle>;
-    using ClientCertificate = std::pair<String, String>;
 
 public:
     using CACertInfo = std::variant<std::monostate, String, CertificateInfo::Certificate>;
@@ -68,12 +67,6 @@ public:
     WEBCORE_EXPORT void setCACertPath(String&&);
     WEBCORE_EXPORT void setCACertData(CertificateInfo::Certificate&&);
     WEBCORE_EXPORT void clearCACertInfo();
-
-    WEBCORE_EXPORT void allowAnyHTTPSCertificatesForHost(const String& host);
-    bool canIgnoreAnyHTTPSCertificatesForHost(const String&) const;
-
-    WEBCORE_EXPORT void setClientCertificateInfo(const String&, const String&, const String&);
-    std::optional<ClientCertificate> getSSLClientCertificate(const String&) const;
 
 private:
 #if NEED_OPENSSL_THREAD_SUPPORT
@@ -111,11 +104,6 @@ private:
     CACertInfo m_caCertInfo;
 
     bool m_ignoreSSLErrors { false };
-
-    mutable Lock m_allowedHostsLock;
-    mutable Lock m_allowedClientHostsLock;
-    HashSet<String, ASCIICaseInsensitiveHash> m_allowedHosts;
-    HashMap<String, ClientCertificate, ASCIICaseInsensitiveHash> m_allowedClientHosts;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2f3f2e9a8c02877a11bbeec4f49353893bb41fd0
<pre>
[Curl] Remove unused functions from CurlSSLHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=257706">https://bugs.webkit.org/show_bug.cgi?id=257706</a>

Reviewed by Fujii Hironori.

Some functions in CurlSSLHandle and CurlContext are no longer needed.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::enableSSL):
(WebCore::CurlHandle::setUrl):
(WebCore::CurlHandle::enableSSLForHost): Deleted.
(WebCore::CurlHandle::setSslCert): Deleted.
(WebCore::CurlHandle::setSslCertType): Deleted.
(WebCore::CurlHandle::setSslKeyPassword): Deleted.
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlSSLHandle.cpp:
(WebCore::CurlSSLHandle::allowAnyHTTPSCertificatesForHost): Deleted.
(WebCore::CurlSSLHandle::canIgnoreAnyHTTPSCertificatesForHost const): Deleted.
(WebCore::CurlSSLHandle::setClientCertificateInfo): Deleted.
(WebCore::CurlSSLHandle::getSSLClientCertificate const): Deleted.
* Source/WebCore/platform/network/curl/CurlSSLHandle.h:

Canonical link: <a href="https://commits.webkit.org/264883@main">https://commits.webkit.org/264883@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfbf2a493c5c6754ea5e712fe1f0188f30547899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10066 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10738 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15649 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11637 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12270 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1042 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->