### PR TITLE
[WebXR] Rename WebXROpaqueFramebuffer buffer binding helpers

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -299,14 +299,14 @@ bool WebXROpaqueFramebuffer::setupFramebuffer()
         m_resolvedFBO.ensure(gl);
 
         auto colorBuffer = allocateColorStorage(gl, sampleCount, m_width, m_height);
-        bindColor(gl, colorBuffer);
+        bindColorBuffer(gl, colorBuffer);
 
         m_multisampleColorBuffer.adopt(gl, colorBuffer);
     }
 
     if (hasDepthOrStencil) {
         auto [depthBuffer, stencilBuffer] = allocateDepthStencilStorage(gl, sampleCount, m_width, m_height);
-        bindDepthStencil(gl, depthBuffer, stencilBuffer);
+        bindDepthStencilBuffer(gl, depthBuffer, stencilBuffer);
 
         m_depthStencilBuffer.adopt(gl, depthBuffer);
         m_stencilBuffer.adopt(gl, stencilBuffer != depthBuffer ? stencilBuffer : 0);
@@ -356,12 +356,12 @@ std::tuple<PlatformGLObject, PlatformGLObject> WebXROpaqueFramebuffer::allocateD
     return std::make_tuple(depthBuffer, stencilBuffer);
 }
 
-void WebXROpaqueFramebuffer::bindColor(GraphicsContextGL& gl, PlatformGLObject colorBuffer)
+void WebXROpaqueFramebuffer::bindColorBuffer(GraphicsContextGL& gl, PlatformGLObject colorBuffer)
 {
     gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, colorBuffer);
 }
 
-void WebXROpaqueFramebuffer::bindDepthStencil(GraphicsContextGL& gl, PlatformGLObject depthBuffer, PlatformGLObject stencilBuffer)
+void WebXROpaqueFramebuffer::bindDepthStencilBuffer(GraphicsContextGL& gl, PlatformGLObject depthBuffer, PlatformGLObject stencilBuffer)
 {
     if (depthBuffer == stencilBuffer && !m_context.isWebGL2()) {
         ASSERT(m_attributes.stencil || m_attributes.depth);

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -69,8 +69,8 @@ private:
     PlatformGLObject allocateRenderbufferStorage(GraphicsContextGL&, GCGLsizei, GCGLenum, GCGLsizei, GCGLsizei);
     PlatformGLObject allocateColorStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
     std::tuple<PlatformGLObject, PlatformGLObject> allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
-    void bindColor(GraphicsContextGL&, PlatformGLObject);
-    void bindDepthStencil(GraphicsContextGL&, PlatformGLObject, PlatformGLObject);
+    void bindColorBuffer(GraphicsContextGL&, PlatformGLObject);
+    void bindDepthStencilBuffer(GraphicsContextGL&, PlatformGLObject, PlatformGLObject);
 
     PlatformXR::LayerHandle m_handle;
     Ref<WebGLFramebuffer> m_framebuffer;


### PR DESCRIPTION
#### 7babae90fd7881c1b52ebef010ceb05c7af37ad8
<pre>
[WebXR] Rename WebXROpaqueFramebuffer buffer binding helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=257777">https://bugs.webkit.org/show_bug.cgi?id=257777</a>
rdar://problem/110364626

Reviewed by Matt Woodrow.

To allow extension, rename BindColor and BindDepthStencil to include Buffer
since they take Renderbuffer parameters

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::bindColorBuffer):
(WebCore::WebXROpaqueFramebuffer::bindDepthStencilBuffer):
(WebCore::WebXROpaqueFramebuffer::bindColor): Deleted.
(WebCore::WebXROpaqueFramebuffer::bindDepthStencil): Deleted.
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:

Canonical link: <a href="https://commits.webkit.org/264924@main">https://commits.webkit.org/264924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d85b8764e06ceb05ebde8061755937c4ebf0dcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10812 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11946 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10256 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10970 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8356 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8240 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2216 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->