### PR TITLE
[macOS] Update ScreenCaptureKit API used

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
@@ -37,10 +37,6 @@
 #if __has_include(<ScreenCaptureKit/SCContentSharingPicker.h>)
 #import <ScreenCaptureKit/SCContentSharingPicker.h>
 #endif
-
-#if __has_include(<ScreenCaptureKit/SCContentSharingPicker_Private.h>)
-#import <ScreenCaptureKit/SCContentSharingPicker_Private.h>
-#endif
 #endif // HAVE(SC_CONTENT_SHARING_PICKER)
 
 #else // USE(APPLE_INTERNAL_SDK)
@@ -94,6 +90,16 @@ typedef NS_ENUM(NSInteger, SCContentFilterType) {
 - (instancetype)initWithSharingSession:(SCContentSharingSession *)session captureOutputProperties:(SCStreamConfiguration *)streamConfig delegate:(id<SCStreamDelegate>)delegate;
 @end
 
+NS_ASSUME_NONNULL_END
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+
+// FIXME: Remove this section once the updated SDK is more widely available.
+
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol SCContentSharingPickerDelegate <NSObject>
 @required
 @optional
@@ -109,11 +115,11 @@ typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
     SCContentSharingPickerAllowedModeSingleDisplay         = 1 << 3,
 };
 
-@interface SCContentSharingPickerConfiguration : NSObject
+@interface SCContentSharingPickerConfiguration (Staging_110281298)
 @property (nonatomic, assign) SCContentSharingAllowedPickerModes allowedPickingModes;
 @end
 
-@interface SCContentSharingPicker : NSObject
+@interface SCContentSharingPicker (Staging_110281298)
 @property (nonatomic, weak, nullable) id<SCContentSharingPickerDelegate> delegate;
 @property (nonatomic, nullable, strong) NSNumber *maxStreamCount;
 @property (nonatomic, nullable, copy) SCContentSharingPickerConfiguration *configuration;
@@ -121,6 +127,6 @@ typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
 
 NS_ASSUME_NONNULL_END
 
-#endif // USE(APPLE_INTERNAL_SDK)
+#endif // HAVE(SC_CONTENT_SHARING_PICKER)
 
 #endif // HAVE(SCREEN_CAPTURE_KIT)

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -42,28 +42,14 @@
 
 using namespace WebCore;
 
-typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
-    WKSCContentSharingPickerModeSingleWindow          = 1 << 0,
-    WKSCContentSharingPickerModeMultipleWindows       = 1 << 1,
-    WKSCContentSharingPickerModeSingleApplication     = 1 << 2,
-    WKSCContentSharingPickerModeMultipleApplications  = 1 << 3,
-    WKSCContentSharingPickerModeSingleDisplay         = 1 << 4
-};
-
-@protocol WKSCContentSharingPickerDelegate <NSObject>
-@required
-- (void)contentSharingPicker:(SCContentSharingPicker *)picker didUpdateWithFilter:(SCContentFilter *)filter forStream:(SCStream *)stream;
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream;
-- (void)contentSharingPickerStartDidFailWithError:(NSError *)error;
-@end
-
 @interface WebDisplayMediaPromptHelper : NSObject <SCContentSharingSessionProtocol
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-    , WKSCContentSharingPickerDelegate
+    , SCContentSharingPickerObserver
 #endif
     > {
     WeakPtr<ScreenCaptureKitSharingSessionManager> _callback;
     Vector<RetainPtr<SCContentSharingSession>> _sessions;
+    BOOL _observingPicker;
 }
 
 - (instancetype)initWithCallback:(ScreenCaptureKitSharingSessionManager*)callback;
@@ -74,8 +60,10 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 - (void)sessionDidChangeContent:(SCContentSharingSession *)session;
 - (void)pickerCanceledForSession:(SCContentSharingSession *)session;
 #if HAVE(SC_CONTENT_SHARING_PICKER)
+- (void)startObservingPicker:(SCContentSharingPicker *)session;
+- (void)stopObservingPicker:(SCContentSharingPicker *)session;
 - (void)contentSharingPicker:(SCContentSharingPicker *)picker didUpdateWithFilter:(SCContentFilter *)filter forStream:(SCStream *)stream;
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream;
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker didCancelForStream:(SCStream *)stream;
 - (void)contentSharingPickerStartDidFailWithError:(NSError *)error;
 #endif
 @end
