### PR TITLE
Arrow key keyboard scrolling in Safari doesn't work

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -129,7 +129,7 @@ void RemoteScrollingTreeMac::didCommitTree()
 {
     ASSERT(isMainRunLoop());
 
-    if (m_nodesWithPendingScrollAnimations.isEmpty())
+    if (m_nodesWithPendingScrollAnimations.isEmpty() && m_nodesWithPendingKeyboardScrollAnimations.isEmpty())
         return;
 
     ScrollingThread::dispatch([protectedThis = Ref { *this }]() {


### PR DESCRIPTION
#### 2ef7008f5d540228d290e4b46b8f703ddfaf4245
<pre>
Arrow key keyboard scrolling in Safari doesn&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=257754">https://bugs.webkit.org/show_bug.cgi?id=257754</a>
rdar://110333066

Reviewed by Aditya Keerthi.

264230@main added an early return in `RemoteScrollingTreeMac::didCommitTree` to ensure that
`RemoteScrollingTreeMac::startPendingScrollAnimations` wasn&apos;t called in the case that there
are zero pending scrolling animations. However, this only checked for non-keyboard scroll
animations. This resulted in the early return happening even when there are pending keyboard
scroll animations causing the keyboard scrolling animations to never start.

This PR fixes this by early returning only if there are zero non-keyboard scroll animations
and zero keyboard scroll animations.

Note that there are existing tests for this which did also catch this, but EWS doesn&apos;t run
with the necessary configuration.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::didCommitTree):

Canonical link: <a href="https://commits.webkit.org/264913@main">https://commits.webkit.org/264913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0776ffb4698165376b8e841a3c509c8bb8cc31e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10740 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9342 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11888 "3 flakes 95 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10202 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10899 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7497 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15780 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8606 "4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7303 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8189 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2208 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->