### PR TITLE
[Cocoa] Expose colorSpace in HW encoders VideoDecoderConfig

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Error in remote https://localhost:9443/webcodecs/full-cycle-test.https.any.js: TypeError: undefined is not an object (evaluating 'encoder_color_space.primaries')
-
-FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 0
-FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 0
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Error in remote https://localhost:9443/webcodecs/full-cycle-test.https.any.js: TypeError: undefined is not an object (evaluating 'encoder_color_space.primaries')
-
-FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 0
-FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 0
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = TypeError: undefined is not an object (evaluating 'encoder_color_space.primaries')
-
-FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 0
-FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 0
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = TypeError: undefined is not an object (evaluating 'encoder_color_space.primaries')
-
-FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 0
-FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 0
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoEncoder.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoEncoder.h
@@ -25,7 +25,7 @@ typedef BOOL (^RTCVideoEncoderCallback)(RTCEncodedImage *frame,
                                         id<RTCCodecSpecificInfo> info,
                                         RTCRtpFragmentationHeader* __nullable header);
 
-typedef void (^RTCVideoEncoderDescriptionCallback)(const uint8_t *frame, size_t size);
+typedef void (^RTCVideoEncoderDescriptionCallback)(const uint8_t* __nullable frame, size_t size);
 
 /** Protocol for encoder implementations. */
 RTC_OBJC_EXPORT

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm
@@ -405,6 +405,7 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
   _frameCount = 0;
   _lastFrameRateEstimationTime = 0;
   _useAnnexB = true;
+  _needsToSendDescription = true;
   return self;
 }
 
@@ -450,7 +451,6 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
 - (void)setUseAnnexB:(bool)useAnnexB
 {
     _useAnnexB = useAnnexB;
-    _needsToSendDescription = !useAnnexB;
 }
 
 - (void)setDescriptionCallback:(RTCVideoEncoderDescriptionCallback)callback
@@ -1003,6 +1003,10 @@ NSUInteger GetMaxSampleRate(const webrtc::H264ProfileLevelId &profile_level_id) 
     if (!webrtc::H264CMSampleBufferToAnnexBBuffer(sampleBuffer, isKeyframe, buffer.get())) {
       RTC_LOG(LS_WARNING) << "Unable to parse H264 encoded buffer";
       return;
+    }
+    if (_descriptionCallback && _needsToSendDescription) {
+      _needsToSendDescription = false;
+      _descriptionCallback(nullptr, 0);
     }
   } else {
     buffer->SetSize(0);

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -27,7 +27,7 @@
 
 #if ENABLE(WEB_CODECS)
 
-#include "PlatformVideoColorSpace.h"
+#include "VideoEncoderActiveConfiguration.h"
 #include "VideoFrame.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
@@ -47,15 +47,7 @@ public:
         double frameRate { 0 };
         bool isRealtime { true };
     };
-    struct ActiveConfiguration {
-        String codec;
-        std::optional<size_t> visibleWidth;
-        std::optional<size_t> visibleHeight;
-        std::optional<size_t> displayWidth;
-        std::optional<size_t> displayHeight;
-        std::optional<Vector<uint8_t>> description;
-        std::optional<PlatformVideoColorSpace> colorSpace;
-    };
+    using ActiveConfiguration = VideoEncoderActiveConfiguration;
     struct EncodedFrame {
         Vector<uint8_t> data;
         bool isKeyFrame { false };

--- a/Source/WebCore/platform/VideoEncoderActiveConfiguration.h
+++ b/Source/WebCore/platform/VideoEncoderActiveConfiguration.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_CODECS)
+
+#include "PlatformVideoColorSpace.h"
+
+namespace WebCore {
+
+struct VideoEncoderActiveConfiguration {
+    String codec;
+    std::optional<size_t> visibleWidth;
+    std::optional<size_t> visibleHeight;
+    std::optional<size_t> displayWidth;
+    std::optional<size_t> displayHeight;
+    std::optional<Vector<uint8_t>> description;
+    std::optional<PlatformVideoColorSpace> colorSpace;
+};
+
+}
+
+#endif // ENABLE(WEB_CODECS)

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -247,8 +247,11 @@ void LibWebRTCCodecsProxy::createEncoder(VideoEncoderIdentifier identifier, Vide
         connection->send(Messages::LibWebRTCCodecs::CompletedEncoding { identifier, IPC::DataReference { buffer, size }, info }, 0);
     });
     auto newConfigurationBlock = makeBlockPtr([connection = m_connection, identifier](const uint8_t* buffer, size_t size) {
-        connection->send(Messages::LibWebRTCCodecs::SetEncodingDescription { identifier, IPC::DataReference { buffer, size } }, 0);
+        // Current encoders are limited to this configuration. We might want in the future to let encoders notify which colorSpace they are selecting.
+        PlatformVideoColorSpace colorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Bt709, true };
+        connection->send(Messages::LibWebRTCCodecs::SetEncodingConfiguration { identifier, IPC::DataReference { buffer, size }, colorSpace }, 0);
     });
