### PR TITLE
ThreadSafeObjectHeap lacks add and remove operations

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -592,7 +592,7 @@ void GPUConnectionToWebProcess::releaseRenderingBackend(RenderingBackendIdentifi
 
 void GPUConnectionToWebProcess::releaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier identifier)
 {
-    m_remoteSerializedImageBufferObjectHeap.retireRemove({ { identifier, 0 }, 0 });
+    m_remoteSerializedImageBufferObjectHeap.remove({ { identifier, 0 }, 0 });
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -92,18 +92,17 @@ void RemoteVideoFrameObjectHeap::close()
 
 RemoteVideoFrameProxy::Properties RemoteVideoFrameObjectHeap::add(Ref<WebCore::VideoFrame>&& frame)
 {
-    auto write = RemoteVideoFrameWriteReference::generateForAdd();
-    auto newFrameReference = write.retiredReference();
-    auto properties = RemoteVideoFrameProxy::properties(WTFMove(newFrameReference), frame);
-    m_heap.retire(WTFMove(write), WTFMove(frame), std::nullopt);
+    auto newFrameReference = RemoteVideoFrameReference::generateForAdd();
+    auto properties = RemoteVideoFrameProxy::properties(newFrameReference, frame);
+    auto success = m_heap.add(newFrameReference, WTFMove(frame));
+    ASSERT_UNUSED(success, success);
     return properties;
 }
 
 void RemoteVideoFrameObjectHeap::releaseVideoFrame(RemoteVideoFrameWriteReference&& write)
 {
     assertIsCurrent(remoteVideoFrameObjectHeapQueue());
-
-    m_heap.retireRemove(WTFMove(write));
+    m_heap.remove(WTFMove(write));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm
@@ -35,7 +35,7 @@ namespace WebKit {
 
 RefPtr<WebCore::VideoFrame> RemoteVideoFrameObjectHeap::get(RemoteVideoFrameReadReference&& read)
 {
-    return m_heap.retire(WTFMove(read), 0_s);
+    return m_heap.read(WTFMove(read), 0_s);
 }
 
 void RemoteVideoFrameObjectHeap::createPixelConformerIfNeeded()

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h
@@ -51,6 +51,8 @@ public:
     }
     T identifier() const { return m_identifier; }
     uint64_t version() const { return m_version; }
+    static ObjectIdentifierReference<T> generateForAdd() { return { T::generate(), 0 }; }
+
     bool operator==(const ObjectIdentifierReference& other) const
     {
         return other.m_identifier == m_identifier && other.m_version == m_version;
@@ -112,7 +114,6 @@ template<typename T>
 class ObjectIdentifierWriteReference {
 public:
     using Reference = ObjectIdentifierReference<T>;
-    static ObjectIdentifierWriteReference<T> generateForAdd() { return { { T::generate(), 0 }, 0 }; }
 
     ObjectIdentifierWriteReference(Reference reference, uint64_t pendingReads)
         : m_reference(reference)
@@ -175,6 +176,10 @@ public:
     WriteReference write() const
     {
         return { { m_identifier, m_version++ }, m_pendingReads.exchange(0) };
+    }
+    Reference add() const
+    {
+        return { m_identifier, m_version };
     }
     T identifier() const
     {

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -42,7 +42,7 @@
 
 namespace WebKit {
 
-RemoteVideoFrameProxy::Properties RemoteVideoFrameProxy::properties(WebKit::RemoteVideoFrameReference&& reference, const WebCore::VideoFrame& videoFrame)
+RemoteVideoFrameProxy::Properties RemoteVideoFrameProxy::properties(WebKit::RemoteVideoFrameReference reference, const WebCore::VideoFrame& videoFrame)
 {
     return {
         WTFMove(reference),

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h
@@ -69,7 +69,7 @@ public:
         template<typename Decoder> static std::optional<Properties> decode(Decoder&);
     };
 
-    static Properties properties(WebKit::RemoteVideoFrameReference&&, const WebCore::VideoFrame&);
+    static Properties properties(WebKit::RemoteVideoFrameReference, const WebCore::VideoFrame&);
 
     static Ref<RemoteVideoFrameProxy> create(IPC::Connection&, RemoteVideoFrameObjectHeapProxy&, Properties&&);
 


### PR DESCRIPTION
#### ecb76a449ffa26cb4da089afe4ee8d7ba90f13a9
<pre>
ThreadSafeObjectHeap lacks add and remove operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257647">https://bugs.webkit.org/show_bug.cgi?id=257647</a>
rdar://110169358

Reviewed by Youenn Fablet.

Before, writing to ThreadSafeObjectHeap was intended to use the
retire(WriteReference, optional&lt;T&gt;, optional&lt;Timeout&gt;). The heap also
was intended to support copy-on-write or overwriting non-depending
update scenarios where an overwriting write could skip ahead the
earlier, non-processed reads and writes.

For example, receiving following sequence with reads omitted:
 write version=0, &quot;1&quot;    (sequence x)
 write version=1, &quot;abc&quot;  (sequence y)
 write version=2, &quot;abcd&quot; (sequence y)

In case of overwriting, non-depending writes, sequence y could proceed
first and insert version 1 and then subsequently version 2. Inserting
version 1 would insert a final read marker for version 0, which would be
noticed by eventual sequence x inserting first version 0. Upon
inserting version 0, the insert would be skipped as that version was
already overwritten.

However, since there was no distinction between &quot;write&quot; and &quot;initial
write&quot;, the final read marker would be needed for inserting any object,
including the initial insert. This in turn would mean that the heap
would be leaking the final read marker for the initial insertion.

Instead, change the API to &quot;add&quot;, &quot;get&quot;, &quot;read&quot;, &quot;take&quot;, &quot;remove&quot;. These
are more intuitive with the use-cases. Each write must naturally remove
the instance from the heap for the duration of the update, as would
de-facto happen in non-overwriting write also previously. Non-blocking
remove and add can be used for overwriting write until more performance
is needed.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::releaseSerializedImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::moveToSerializedBuffer):
(WebKit::RemoteRenderingBackend::moveToImageBuffer):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::add):
(WebKit::RemoteVideoFrameObjectHeap::releaseVideoFrame):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.mm:
(WebKit::RemoteVideoFrameObjectHeap::get):
* Source/WebKit/Platform/IPC/ObjectIdentifierReferenceTracker.h:
(IPC::ObjectIdentifierReference::generateForAdd):
(IPC::ObjectIdentifierReferenceTracker::add const):
(IPC::ObjectIdentifierWriteReference::generateForAdd): Deleted.
* Source/WebKit/Platform/IPC/ThreadSafeObjectHeap.h:
(IPC::ThreadSafeObjectHeap::ReferenceState::ReferenceState):
(IPC::HeldType&gt;::add):
(IPC::HeldType&gt;::get):
(IPC::HeldType&gt;::read):
(IPC::HeldType&gt;::remove):
(IPC::HeldType&gt;::sizeForTesting const):
(IPC::HeldType&gt;::retire): Deleted.
(IPC::HeldType&gt;::retireRemove): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
(WebKit::RemoteVideoFrameProxy::properties):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.h:
* Tools/TestWebKitAPI/Tests/IPC/ThreadSafeObjectHeapTests.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/265063@main">https://commits.webkit.org/265063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60a6ed634666b496dffcc9a17499621f46160953

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9324 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12232 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11322 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16070 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12136 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7553 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8490 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2326 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->