### PR TITLE
[GStreamer][WebCodecs] Rebaseline following 264881@main

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1137,18 +1137,6 @@ webkit.org/b/239750 media/media-source/media-mp4-xhe-aac.html [ Skip ]
 media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?av [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_avc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp8 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p0 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?vp9_p2 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?av1 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h264_avc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp8 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p0 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?vp9_p2 [ Failure ]
 
 # Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
-FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 10
+FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 10
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
-FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
-FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+FAIL Encoding and decoding cycle assert_equals: frames_decoded expected 16 but got 10
+FAIL Encoding and decoding cycle w/ stripped color space assert_equals: frames_decoded expected 16 but got 10
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle assert_not_equals: colorSpace.primaries got disallowed value null
-FAIL Encoding and decoding cycle w/ stripped color space assert_not_equals: colorSpace.primaries got disallowed value null
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -1,0 +1,9 @@
+
+
+FAIL <video> and VideoFrame constructed VideoFrame assert_equals: top left corner expected "Yellow" but got "#ffdd13ff"
+PASS CSSImageValue constructed VideoFrame
+PASS Image element constructed VideoFrame
+PASS SVGImageElement constructed VideoFrame
+PASS Canvas element constructed VideoFrame
+PASS Copy of canvas element constructed VideoFrame
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Test we can construct a VideoFrame.
-FAIL Test closed VideoFrame. assert_equals: timestamp expected 10 but got 0
+FAIL Test closed VideoFrame. null is not an object (evaluating 'frame.colorSpace.primaries')
 PASS Test we can construct a VideoFrame with a negative timestamp.
 PASS Test that timestamp is required when constructing VideoFrame from ImageBitmap
 PASS Test that timestamp is required when constructing VideoFrame from OffscreenCanvas

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -108,7 +108,7 @@ void GStreamerVideoEncoder::create(const String& codecName, const VideoEncoder::
 
             VideoEncoder::ActiveConfiguration configuration;
             // FIXME: How to properly fill configuration.colorspace?
-            configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Bt709, PlatformVideoTransferCharacteristics::Iec6196621, PlatformVideoMatrixCoefficients::Smpte170m, false };
+            configuration.colorSpace = PlatformVideoColorSpace { PlatformVideoColorPrimaries::Smpte170m, PlatformVideoTransferCharacteristics::Smpte170m, PlatformVideoMatrixCoefficients::Smpte170m, false };
             descriptionCallback(WTFMove(configuration));
         });
     });


### PR DESCRIPTION
#### d3625eb06e387247f2fe998ab9ab33888ee74c33
<pre>
[GStreamer][WebCodecs] Rebaseline following 264881@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=257787">https://bugs.webkit.org/show_bug.cgi?id=257787</a>

Reviewed by Xabier Rodriguez-Calvar.

Reconfigure the encoder colorimetry to match what the WPT tests expect. Ideally we should perform a
video conversion matching the requested colorimetry before encoding, but this is for another time.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_av1-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_vp9_p2-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_av1-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_vp9_p2-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any.worker_av1-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/reconfiguring-encoder.https.any_av1-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker_av1-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any_av1-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::create):

Canonical link: <a href="https://commits.webkit.org/264982@main">https://commits.webkit.org/264982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b7864bb6a2fb0653df160c3026a44d1853137a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12107 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10418 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11167 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8528 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15968 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8386 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->