### PR TITLE
Use WebProcess::singleton instead of unnecessarily storing a duplicate pointer

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
@@ -37,12 +37,12 @@ namespace WebKit {
 
 using namespace WebCore;
 
-Ref<RemoteAudioHardwareListener> RemoteAudioHardwareListener::create(AudioHardwareListener::Client& client, WebProcess& webProcess)
+Ref<RemoteAudioHardwareListener> RemoteAudioHardwareListener::create(AudioHardwareListener::Client& client)
 {
-    return adoptRef(*new RemoteAudioHardwareListener(client, webProcess));
+    return adoptRef(*new RemoteAudioHardwareListener(client));
 }
 
-RemoteAudioHardwareListener::RemoteAudioHardwareListener(AudioHardwareListener::Client& client, WebProcess& webProcess)
+RemoteAudioHardwareListener::RemoteAudioHardwareListener(AudioHardwareListener::Client& client)
     : AudioHardwareListener(client)
     , m_identifier(RemoteAudioHardwareListenerIdentifier::generate())
     , m_gpuProcessConnection(WebProcess::singleton().ensureGPUProcessConnection())

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h
@@ -48,7 +48,7 @@ class RemoteAudioHardwareListener final
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&, WebProcess&);
+    static Ref<RemoteAudioHardwareListener> create(WebCore::AudioHardwareListener::Client&);
     ~RemoteAudioHardwareListener();
 
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::ref(); }
@@ -56,7 +56,7 @@ public:
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioHardwareListener>::controlBlock(); }
 
 private:
-    RemoteAudioHardwareListener(WebCore::AudioHardwareListener::Client&, WebProcess&);
+    explicit RemoteAudioHardwareListener(WebCore::AudioHardwareListener::Client&);
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -39,13 +39,12 @@ namespace WebKit {
 
 using namespace WebCore;
 
-UniqueRef<RemoteAudioSession> RemoteAudioSession::create(WebProcess& process)
+UniqueRef<RemoteAudioSession> RemoteAudioSession::create()
 {
-    return makeUniqueRef<RemoteAudioSession>(process);
+    return makeUniqueRef<RemoteAudioSession>();
 }
 
-RemoteAudioSession::RemoteAudioSession(WebProcess& process)
-    : m_process(process)
+RemoteAudioSession::RemoteAudioSession()
 {
     addInterruptionObserver(*this);
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -49,7 +49,7 @@ class RemoteAudioSession final
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static UniqueRef<RemoteAudioSession> create(WebProcess&);
+    static UniqueRef<RemoteAudioSession> create();
     ~RemoteAudioSession();
 
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::ref(); }
@@ -57,8 +57,8 @@ public:
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteAudioSession>::controlBlock(); }
 
 private:
-    friend UniqueRef<RemoteAudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteAudioSession>(WebProcess&);
-    explicit RemoteAudioSession(WebProcess&);
+    friend UniqueRef<RemoteAudioSession> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteAudioSession>();
+    RemoteAudioSession();
     IPC::Connection& ensureConnection();
 
     // IPC::MessageReceiver
@@ -110,8 +110,6 @@ private:
     // InterruptionObserver
     void beginAudioSessionInterruption() final;
     void endAudioSessionInterruption(WebCore::AudioSession::MayResume) final;
-
-    WebProcess& m_process;
 
     WeakHashSet<ConfigurationChangeObserver> m_configurationChangeObservers;
     CategoryType m_category { CategoryType::None };

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -39,8 +39,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RemoteCDMFactory::RemoteCDMFactory(WebProcess& process)
-    : m_process(process)
+RemoteCDMFactory::RemoteCDMFactory(WebProcess&)
 {
 }
 
@@ -58,7 +57,7 @@ const char* RemoteCDMFactory::supplementName()
 
 GPUProcessConnection& RemoteCDMFactory::gpuProcessConnection()
 {
-    return m_process.ensureGPUProcessConnection();
+    return WebProcess::singleton().ensureGPUProcessConnection();
 }
 
 bool RemoteCDMFactory::supportsKeySystem(const String& keySystem)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -61,7 +61,6 @@ public:
     virtual ~RemoteCDMFactory();
 
     static const char* supplementName();
-    WebProcess& process() const { return m_process; }
 
     GPUProcessConnection& gpuProcessConnection();
 
@@ -80,7 +79,6 @@ private:
 
     HashMap<RemoteCDMInstanceSessionIdentifier, WeakPtr<RemoteCDMInstanceSession>> m_sessions;
     HashMap<RemoteCDMIdentifier, std::unique_ptr<RemoteCDM>> m_cdms;
