### PR TITLE
Adjust preprocessor guards for bmalloc test in StdLibExtrasTests.cpp

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -29,7 +29,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
 
-#if !USE(CAIRO)
+#if !USE(SYSTEM_MALLOC)
 #include <bmalloc/Algorithm.h>
 #endif
 namespace TestWebKitAPI {
@@ -158,7 +158,7 @@ TEST(WTF_StdLibExtras, RoundUpToMultipleOfNonPowerOfTwoWorks)
         EXPECT_EQ(x, roundUpToMultipleOfNonPowerOfTwo(CheckedUint64 { divisor }, CheckedUint64 { x }));
     }
 
-#if !USE(CAIRO)
+#if !USE(SYSTEM_MALLOC)
     // Test that bmalloc::roundUpToMultipleOfNonPowerOfTwo does not have the bug. The function uses size_t.
     {
         size_t x = std::numeric_limits<size_t>::max() - 2;


### PR DESCRIPTION
#### bdfef46eb471404fa96590ae8cd5172d22afe3ef
<pre>
Adjust preprocessor guards for bmalloc test in StdLibExtrasTests.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=257452">https://bugs.webkit.org/show_bug.cgi?id=257452</a>

Unreviewed build fix.

This code has nothing to do with cairo. We instead need to check whether
bmalloc is built -- !USE(SYSTEM_MALLOC) -- before trying to use bmalloc.
This fixes the build on Linux JSCOnly with system malloc. GTK and WPE
were fine because they use Cairo and therefore this test was
unnecessarily disabled there.

* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264902@main">https://commits.webkit.org/264902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d45d5a0ad88cd3624e108eb645d0d882572dc105

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10180 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10873 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7475 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11754 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7285 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->