### PR TITLE
Make getName should return DOMString? instead of DOMString or undefined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
@@ -36,10 +36,10 @@ PASS CustomElementRegistry interface must have get as a method
 PASS customElements.get must return undefined when the registry does not contain an entry with the given name
 PASS customElements.get must return undefined when the registry does not contain an entry with the given name even if the name was not a valid custom element name
 PASS customElements.get return the constructor of the entry with the given name when there is a matching entry.
-PASS customElements.getName must return undefined when called with undefined
-PASS customElements.getName must return undefined when called with null
-PASS customElements.getName must return undefined when called with a string
-PASS customElements.getName must return undefined when the registry does not contain an entry with the given constructor
+PASS customElements.getName must return null when the registry does not contain an entry with the given constructor
+PASS customElements.getName must return null when called with undefined
+PASS customElements.getName must return null when called with null
+PASS customElements.getName must return null when called with a string
 PASS customElements.getName returns the name of the entry with the given constructor when there is a matching entry.
 PASS customElements.whenDefined must return a promise for a valid custom element name
 PASS customElements.whenDefined must return the same promise each time invoked for a valid custom element name which has not been defined

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html
@@ -624,26 +624,26 @@ test(function () {
 }, 'customElements.get return the constructor of the entry with the given name when there is a matching entry.');
 
 test(function () {
-  assert_equals(customElements.getName(undefined), undefined);
-}, 'customElements.getName must return undefined when called with undefined');
+  assert_equals(customElements.getName(class extends HTMLElement {}), null);
+}, 'customElements.getName must return null when the registry does not contain an entry with the given constructor');
 
 test(function () {
-  assert_equals(customElements.getName(null), undefined);
-}, 'customElements.getName must return undefined when called with null');
+  assert_equals(customElements.getName(undefined), null);
+}, 'customElements.getName must return null when called with undefined');
 
 test(function () {
-  assert_equals(customElements.getName(''), undefined);
-}, 'customElements.getName must return undefined when called with a string');
+  assert_equals(customElements.getName(null), null);
+}, 'customElements.getName must return null when called with null');
 
 test(function () {
-  assert_equals(customElements.getName(class extends HTMLElement {}), undefined);
-}, 'customElements.getName must return undefined when the registry does not contain an entry with the given constructor');
+  assert_equals(customElements.getName(''), null);
+}, 'customElements.getName must return null when called with a string');
 
 test(function () {
-    class ExistingCustomElement extends HTMLElement {};
-    assert_equals(customElements.getName(ExistingCustomElement), undefined);
-    customElements.define('other-custom-element', ExistingCustomElement);
-    assert_equals(customElements.getName(ExistingCustomElement), 'other-custom-element');
+    class OtherExistingCustomElement extends HTMLElement {};
+    assert_equals(customElements.getName(OtherExistingCustomElement), null);
+    customElements.define('other-existing-custom-element', OtherExistingCustomElement);
+    assert_equals(customElements.getName(OtherExistingCustomElement), 'other-existing-custom-element');
 }, 'customElements.getName returns the name of the entry with the given constructor when there is a matching entry.');
 
 test(function () {

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -128,15 +128,15 @@ JSC::JSValue CustomElementRegistry::get(const AtomString& name)
     return JSC::jsUndefined();
 }
 
-JSC::JSValue CustomElementRegistry::getName(JSC::JSGlobalObject& globalObject, JSC::JSValue constructorValue)
+String CustomElementRegistry::getName(JSC::JSValue constructorValue)
 {
     auto* constructor = constructorValue.getObject();
     if (!constructor)
-        return JSC::jsUndefined();
+        return String { };
     auto* elementInterface = findInterface(constructor);
     if (!elementInterface)
-        return JSC::jsUndefined();
-    return JSC::jsString(globalObject.vm(), elementInterface->name().localName());
+        return String { };
+    return elementInterface->name().localName();
 }
 
 static void upgradeElementsInShadowIncludingDescendants(ContainerNode& root)

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -70,7 +70,7 @@ public:
     bool containsConstructor(const JSC::JSObject*) const;
 
     JSC::JSValue get(const AtomString&);
-    JSC::JSValue getName(JSC::JSGlobalObject&, JSC::JSValue);
+    String getName(JSC::JSValue);
     void upgrade(Node& root);
 
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }

--- a/Source/WebCore/dom/CustomElementRegistry.idl
+++ b/Source/WebCore/dom/CustomElementRegistry.idl
@@ -32,8 +32,7 @@
     [CEReactions=Needed, Custom] undefined define(DOMString name, Function constructor);
     any get([AtomString] DOMString name);
 
-    // FIXME: This should return (DOMString or undefined). See webkit.org/b/232734.
-    [CallWith=CurrentGlobalObject] any getName(any constructor);
+    DOMString? getName(any constructor);
 
     [Custom, ReturnsOwnPromise] Promise<undefined> whenDefined(DOMString name);
     [CEReactions=Needed] undefined upgrade(Node root);


### PR DESCRIPTION
#### 1515a23b954f8ba0fba56b97fb9ba697833ccab2
<pre>
Make getName should return DOMString? instead of DOMString or undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=257759">https://bugs.webkit.org/show_bug.cgi?id=257759</a>

Reviewed by Chris Dumez.

Update the implementation of CustomElementsRegistry.prototype.getName to match the latest PR.
Namely, it now returns DOMString? instead of (DOMString or undefined):
<a href="https://github.com/whatwg/html/pull/9195">https://github.com/whatwg/html/pull/9195</a>
<a href="https://github.com/web-platform-tests/wpt/pull/39640">https://github.com/web-platform-tests/wpt/pull/39640</a>

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::getName):
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/CustomElementRegistry.idl:

Canonical link: <a href="https://commits.webkit.org/264916@main">https://commits.webkit.org/264916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e812ed8fe5e9959b004607b43624a0bc6d7d0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11892 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10208 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10906 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15786 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8612 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11776 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8958 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7307 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8209 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12416 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->