-    WebProcess& m_process;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -59,8 +59,7 @@ void RemoteImageDecoderAVFManager::deleteRemoteImageDecoder(const ImageDecoderId
         gpuProcessConnection->connection().send(Messages::RemoteImageDecoderAVFProxy::DeleteDecoder(identifier), 0);
 }
 
-RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager(WebProcess& process)
-    : m_process(process)
+RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager(WebProcess&)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h
@@ -74,7 +74,6 @@ private:
 
     HashMap<WebCore::ImageDecoderIdentifier, WeakPtr<RemoteImageDecoderAVF>> m_remoteImageDecoders;
 
-    WebProcess& m_process;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -41,8 +41,7 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess& process)
-    : m_process(process)
+RemoteLegacyCDMFactory::RemoteLegacyCDMFactory(WebProcess&)
 {
 }
 
@@ -73,7 +72,7 @@ const char* RemoteLegacyCDMFactory::supplementName()
 
 GPUProcessConnection& RemoteLegacyCDMFactory::gpuProcessConnection()
 {
-    return m_process.ensureGPUProcessConnection();
+    return WebProcess::singleton().ensureGPUProcessConnection();
 }
 
 bool RemoteLegacyCDMFactory::supportsKeySystem(const String& keySystem)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -67,7 +67,6 @@ public:
     void registerFactory();
 
     static const char* supplementName();
-    WebProcess& process() const { return m_process; }
 
     GPUProcessConnection& gpuProcessConnection();
 
@@ -85,7 +84,6 @@ private:
     HashMap<RemoteLegacyCDMIdentifier, WeakPtr<RemoteLegacyCDM>> m_cdms;
     HashMap<String, bool> m_supportsKeySystemCache;
     HashMap<std::pair<String, String>, bool> m_supportsKeySystemAndMimeTypeCache;
-    WebProcess& m_process;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp
@@ -40,8 +40,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-RemoteMediaEngineConfigurationFactory::RemoteMediaEngineConfigurationFactory(WebProcess& process)
-    : m_process(process)
+RemoteMediaEngineConfigurationFactory::RemoteMediaEngineConfigurationFactory(WebProcess&)
 {
 }
 
@@ -83,7 +82,7 @@ const char* RemoteMediaEngineConfigurationFactory::supplementName()
 
 GPUProcessConnection& RemoteMediaEngineConfigurationFactory::gpuProcessConnection()
 {
-    return m_process.ensureGPUProcessConnection();
+    return WebProcess::singleton().ensureGPUProcessConnection();
 }
 
 void RemoteMediaEngineConfigurationFactory::createDecodingConfiguration(MediaDecodingConfiguration&& configuration, MediaEngineConfigurationFactory::DecodingConfigurationCallback&& callback)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h
@@ -55,7 +55,6 @@ public:
     void registerFactory();
 
     static const char* supplementName();
-    WebProcess& process() const { return m_process; }
 
     GPUProcessConnection& gpuProcessConnection();
 
@@ -64,8 +63,6 @@ public:
 private:
     void createDecodingConfiguration(WebCore::MediaDecodingConfiguration&&, WebCore::MediaEngineConfigurationFactory::DecodingConfigurationCallback&&);
     void createEncodingConfiguration(WebCore::MediaEncodingConfiguration&&, WebCore::MediaEngineConfigurationFactory::EncodingConfigurationCallback&&);
-
-    WebProcess& m_process;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -102,8 +102,7 @@ private:
     RemoteMediaPlayerManager& m_manager;
 };
 
-RemoteMediaPlayerManager::RemoteMediaPlayerManager(WebProcess& process)
-    : m_process(process)
+RemoteMediaPlayerManager::RemoteMediaPlayerManager(WebProcess&)
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -55,7 +55,6 @@ public:
     ~RemoteMediaPlayerManager();
 
     static const char* supplementName();
-    WebProcess& parentProcess() const { return m_process; }
 
     void setUseGPUProcess(bool);
 
@@ -91,7 +90,6 @@ private:
     void clearMediaCacheForOrigins(WebCore::MediaPlayerEnums::MediaEngineIdentifier, const String&, const HashSet<WebCore::SecurityOriginData>&);
 
     HashMap<WebCore::MediaPlayerIdentifier, WeakPtr<MediaPlayerPrivateRemote>> m_players;
