### PR TITLE
Use "enum class" instead of plain enum for ThemeTypes

### DIFF
--- a/Source/WebCore/platform/ThemeTypes.cpp
+++ b/Source/WebCore/platform/ThemeTypes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +33,8 @@ namespace WebCore {
 TextStream& operator<<(TextStream& ts, SelectionPart selectionPart)
 {
     switch (selectionPart) {
-    case SelectionBackground: ts << "selection-background"; break;
-    case SelectionForeground: ts << "selection-foreground"; break;
+    case SelectionPart::Background: ts << "selection-background"; break;
+    case SelectionPart::Foreground: ts << "selection-foreground"; break;
     }
     return ts;
 }
@@ -42,15 +42,15 @@ TextStream& operator<<(TextStream& ts, SelectionPart selectionPart)
 TextStream& operator<<(TextStream& ts, ThemeFont themeFont)
 {
     switch (themeFont) {
-    case CaptionFont: ts << "caption-font"; break;
-    case IconFont: ts << "icon-font"; break;
-    case MenuFont: ts << "menu-font"; break;
-    case MessageBoxFont: ts << "messagebox-font"; break;
-    case SmallCaptionFont: ts << "small-caption-font"; break;
-    case StatusBarFont: ts << "statusbar-font"; break;
-    case MiniControlFont: ts << "minicontrol-font"; break;
-    case SmallControlFont: ts << "small-control-font"; break;
-    case ControlFont: ts << "control-font"; break;
+    case ThemeFont::CaptionFont: ts << "caption-font"; break;
+    case ThemeFont::IconFont: ts << "icon-font"; break;
+    case ThemeFont::MenuFont: ts << "menu-font"; break;
+    case ThemeFont::MessageBoxFont: ts << "messagebox-font"; break;
+    case ThemeFont::SmallCaptionFont: ts << "small-caption-font"; break;
+    case ThemeFont::StatusBarFont: ts << "statusbar-font"; break;
+    case ThemeFont::MiniControlFont: ts << "minicontrol-font"; break;
+    case ThemeFont::SmallControlFont: ts << "small-control-font"; break;
+    case ThemeFont::ControlFont: ts << "control-font"; break;
     }
     return ts;
 }
@@ -58,42 +58,42 @@ TextStream& operator<<(TextStream& ts, ThemeFont themeFont)
 TextStream& operator<<(TextStream& ts, ThemeColor themeColor)
 {
     switch (themeColor) {
-    case ActiveBorderColor: ts << "active-border-color"; break;
-    case ActiveCaptionColor: ts << "active-caption-color"; break;
-    case ActiveTextColor: ts << "active-text-color"; break;
-    case AppWorkspaceColor: ts << "app-workspace-color"; break;
-    case BackgroundColor: ts << "background-color"; break;
-    case ButtonFaceColor: ts << "button-face-color"; break;
-    case ButtonHighlightColor: ts << "button-highlight-color"; break;
-    case ButtonShadowColor: ts << "button-shadow-color"; break;
-    case ButtonTextColor: ts << "button-text-color"; break;
-    case CanvasColor: ts << "canvas-color"; break;
-    case CanvasTextColor: ts << "canvas-text-color"; break;
-    case CaptionTextColor: ts << "caption-text-color"; break;
-    case FieldColor: ts << "field-color"; break;
-    case FieldTextColor: ts << "field-text-color"; break;
-    case GrayTextColor: ts << "gray-text-color"; break;
-    case HighlightColor: ts << "highlight-color"; break;
-    case HighlightTextColor: ts << "highlight-text-color"; break;
-    case InactiveBorderColor: ts << "inactive-border-color"; break;
-    case InactiveCaptionColor: ts << "inactive-caption-color"; break;
-    case InactiveCaptionTextColor: ts << "inactive-caption-text-color"; break;
-    case InfoBackgroundColor: ts << "info-background-color"; break;
-    case InfoTextColor: ts << "info-text-color"; break;
-    case LinkTextColor: ts << "link-text-color"; break;
-    case MatchColor: ts << "match-color"; break;
-    case MenuTextColor: ts << "menu-text-color"; break;
-    case ScrollbarColor: ts << "scrollbar-color"; break;
-    case ThreeDDarkShadowColor: ts << "threeD-dark-shadow-color"; break;
-    case ThreeDFaceColor: ts << "threeD-face-color"; break;
-    case ThreeDHighlightColor: ts << "threeD-highlight-color"; break;
-    case ThreeDLightShadowColor: ts << "threeD-light-shadow-color"; break;
-    case ThreeDShadowColor: ts << "threeD-shadow-color"; break;
-    case VisitedTextColor: ts << "visited-text-color"; break;
-    case WindowColor: ts << "window-color"; break;
-    case WindowFrameColor: ts << "window-frame-color"; break;
-    case WindowTextColor: ts << "window-text-color"; break;
-    case FocusRingColor: ts << "focus-ring-color"; break;
+    case ThemeColor::ActiveBorderColor: ts << "active-border-color"; break;
+    case ThemeColor::ActiveCaptionColor: ts << "active-caption-color"; break;
+    case ThemeColor::ActiveTextColor: ts << "active-text-color"; break;
+    case ThemeColor::AppWorkspaceColor: ts << "app-workspace-color"; break;
+    case ThemeColor::BackgroundColor: ts << "background-color"; break;
+    case ThemeColor::ButtonFaceColor: ts << "button-face-color"; break;
+    case ThemeColor::ButtonHighlightColor: ts << "button-highlight-color"; break;
+    case ThemeColor::ButtonShadowColor: ts << "button-shadow-color"; break;
+    case ThemeColor::ButtonTextColor: ts << "button-text-color"; break;
+    case ThemeColor::CanvasColor: ts << "canvas-color"; break;
+    case ThemeColor::CanvasTextColor: ts << "canvas-text-color"; break;
+    case ThemeColor::CaptionTextColor: ts << "caption-text-color"; break;
+    case ThemeColor::FieldColor: ts << "field-color"; break;
+    case ThemeColor::FieldTextColor: ts << "field-text-color"; break;
+    case ThemeColor::GrayTextColor: ts << "gray-text-color"; break;
+    case ThemeColor::HighlightColor: ts << "highlight-color"; break;
+    case ThemeColor::HighlightTextColor: ts << "highlight-text-color"; break;
+    case ThemeColor::InactiveBorderColor: ts << "inactive-border-color"; break;
+    case ThemeColor::InactiveCaptionColor: ts << "inactive-caption-color"; break;
+    case ThemeColor::InactiveCaptionTextColor: ts << "inactive-caption-text-color"; break;
+    case ThemeColor::InfoBackgroundColor: ts << "info-background-color"; break;
+    case ThemeColor::InfoTextColor: ts << "info-text-color"; break;
+    case ThemeColor::LinkTextColor: ts << "link-text-color"; break;
+    case ThemeColor::MatchColor: ts << "match-color"; break;
+    case ThemeColor::MenuTextColor: ts << "menu-text-color"; break;
+    case ThemeColor::ScrollbarColor: ts << "scrollbar-color"; break;
+    case ThemeColor::ThreeDDarkShadowColor: ts << "threeD-dark-shadow-color"; break;
+    case ThemeColor::ThreeDFaceColor: ts << "threeD-face-color"; break;
+    case ThemeColor::ThreeDHighlightColor: ts << "threeD-highlight-color"; break;
+    case ThemeColor::ThreeDLightShadowColor: ts << "threeD-light-shadow-color"; break;
+    case ThemeColor::ThreeDShadowColor: ts << "threeD-shadow-color"; break;
+    case ThemeColor::VisitedTextColor: ts << "visited-text-color"; break;
+    case ThemeColor::WindowColor: ts << "window-color"; break;
+    case ThemeColor::WindowFrameColor: ts << "window-frame-color"; break;
+    case ThemeColor::WindowTextColor: ts << "window-text-color"; break;
+    case ThemeColor::FocusRingColor: ts << "focus-ring-color"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/ThemeTypes.h
+++ b/Source/WebCore/platform/ThemeTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008, 2009, 2010 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,12 +33,12 @@ class TextStream;
 
 namespace WebCore {
 
-enum SelectionPart {
-    SelectionBackground,
-    SelectionForeground
+enum class SelectionPart : bool {
+    Background,
+    Foreground
 };
 
-enum ThemeFont {
+enum class ThemeFont : uint8_t {
     CaptionFont,
     IconFont,
     MenuFont,
@@ -50,7 +50,7 @@ enum ThemeFont {
     ControlFont
 };
 
-enum ThemeColor {
+enum class ThemeColor : uint8_t {
     ActiveBorderColor,
     ActiveCaptionColor,
     ActiveTextColor,


### PR DESCRIPTION
#### fea0e1d56ed57b95191a9a593e0cd7a6e8b2c975
<pre>
Use &quot;enum class&quot; instead of plain enum for ThemeTypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257784">https://bugs.webkit.org/show_bug.cgi?id=257784</a>
rdar://110378475

Reviewed by Youenn Fablet.

* Source/WebCore/platform/ThemeTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ThemeTypes.h

Canonical link: <a href="https://commits.webkit.org/264939@main">https://commits.webkit.org/264939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af2befb3e4f3ea4a63013b1dc9ab1f14fa287704

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10852 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10291 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11008 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15855 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11862 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9039 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8265 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2231 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->