### PR TITLE
Disable some Proxy API tests on the ios-simulator for now

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm
@@ -162,6 +162,9 @@ TEST(WebKit, SOCKS5)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
 
+// FIXME: Try to re-enable on the simulator after rdar://110076935 is resolved
+#if !PLATFORM(IOS_FAMILY_SIMULATOR)
+
 #if HAVE(NW_PROXY_CONFIG) && __has_include(<Network/proxy_config_private.h>)
 TEST(WebKit, HTTPSProxyAPI)
 {
@@ -289,6 +292,7 @@ TEST(WebKit, SOCKS5API)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "success!");
 }
 #endif // HAVE(NW_PROXY_CONFIG) && __has_include(<Network/proxy_config_private.h>)
+#endif // !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 static HTTPServer proxyAuthenticationServer()
 {


### PR DESCRIPTION
#### 50c275682eb0e022a1ec663b353eab990192b969
<pre>
Disable some Proxy API tests on the ios-simulator for now
<a href="https://bugs.webkit.org/show_bug.cgi?id=257765">https://bugs.webkit.org/show_bug.cgi?id=257765</a>
rdar://109238517

Reviewed by Brent Fulgham.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:

Canonical link: <a href="https://commits.webkit.org/264915@main">https://commits.webkit.org/264915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f0cc9a2855a14ad7cd8dfb5105475487d96668d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10225 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10930 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15802 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8467 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11792 "8 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7323 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2210 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->