+
     auto* encoder = webrtc::createLocalEncoder(webrtc::SdpVideoFormat { codecType == VideoCodecType::H264 ? "H264" : "H265", rtcParameters }, useAnnexB, newFrameBlock.get(), newConfigurationBlock.get());
     webrtc::setLocalEncoderLowLatency(encoder, useLowLatency);
     auto result = m_encoders.add(identifier, Encoder { encoder, makeUnique<SharedVideoFrameReader>(Ref { m_videoFrameObjectHeap }, m_resourceOwner) });

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -39,6 +39,7 @@
 #include "VideoDecoderIdentifier.h"
 #include "VideoEncoderIdentifier.h"
 #include "WorkQueueMessageReceiver.h"
+#include <WebCore/VideoEncoderActiveConfiguration.h>
 #include <map>
 #include <wtf/Deque.h>
 #include <wtf/HashMap.h>
@@ -102,7 +103,7 @@ public:
     void registerDecodeFrameCallback(Decoder&, void* decodedImageCallback);
     void registerDecodedVideoFrameCallback(Decoder&, DecoderCallback&&);
 
-    using DescriptionCallback = Function<void(std::span<const uint8_t>&&)>;
+    using DescriptionCallback = Function<void(WebCore::VideoEncoderActiveConfiguration&&)>;
     using EncoderCallback = Function<void(std::span<const uint8_t>&&, bool isKeyFrame, int64_t timestamp)>;
     struct EncoderInitializationData {
         uint16_t width;
@@ -172,7 +173,7 @@ private:
     void completedDecodingCV(VideoDecoderIdentifier, int64_t timeStamp, int64_t timeStampNs, RetainPtr<CVPixelBufferRef>&&);
     void completedEncoding(VideoEncoderIdentifier, IPC::DataReference&&, const webrtc::WebKitEncodedFrameInfo&);
     void flushEncoderCompleted(VideoEncoderIdentifier);
-    void setEncodingDescription(WebKit::VideoEncoderIdentifier, IPC::DataReference&&);
+    void setEncodingConfiguration(WebKit::VideoEncoderIdentifier, IPC::DataReference&&, std::optional<WebCore::PlatformVideoColorSpace>);
     RetainPtr<CVPixelBufferRef> convertToBGRA(CVPixelBufferRef);
 
     // GPUProcessConnection::Client

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in
@@ -29,7 +29,7 @@ messages -> LibWebRTCCodecs NotRefCounted {
     CompletedDecodingCV(WebKit::VideoDecoderIdentifier identifier, int64_t timeStamp, int64_t timeStampNs, RetainPtr<CVPixelBufferRef> pixelBuffer)
     CompletedEncoding(WebKit::VideoEncoderIdentifier identifier, IPC::DataReference data, struct webrtc::WebKitEncodedFrameInfo info);
     FlushEncoderCompleted(WebKit::VideoEncoderIdentifier id)
-    SetEncodingDescription(WebKit::VideoEncoderIdentifier identifier, IPC::DataReference data);
+    SetEncodingConfiguration(WebKit::VideoEncoderIdentifier identifier, struct IPC::DataReference description, std::optional<WebCore::PlatformVideoColorSpace> colorSpace);
 }
 
 #endif // USE(LIBWEBRTC) && PLATFORM(COCOA) && ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### f9e9fc8f8b1b89d88194a1fc76dd13031749b87f
<pre>
[Cocoa] Expose colorSpace in HW encoders VideoDecoderConfig
<a href="https://bugs.webkit.org/show_bug.cgi?id=257742">https://bugs.webkit.org/show_bug.cgi?id=257742</a>
rdar://problem/110310512

Reviewed by Eric Carlson.

We were setting colorSpace for libvpx encoders but not for remote encoders.
Add support for this in LibWebRTCCodecsProxy.
We make changes to RTCVideoEncoderH264 to trigger the description callback in the annexB case too so that we can send the color space.
In the future, RTCVideoEncoderH264 and others might send themselves their color space.

Update WebProcess side to create the VideoEncoderActiveConfiguration with colorSpace in LibWebRTCCodecs.
We separate VideoEncoderActiveConfiguration in its own file to reduce header and it might be useful in
the future to directly send VideoEncoderActiveConfiguration from GPUProcess to WebProcess.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h264_avc-expected.txt:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/base/RTCVideoEncoder.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH264.mm:
(-[RTCVideoEncoderH264 initWithCodecInfo:]):
(-[RTCVideoEncoderH264 setUseAnnexB:]):
(-[RTCVideoEncoderH264 frameWasEncoded:flags:sampleBuffer:codecSpecificInfo:width:height:renderTimeMs:timestamp:rotation:isKeyFrameRequired:]):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/VideoEncoder.h:
* Source/WebCore/platform/VideoEncoderActiveConfiguration.h: Added.
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::createEncoder):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoEncoder::RemoteVideoEncoder):
(WebKit::RemoteVideoEncoderCallbacks::notifyEncoderDescription):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::setEncodingConfiguration):
(WebKit::LibWebRTCCodecs::setEncodingDescription): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.messages.in:

Canonical link: <a href="https://commits.webkit.org/264933@main">https://commits.webkit.org/264933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0e7490b89f71215dc4b250169132bfa5697221a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11854 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10164 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10855 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15747 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11737 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7270 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8158 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2226 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->