-    WebProcess& m_process;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp
@@ -38,14 +38,13 @@ namespace WebKit {
 
 using namespace WebCore;
 
-Ref<RemoteRemoteCommandListener> RemoteRemoteCommandListener::create(RemoteCommandListenerClient& client, WebProcess& webProcess)
+Ref<RemoteRemoteCommandListener> RemoteRemoteCommandListener::create(RemoteCommandListenerClient& client)
 {
-    return adoptRef(*new RemoteRemoteCommandListener(client, webProcess));
+    return adoptRef(*new RemoteRemoteCommandListener(client));
 }
 
-RemoteRemoteCommandListener::RemoteRemoteCommandListener(RemoteCommandListenerClient& client, WebProcess& webProcess)
+RemoteRemoteCommandListener::RemoteRemoteCommandListener(RemoteCommandListenerClient& client)
     : RemoteCommandListener(client)
-    , m_process(webProcess)
     , m_identifier(RemoteRemoteCommandListenerIdentifier::generate())
 {
     ensureGPUProcessConnection();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h
@@ -48,8 +48,8 @@ class RemoteRemoteCommandListener final
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&, WebProcess&);
-    RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&, WebProcess&);
+    static Ref<RemoteRemoteCommandListener> create(WebCore::RemoteCommandListenerClient&);
+    explicit RemoteRemoteCommandListener(WebCore::RemoteCommandListenerClient&);
     ~RemoteRemoteCommandListener();
 
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteRemoteCommandListener>::ref(); }
@@ -71,7 +71,6 @@ private:
 
     GPUProcessConnection& ensureGPUProcessConnection();
 
-    WebProcess& m_process;
     RemoteRemoteCommandListenerIdentifier m_identifier;
     WebCore::RemoteCommandListener::RemoteCommandsSet m_currentCommands;
     bool m_currentSupportSeeking { false };

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -41,16 +41,13 @@ namespace WebKit {
 
 using namespace WebCore;
 
-RemoteMediaSessionHelper::RemoteMediaSessionHelper(WebProcess& process)
-    : m_process(process)
-{
-}
+RemoteMediaSessionHelper::RemoteMediaSessionHelper() = default;
 
 IPC::Connection& RemoteMediaSessionHelper::ensureConnection()
 {
     auto gpuProcessConnection = m_gpuProcessConnection.get();
     if (!gpuProcessConnection) {
-        gpuProcessConnection = &m_process.ensureGPUProcessConnection();
+        gpuProcessConnection = &WebProcess::singleton().ensureGPUProcessConnection();
         m_gpuProcessConnection = gpuProcessConnection;
         gpuProcessConnection->addClient(*this);
         gpuProcessConnection->messageReceiverMap().addMessageReceiver(Messages::RemoteMediaSessionHelper::messageReceiverName(), *this);

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -41,7 +41,7 @@ class RemoteMediaSessionHelper final
     , public IPC::MessageReceiver
     , public GPUProcessConnection::Client {
 public:
-    RemoteMediaSessionHelper(WebProcess&);
+    RemoteMediaSessionHelper();
     virtual ~RemoteMediaSessionHelper() = default;
 
     IPC::Connection& ensureConnection();
@@ -71,7 +71,6 @@ private:
     // Messages
     void activeVideoRouteDidChange(SupportsAirPlayVideo, WebCore::MediaPlaybackTargetContext&&);
 
-    WebProcess& m_process;
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };
 

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -54,9 +54,8 @@ const char* WebGeolocationManager::supplementName()
 }
 
 WebGeolocationManager::WebGeolocationManager(WebProcess& process)
-    : m_process(process)
 {
-    m_process.addMessageReceiver(Messages::WebGeolocationManager::messageReceiverName(), *this);
+    process.addMessageReceiver(Messages::WebGeolocationManager::messageReceiverName(), *this);
 }
 
 WebGeolocationManager::~WebGeolocationManager() = default;
@@ -77,13 +76,13 @@ void WebGeolocationManager::registerWebPage(WebPage& page, const String& authori
     m_pageToRegistrableDomain.add(page, registrableDomain);
 
     if (!wasUpdating) {
-        m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StartUpdating(registrableDomain, page.webPageProxyIdentifier(), authorizationToken, needsHighAccuracy), 0);
+        WebProcess::singleton().parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StartUpdating(registrableDomain, page.webPageProxyIdentifier(), authorizationToken, needsHighAccuracy), 0);
         return;
     }
 
     bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
     if (highAccuracyWasEnabled != highAccuracyShouldBeEnabled)
-        m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+        WebProcess::singleton().parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
 }
 
 void WebGeolocationManager::unregisterWebPage(WebPage& page)
