### PR TITLE
Fix imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub-expected.txt
@@ -1,16 +1,14 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test creating a VideoFrame with a same-origin HTMLImageElement
 PASS Test creating a VideoFrame with a cross-origin HTMLImageElement
 PASS Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement without setting crossorigin
 PASS Test creating a VideoFrame with a CORS enabled cross-origin HTMLImageElement with crossorigin="anonymous"
-TIMEOUT Test creating a VideoFrame with a same-origin SVGImageElement Test timed out
-NOTRUN Test creating a VideoFrame with a cross-origin SVGImageElement
-NOTRUN Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement without setting crossorigin
-NOTRUN Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement with crossorigin="anonymous"
-NOTRUN Test creating a VideoFrame with a same-origin HTMLVideoElement
-NOTRUN Test creating a VideoFrame with a cross-origin HTMLVideoElement
-NOTRUN Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement without setting crossorigin
-NOTRUN Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement with crossorigin="anonymous"
+PASS Test creating a VideoFrame with a same-origin SVGImageElement
+PASS Test creating a VideoFrame with a cross-origin SVGImageElement
+PASS Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement without setting crossorigin
+PASS Test creating a VideoFrame with a CORS enabled cross-origin SVGImageElement with crossorigin="anonymous"
+PASS Test creating a VideoFrame with a same-origin HTMLVideoElement
+PASS Test creating a VideoFrame with a cross-origin HTMLVideoElement
+PASS Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement without setting crossorigin
+PASS Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement with crossorigin="anonymous"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html
@@ -7,9 +7,29 @@
   <script src="/common/get-host-info.sub.js"></script>
 </head>
 <body>
+<svg id="svg" width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+</svg>
 <script>
 const SAMEORIGIN_BASE = get_host_info().HTTP_ORIGIN;
 const CROSSORIGIN_BASE = get_host_info().HTTP_NOTSAMESITE_ORIGIN;