@@ -84,8 +72,10 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 - (instancetype)initWithCallback:(ScreenCaptureKitSharingSessionManager*)callback
 {
     self = [super init];
-    if (self)
+    if (self) {
         _callback = WeakPtr { callback };
+        _observingPicker = NO;
+    }
 
     return self;
 }
@@ -144,7 +134,7 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 }
 
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker didCancelForStream:(SCStream *)stream
 {
     UNUSED_PARAM(picker);
     RunLoop::main().dispatch([self, protectedSelf = RetainPtr { self }]() mutable {
@@ -167,6 +157,24 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
         if (_callback)
             _callback->contentSharingPickerUpdatedFilterForStream(filter.get(), stream.get());
     });
+}
+
+- (void)startObservingPicker:(SCContentSharingPicker *)picker
+{
+    if (_observingPicker)
+        return;
+
+    [picker addObserver:self];
+    _observingPicker = YES;
+}
+
+- (void)stopObservingPicker:(SCContentSharingPicker *)picker
+{
+    if (!_observingPicker)
+        return;
+
+    _observingPicker = NO;
+    [picker removeObserver:self];
 }
 #endif
 
@@ -206,12 +214,13 @@ ScreenCaptureKitSharingSessionManager::ScreenCaptureKitSharingSessionManager()
 
 ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager()
 {
+    m_activeSources.clear();
+    cancelPicking();
+
     if (m_promptHelper) {
         [m_promptHelper disconnect];
         m_promptHelper = nullptr;
     }
-
-    cancelPicking();
 }
 
 void ScreenCaptureKitSharingSessionManager::cancelPicking()
@@ -229,7 +238,8 @@ void ScreenCaptureKitSharingSessionManager::cancelPicking()
     if (useSCContentSharingPicker()) {
         SCContentSharingPicker* picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
         picker.active = NO;
-        picker.delegate = nullptr;
+        if (m_activeSources.isEmpty())
+            [m_promptHelper stopObservingPicker:picker];
     }
 #endif
 
@@ -424,21 +434,21 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
     auto configuration = adoptNS([PAL::allocSCContentSharingPickerConfigurationInstance() init]);
     switch (promptType) {
     case DisplayCapturePromptType::Window:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)WKSCContentSharingPickerModeSingleWindow];
+        [configuration setAllowedPickerModes:SCContentSharingPickerAllowedModeSingleWindow];
         break;
     case DisplayCapturePromptType::Screen:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)WKSCContentSharingPickerModeSingleDisplay];
+        [configuration setAllowedPickerModes:SCContentSharingPickerAllowedModeSingleDisplay];
         break;
     case DisplayCapturePromptType::UserChoose:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)(WKSCContentSharingPickerModeSingleWindow | WKSCContentSharingPickerModeSingleDisplay)];
+        [configuration setAllowedPickerModes:SCContentSharingPickerAllowedModeSingleWindow | SCContentSharingPickerAllowedModeSingleDisplay];
         break;
     }
 
     SCContentSharingPicker* picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
     picker.active = YES;
-    picker.maxStreamCount = @(1);
-    picker.configuration = configuration.get();
-    picker.delegate = (id<SCContentSharingPickerDelegate> _Nullable)m_promptHelper.get();
+    picker.maximumStreamCount = @(1);
+    picker.defaultConfiguration = configuration.get();
+    [m_promptHelper startObservingPicker:picker];
     [picker present];
 
     return true;


### PR DESCRIPTION
#### 0b941e1c1cc820380a9560f39012804ead3ea994
<pre>
[macOS] Update ScreenCaptureKit API used
<a href="https://bugs.webkit.org/show_bug.cgi?id=257816">https://bugs.webkit.org/show_bug.cgi?id=257816</a>
rdar://110408877

Reviewed by Youenn Fablet.

Update to the most recent version of ScreenCaptureKit API.

* Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper initWithCallback:]):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didCancelForStream:]):
(-[WebDisplayMediaPromptHelper startObservingPicker:]):
(-[WebDisplayMediaPromptHelper stopObservingPicker:]):
(WebCore::ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(-[WebDisplayMediaPromptHelper contentSharingPickerDidCancel:forStream:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/264988@main">https://commits.webkit.org/264988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21969630d205136ff67c469b2b4a931e691f40b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9198 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12085 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10389 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11140 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15953 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8649 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11998 "6 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7449 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8360 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2269 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->