### PR TITLE
[WebXR] Use WebCore type for framebuffer size.

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -51,24 +51,24 @@ public:
         bool stencil { false };
     };
 
-    static std::unique_ptr<WebXROpaqueFramebuffer> create(PlatformXR::LayerHandle, WebGLRenderingContextBase&, Attributes&&, uint32_t width, uint32_t height);
+    static std::unique_ptr<WebXROpaqueFramebuffer> create(PlatformXR::LayerHandle, WebGLRenderingContextBase&, Attributes&&, IntSize);
     ~WebXROpaqueFramebuffer();
 
     PlatformXR::LayerHandle handle() const { return m_handle; }
     const WebGLFramebuffer& framebuffer() const { return m_framebuffer.get(); }
-    uint32_t width() const { return m_width; }
-    uint32_t height() const { return m_height; }
+    GCGLint width() const { return m_framebufferSize.width(); }
+    GCGLint height() const { return m_framebufferSize.height(); }
 
     void startFrame(const PlatformXR::Device::FrameData::LayerData&);
     void endFrame();
 
 private:
-    WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, uint32_t width, uint32_t height);
+    WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, IntSize);
 
     bool setupFramebuffer();
-    PlatformGLObject allocateRenderbufferStorage(GraphicsContextGL&, GCGLsizei, GCGLenum, GCGLsizei, GCGLsizei);
-    PlatformGLObject allocateColorStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
-    std::tuple<PlatformGLObject, PlatformGLObject> allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
+    PlatformGLObject allocateRenderbufferStorage(GraphicsContextGL&, GCGLsizei, GCGLenum, IntSize);
+    PlatformGLObject allocateColorStorage(GraphicsContextGL&, GCGLsizei, IntSize);
+    std::tuple<PlatformGLObject, PlatformGLObject> allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, IntSize);
     void bindColorBuffer(GraphicsContextGL&, PlatformGLObject);
     void bindDepthStencilBuffer(GraphicsContextGL&, PlatformGLObject, PlatformGLObject);
 
@@ -76,8 +76,7 @@ private:
     Ref<WebGLFramebuffer> m_framebuffer;
     WebGLRenderingContextBase& m_context;
     Attributes m_attributes;
-    uint32_t m_width { 0 };
-    uint32_t m_height { 0 };
+    IntSize m_framebufferSize;
     GCGLOwnedRenderbuffer m_depthStencilBuffer;
     GCGLOwnedRenderbuffer m_stencilBuffer;
     GCGLOwnedRenderbuffer m_multisampleColorBuffer;

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -64,16 +64,15 @@ static ExceptionOr<std::unique_ptr<WebXROpaqueFramebuffer>> createOpaqueFramebuf
 
     float scaleFactor = std::clamp(init.framebufferScaleFactor, MinFramebufferScalingFactor, device->maxFramebufferScalingFactor());
 
-    IntSize recommendedSize = session.recommendedWebGLFramebufferResolution();
-    auto width = static_cast<uint32_t>(std::ceil(recommendedSize.width() * scaleFactor));
-    auto height = static_cast<uint32_t>(std::ceil(recommendedSize.height() * scaleFactor));
+    FloatSize recommendedSize = session.recommendedWebGLFramebufferResolution();
+    IntSize size = expandedIntSize(recommendedSize.scaled(scaleFactor));
 
     // 9.3. Initialize layer’s framebuffer to a new opaque framebuffer with the dimensions framebufferSize
     //      created with context, session initialized to session, and layerInit’s depth, stencil, and alpha values.
     // 9.4. Allocate and initialize resources compatible with session’s XR device, including GPU accessible memory buffers,
     //      as required to support the compositing of layer.
     // 9.5. If layer’s resources were unable to be created for any reason, throw an OperationError and abort these steps.
-    auto layerHandle = device->createLayerProjection(width, height, init.alpha);
+    auto layerHandle = device->createLayerProjection(size.width(), size.height(), init.alpha);
     if (!layerHandle)
         return Exception { OperationError, "Unable to allocate XRWebGLLayer GPU resources."_s };
 
@@ -84,7 +83,7 @@ static ExceptionOr<std::unique_ptr<WebXROpaqueFramebuffer>> createOpaqueFramebuf
         .stencil = init.stencil
     };
 
-    auto framebuffer = WebXROpaqueFramebuffer::create(*layerHandle, context, WTFMove(attributes), width, height);
+    auto framebuffer = WebXROpaqueFramebuffer::create(*layerHandle, context, WTFMove(attributes), size);
     if (!framebuffer)
         return Exception { OperationError, "Unable to create a framebuffer."_s };
     


### PR DESCRIPTION
#### 2ef6856abf7b164414faa05f88d511caf7913e8c
<pre>
[WebXR] Use WebCore type for framebuffer size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257781">https://bugs.webkit.org/show_bug.cgi?id=257781</a>
rdar://problem/110377022

Reviewed by Kimmo Kinnunen.

WebXRWebGLLayer converts the IntSize representing the framebuffer dimensions
into seperate width and height values, as well as converting signed to unsigned
integer, when scaling the dimensions to accommodate DPI.

This patch uses the WebCore type IntSize to store the framebuffer dimensions
instead of separate width &amp; height and keeps the values as signed integers.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::create):
(WebCore::WebXROpaqueFramebuffer::WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::allocateRenderbufferStorage):
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):
(WebCore::WebXROpaqueFramebuffer::allocateDepthStencilStorage):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
(WebCore::WebXROpaqueFramebuffer::width const):
(WebCore::WebXROpaqueFramebuffer::height const):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::createOpaqueFramebuffer):

Canonical link: <a href="https://commits.webkit.org/264966@main">https://commits.webkit.org/264966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/060864dfbe2f07b7556f16846336e41d7d40ea2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9805 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10958 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10374 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11117 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8481 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2251 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->