### PR TITLE
Fix Speedometer3 signpost patch

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
@@ -1,33 +1,39 @@
 diff --git a/resources/benchmark-runner.mjs b/resources/benchmark-runner.mjs
-index 90416e5..48d187b 100644
+index bce469d..9cebc9d 100644
 --- a/resources/benchmark-runner.mjs
 +++ b/resources/benchmark-runner.mjs
-@@ -226,22 +226,28 @@ export class BenchmarkRunner {
+@@ -348,6 +348,8 @@ export class BenchmarkRunner {
          const syncEndLabel = `${suite.name}.${test.name}-sync-end`;
          const asyncStartLabel = `${suite.name}.${test.name}-async-start`;
          const asyncEndLabel = `${suite.name}.${test.name}-async-end`;
 +        const syncName = `${suite.name}.${test.name}-sync`;
 +        const asyncName = `${suite.name}.${test.name}-async`;
  
-         performance.mark(startLabel);
-+        __signpostStart(syncName);
-         const syncStartTime = performance.now();
-         test.run(page);
-         const syncEndTime = performance.now();
-+        __signpostStop(syncName);
-         performance.mark(syncEndLabel);
+         let syncTime;
+         let asyncStartTime;
+@@ -362,14 +364,17 @@ export class BenchmarkRunner {
+                 performance.mark("warmup-end");
+             }
+             performance.mark(startLabel);
++            __signpostStart(syncName);
+             const syncStartTime = performance.now();
+             test.run(this._page);
+             const syncEndTime = performance.now();
++            __signpostStop(syncName);
+             performance.mark(syncEndLabel);
  
-         const syncTime = syncEndTime - syncStartTime;
+             syncTime = syncEndTime - syncStartTime;
  
-         performance.mark(asyncStartLabel);
-         const asyncStartTime = performance.now();
-+        __signpostStart(asyncName);
-         setTimeout(() => {
-             // Some browsers don't immediately update the layout for paint.
-             // Force the layout here to ensure we're measuring the layout time.
-             const height = this._frame.contentDocument.body.getBoundingClientRect().height;
+             performance.mark(asyncStartLabel);
++            __signpostStart(asyncName);
+             asyncStartTime = performance.now();
+         };
+         const measureAsync = () => {
+@@ -379,6 +384,7 @@ export class BenchmarkRunner {
              const asyncEndTime = performance.now();
-+            __signpostStop(asyncName);
-             const asyncTime = asyncEndTime - asyncStartTime;
+             asyncTime = asyncEndTime - asyncStartTime;
              this._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
++            __signpostStop(asyncName);
              performance.mark(asyncEndLabel);
+             if (params.warmupBeforeSync)
+                 performance.measure("warmup", "warmup-start", "warmup-end");


### PR DESCRIPTION
#### 5b1638d39320925ef5c5b96d398ae355dd2c5c66
<pre>
Fix Speedometer3 signpost patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=257734">https://bugs.webkit.org/show_bug.cgi?id=257734</a>

Reviewed by Dewei Zhu.

Updated the Speedometer 3 signpost patch.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch:

Canonical link: <a href="https://commits.webkit.org/264882@main">https://commits.webkit.org/264882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dc3b1f29e5ac54ce9915b9b0223e75344a6301e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9015 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10668 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11828 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9161 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10827 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9139 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8236 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11711 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/8886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1041 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->