@@ -103,11 +102,11 @@ void WebGeolocationManager::unregisterWebPage(WebPage& page)
     pageSets.highAccuracyPageSet.remove(page);
 
     if (!isUpdating(pageSets))
-        m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StopUpdating(registrableDomain), 0);
+        WebProcess::singleton().parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StopUpdating(registrableDomain), 0);
     else {
         bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
         if (highAccuracyWasEnabled != highAccuracyShouldBeEnabled)
-            m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+            WebProcess::singleton().parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
     }
 
     if (pageSets.pageSet.isEmptyIgnoringNullReferences() && pageSets.highAccuracyPageSet.isEmptyIgnoringNullReferences())
@@ -135,7 +134,7 @@ void WebGeolocationManager::setEnableHighAccuracyForPage(WebPage& page, bool ena
 
     bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
     if (highAccuracyWasEnabled != isHighAccuracyEnabled(pageSets))
-        m_process.parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+        WebProcess::singleton().parentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
 }
 
 void WebGeolocationManager::didChangePosition(const WebCore::RegistrableDomain& registrableDomain, const GeolocationPositionData& position)

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h
@@ -74,7 +74,6 @@ private:
     bool isUpdating(const PageSets&) const;
     bool isHighAccuracyEnabled(const PageSets&) const;
 
-    WebProcess& m_process;
     HashMap<WebCore::RegistrableDomain, PageSets> m_pageSets;
     WeakHashMap<WebPage, WebCore::RegistrableDomain> m_pageToRegistrableDomain;
 };

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -98,10 +98,9 @@ const char* WebNotificationManager::supplementName()
 }
 
 WebNotificationManager::WebNotificationManager(WebProcess& process)
-    : m_process(process)
 {
 #if ENABLE(NOTIFICATIONS)
-    m_process.addMessageReceiver(Messages::WebNotificationManager::messageReceiverName(), *this);
+    process.addMessageReceiver(Messages::WebNotificationManager::messageReceiverName(), *this);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -84,8 +84,6 @@ private:
     void didCloseNotifications(const Vector<UUID>& notificationIDs);
     void didRemoveNotificationDecisions(const Vector<String>& originStrings);
 
-    WebProcess& m_process;
-
 #if ENABLE(NOTIFICATIONS)
     HashMap<UUID, WebCore::ScriptExecutionContextIdentifier> m_nonPersistentNotificationsContexts;
     HashMap<String, bool> m_permissionsMap;

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -39,8 +39,7 @@ namespace WebKit {
 using namespace WebCore;
 
 AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process)
-    : m_process(process)
-    , m_observer([this] (AudioSession& session) { session.setRoutingArbitrationClient(*this); })
+    : m_observer([this] (AudioSession& session) { session.setRoutingArbitrationClient(*this); })
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 {
     AudioSession::addAudioSessionChangedObserver(m_observer);
@@ -55,17 +54,17 @@ const char* AudioSessionRoutingArbitrator::supplementName()
 
 void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
-    m_process.parentProcessConnection()->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), AudioSessionRoutingArbitratorProxy::destinationId());
+    WebProcess::singleton().parentProcessConnection()->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), AudioSessionRoutingArbitratorProxy::destinationId());
 }
 
 void AudioSessionRoutingArbitrator::leaveRoutingAbritration()
 {
-    m_process.parentProcessConnection()->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
 }
 
 bool AudioSessionRoutingArbitrator::canLog() const
 {
-    return m_process.sessionID().isAlwaysOnLoggingAllowed();
+    return WebProcess::singleton().sessionID().isAlwaysOnLoggingAllowed();
 }
 
 }

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -55,7 +55,6 @@ private:
     const void* logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
-    WebProcess& m_process;
     WebCore::AudioSession::ChangedObserver m_observer;
     const void* m_logIdentifier;
 };

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -47,12 +47,11 @@ using namespace PAL;
 using namespace WebCore;
 
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
-    : m_process(process)
-    , m_audioFactory(*this)
+    : m_audioFactory(*this)
     , m_videoFactory(*this)
     , m_displayFactory(*this)
 {
-    m_process.addMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName(), *this);
+    process.addMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName(), *this);
 }
 
 UserMediaCaptureManager::~UserMediaCaptureManager()
@@ -60,7 +59,7 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
     RealtimeMediaSourceCenter::singleton().unsetAudioCaptureFactory(m_audioFactory);
     RealtimeMediaSourceCenter::singleton().unsetDisplayCaptureFactory(m_displayFactory);
     RealtimeMediaSourceCenter::singleton().unsetVideoCaptureFactory(m_videoFactory);