+
+async function getVideoFilename()
+{
+     const videoConfiguration = {
+       type: 'file',
+       video: {
+           contentType: 'video/mp4; codecs=avc1',
+           width: 640,
+           height: 480,
+           bitrate: 800,
+           framerate: 30
+         }
+     };
+     const result = await navigator.mediaCapabilities.decodingInfo(videoConfiguration);
+     if (result.supported)
+         return '/webcodecs/h264.mp4';
+     return '/webcodecs/av1.mp4';
+}
 
 const TESTS = [
   // HTMLImageElement
@@ -68,6 +88,7 @@ const TESTS = [
     factory: () => {
       return new Promise((resolve, reject) => {
         const image = document.createElementNS('http://www.w3.org/2000/svg','image');
+        svg.appendChild(image);
         image.onload = () => resolve(image);
         image.onerror = reject;
         image.setAttribute('href', SAMEORIGIN_BASE + '/webcodecs/four-colors.jpg');
@@ -80,6 +101,7 @@ const TESTS = [
     factory: () => {
       return new Promise((resolve, reject) => {
         const image = document.createElementNS('http://www.w3.org/2000/svg','image');
+        svg.appendChild(image);
         image.onload = () => resolve(image);
         image.onerror = reject;
         image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg');
@@ -92,6 +114,7 @@ const TESTS = [
     factory: () => {
       return new Promise((resolve, reject) => {
         const image = document.createElementNS('http://www.w3.org/2000/svg','image');
+        svg.appendChild(image);
         image.onload = () => resolve(image);
         image.onerror = reject;
         image.setAttribute('href', CROSSORIGIN_BASE + '/webcodecs/four-colors.jpg?pipe=header(Access-Control-Allow-Origin,*)');
@@ -104,6 +127,7 @@ const TESTS = [
     factory: () => {
       return new Promise((resolve, reject) => {
         const image = document.createElementNS('http://www.w3.org/2000/svg','image');
+        svg.appendChild(image);
         image.onload = () => resolve(image);
         image.onerror = reject;
         image.crossOrigin = 'anonymous';
@@ -120,11 +144,11 @@ const TESTS = [
   {
     title: 'Test creating a VideoFrame with a same-origin HTMLVideoElement',
     factory: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
         const video = document.createElement('video');
         on_frame_available(video, () => resolve(video));
         video.onerror = reject;
-        video.src = SAMEORIGIN_BASE + '/webcodecs/av1.mp4';
+        video.src = SAMEORIGIN_BASE + await getVideoFilename();
       });
     },
     should_throw: false,
@@ -132,11 +156,11 @@ const TESTS = [
   {
     title: 'Test creating a VideoFrame with a cross-origin HTMLVideoElement',
     factory: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
         const video = document.createElement('video');
         on_frame_available(video, () => resolve(video));
         video.onerror = reject;
-        video.src = CROSSORIGIN_BASE + '/webcodecs/av1.mp4';
+        video.src = CROSSORIGIN_BASE + await getVideoFilename();
       });
     },
     should_throw: true,
@@ -144,11 +168,11 @@ const TESTS = [
   {
     title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement without setting crossorigin',
     factory: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
         const video = document.createElement('video');
         on_frame_available(video, () => resolve(video));
         video.onerror = reject;
-        video.src = CROSSORIGIN_BASE + '/webcodecs/av1.mp4?pipe=header(Access-Control-Allow-Origin,*)';
+        video.src = CROSSORIGIN_BASE + await getVideoFilename() + '?pipe=header(Access-Control-Allow-Origin,*)';
       });
     },
     should_throw: true,
@@ -156,12 +180,12 @@ const TESTS = [
   {
     title: 'Test creating a VideoFrame with a CORS enabled cross-origin HTMLVideoElement with crossorigin="anonymous"',
     factory: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise(async (resolve, reject) => {
         const video = document.createElement('video');
         on_frame_available(video, () => resolve(video));
         video.onerror = reject;
         video.crossOrigin = 'anonymous';
-        video.src = CROSSORIGIN_BASE + '/webcodecs/av1.mp4?pipe=header(Access-Control-Allow-Origin,*)';
+        video.src = CROSSORIGIN_BASE + await getVideoFilename() +'?pipe=header(Access-Control-Allow-Origin,*)';
       });
     },
     should_throw: false,

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -93,6 +93,9 @@ static std::optional<Exception> checkImageUsability(ScriptExecutionContext& cont
         return { };
     },
     [] (const RefPtr<SVGImageElement>& imageElement) -> std::optional<Exception> {
+        if (imageElement->renderingTaintsOrigin())
+            return Exception { SecurityError, "Image element is tainted"_s };
+
         auto* image = imageElement->cachedImage() ? imageElement->cachedImage()->image() : nullptr;
         if (!image)
             return Exception { InvalidStateError,  "Image element has no data"_s };

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1080,11 +1080,11 @@ bool HTMLImageElement::originClean(const SecurityOrigin& origin) const
     if (!image)
         return true;
 
-    if (image->sourceURL().protocolIsData())
-        return true;
-
     if (image->renderingTaintsOrigin())
         return false;
+
+    if (image->sourceURL().protocolIsData())
+        return true;
 
     if (cachedImage->isCORSCrossOrigin())
         return false;

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -86,8 +86,17 @@ bool SVGImageElement::renderingTaintsOrigin() const
     if (!cachedImage)
         return false;
 
-    auto* image = cachedImage->image();
-    return image && image->renderingTaintsOrigin();
+    RefPtr image = cachedImage->image();
+    if (!image)
+        return false;
+
+    if (image->renderingTaintsOrigin())
+        return true;
+
+    if (image->sourceURL().protocolIsData())
+        return false;
+
+    return cachedImage->isCORSCrossOrigin();
 }
 
 void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)


### PR DESCRIPTION
#### e428405c2a7e87e904e09a8122b3ae9d223b59aa
<pre>
Fix imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=257749">https://bugs.webkit.org/show_bug.cgi?id=257749</a>
rdar://110322419

Reviewed by Eric Carlson.

Update imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html to work around specificities related to not rendered SVG images.
The specificities are that the load event is not fired when the SVG image is detached from the DOM and that there is no CachedImage if it is not visible.
We should investigate both specificities independently.
Update SVGImageElement::renderingTaintsOrigin to take into account CORS and add a CORS check in the SVG Image to VideoFrame code path.
We move the data URL check after the imge renderingTaintsOrigin check as we should first check whether its content is not tainting and then if its origin would taint or not.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.crossOriginSource.sub.html:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::checkImageUsability):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::originClean const):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::renderingTaintsOrigin const):

Canonical link: <a href="https://commits.webkit.org/265142@main">https://commits.webkit.org/265142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af283c425250ae2b54f813807f4dad9f739e087a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11372 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11532 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16233 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9471 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7817 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2390 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->