### PR TITLE
[WPE][Tools] cross-toolchain-helper: Add a RISCV64 target

### DIFF
--- a/Tools/yocto/riscv/bblayers.conf
+++ b/Tools/yocto/riscv/bblayers.conf
@@ -1,0 +1,20 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  %(BSPDIR)s/sources/poky/meta \
+  %(BSPDIR)s/sources/poky/meta-poky \
+  %(BSPDIR)s/sources/poky/meta-yocto-bsp \
+  %(BSPDIR)s/sources/meta-openembedded/meta-multimedia \
+  %(BSPDIR)s/sources/meta-openembedded/meta-networking \
+  %(BSPDIR)s/sources/meta-openembedded/meta-oe \
+  %(BSPDIR)s/sources/meta-openembedded/meta-perl \
+  %(BSPDIR)s/sources/meta-openembedded/meta-python \
+  %(BSPDIR)s/sources/meta-openembedded/meta-webserver \
+  %(BSPDIR)s/sources/meta-webkit \
+  %(BSPDIR)s/sources/meta-riscv \
+  "

--- a/Tools/yocto/riscv/fix-nativesdk-image-defs.patch
+++ b/Tools/yocto/riscv/fix-nativesdk-image-defs.patch
@@ -1,0 +1,85 @@
+diff --git a/sources/poky/meta/recipes-devtools/python/python3-markdown_3.4.1.bb b/sources/poky/meta/recipes-devtools/python/python3-markdown_3.4.1.bb
+index e99c3310ac..b398cd8bc4 100644
+--- a/sources/poky/meta/recipes-devtools/python/python3-markdown_3.4.1.bb
++++ b/sources/poky/meta/recipes-devtools/python/python3-markdown_3.4.1.bb
+@@ -8,6 +8,6 @@ inherit pypi python_setuptools_build_meta
+ PYPI_PACKAGE = "Markdown"
+ SRC_URI[sha256sum] = "3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff"
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+ 
+ RDEPENDS:${PN} += "${PYTHON_PN}-logging ${PYTHON_PN}-setuptools"
+diff --git a/sources/poky/meta/recipes-devtools/python/python3-smartypants_2.0.0.bb b/sources/poky/meta/recipes-devtools/python/python3-smartypants_2.0.0.bb
+index 05c94c390f..d089a89b95 100644
+--- a/sources/poky/meta/recipes-devtools/python/python3-smartypants_2.0.0.bb
++++ b/sources/poky/meta/recipes-devtools/python/python3-smartypants_2.0.0.bb
+@@ -9,6 +9,6 @@ PYPI_PACKAGE = "smartypants"
+ SRC_URI += "file://0001-Change-hash-bang-to-python3.patch"
+ SRC_URI[sha256sum] = "7812353a32022699a1aa8cd5626e01c94a946dcaeedaee2d0b382bae4c4cbf36"
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+ 
+ UPSTREAM_CHECK_REGEX = "/${PYPI_PACKAGE}/(?P<pver>(?!2\.0\.1)(\d+[\.\-_]*)+)/"
+diff --git a/sources/poky/meta/recipes-devtools/python/python3-typogrify_2.0.7.bb b/sources/poky/meta/recipes-devtools/python/python3-typogrify_2.0.7.bb
+index 83e9b5eadb..826f126ad9 100644
+--- a/sources/poky/meta/recipes-devtools/python/python3-typogrify_2.0.7.bb
++++ b/sources/poky/meta/recipes-devtools/python/python3-typogrify_2.0.7.bb
+@@ -8,7 +8,7 @@ inherit pypi setuptools3
+ PYPI_PACKAGE = "typogrify"
+ SRC_URI[sha256sum] = "8be4668cda434163ce229d87ca273a11922cb1614cb359970b7dc96eed13cb38"
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+ 
+ RDEPENDS:${PN} += "${PYTHON_PN}-smartypants"
+ 
+diff --git a/sources/poky/meta/recipes-devtools/ruby/ruby_3.1.3.bb b/sources/poky/meta/recipes-devtools/ruby/ruby_3.1.3.bb
+index c8454da3a9..85d6184a04 100644
+--- a/sources/poky/meta/recipes-devtools/ruby/ruby_3.1.3.bb
++++ b/sources/poky/meta/recipes-devtools/ruby/ruby_3.1.3.bb
+@@ -15,6 +15,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=5b8c87559868796979806100db3f3805 \
+ 
+ DEPENDS = "zlib openssl libyaml gdbm readline libffi"
+ DEPENDS:append:class-target = " ruby-native"
++DEPENDS:append:class-nativesdk = " ruby-native"
+ 
+ SHRT_VER = "${@oe.utils.trim_version("${PV}", 2)}"
+ SRC_URI = "http://cache.ruby-lang.org/pub/ruby/${SHRT_VER}/ruby-${PV}.tar.gz \
+@@ -139,4 +140,4 @@ FILES:${PN}-ptest:append:class-target = "\
+     ${libdir}/ruby/${SHRT_VER}.0/*/-test- \
+ "
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+diff --git a/sources/poky/meta/recipes-devtools/unifdef/unifdef_2.12.bb b/sources/poky/meta/recipes-devtools/unifdef/unifdef_2.12.bb
+index b42051b8b6..3e08b3a0a4 100644
+--- a/sources/poky/meta/recipes-devtools/unifdef/unifdef_2.12.bb
++++ b/sources/poky/meta/recipes-devtools/unifdef/unifdef_2.12.bb
+@@ -18,4 +18,4 @@ do_install() {
+ 	oe_runmake install DESTDIR=${D} prefix=${prefix}
+ }
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+diff --git a/sources/poky/meta/recipes-extended/gperf/gperf_3.1.bb b/sources/poky/meta/recipes-extended/gperf/gperf_3.1.bb
+index c9f09c7931..4c32a5dc83 100644
+--- a/sources/poky/meta/recipes-extended/gperf/gperf_3.1.bb
++++ b/sources/poky/meta/recipes-extended/gperf/gperf_3.1.bb
+@@ -17,4 +17,4 @@ inherit autotools
+ # it where to look explicitly (mirroring the behaviour of upstream's Makefile.devel).
+ EXTRA_AUTORECONF += " -I ${S} --exclude=aclocal"
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+diff --git a/sources/poky/meta/recipes-gnome/gi-docgen/gi-docgen_git.bb b/sources/poky/meta/recipes-gnome/gi-docgen/gi-docgen_git.bb
+index 6a7124c3fe..000bc697a3 100644
+--- a/sources/poky/meta/recipes-gnome/gi-docgen/gi-docgen_git.bb
++++ b/sources/poky/meta/recipes-gnome/gi-docgen/gi-docgen_git.bb
+@@ -19,4 +19,4 @@ inherit setuptools3
+ 
+ RDEPENDS:${PN} += "python3-asyncio python3-core python3-jinja2 python3-json python3-markdown python3-markupsafe python3-pygments python3-toml python3-typogrify python3-xml"
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"

--- a/Tools/yocto/riscv/local-qemu-riscv64.conf
+++ b/Tools/yocto/riscv/local-qemu-riscv64.conf
@@ -1,0 +1,42 @@
+## -------------------------------------
+## General distro settings below
+## -------------------------------------
+
+# Default help comments were removed to make this file shorter. If you are interested, check:
+# https://git.yoctoproject.org/poky/plain/meta-poky/conf/templates/default/local.conf.sample
+#
+# Check also the README.md file on this repository in the directory: Tools/yocto
+#
+
+# Distro and build base settings
+DISTRO = "webkitdevci"
+PACKAGE_CLASSES ?= "package_rpm"
+USER_CLASSES ?= "buildstats"
+PATCHRESOLVE = "noop"
+BB_DISKMON_DIRS ??= "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
+CONF_VERSION = "2"
+
+# Uncomment this to have debug symbols for libraries (-dbg packages) installed by default
+#EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+## -------------------------------------
+## Specific machine config options below
+## -------------------------------------
+
+## For documentation about this value and defaults suggested check:
+## https://github.com/Igalia/meta-webkit/wiki/RPi
+
+# Machine selection
+MACHINE = "qemuriscv64"
+
+# WPE Backend selection
+PREFERRED_PROVIDER_virtual/wpebackend = "wpebackend-fdo"
+

--- a/Tools/yocto/riscv/manifest.xml
+++ b/Tools/yocto/riscv/manifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <default sync-j="4"/>
+
+  <remote fetch="https://git.openembedded.org/" name="oe"/>
+  <remote fetch="https://git.yoctoproject.org/git/" name="yocto"/>
+  <remote fetch="https://github.com" name="github"/>
+
+  <!-- Yocto version: langdale -->
+
+  <project remote="yocto"  revision="965c2ec095267c917bac66880b14884b399943ce" name="poky" path="sources/poky"/>
+  <project remote="github" revision="b4ff73905b887cf7c489248de80dab2721090cbf" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="github" revision="d5628ffd5adadb879dee96b3beb076ca2abfcf6d" name="riscv/meta-riscv" path="sources/meta-riscv"/>
+  <project remote="github" revision="18e5909021ba6aa1b3e428719abac08ddcd74691" name="Igalia/meta-webkit.git" path="sources/meta-webkit"/>
+
+</manifest>

--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -79,3 +79,12 @@ patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
+
+[qemu-riscv64]
+repo_manifest_path = riscv/manifest.xml
+conf_bblayers_path = riscv/bblayers.conf
+conf_local_path = riscv/local-qemu-riscv64.conf
+patch_file_path = riscv/fix-nativesdk-image-defs.patch
+image_basename = webkit-dev-ci-tools
+image_types = tar.xz wic.xz wic.bmap
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### efa0c0b68c2aeb85977e6514481e3c7aeac68f4d
<pre>
[WPE][Tools] cross-toolchain-helper: Add a RISCV64 target
<a href="https://bugs.webkit.org/show_bug.cgi?id=257789">https://bugs.webkit.org/show_bug.cgi?id=257789</a>

Reviewed by Philippe Normand.

This adds a qemu-riscv64 target that can be used to easily
cross-build for RISCV64. This will help with developing
the port. Once a popular RISCV64 board is out we can
replace the qemu target with that one.

To test this simply pass the flag --cross-target=qemu-riscv64
to the script build-webkit

* Tools/yocto/riscv/bblayers.conf: Added.
* Tools/yocto/riscv/fix-nativesdk-image-defs.patch: Added.
* Tools/yocto/riscv/local-qemuriscv64.conf: Added.
* Tools/yocto/riscv/manifest.xml: Added.
* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/265390@main">https://commits.webkit.org/265390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5f073bca450898f1f8339ccb74fc2fbe5bbb357

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15857 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12491 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1213 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->