### PR TITLE
REGRESSION(264582@main): [GTK] UI process crash: Assertion 'this->_M_is_engaged()' failed.

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1650,6 +1650,9 @@ static void webkitWebViewBaseLeave(WebKitWebViewBase* webViewBase, GdkCrossingMo
         return;
 #endif
 
+    if (!priv->lastMotionEvent)
+        return;
+
     // We need to synthesize a fake mouse event here to let WebCore know that the mouse has left the
     // web view. Let's compute a point outside the web view that is close to the previous
     // coordinates of the pointer before it left the web view. First we'll figure out which
@@ -1657,7 +1660,6 @@ static void webkitWebViewBaseLeave(WebKitWebViewBase* webViewBase, GdkCrossingMo
     // pixel outside the view. This is not necessarily the closest point outside the web view, but
     // it's simple to calculate and surely good enough.
 
-    ASSERT(priv->lastMotionEvent);
     int previousX = std::round(priv->lastMotionEvent->position.x());
     int previousY = std::round(priv->lastMotionEvent->position.y());
     int width = gtk_widget_get_width(GTK_WIDGET(webViewBase));


### PR DESCRIPTION
#### d501d8dce059d7c3307c022e51e1853e348439ac
<pre>
REGRESSION(264582@main): [GTK] UI process crash: Assertion &apos;this-&gt;_M_is_engaged()&apos; failed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257690">https://bugs.webkit.org/show_bug.cgi?id=257690</a>

Reviewed by Carlos Garcia Campos.

I incorrectly assumed that there would always be at least one pointer
motion event before a pointer leave event. This is not correct; e.g. it
happens when Epiphany restores a previous browser session. Instead of
crashing when libstdc++ assertions are enabled, let&apos;s just bail. There
is probably no need to synthesize a fake motion event for WebCore.

* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseLeave):

Canonical link: <a href="https://commits.webkit.org/264895@main">https://commits.webkit.org/264895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ef0c35e3e2649273b79285d3182cdcfa24fbb4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9106 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10092 "4 flakes 2 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10772 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7387 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15677 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8496 "5 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7210 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8092 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->