### PR TITLE
[Cocoa] Enable HEIC

### DIFF
--- a/LayoutTests/fast/canvas/toDataURL-unsupportedTypes-expected.txt
+++ b/LayoutTests/fast/canvas/toDataURL-unsupportedTypes-expected.txt
@@ -3,8 +3,6 @@ This is a test of the unsupported mime-types for canvas.toDataURL().
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS canvas.toDataURL('image/heic') is canvas.toDataURL('image/png')
-PASS canvas.toDataURL('image/heic-sequence') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('image/vnd.adobe.photoshop') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('application/pdf') is canvas.toDataURL('image/png')
 PASS canvas.toDataURL('image/targa') is canvas.toDataURL('image/png')

--- a/LayoutTests/fast/canvas/toDataURL-unsupportedTypes.html
+++ b/LayoutTests/fast/canvas/toDataURL-unsupportedTypes.html
@@ -10,8 +10,6 @@
         canvas.height = 8;
 
         description("This is a test of the unsupported mime-types for canvas.toDataURL().");
-        shouldBe("canvas.toDataURL('image/heic')", "canvas.toDataURL('image/png')");
-        shouldBe("canvas.toDataURL('image/heic-sequence')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('image/vnd.adobe.photoshop')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('application/pdf')", "canvas.toDataURL('image/png')");
         shouldBe("canvas.toDataURL('image/targa')", "canvas.toDataURL('image/png')");

--- a/LayoutTests/fast/forms/file/entries-api/image-no-transcode-drag-drop-expected.txt
+++ b/LayoutTests/fast/forms/file/entries-api/image-no-transcode-drag-drop-expected.txt
@@ -6,9 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS fileList.length is 1
 PASS file.type is "image/heic"
 PASS file.size is non-zero.
-Image could not be loaded.
-PASS img.width is not 400
-PASS img.height is not 400
+Image was loaded.
+PASS img.width is 400
+PASS img.height is 400
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel-expected.txt
+++ b/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel-expected.txt
@@ -7,9 +7,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS fileList.length is 1
 PASS file.type is "image/heic"
 PASS file.size is non-zero.
-Image could not be loaded.
-PASS img.width is not 400
-PASS img.height is not 400
+Image was loaded.
+PASS img.width is 400
+PASS img.height is 400
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/images/animated-heics-draw.html
+++ b/LayoutTests/fast/images/animated-heics-draw.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ additionalSupportedImageTypes=public.heic;public.heics ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/images/animated-heics-verify.html
+++ b/LayoutTests/fast/images/animated-heics-verify.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ additionalSupportedImageTypes=public.heic;public.heics ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/images/heic-as-background-image.html
+++ b/LayoutTests/fast/images/heic-as-background-image.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ additionalSupportedImageTypes=public.heic;public.heics ] -->
+<!DOCTYPE html>
 <style>
     .green-box {
         width: 100px;

--- a/LayoutTests/http/tests/misc/heic-accept-header.html
+++ b/LayoutTests/http/tests/misc/heic-accept-header.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ additionalSupportedImageTypes=public.heic;public.heics ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <script>

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1552,3 +1552,7 @@
     || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 100000)
 #define HAVE_JPEGXL 1
 #endif
+
+#if PLATFORM(COCOA)
+#define HAVE_HEIC 1
+#endif

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -155,6 +155,15 @@ static constexpr ASCIILiteral acceptHeaderValueForJPEGXLImageResource()
 #endif
 }
 
+static constexpr ASCIILiteral acceptHeaderValueForHEICImageResource()
+{
+#if HAVE(HEIC)
+    return "image/heic,image/heic-sequence,"_s;
+#else
+    return ""_s;
+#endif
+}
+
 static String acceptHeaderValueForAdditionalSupportedImageMIMETypes()
 {
     StringBuilder sb;
@@ -175,6 +184,7 @@ static String acceptHeaderValueForImageResource()
     return String(acceptHeaderValueForWebPImageResource())
         + acceptHeaderValueForAVIFImageResource()
         + acceptHeaderValueForJPEGXLImageResource()
+        + acceptHeaderValueForHEICImageResource()
         + acceptHeaderValueForAdditionalSupportedImageMIMETypes()
         + acceptHeaderValueForVideoImageResource(ImageDecoder::supportsMediaType(ImageDecoder::MediaType::Video))
         + "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"_s;

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -98,6 +98,10 @@ constexpr ComparableCaseFoldingASCIILiteral supportedImageMIMETypeArray[] = {
     "image/gi_",
 #endif
     "image/gif",
+#if HAVE(HEIC)
+    "image/heic",
+    "image/heic-sequence",
+#endif
 #if USE(CG) || USE(OPENJPEG)
     "image/jp2",
 #endif

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -69,6 +69,10 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageType
             "public.jpegxl"_s,
             "public.jpeg-xl"_s,
 #endif
+#if HAVE(HEIC)
+            "public.heic"_s,
+            "public.heics"_s,
+#endif
         };
 
         auto systemSupportedCFImageTypes = adoptCF(CGImageSourceCopyTypeIdentifiers());


### PR DESCRIPTION
#### 8d15007530ba97cafde25c94d23e3ec6bb6dafe4
<pre>
[Cocoa] Enable HEIC
<a href="https://bugs.webkit.org/show_bug.cgi?id=257763">https://bugs.webkit.org/show_bug.cgi?id=257763</a>
rdar://110346646

Reviewed by Said Abou-Hallawa.

There are 3 reasons to enable it:
1. HEIC uses the same technology as H.265 videos, which are already enabled by default in
       many (most? almost all?) major browsers. So there is no concern about increasing
       the surface area of new technology on the web.
2. It&apos;s just a true fact that there are just a lot of HEIC images out there in the wild.
       Some of them end up on the internet. You can&apos;t stop them. It just happens.
3. Apple&apos;s devices have hardware decoders for HEIC, which make them both more performant
       and use less energy than other image formats. Running some tests, using hardware
       decoding HEIC images uses 26% less power and 13% less time than using software
       decoding of AVIF, for (roughly) equivalent quality images.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::acceptHeaderValueForHEICImageResource):
(WebCore::acceptHeaderValueForImageResource):
* Source/WebCore/platform/MIMETypeRegistry.cpp:
* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::defaultSupportedImageTypes):

Canonical link: <a href="https://commits.webkit.org/264971@main">https://commits.webkit.org/264971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66f9720b346af702b8fbda1c8ee52de30bb46fc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10982 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12086 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10392 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11141 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8501 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/7991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8652 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11990 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8923 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9147 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9496 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8407 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2253 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9737 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8910 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2390 "Passed tests") | 
<!--EWS-Status-Bubble-End-->