### PR TITLE
wip: vm_copy bitmap data to ShareableMemory

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -366,7 +366,7 @@ void RemoteRenderingBackend::cacheNativeImageWithQualifiedIdentifier(ShareableBi
 {
     ASSERT(!RunLoop::isMain());
 
-    auto bitmap = ShareableBitmap::create(WTFMove(handle));
+    auto bitmap = ShareableBitmap::create(WTFMove(handle), SharedMemory::Protection::ReadOnly);
     if (!bitmap)
         return;
 

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -113,6 +113,7 @@ public:
 #if USE(UNIX_DOMAIN_SOCKETS)
     static RefPtr<SharedMemory> wrapMap(void*, size_t, int fileDescriptor);
 #elif OS(DARWIN)
+    static RefPtr<SharedMemory> createReadOnlyVirtualCopy(const void*, size_t);
     static RefPtr<SharedMemory> wrapMap(void*, size_t, Protection);
 #endif
 #if OS(WINDOWS)

--- a/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
+++ b/Source/WebKit/Shared/cg/ShareableBitmapCG.cpp
@@ -136,11 +136,9 @@ RefPtr<ShareableBitmap> ShareableBitmap::createFromImagePixels(NativeImage& imag
         return nullptr;
     }
 
-    RefPtr<SharedMemory> sharedMemory = SharedMemory::allocate(sizeInBytes);
+    RefPtr<SharedMemory> sharedMemory = SharedMemory::createReadOnlyVirtualCopy(bytes, sizeInBytes);
     if (!sharedMemory)
         return nullptr;
-
-    memcpy(sharedMemory->data(), bytes, sizeInBytes);
 
     return adoptRef(new ShareableBitmap(configuration, sharedMemory.releaseNonNull()));
 }


### PR DESCRIPTION
#### 6e35acec09e465bbb97317a302671d328c8db9a7
<pre>
wip: vm_copy bitmap data to ShareableMemory
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e35acec09e465bbb97317a302671d328c8db9a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9142 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9423 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9072 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11410 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11929 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9288 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/11410 "Failed to compile WebKit") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10952 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/11410 "Failed to compile WebKit") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15813 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/11410 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8483 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11811 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8992 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7336 "18 flakes 3 failures") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8224 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12447 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8750 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->