### PR TITLE
Add signposts and profiling support to MotionMark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark.patch
@@ -1,0 +1,47 @@
+diff --git a/resources/runner/benchmark-runner.js b/resources/runner/benchmark-runner.js
+index 1aa630356cff..ef393bcdebc0 100644
+--- a/resources/runner/benchmark-runner.js
++++ b/resources/runner/benchmark-runner.js
+@@ -92,10 +92,13 @@ BenchmarkRunner = Utilities.createClass(
+         var options = { complexity: test.complexity };
+         Utilities.extendObject(options, this._client.options);
+         Utilities.extendObject(options, contentWindow.Utilities.parseParameters());
++        Utilities.extendObject(options, { "suite": suite, "test": test });
+ 
+         var benchmark = new contentWindow.benchmarkClass(options);
+         document.body.style.backgroundColor = benchmark.backgroundColor();
++        __signpostStart(`${suite.name}.${test.name}`);
+         benchmark.run().then(function(testData) {
++            __signpostStop(`${suite.name}.${test.name}`);
+             var suiteResults = self._suitesResults[suite.name] || {};
+             suiteResults[test.name] = testData;
+             self._suitesResults[suite.name] = suiteResults;
+diff --git a/tests/resources/main.js b/tests/resources/main.js
+index 3608a9e1ac90..3847a28e6781 100644
+--- a/tests/resources/main.js
++++ b/tests/resources/main.js
+@@ -842,6 +842,8 @@ Benchmark = Utilities.createClass(
+         this._frameCount = 0;
+         this._warmupFrameCount = options["warmup-frame-count"];
+         this._firstFrameMinimumLength = options["first-frame-minimum-length"];
++        this._suite = options["suite"]
++        this._test = options["test"]
+ 
+         this._stage = stage;
+         this._stage.initialize(this, options);
+@@ -899,6 +901,7 @@ Benchmark = Utilities.createClass(
+             this._finishPromise = new SimplePromise;
+             this._previousTimestamp = undefined;
+             this._didWarmUp = false;
++            __signpostStart(`${this._suite.name}.${this._test.name}: warmup`);
+             this._stage.tune(this._controller.initialComplexity - this._stage.complexity());
+             this._animateLoop();
+             return this._finishPromise;
+@@ -929,6 +932,7 @@ Benchmark = Utilities.createClass(
+                 this._benchmarkStartTimestamp = timestamp;
+             } else if (timestamp - this._previousTimestamp >= this._warmupLength && this._frameCount >= this._warmupFrameCount) {
+                 this._didWarmUp = true;
++                __signpostStop(`${this._suite.name}.${this._test.name}: warmup`);
+                 this._benchmarkStartTimestamp = timestamp;
+                 this._controller.start(timestamp, this._stage);
+                 this._previousTimestamp = timestamp;

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
@@ -5,6 +5,7 @@
     "github_source": "https://github.com/WebKit/WebKit/tree/86daf4fcece9d2dafe67ef0de1e23bda72b56378/PerformanceTests/MotionMark",
     "webserver_benchmark_patch": "data/patches/webserver/MotionMark.patch",
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
+    "signpost_patch": "data/patches/signposts/MotionMark.patch",
     "entry_point": "index.html",
     "subtest_entry_point": "developer.html",
     "config": {


### PR DESCRIPTION
#### 7627468cdd1d9e63d527fe9af141e0b8217e7377
<pre>
Add signposts and profiling support to MotionMark
<a href="https://bugs.webkit.org/show_bug.cgi?id=249595">https://bugs.webkit.org/show_bug.cgi?id=249595</a>
rdar://103522107

Reviewed by Dewei Zhu.

This patch adds signpost patches to Speedometer plans, which will allow us to annotate generated profiles (--profile).

Currently, for each iteration, two signposts are created: one overarching signpost called &quot;${suite}.${test}&quot; labeling the full subtest run, and &quot;${suite}.${test}: warmup&quot; labeling just the warmup section.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan:

Canonical link: <a href="https://commits.webkit.org/264951@main">https://commits.webkit.org/264951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23652f177610b80524eae376389e8504034fd76d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12010 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10324 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11051 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9355 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8426 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15890 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11917 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8848 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9073 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9412 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8332 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12521 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9650 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8832 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2369 "Passed tests") | 
<!--EWS-Status-Bubble-End-->