### PR TITLE
[WGSL] Add support for field access with packed types

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -2,8 +2,14 @@
 // RUN: %metal main 2>&1 | %check
 
 struct T {
-    x: vec3<f32>,
-    y: i32,
+    v2f: vec2<f32>,
+    v3f: vec3<f32>,
+    v4f: vec4<f32>,
+    v2u: vec2<u32>,
+    v3u: vec3<u32>,
+    v4u: vec4<u32>,
+    f: f32,
+    u: u32,
 }
 
 var<private> t: T;
@@ -14,12 +20,13 @@ var<private> m: mat3x3<f32>;
 
 fn testUnpacked() -> i32
 {
-    _ = t.x * m;
-    _ = m * t.x;
+    _ = t.v3f * m;
+    _ = m * t.v3f;
     return 0;
 }
 
-fn testAssignment() -> i32 {
+fn testAssignment() -> i32
+{
     // packed struct
     // CHECK: local\d+ = __unpack\(parameter\d+\);
     var t = t1;
@@ -31,9 +38,102 @@ fn testAssignment() -> i32 {
     return 0;
 }
 
+fn testFieldAccess() -> i32
+{
+    // CHECK: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
+    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
+    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = float3\(parameter\d+\.v3f\);
+    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
+    // CHECK-NEXT: parameter\d+\.v3u = uint3\(parameter\d+\.v3u\);
+    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
+    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
+    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    t.v2f.x = t1.v2f.x;
+    t.v3f.x = t1.v3f.x;
+    t.v4f.x = t1.v4f.x;
+    t.v2u.x = t1.v2u.x;
+    t.v3u.x = t1.v3u.x;
+    t.v4u.x = t1.v4u.x;
+    t.v2f   = t1.v2f;
+    t.v3f   = t1.v3f;
+    t.v4f   = t1.v4f;
+    t.v2u   = t1.v2u;
+    t.v3u   = t1.v3u;
+    t.v4u   = t1.v4u;
+    t.f     = t1.f;
+    t.u     = t1.u;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
+    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
+    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = parameter\d+\.v3f;
+    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
+    // CHECK-NEXT: parameter\d+\.v3u = parameter\d+\.v3u;
+    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
+    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
+    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    t1.v2f.x = t2.v2f.x;
+    t1.v3f.x = t2.v3f.x;
+    t1.v4f.x = t2.v4f.x;
+    t1.v2u.x = t2.v2u.x;
+    t1.v3u.x = t2.v3u.x;
+    t1.v4u.x = t2.v4u.x;
+    t1.v2f   = t2.v2f;
+    t1.v3f   = t2.v3f;
+    t1.v4f   = t2.v4f;
+    t1.v2u   = t2.v2u;
+    t1.v3u   = t2.v3u;
+    t1.v4u   = t2.v4u;
+    t1.f     = t2.f;
+    t1.u     = t2.u;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2u\.x = parameter\d+\.v2u\.x;
+    // CHECK-NEXT: parameter\d+\.v3u\.x = parameter\d+\.v3u\.x;
+    // CHECK-NEXT: parameter\d+\.v4u\.x = parameter\d+\.v4u\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(parameter\d+\.v3f\);
+    // CHECK-NEXT: parameter\d+\.v4f = parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.v2u = parameter\d+\.v2u;
+    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(parameter\d+\.v3u\);
+    // CHECK-NEXT: parameter\d+\.v4u = parameter\d+\.v4u;
+    // CHECK-NEXT: parameter\d+\.f = parameter\d+\.f;
+    // CHECK-NEXT: parameter\d+\.u = parameter\d+\.u;
+    t2.v2f.x = t.v2f.x;
+    t2.v3f.x = t.v3f.x;
+    t2.v4f.x = t.v4f.x;
+    t2.v2u.x = t.v2u.x;
+    t2.v3u.x = t.v3u.x;
+    t2.v4u.x = t.v4u.x;
+    t2.v2f   = t.v2f;
+    t2.v3f   = t.v3f;
+    t2.v4f   = t.v4f;
+    t2.v2u   = t.v2u;
+    t2.v3u   = t.v3u;
+    t2.v4u   = t.v4u;
+    t2.f     = t.f;
+    t2.u     = t.u;
+
+    return 0;
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
     _ = testUnpacked();
     _ = testAssignment();
+    _ = testFieldAccess();
 }


### PR DESCRIPTION
#### 776ed98f4d630cc6ac54d25cee46cee49a50af11
<pre>
[WGSL] Add support for field access with packed types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257812">https://bugs.webkit.org/show_bug.cgi?id=257812</a>
rdar://110406636

Reviewed by Dan Glastonbury.

Build onto PR#14736 and extend the support for packing/unpacking values resulting
from field accesses into packed/unpacked types.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
(WGSL::RewriteGlobalVariables::packingForType):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/264978@main">https://commits.webkit.org/264978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda83799df99bf77a28d154479d65c53e4d984bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9622 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11006 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9220 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12103 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10414 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11163 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7710 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15964 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8675 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9169 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8382 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->