### PR TITLE
Address socket option telemetry

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -78,6 +78,7 @@
     (require-all
         (socket-option-level SOL_SOCKET)
         (socket-option-name
+            131072
             SO_DELEGATED
             SO_DELEGATED_UUID
             SO_MARK_KNOWN_TRACKER

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -75,6 +75,7 @@
     (require-all
         (socket-option-level SOL_SOCKET)
         (socket-option-name
+            131072
             SO_MARK_KNOWN_TRACKER
             SO_NECP_LISTENUUID
             SO_NOSIGPIPE


### PR DESCRIPTION
#### 81084d1e70d6177c4e9391b092f6c029f19fb3db
<pre>
Address socket option telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=257767">https://bugs.webkit.org/show_bug.cgi?id=257767</a>
rdar://107427539

Reviewed by Brent Fulgham.

Address socket option telemetry in the Networking process sandbox.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:

Canonical link: <a href="https://commits.webkit.org/264941@main">https://commits.webkit.org/264941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99c644bb596e55db575d2e99a930497b3840cbbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9065 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10228 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10936 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7523 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15805 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11796 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7327 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12440 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1053 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8737 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->