### PR TITLE
[WGSL] Constant rewriter should handle shadowing

### DIFF
--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -20,6 +20,13 @@ config.test_format = lit.formats.ShTest(True)
 config.test_exec_root = os.environ['LIT_TEST_DIR']
 config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 
+# FIXME: fix these so this list is empty
+ignored_warnings = [
+    '-Wno-uninitialized',
+    '-Wno-unused-variable',
+    '-Wno-missing-braces',
+]
+
 config.substitutions.append(('%check', '{}/bin/OutputCheck --comment=".*//" %s'.format(site.getuserbase())))
 config.substitutions.append(('%wgslc', '{} %s _ 2>&1'.format(wgslc)))
 config.substitutions.append(('%not', 'eval !'))
@@ -27,7 +34,7 @@ config.substitutions.append(('%metal-compile', (
     "function metal_compile() {"
     "    set -e -o pipefail;"
     f"    {wgslc} --dump-generated-code '%s' \"$1\" > '%t.metal';"
-    "    xcrun -sdk macosx metal -c '%t.metal' -o /dev/null;"
+    f"    xcrun -sdk macosx metal -Werror {' '.join(ignored_warnings)} -c '%t.metal' -o /dev/null;"
     "};"
     "metal_compile ")))
 config.substitutions.append(('%metal', '{} --dump-generated-code %s'.format(wgslc)))

--- a/Source/WebGPU/WGSL/tests/valid/shadowing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/shadowing.wgsl
@@ -1,0 +1,143 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(0) var<storage> r: f32;
+
+fn testI32(x: i32) -> i32 { return x; }
+
+fn testResourceShadowedByLocal() -> i32
+{
+    var r : i32;
+    _ = testI32(r);
+    return 0;
+}
+
+fn testResourceShadowedByParameter(r: i32) -> i32
+{
+    _ = testI32(r);
+    return 0;
+}
+
+fn testLocalConstShadowedByLocal() -> i32
+{
+    const x: f32 = 0.1;
+    {
+        let x: i32 = 1;
+        _ = testI32(x);
+    }
+    return 0;
+}
+
+const x: f32 = 0.1123;
+fn testGlobalConstShadowedByLocal() -> i32
+{
+    let x: i32 = 1;
+    _ = testI32(x);
+    return 0;
+}
+
+fn testGlobalConstShadowedByParameter(x: i32) -> i32
+{
+    _ = testI32(x);
+    return 0;
+}
+
+fn testParameterShadowedByLocal(x: f32) -> i32
+{
+    {
+        let x: i32 = 1;
+        _ = testI32(x);
+    }
+    return 0;
+}
+
+fn testUserDefinedFunctionShadowedByLocal() -> i32
+{
+    let main: i32 = 1;
+    _ = testI32(main);
+    return 0;
+}
+
+fn testUserDefinedFunctionShadowedByLocalConst() -> i32
+{
+    const main: i32 = 1;
+    _ = testI32(main);
+    return 0;
+}
+
+fn testBuiltinShadowedByLocal() -> i32
+{
+    let textureLoad: i32 = 1;
+    _ = testI32(textureLoad);
+    return 0;
+}
+
+fn testBuiltinShadowedByLocalConst() -> i32
+{
+    const textureLoad: i32 = 1;
+    _ = testI32(textureLoad);
+    return 0;
+}
+
+@group(0) @binding(1) var<storage> transpose: i32;
+fn testBuiltinShadowedByGlobal() -> i32
+{
+    _ = testI32(transpose);
+    return 0;
+}
+
+const step: i32 = 42;
+fn testBuiltinShadowedByGlobalConst() -> i32
+{
+    _ = testI32(step);
+    return 0;
+}
+
+fn testBuiltinShadowedByParameter(textureLoad: i32) -> i32
+{
+    _ = testI32(textureLoad);
+    return 0;
+}
+
+fn trunc(x: i32) -> i32 { return x; }
+
+fn testBuiltinShadowedByUserDefinedFunction() -> i32
+{
+    _ = trunc(42);
+    return 0;
+}
+
+struct max { x: i32 }
+fn testBuiltinShadowedByStruct() -> i32
+{
+    _ = testI32(max(42).x);
+    return 0;
+}
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = testResourceShadowedByLocal();
+    _ = testResourceShadowedByParameter(42);
+
+    _ = testLocalConstShadowedByLocal();
+
+    _ = testGlobalConstShadowedByLocal();
+    _ = testGlobalConstShadowedByParameter(42);
+
+    _ = testParameterShadowedByLocal(0.1);
+
+    _ = testUserDefinedFunctionShadowedByLocal();
+    _ = testUserDefinedFunctionShadowedByLocalConst();
+
+    _ = testBuiltinShadowedByLocal();
+    _ = testBuiltinShadowedByLocalConst();
+    _ = testBuiltinShadowedByGlobal();
+    _ = testBuiltinShadowedByGlobalConst();
+    _ = testBuiltinShadowedByParameter(42);
+    _ = testBuiltinShadowedByUserDefinedFunction();
+    _ = testBuiltinShadowedByStruct();
+
+    // FIXME: test shadowing types once we support it
+    // const i32 = 0;
+    // const vec2 = 0;
+}


### PR DESCRIPTION
#### 855f8d34596ce76104a6e39ff7bec126130fe1ce
<pre>
[WGSL] Constant rewriter should handle shadowing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257718">https://bugs.webkit.org/show_bug.cgi?id=257718</a>
rdar://110266026

Reviewed by Myles C. Maxfield.

The constant rewriter currently only looks into constant declarations, but it
also needs to look at other definitions in order to account for shadowing.
E.g.

const x = 1; { let x = 2; f(x); }

Incorrectly gets rewritten into:

const x = 1; { let x = 2; f(1); }

The patch introduces fairly extensive tests for different kinds of shadowing.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::rewrite):
(WGSL::ConstantRewriter::visit):
* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/shadowing.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264926@main">https://commits.webkit.org/264926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66ac8c4d9ed6dd0f5d36a587ed44783f8ed11041

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10609 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11780 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10768 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7383 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15675 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11662 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8088 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2221 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->