### PR TITLE
REGRESSION (263724@main): Jumpiness and jitteriness in scrolling on searchfox.org

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring-after-page-load-expected.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-after-page-load-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="tallContent" style="height: 2000px;"></div>
+<span>This test should not be visible.</span>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring-after-page-load.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-after-page-load.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="tallContent"></div>
+<a name="target">This test should not be visible.</a>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+let content = '';
+let contentIndex = 0;
+setTimeout(() => {
+    tallContent.style.height = '2000px';
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}, 0);
+location.href = '#target';
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1252,6 +1252,9 @@ void FrameLoader::completed()
         if (auto* localParent = dynamicDowncast<LocalFrame>(parent))
             localParent->loader().checkCompleted();
     }
+
+    if (m_frame.view())
+        m_frame.view()->maintainScrollPositionAtAnchor(nullptr);
 }
 
 void FrameLoader::started()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3646,6 +3646,11 @@ bool LocalFrameView::safeToPropagateScrollToParent() const
 
 void LocalFrameView::scheduleScrollToAnchorAndTextFragment()
 {
+    RefPtr<ContainerNode> anchorNode = m_maintainScrollPositionAnchor;
+    if (!anchorNode)
+        return;
+    m_scheduledMaintainScrollPositionAnchor = anchorNode;
+
     if (m_scheduledToScrollToAnchor)
         return;
 
@@ -3657,7 +3662,12 @@ void LocalFrameView::scheduleScrollToAnchorAndTextFragment()
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->scrollToAnchorAndTextFragmentNowIfNeeded();
+        if (!protectedThis->m_maintainScrollPositionAnchor) {
+            SetForScope scrollPositionAnchor(protectedThis->m_maintainScrollPositionAnchor, protectedThis->m_scheduledMaintainScrollPositionAnchor);
+            protectedThis->scrollToAnchorAndTextFragmentNowIfNeeded();
+        } else
+            protectedThis->scrollToAnchorAndTextFragmentNowIfNeeded();
+        protectedThis->m_scheduledMaintainScrollPositionAnchor = nullptr;
     });
 }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -936,6 +936,7 @@ private:
     std::unique_ptr<WeakHashSet<RenderElement>> m_slowRepaintObjects;
 
     RefPtr<ContainerNode> m_maintainScrollPositionAnchor;
+    RefPtr<ContainerNode> m_scheduledMaintainScrollPositionAnchor;
     RefPtr<Node> m_nodeToDraw;
     std::optional<SimpleRange> m_pendingTextFragmentIndicatorRange;
     String m_pendingTextFragmentIndicatorText;


### PR DESCRIPTION
#### 7c2201e62a9afb3da7a0f19e6bcd8bda1f0dd2e2
<pre>
REGRESSION (263724@main): Jumpiness and jitteriness in scrolling on searchfox.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=257576">https://bugs.webkit.org/show_bug.cgi?id=257576</a>
&lt;rdar://problem/110095194&gt;

Reviewed by Simon Fraser.

The bug was caused by WebKit no longer clearing the scroll anchoring element upon page load completion.
This turned out to be not a Web compatible change.

Fix fast/dynamic/anchor-lock.html in another way by remembering to which node scrolling was scheduled
in LocalFrameView instead of relying on m_maintainScrollPositionAnchor to be not cleared upon page load
completion, which is not generally Web compatible.

* LayoutTests/fast/scrolling/scroll-anchoring-after-page-load-expected.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-after-page-load.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::completed):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scheduleScrollToAnchorAndTextFragment):
* Source/WebCore/page/LocalFrameView.h:

Canonical link: <a href="https://commits.webkit.org/264940@main">https://commits.webkit.org/264940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c402c5bcc1984fba9eadfa37b17347abe8ce70a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9146 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11934 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10243 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10956 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15819 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8644 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8495 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11819 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7338 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8255 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12451 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1052 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->