### PR TITLE
Implement scrollbar-gutter both-edges support on non-viewports

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6543,10 +6543,6 @@ imported/w3c/web-platform-tests/css/css-overflow/webkit-line-clamp-block-in-inli
 # Skipping scrollbar-gutter tests until the feature gets implemented. webkit.org/b/167335
 imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-002.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-rtl-002.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-002.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-002.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-002.html [ Skip ]
 
 webkit.org/b/257336 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-001-expected.txt
@@ -24,9 +24,9 @@ PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
 PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 18 but got 18
-FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 238 but got 238
+PASS overflow auto, scrollbar-gutter stable both-edges
+PASS overflow scroll, scrollbar-gutter stable both-edges
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 678 but got 678
+PASS overflow hidden, scrollbar-gutter stable both-edges
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-rtl-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-rtl-001-expected.txt
@@ -24,9 +24,9 @@ PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
 PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: compare with "stable" expected a number less than 185 but got 185
-FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: compare with "stable" expected a number less than 185 but got 185
+PASS overflow auto, scrollbar-gutter stable both-edges
+PASS overflow scroll, scrollbar-gutter stable both-edges
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: compare with "stable" expected a number less than 185 but got 185
+PASS overflow hidden, scrollbar-gutter stable both-edges
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt
@@ -24,9 +24,9 @@ PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
 PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
-FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
+PASS overflow auto, scrollbar-gutter stable both-edges
+PASS overflow scroll, scrollbar-gutter stable both-edges
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
+PASS overflow hidden, scrollbar-gutter stable both-edges
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt
@@ -24,9 +24,9 @@ PASS overflow scroll, scrollbar-gutter stable
 PASS overflow visible, scrollbar-gutter stable
 PASS overflow hidden, scrollbar-gutter stable
 PASS overflow clip, scrollbar-gutter stable
-FAIL overflow auto, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
-FAIL overflow scroll, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
+PASS overflow auto, scrollbar-gutter stable both-edges
+PASS overflow scroll, scrollbar-gutter stable both-edges
 PASS overflow visible, scrollbar-gutter stable both-edges
