### PR TITLE
Stop propagating text decorations on outermost SVG roots

### DIFF
--- a/LayoutTests/svg/text/text-decoration-propagation-2-expected.html
+++ b/LayoutTests/svg/text/text-decoration-propagation-2-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<style>
+#outer { text-decoration: underline; }
+</style>
+<svg id=outer>
+  <text y="20">Text which does have an underline</text>
+</svg>

--- a/LayoutTests/svg/text/text-decoration-propagation-2.html
+++ b/LayoutTests/svg/text/text-decoration-propagation-2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+#outer { text-decoration: underline; }
+</style>
+<svg id=outer>
+  <svg>
+    <text y="20">Text which does have an underline</text>
+  </svg>
+</svg>

--- a/LayoutTests/svg/text/text-decoration-propagation-expected.html
+++ b/LayoutTests/svg/text/text-decoration-propagation-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<span>
+  <svg>
+    <text y="20">Text which does NOT have an underline</text>
+  </svg>
+</span>

--- a/LayoutTests/svg/text/text-decoration-propagation.html
+++ b/LayoutTests/svg/text/text-decoration-propagation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+span { text-decoration: underline; }
+</style>
+<span>
+  <svg>
+    <text y="20">Text which does NOT have an underline</text>
+  </svg>
+</span>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -8,7 +8,7 @@
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (c) 2011, Code Aurora Forum. All rights reserved.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
- * Copyright (C) 2012, 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2012-2015 Google Inc. All rights reserved.
  * Copyright (C) 2014, 2020, 2022 Igalia S.L.
  *
  * This library is free software; you can redistribute it and/or
@@ -155,6 +155,11 @@ static DisplayType equivalentBlockDisplay(const RenderStyle& style)
     return DisplayType::Block;
 }
 
+static bool isOutermostSVGElement(const Element* element)
+{
+    return element && element->isSVGElement() && downcast<SVGElement>(*element).isOutermostSVGSVGElement();
+}
+
 static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const Element* element)
 {
     if (style.isFloating() || style.hasOutOfFlowPosition())
@@ -166,6 +171,10 @@ static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const
         auto* parentNode = element->parentNode();
         return parentNode && parentNode->isUserAgentShadowRoot();
     }();
+
+    // Outermost <svg> roots are considered to be atomic inline-level.
+    if (isOutermostSVGElement(element))
+        return false;
 
     // There is no other good way to prevent decorations from affecting user agent shadow trees.
     if (isAtUserAgentShadowBoundary)


### PR DESCRIPTION
#### b3a3c589507eb4de25b0be22473e4bacf690922a
<pre>
Stop propagating text decorations on outermost SVG roots

<a href="https://bugs.webkit.org/show_bug.cgi?id=248567">https://bugs.webkit.org/show_bug.cgi?id=248567</a>
rdar://problem/103093226

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=199132

Outermost SVG roots should be consider atomic inline-level, and hence
text decorations should not propagate into them from the outside.

* Source/WebCore/style/StyleAdjuster.cpp:
(isOutermostSVGElement): Add new static function
(shouldInheritTextDecorationsInEffect): Update as per commit
* LayoutTests/svg/text/text-decoration-propagation.html: Add Test Case
* LayoutTests/svg/text/text-decoration-propagation-expected.html: Add Test Case Expectation
* LayoutTests/svg/text/text-decoration-propagation-2.html: Add Test Case
* LayoutTests/svg/text/text-decoration-propagation-2-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264894@main">https://commits.webkit.org/264894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fc9f9ff62d8c3abaaae3aea300b5b478fc48ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11802 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10118 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10797 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15699 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8371 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11686 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7229 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2186 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8608 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->