### PR TITLE
[WGSL] Initial support for packing and unpacking values on assignment

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -55,22 +55,25 @@ public:
     Identifier& name() { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     StructureMember::List& members() { return m_members; }
+    Structure* original() const { return m_original; }
 
     void setRole(StructureRole role) { m_role = role; }
 
 private:
-    Structure(SourceSpan span, Identifier&& name, StructureMember::List&& members, Attribute::List&& attributes, StructureRole role)
+    Structure(SourceSpan span, Identifier&& name, StructureMember::List&& members, Attribute::List&& attributes, StructureRole role, Structure* original = nullptr)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_attributes(WTFMove(attributes))
         , m_members(WTFMove(members))
         , m_role(role)
+        , m_original(original)
     { }
 
     Identifier m_name;
     Attribute::List m_attributes;
     StructureMember::List m_members;
     StructureRole m_role;
+    Structure* m_original;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -1,4 +1,5 @@
 // RUN: %metal-compile main
+// RUN: %metal main 2>&1 | %check
 
 struct T {
     x: vec3<f32>,
@@ -8,15 +9,31 @@ struct T {
 var<private> t: T;
 var<private> m: mat3x3<f32>;
 
-@compute @workgroup_size(1)
-fn main()
-{
-    _ = testUnpacked();
-}
+@group(0) @binding(0) var<storage, read_write> t1: T;
+@group(0) @binding(1) var<storage, read_write> t2: T;
 
 fn testUnpacked() -> i32
 {
     _ = t.x * m;
     _ = m * t.x;
     return 0;
+}
+
+fn testAssignment() -> i32 {
+    // packed struct
+    // CHECK: local\d+ = __unpack\(parameter\d+\);
+    var t = t1;
+    // CHECK-NEXT: parameter\d+ = parameter\d+;
+    t1 = t2;
+    // CHECK-NEXT: parameter\d+ = __pack\(local\d+\);
+    t2 = t;
+
+    return 0;
+}
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = testUnpacked();
+    _ = testAssignment();
 }


### PR DESCRIPTION
#### 074a78d9d7fba2ccf27d4d98fd25cdddb638a498
<pre>
[WGSL] Initial support for packing and unpacking values on assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=257797">https://bugs.webkit.org/show_bug.cgi?id=257797</a>
rdar://110389019

Reviewed by Dan Glastonbury.

In 264864@main I started the process of distinguishing between structs that need
to be &quot;packed&quot;, i.e. respect the size and alignment of types as defined in the WGSL
spec. This is the first patch that introduces explicit convertions between packed
and unpacked structs. For now, we only pack/unpack at assignments, which is not
enough, but other patches will follow extending this functionality to other operations.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::packResourceStruct):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::generatePackingHelpers):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/264975@main">https://commits.webkit.org/264975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d331afc882d63f45a7e7ecbc1392e3a8c134537

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9152 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9499 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12026 "2 flakes 95 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10336 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11068 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7632 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15909 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8732 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7415 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8313 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2256 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->