### PR TITLE
Reduce sizeof(ThreadSafeWeakPtr)

### DIFF
--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -34,9 +34,24 @@ namespace WTF {
 template<typename T, typename Type>
 class CompactRefPtrTuple final {
     WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(CompactRefPtrTuple);
 public:
     CompactRefPtrTuple() = default;
+
+    CompactRefPtrTuple(CompactRefPtrTuple<T, Type>&&) = default;
+    CompactRefPtrTuple& operator=(CompactRefPtrTuple<T, Type>&&) = default;
+
+    CompactRefPtrTuple(const CompactRefPtrTuple<T, Type>& other)
+    {
+        setPointer(other.pointer());
+        setType(other.type());
+    }
+    CompactRefPtrTuple& operator=(const CompactRefPtrTuple<T, Type>& other)
+    {
+        setPointer(other.pointer());
+        setType(other.type());
+        return *this;
+    }
+
     ~CompactRefPtrTuple()
     {
         WTF::DefaultRefDerefTraits<T>::derefIfNotNull(m_data.pointer());

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -2753,6 +2753,7 @@ std::atomic<size_t> ThreadSafeInstanceCounter::instanceCount;
 
 TEST(WTF_ThreadSafeWeakPtr, ThreadSafety)
 {
+    static_assert(sizeof(ThreadSafeWeakPtr<ThreadSafeInstanceCounter>) == sizeof(uint64_t));
     RefPtr counter = adoptRef(*new ThreadSafeInstanceCounter());
     ThreadSafeWeakPtr<ThreadSafeInstanceCounter> weakPtr(counter);
     EXPECT_NOT_NULL(weakPtr.get());


### PR DESCRIPTION
#### eba05d64b3a6f968503ccc46d52a99ae8f708143
<pre>
Reduce sizeof(ThreadSafeWeakPtr)
<a href="https://bugs.webkit.org/show_bug.cgi?id=257779">https://bugs.webkit.org/show_bug.cgi?id=257779</a>
rdar://110368849

Reviewed by NOBODY (OOPS!).

In 264919@main I made ThreadSafeWeakPtr keep two pointers to support multiple inheritance.
We need a pointer to the control block, but also a pointer to the object of the correct type.
This is needed because if you have A inherit from B, then casting an A* to a B* gives you a
different location in memory.  With multiple inheritance, the pointer to the object needs to
be stored in the smart pointer.

However, if we assume that our structures are less than 65kb, then the pointer can be reconstructed
from a base pointer which we already store in the control block and an offset that only requires
16 bits.  If you assume that the virtual address space will never be completely used (which we already
do for users of CompactRefPtrTuple) then you can store that offset in the same register as the pointer.

* Source/WTF/wtf/CompactRefPtrTuple.h:
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::makeStrongReferenceIfPossible const):
(WTF::ThreadSafeWeakPtrControlBlock::objectOffset):
(WTF::ThreadSafeWeakPtr::ThreadSafeWeakPtr):
(WTF::ThreadSafeWeakPtr::operator=):
(WTF::ThreadSafeWeakPtr::get const):
(WTF::ThreadSafeWeakPtr::controlBlockAndObjectOffset):
(WTF::ThreadSafeWeakPtr::controlBlock): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0603be123bfa37ca06a86272347b2124f961daa2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9097 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9320 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10269 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10985 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7570 "4 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15839 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7880 "Found 12 jsc stress test failures: wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.default-wasm, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-agressive-inline, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-air, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-b3, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq ...") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8668 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8520 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11840 "Passed tests") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8792 "Found 11 jsc stress test failures: wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.default-wasm, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-agressive-inline, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-air, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-b3, wasm.yaml/wasm/function-tests/memory-access-past-4gib.js.wasm-bbq ...") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9020 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7359 "13 flakes 3 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9357 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8249 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2973 "Failed to checkout and rebase branch from PR 14728") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12472 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9588 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8779 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2355 "Passed tests") | 
<!--EWS-Status-Bubble-End-->