### PR TITLE
[WGSL] GlobalRewriter reads and defs shouldn't leak between callees

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -3,17 +3,41 @@
 var<private> x: i32;
 var<private> y: i32;
 
-// CHECK: void f\(int parameter\d\)
-fn f() {
+// CHECK: int f\(int parameter\d\)
+fn f() -> i32
+{
     //CHECK: parameter\d
     _ = y;
+    return 0;
+}
+
+// CHECK: int g\(\)
+fn g() -> i32
+{
+    let y = 42;
+    return 0;
+}
+
+// CHECK: int h\(int parameter\d\)
+fn h() -> i32
+{
+    _ = y;
+    return 0;
 }
 
 @compute @workgroup_size(1)
-fn main() {
+fn main()
+{
     // CHECK: int local\d;
     // CHECK: int local\d;
     _ = x;
+
     // CHECK: f\(local\d\)
     _ = f();
+
+    // CHECK: g\(\)
+    _ = g();
+
+    // CHECK: h\(local\d\)
+    _ = h();
 }


### PR DESCRIPTION
#### 7687bb2974f4423c83cdfa0a8fd6e1df48fa4678
<pre>
[WGSL] GlobalRewriter reads and defs shouldn&apos;t leak between callees
<a href="https://bugs.webkit.org/show_bug.cgi?id=257715">https://bugs.webkit.org/show_bug.cgi?id=257715</a>
rdar://110264659

Reviewed by Myles C. Maxfield.

The global rewriter was only cleaning reads and defs in between different entry
points, but that&apos;s not correct. As a result, two subsequent calls, e.g. `f(); g()`,
would cause the globals read by `f` to also be passed to `g` and variables defined
in `f` to shadow globals used in `g`. To fix that we need to clean defs on every
function, since they are local to a function (not an entrypoint), and reads have
to be computed individually per calle and then merged in the caller, since the
caller needs all globals used by its callees in order to propagate it down.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::run):
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::def):
(WGSL::RewriteGlobalVariables::readVariable):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:

Canonical link: <a href="https://commits.webkit.org/264927@main">https://commits.webkit.org/264927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50d2d64c76bcc949e1b4835f09683b24d51481c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11776 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10764 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7384 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15672 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11659 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8084 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2220 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->