-FAIL overflow hidden, scrollbar-gutter stable both-edges assert_less_than: content position expected a number less than 458 but got 458
+PASS overflow hidden, scrollbar-gutter stable both-edges
 PASS overflow clip, scrollbar-gutter stable both-edges
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1166,8 +1166,10 @@ void RenderBlockFlow::determineLogicalLeftPositionForChild(RenderBox& child, App
 {
     LayoutUnit startPosition = borderStart() + paddingStart();
     LayoutUnit initialStartPosition = startPosition;
-    if (shouldPlaceVerticalScrollbarOnLeft() && isHorizontalWritingMode())
+    if ((shouldPlaceVerticalScrollbarOnLeft() || style().scrollbarGutter().bothEdges) && isHorizontalWritingMode())
         startPosition += (style().isLeftToRightDirection() ? 1 : -1) * verticalScrollbarWidth();
+    if (style().scrollbarGutter().bothEdges && !isHorizontalWritingMode())
+        startPosition += (style().isLeftToRightDirection() ? 1 : -1) * horizontalScrollbarHeight();
     LayoutUnit totalAvailableLogicalWidth = borderAndPaddingLogicalWidth() + availableLogicalWidth();
 
     LayoutUnit childMarginStart = marginStartForChild(child);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -762,8 +762,9 @@ LayoutRect RenderBox::paddingBoxRect() const
 
 LayoutPoint RenderBox::contentBoxLocation() const
 {
-    LayoutUnit scrollbarSpace = shouldPlaceVerticalScrollbarOnLeft() ? verticalScrollbarWidth() : 0;
-    return { borderLeft() + paddingLeft() + scrollbarSpace, borderTop() + paddingTop() };
+    LayoutUnit verticalScrollbarSpace = (shouldPlaceVerticalScrollbarOnLeft() || style().scrollbarGutter().bothEdges) ? verticalScrollbarWidth() : 0;
+    LayoutUnit horizontalScrollbarSpace = style().scrollbarGutter().bothEdges ? horizontalScrollbarHeight() : 0;
+    return { borderLeft() + paddingLeft() + verticalScrollbarSpace, borderTop() + paddingTop() + horizontalScrollbarSpace };
 }
 
 FloatRect RenderBox::referenceBoxRect(CSSBoxType boxType) const

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -34,14 +34,14 @@ inline LayoutUnit RenderBox::clientLogicalBottom() const { return borderBefore()
 inline LayoutUnit RenderBox::clientLogicalHeight() const { return style().isHorizontalWritingMode() ? clientHeight() : clientWidth(); }
 inline LayoutUnit RenderBox::clientLogicalWidth() const { return style().isHorizontalWritingMode() ? clientWidth() : clientHeight(); }
 inline LayoutUnit RenderBox::clientTop() const { return borderTop(); }
-inline LayoutRect RenderBox::computedCSSContentBoxRect() const { return LayoutRect(borderLeft() + computedCSSPaddingLeft(), borderTop() + computedCSSPaddingTop(), paddingBoxWidth() - computedCSSPaddingLeft() - computedCSSPaddingRight(), paddingBoxHeight() - computedCSSPaddingTop() - computedCSSPaddingBottom()); }
+inline LayoutRect RenderBox::computedCSSContentBoxRect() const { return LayoutRect(borderLeft() + computedCSSPaddingLeft(), borderTop() + computedCSSPaddingTop(), paddingBoxWidth() - computedCSSPaddingLeft() - computedCSSPaddingRight()  - (style().scrollbarGutter().bothEdges ? verticalScrollbarWidth() : 0), paddingBoxHeight() - computedCSSPaddingTop() - computedCSSPaddingBottom() - (style().scrollbarGutter().bothEdges ? horizontalScrollbarHeight() : 0)); }
 inline LayoutRect RenderBox::contentBoxRect() const { return { contentBoxLocation(), contentSize() }; }
-inline LayoutUnit RenderBox::contentHeight() const { return std::max(0_lu, paddingBoxHeight() - paddingTop() - paddingBottom()); }
+inline LayoutUnit RenderBox::contentHeight() const { return std::max(0_lu, paddingBoxHeight() - paddingTop() - paddingBottom() - (style().scrollbarGutter().bothEdges ? horizontalScrollbarHeight() : 0)); }
 inline LayoutUnit RenderBox::contentLogicalHeight() const { return style().isHorizontalWritingMode() ? contentHeight() : contentWidth(); }
 inline LayoutSize RenderBox::contentLogicalSize() const { return style().isHorizontalWritingMode() ? contentSize() : contentSize().transposedSize(); }
 inline LayoutUnit RenderBox::contentLogicalWidth() const { return style().isHorizontalWritingMode() ? contentWidth() : contentHeight(); }
 inline LayoutSize RenderBox::contentSize() const { return { contentWidth(), contentHeight() }; }
-inline LayoutUnit RenderBox::contentWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight()); }
+inline LayoutUnit RenderBox::contentWidth() const { return std::max(0_lu, paddingBoxWidth() - paddingLeft() - paddingRight() - (style().scrollbarGutter().bothEdges ? verticalScrollbarWidth() : 0)); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalHeight() const { return style().isHorizontalWritingMode() ? explicitIntrinsicInnerHeight() : explicitIntrinsicInnerWidth(); }
 inline std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerLogicalWidth() const { return style().isHorizontalWritingMode() ? explicitIntrinsicInnerWidth() : explicitIntrinsicInnerHeight(); }
 inline bool RenderBox::hasHorizontalOverflow() const { return scrollWidth() != roundToInt(paddingBoxWidth()); }
@@ -63,8 +63,8 @@ inline LayoutUnit RenderBox::logicalRightVisualOverflow() const { return style()
 inline LayoutSize RenderBox::logicalSize() const { return style().isHorizontalWritingMode() ? m_frameRect.size() : m_frameRect.size().transposedSize(); }
 inline LayoutUnit RenderBox::logicalTop() const { return style().isHorizontalWritingMode() ? y() : x(); }
 inline LayoutUnit RenderBox::logicalWidth() const { return style().isHorizontalWritingMode() ? width() : height(); }
-inline LayoutUnit RenderBox::overridingContentLogicalHeight() const { return std::max(LayoutUnit(), overridingLogicalHeight() - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight()); }
-inline LayoutUnit RenderBox::overridingContentLogicalWidth() const { return std::max(LayoutUnit(), overridingLogicalWidth() - borderAndPaddingLogicalWidth() - scrollbarLogicalWidth()); }
+inline LayoutUnit RenderBox::overridingContentLogicalHeight() const { return std::max(LayoutUnit(), overridingLogicalHeight() - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight() - (style().scrollbarGutter().bothEdges ? scrollbarLogicalHeight() : 0)); }
+inline LayoutUnit RenderBox::overridingContentLogicalWidth() const { return std::max(LayoutUnit(), overridingLogicalWidth() - borderAndPaddingLogicalWidth() - scrollbarLogicalWidth() - (style().scrollbarGutter().bothEdges ? scrollbarLogicalWidth() : 0)); }
 inline LayoutUnit RenderBox::paddingBoxHeight() const { return std::max(0_lu, height() - borderTop() - borderBottom() - horizontalScrollbarHeight()); }
 inline LayoutRect RenderBox::paddingBoxRectIncludingScrollbar() const { return LayoutRect(borderLeft(), borderTop(), width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom()); }
 inline LayoutUnit RenderBox::paddingBoxWidth() const { return std::max(0_lu, width() - borderLeft() - borderRight() - verticalScrollbarWidth()); }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -969,7 +969,7 @@ public:
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
 
-    const ScrollbarGutter scrollbarGutter() const;
+    WEBCORE_EXPORT const ScrollbarGutter scrollbarGutter() const;
     WEBCORE_EXPORT ScrollbarWidth scrollbarWidth() const;
 
 #if ENABLE(TOUCH_EVENTS)


### PR DESCRIPTION
#### 9a055c133ed578da42d94db83e7e62e367f0e25f
<pre>
Implement scrollbar-gutter both-edges support on non-viewports
<a href="https://bugs.webkit.org/show_bug.cgi?id=257708">https://bugs.webkit.org/show_bug.cgi?id=257708</a>

Reviewed by Simon Fraser.

Scrollbar gutter now correctly works (on non-viewports) for both the
&quot;stable&quot; and &quot;stable both-edges&quot; values.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-rtl-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001-expected.txt:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::determineLogicalLeftPositionForChild):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::contentBoxLocation const):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::RenderBox::computedCSSContentBoxRect const):
(WebCore::RenderBox::contentHeight const):
(WebCore::RenderBox::contentWidth const):
(WebCore::RenderBox::overridingContentLogicalHeight const):
(WebCore::RenderBox::overridingContentLogicalWidth const):
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/265199@main">https://commits.webkit.org/265199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7efe6a9cf19ba2dafaeebfa07197d264e85db2bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9838 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10208 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12225 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16528 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8609 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9504 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9387 "1 flakes 3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12634 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9844 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10330 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9003 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9130 "Exiting early after 10 failures. 6071 tests run. 1 flakes") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2446 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13251 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10611 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9671 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2628 "Passed tests") | 
<!--EWS-Status-Bubble-End-->