### PR TITLE
bbc.co.uk: Video goes black with only audio playing when exiting PiP mode

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -43,6 +43,7 @@
 #include "Page.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "QualifiedName.h"
+#include "Quirks.h"
 #include "Settings.h"
 #include <wtf/LoggerHelper.h>
 
@@ -517,13 +518,17 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
     if (is<HTMLIFrameElement>(element))
         element.setIFrameFullscreenFlag(true);
 
-    notifyAboutFullscreenChangeOrError();
+    if (!document().quirks().shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk())
+        notifyAboutFullscreenChangeOrError();
 
     return true;
 }
 
 bool FullscreenManager::didEnterFullscreen()
 {
+    if (document().quirks().shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk())
+        notifyAboutFullscreenChangeOrError();
+
     if (!m_fullscreenElement) {
         ERROR_LOG(LOGIDENTIFIER, "No fullscreenElement; bailing");
         return false;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1404,6 +1404,25 @@ bool Quirks::shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFull
 #endif
 }
 
+bool Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    // This quirk delay the "webkitstartfullscreen" and "fullscreenchange" event when a video exits picture-in-picture
+    // to fullscreen.
+    if (!needsQuirks())
+        return false;
+
+    if (!m_shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk) {
+        auto domain = RegistrableDomain(m_document->topDocument().url());
+        m_shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk = domain == "bbc.com"_s;
+    }
+
+    return *m_shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
+#else
+    return false;
+#endif
+}
+
 // teams.live.com rdar://88678598
 // teams.microsoft.com rdar://90434296
 bool Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -136,6 +136,7 @@ public:
     WEBCORE_EXPORT bool blocksReturnToFullscreenFromPictureInPictureQuirk() const;
     WEBCORE_EXPORT bool blocksEnteringStandardFullscreenFromPictureInPictureQuirk() const;
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk() const;
+    bool shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk() const;
 
 #if ENABLE(TRACKING_PREVENTION)
     static bool isMicrosoftTeamsRedirectURL(const URL&);
@@ -208,6 +209,7 @@ private:
     mutable std::optional<bool> m_blocksReturnToFullscreenFromPictureInPictureQuirk;
     mutable std::optional<bool> m_blocksEnteringStandardFullscreenFromPictureInPictureQuirk;
     mutable std::optional<bool> m_shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk;
+    mutable std::optional<bool> m_shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk;
 #if PLATFORM(IOS) || PLATFORM(VISION)
     mutable std::optional<bool> m_allowLayeredFullscreenVideos;
 #endif


### PR DESCRIPTION
#### ba3971672860729711b0a50ce424ab62ca319ca7
<pre>
bbc.co.uk: Video goes black with only audio playing when exiting PiP mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=257711">https://bugs.webkit.org/show_bug.cgi?id=257711</a>
rdar://108304377

Reviewed by Jer Noble.

Only fire the fullscreen change event once we did enter fullscreen.
This gives time for the UI process to complete exiting PiP in the UI process.

The process for exiting PiP and go back into fullscreen is a complicated
(and unnecessary) dance between the content and the UI process.
didStopPictureInPicture (UI) -&gt; requestRestoreFullScreen (CP) -&gt; EnterFullScreen (UI)
 -&gt; WillEnterFullscreen (CP) -&gt; beganEnterFullScreen (UI) -&gt; didEnterFullScreen (UI)
 -&gt; didEnterFullScreen (CP)

Previously, the events `fullscreenchange` was fired in WillEnterFullscreen.
if a JS event listener was set, and attempted to exit PiP then (as BBC website is doing)
it would have left VideoFullscreenInterfaceAVKit in a broken state
once it received `beganEnterFullScreen` as it&apos;s not an handled chained of event.

By letting the UI process complete the exit of PiP back to fullscreen,
we can avoid the problem from occurring alltogether, and this is simply
done by firing the events and resolving the promise in didEnterFullScreen.

We limit this behaviour to BBC.com

This entire code is in serious need of a rewrite.

Manually tested under all possible interface scenarios:
- Entering PiP, Exiting PiP using BBC main player control.
- Entering PiP, Exiting PiP using PiP controller button.
- Entering fullscreen via BBC control, entering PiP using PiP button, exiting PiP using BBC main player control
- As above but using PiP controller button as last step.
- Going into Auto-Pip by swiping home and exiting PiP.
- Entering PiP, quitting PiP (X button)

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::didEnterFullscreen):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDelayFullscreenEventWhenExitingPictureInPictureQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/264974@main">https://commits.webkit.org/264974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93cdf18d7b62052131b0f8f5b6579f66e639d385

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9325 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12082 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10390 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11136 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7686 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15951 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11995 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9143 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7448 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8357 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2255 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->