### PR TITLE
Remove XPC endpoint headers from module map

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -1689,16 +1689,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module XPCEndpoint {
-    header "XPCEndpoint.h"
-    export *
-  }
-
-  explicit module XPCEndpointClient {
-    header "XPCEndpointClient.h"
-    export *
-  }
-
   explicit module _WKAppHighlight {
     header "_WKAppHighlight.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -2591,16 +2591,6 @@ framework module WebKit_Private [system] {
     export *
   }
 
-  explicit module XPCEndpoint {
-    header "XPCEndpoint.h"
-    export *
-  }
-
-  explicit module XPCEndpointClient {
-    header "XPCEndpointClient.h"
-    export *
-  }
-
   explicit module _WKAppHighlight {
     header "_WKAppHighlight.h"
     export *


### PR DESCRIPTION
#### 28950725e15b86c5d62dc2b8a2598d344e700714
<pre>
Remove XPC endpoint headers from module map
<a href="https://bugs.webkit.org/show_bug.cgi?id=257817">https://bugs.webkit.org/show_bug.cgi?id=257817</a>
rdar://107568693

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Modules/OSX_Private.modulemap:
* Source/WebKit/Modules/iOS_Private.modulemap:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28950725e15b86c5d62dc2b8a2598d344e700714

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9148 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11063 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7628 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15903 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->