-    m_process.removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
+    WebProcess::singleton().removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
     m_remoteCaptureSampleManager.stopListeningForIPC();
 }
 

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -133,7 +133,6 @@ private:
 
     using Source = std::variant<std::nullptr_t, Ref<RemoteRealtimeAudioSource>, Ref<RemoteRealtimeVideoSource>>;
     HashMap<WebCore::RealtimeMediaSourceIdentifier, Source> m_sources;
-    WebProcess& m_process;
     NoOpCaptureDeviceManager m_noOpCaptureDeviceManager;
     AudioFactory m_audioFactory;
     VideoFactory m_videoFactory;

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -39,14 +39,13 @@ namespace WebKit {
 using namespace WebCore;
 
 UserMediaCaptureManager::UserMediaCaptureManager(WebProcess& process)
-    : m_process(process)
 {
-    m_process.addMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName(), *this);
+    process.addMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName(), *this);
 }
 
 UserMediaCaptureManager::~UserMediaCaptureManager()
 {
-    m_process.removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
+    WebProcess::singleton().removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
 }
 
 void UserMediaCaptureManager::validateUserMediaRequestConstraints(WebCore::MediaStreamRequest request, WebCore::MediaDeviceHashSalts&& deviceIdentifierHashSalts, ValidateUserMediaRequestConstraintsCallback&& completionHandler)

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -62,8 +62,6 @@ private:
 
     using GetMediaStreamDevicesCallback = CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>;
     void getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&&);
-
-    WebProcess& m_process;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### ca61c4e9a1033605f980bd6a33188e8bd5c08e5f
<pre>
Use WebProcess::singleton instead of unnecessarily storing a duplicate pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=257778">https://bugs.webkit.org/show_bug.cgi?id=257778</a>
rdar://110364959

Reviewed by Michael Catanzaro.

This reduces memory use.  I&apos;m not aware of any reason why we should store duplicate pointers
to a singleton object.  I&apos;m not aware of plans to make it not a singleton.

We need to still pass WebProcess&amp; as a parameter to functions called from the WebProcess constructor,
or we get infinite recursion in the singleton call.

* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.cpp:
(WebKit::RemoteAudioHardwareListener::create):
(WebKit::RemoteAudioHardwareListener::RemoteAudioHardwareListener):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioHardwareListener.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::create):
(WebKit::RemoteAudioSession::RemoteAudioSession):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::RemoteCDMFactory):
(WebKit::RemoteCDMFactory::gpuProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp:
(WebKit::RemoteImageDecoderAVFManager::RemoteImageDecoderAVFManager):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVFManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::RemoteLegacyCDMFactory):
(WebKit::RemoteLegacyCDMFactory::gpuProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.cpp:
(WebKit::RemoteMediaEngineConfigurationFactory::RemoteMediaEngineConfigurationFactory):
(WebKit::RemoteMediaEngineConfigurationFactory::gpuProcessConnection):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaEngineConfigurationFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::RemoteMediaPlayerManager):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
(WebKit::RemoteMediaPlayerManager::parentProcess const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.cpp:
(WebKit::RemoteRemoteCommandListener::create):
(WebKit::RemoteRemoteCommandListener::RemoteRemoteCommandListener):
* Source/WebKit/WebProcess/GPU/media/RemoteRemoteCommandListener.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::RemoteMediaSessionHelper):
(WebKit::RemoteMediaSessionHelper::ensureConnection):
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::WebGeolocationManager):
(WebKit::WebGeolocationManager::registerWebPage):
(WebKit::WebGeolocationManager::unregisterWebPage):
(WebKit::WebGeolocationManager::setEnableHighAccuracyForPage):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::WebNotificationManager::WebNotificationManager):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::transformHandlesToObjects):
(WebKit::WebProcess::setUseGPUProcessForMedia):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator):
(WebKit::AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory):
(WebKit::AudioSessionRoutingArbitrator::leaveRoutingAbritration):
(WebKit::AudioSessionRoutingArbitrator::canLog const):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::~UserMediaCaptureManager):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::transformHandlesToObjects):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::~UserMediaCaptureManager):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:

Canonical link: <a href="https://commits.webkit.org/265274@main">https://commits.webkit.org/265274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53f8362149d3fcf644940569cffd7d2e233e4034

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10026 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11493 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12493 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8792 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9610 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10048 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9206 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->