### PR TITLE
Only restore dialog focus if focus is in dialog

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt
@@ -1,10 +1,8 @@
 button 1 button 2
 
-FAIL Focus should not be restored if the currently focused element is not inside the dialog. assert_equals: expected Element node <button id="b2">button 2</button> but got Element node <button id="b1">button 1</button>
-FAIL Focus restore should not occur when the focused element is in a shadowroot outside of the dialog. assert_equals: document.activeElement should point at the shadow host. expected Element node <div id="host">
-
-</div> but got Element node <button id="b2">button 2</button>
+PASS Focus should not be restored if the currently focused element is not inside the dialog.
+PASS Focus restore should not occur when the focused element is in a shadowroot outside of the dialog.
 PASS Focus restore should occur when the focused element is in a shadowroot inside the dialog.
-PASS Focus restore should occur when the focused element is slotted into a dialog.
+FAIL Focus restore should occur when the focused element is slotted into a dialog. assert_equals: expected Element node <button id="b2">button 2</button> but got Element node <button id="host2button">button</button>
 PASS Focus restore should always occur for modal dialogs.
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -126,7 +126,9 @@ void HTMLDialogElement::close(const String& result)
 
     setBooleanAttribute(openAttr, false);
 
-    if (isModal())
+    bool wasModal = isModal();
+
+    if (wasModal)
         removeFromTopLayer();
 
     setIsModal(false);
@@ -135,9 +137,12 @@ void HTMLDialogElement::close(const String& result)
         m_returnValue = result;
 
     if (RefPtr element = std::exchange(m_previouslyFocusedElement, nullptr).get()) {
-        FocusOptions options;
-        options.preventScroll = true;
-        element->focus(options);
+        RefPtr focusedElement = document().focusedElement();
+        if ((focusedElement && containsIncludingShadowDOM(focusedElement)) || wasModal) {
+            FocusOptions options;
+            options.preventScroll = true;
+            element->focus(options);
+        }
     }
 
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().closeEvent, Event::CanBubble::No, Event::IsCancelable::No));


### PR DESCRIPTION
#### b69e934641e713d0da038ee473ed6dfd90170e25
<pre>
Only restore dialog focus if focus is in dialog
<a href="https://bugs.webkit.org/show_bug.cgi?id=256717">https://bugs.webkit.org/show_bug.cgi?id=256717</a>
<a href="https://rdar.apple.com/109572320">rdar://109572320</a>

Reviewed by NOBODY (OOPS!).

Implement whatwg/html#9178 to avoid unexpected focus shifting when focus is already outside of the dialog.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside-expected.txt:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::close):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b69e934641e713d0da038ee473ed6dfd90170e25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/83055 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/2696 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/88164 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/34101 "Hash b69e9346 for PR 14683 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/85147 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/2771 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/10617 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/88164 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/34101 "Hash b69e9346 for PR 14683 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/86110 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/2771 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/88164 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/2771 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/33135 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/2771 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/89530 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/10337 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/10617 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/89530 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/10566 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/89530 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/37348 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/1716 "Hash b69e9346 for PR 14683 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/10290 "Hash b69e9346 for PR 14683 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/15806 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/10162 "Hash b69e9346 for PR 14683 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/13627 "Hash b69e9346 for PR 14683 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/11931 "Hash b69e9346 for PR 14683 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->