### PR TITLE
[JSC] Use allocated scratch FPR for ARM64 countPopulation

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -869,20 +869,20 @@ public:
         m_assembler.illegalInstruction();
     }
 
-    void countPopulation32(RegisterID src, RegisterID dst)
+    void countPopulation32(RegisterID src, RegisterID dst, FPRegisterID temp)
     {
-        move32ToFloat(src, fpTempRegister);
-        m_assembler.vectorCnt(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
-        m_assembler.addv(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
-        moveFloatTo32(fpTempRegister, dst);
+        move32ToFloat(src, temp);
+        m_assembler.vectorCnt(temp, temp, SIMDLane::i8x16);
+        m_assembler.addv(temp, temp, SIMDLane::i8x16);
+        moveFloatTo32(temp, dst);
     }
 
-    void countPopulation64(RegisterID src, RegisterID dst)
+    void countPopulation64(RegisterID src, RegisterID dst, FPRegisterID temp)
     {
-        move64ToDouble(src, fpTempRegister);
-        m_assembler.vectorCnt(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
-        m_assembler.addv(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
-        moveDoubleTo64(fpTempRegister, dst);
+        move64ToDouble(src, temp);
+        m_assembler.vectorCnt(temp, temp, SIMDLane::i8x16);
+        m_assembler.addv(temp, temp, SIMDLane::i8x16);
+        moveDoubleTo64(temp, dst);
     }
 
     void lshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -409,6 +409,18 @@ public:
         m_assembler.popcnt_rr(src, dst);
     }
 
+    void countPopulation32(Address src, RegisterID dst, FPRegisterID)
+    {
+        ASSERT(supportsCountPopulation());
+        m_assembler.popcnt_mr(src.offset, src.base, dst);
+    }
+
+    void countPopulation32(RegisterID src, RegisterID dst, FPRegisterID)
+    {
+        ASSERT(supportsCountPopulation());
+        m_assembler.popcnt_rr(src, dst);
+    }
+
     void byteSwap32(RegisterID dst)
     {
         m_assembler.bswapl_r(dst);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -553,6 +553,18 @@ public:
         m_assembler.popcntq_mr(src.offset, src.base, dst);
     }
 
+    void countPopulation64(RegisterID src, RegisterID dst, FPRegisterID)
+    {
+        ASSERT(supportsCountPopulation());
+        m_assembler.popcntq_rr(src, dst);
+    }
+
+    void countPopulation64(Address src, RegisterID dst, FPRegisterID)
+    {
+        ASSERT(supportsCountPopulation());
+        m_assembler.popcntq_mr(src.offset, src.base, dst);
+    }
+
     void lshift64(TrustedImm32 imm, RegisterID dest)
     {
         m_assembler.shlq_i8r(imm.m_value, dest);

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -4105,7 +4105,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI32Popcnt(ExpressionType ar
 {
     result = self().g32();
 
-#if CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64)
     if (MacroAssembler::supportsCountPopulation()) {
         auto* patchpoint = addPatchpoint(B3::Int32);
         patchpoint->effects = B3::Effects::none();
@@ -4126,7 +4126,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI64Popcnt(ExpressionType ar
 {
     result = self().g64();
 
-#if CPU(X86_64) || CPU(ARM64)
+#if CPU(X86_64)
     if (MacroAssembler::supportsCountPopulation()) {
         auto* patchpoint = addPatchpoint(B3::Int64);
         patchpoint->effects = B3::Effects::none();

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -5201,9 +5201,16 @@ auto B3IRGenerator::addI32Popcnt(ExpressionType argVar, ExpressionType& result) 
     if (MacroAssembler::supportsCountPopulation()) {
         PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, Int32, origin());
         patchpoint->append(arg, ValueRep::SomeRegister);
+#if CPU(X86_64)
         patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             jit.countPopulation32(params[1].gpr(), params[0].gpr());
         });
+#else
+        patchpoint->numFPScratchRegisters = 1;
+        patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+            jit.countPopulation32(params[1].gpr(), params[0].gpr(), params.fpScratch(0));
+        });
+#endif
         patchpoint->effects = Effects::none();
         result = push(patchpoint);
         return { };
@@ -5221,9 +5228,16 @@ auto B3IRGenerator::addI64Popcnt(ExpressionType argVar, ExpressionType& result) 
     if (MacroAssembler::supportsCountPopulation()) {
         PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, Int64, origin());
         patchpoint->append(arg, ValueRep::SomeRegister);
+#if CPU(X86_64)
         patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
             jit.countPopulation64(params[1].gpr(), params[0].gpr());
         });
+#else
+        patchpoint->numFPScratchRegisters = 1;
+        patchpoint->setGenerator([=] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+            jit.countPopulation64(params[1].gpr(), params[0].gpr(), params.fpScratch(0));
+        });
+#endif
         patchpoint->effects = Effects::none();
         result = push(patchpoint);
         return { };

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -6047,7 +6047,7 @@ public:
             BLOCK(Value::fromI32(__builtin_popcount(operand.asI32()))),
             BLOCK(
                 if (m_jit.supportsCountPopulation())
-                    m_jit.countPopulation32(operandLocation.asGPR(), resultLocation.asGPR());
+                    m_jit.countPopulation32(operandLocation.asGPR(), resultLocation.asGPR(), wasmScratchFPR);
                 else {
                     // The EMIT_UNARY(...) macro will already assign result to the top value on the stack and give it a register,
                     // so it should be able to be passed in. However, this creates a somewhat nasty tacit dependency - emitCCall
@@ -6071,7 +6071,7 @@ public:
             BLOCK(Value::fromI64(__builtin_popcountll(operand.asI64()))),
             BLOCK(
                 if (m_jit.supportsCountPopulation())
-                    m_jit.countPopulation64(operandLocation.asGPR(), resultLocation.asGPR());
+                    m_jit.countPopulation64(operandLocation.asGPR(), resultLocation.asGPR(), wasmScratchFPR);
                 else {
                     // The EMIT_UNARY(...) macro will already assign result to the top value on the stack and give it a register,
                     // so it should be able to be passed in. However, this creates a somewhat nasty tacit dependency - emitCCall


### PR DESCRIPTION
#### 8a8e7575601057b02891fee4723fd3123a161500
<pre>
[JSC] Use allocated scratch FPR for ARM64 countPopulation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257753">https://bugs.webkit.org/show_bug.cgi?id=257753</a>
rdar://110327985

Reviewed by Justin Michaud.

fpTempRegister is not available in Air, so we should not use it in ARM64 countPopulation implementation.
This patch explicitly allocates FPR scratch register to use it in ARM64 countPopulation.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::countPopulation32):
(JSC::MacroAssemblerARM64::countPopulation64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::countPopulation32):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addI32Popcnt):
(JSC::Wasm::ExpressionType&gt;::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addI32Popcnt):
(JSC::Wasm::B3IRGenerator::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJIT::addI64Popcnt):

Canonical link: <a href="https://commits.webkit.org/264907@main">https://commits.webkit.org/264907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfa511475a59afc2737bb45018b6c6b94cc477f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9035 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11884 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9228 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10201 "2 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10894 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15781 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7817 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11771 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7301 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9247 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8186 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2199 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12406 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9484 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8701 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2329 "Passed tests") | 
<!--EWS-Status-Bubble-End-->