### PR TITLE
[WGSL] Add support for binary and unary expressions with packed types

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -117,6 +117,8 @@ private:
     Packing pack(Packing, AST::Expression&);
     Packing getPacking(AST::IdentifierExpression&);
     Packing getPacking(AST::FieldAccessExpression&);
+    Packing getPacking(AST::BinaryExpression&);
+    Packing getPacking(AST::UnaryExpression&);
     Packing packingForType(const Type*);
 
     CallGraph& m_callGraph;
@@ -306,6 +308,10 @@ auto RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& expr
         return visitAndReplace(downcast<AST::IdentifierExpression>(expression));
     case AST::NodeKind::FieldAccessExpression:
         return visitAndReplace(downcast<AST::FieldAccessExpression>(expression));
+    case AST::NodeKind::BinaryExpression:
+        return visitAndReplace(downcast<AST::BinaryExpression>(expression));
+    case AST::NodeKind::UnaryExpression:
+        return visitAndReplace(downcast<AST::UnaryExpression>(expression));
     default:
         AST::Visitor::visit(expression);
         return Packing::Unpacked;
@@ -348,6 +354,19 @@ auto RewriteGlobalVariables::getPacking(AST::FieldAccessExpression& expression) 
     auto& structType = std::get<Types::Struct>(*baseType);
     auto* fieldType = structType.fields.get(expression.fieldName());
     return packingForType(fieldType);
+}
+
+auto RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression) -> Packing
+{
+    pack(Packing::Unpacked, expression.leftExpression());
+    pack(Packing::Unpacked, expression.rightExpression());
+    return Packing::Unpacked;
+}
+
+auto RewriteGlobalVariables::getPacking(AST::UnaryExpression& expression) -> Packing
+{
+    pack(Packing::Unpacked, expression.expression());
+    return Packing::Unpacked;
 }
 
 auto RewriteGlobalVariables::packingForType(const Type* type) -> Packing

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -18,6 +18,9 @@ var<private> m: mat3x3<f32>;
 @group(0) @binding(0) var<storage, read_write> t1: T;
 @group(0) @binding(1) var<storage, read_write> t2: T;
 
+@group(0) @binding(2) var<storage, read_write> v1: vec3<f32>;
+@group(0) @binding(3) var<storage, read_write> v2: vec3<f32>;
+
 fn testUnpacked() -> i32
 {
     _ = t.v3f * m;
@@ -130,10 +133,154 @@ fn testFieldAccess() -> i32
     return 0;
 }
 
+fn testBinaryOperations() -> i32
+{
+    // CHECK: parameter\d+\.v2f\.x = \(2 \* parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2 \* parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2 \* parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2 \* parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2 \* parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2 \* parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = \(2 \* parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = \(2 \* float3\(parameter\d+\.v3f\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = \(2 \* parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = \(2 \* parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = \(2 \* uint3\(parameter\d+\.v3u\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = \(2 \* parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = \(2 \* parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = \(2 \* parameter\d+\.u\);
+    t.v2f.x = 2 * t1.v2f.x;
+    t.v3f.x = 2 * t1.v3f.x;
+    t.v4f.x = 2 * t1.v4f.x;
+    t.v2u.x = 2 * t1.v2u.x;
+    t.v3u.x = 2 * t1.v3u.x;
+    t.v4u.x = 2 * t1.v4u.x;
+    t.v2f   = 2 * t1.v2f;
+    t.v3f   = 2 * t1.v3f;
+    t.v4f   = 2 * t1.v4f;
+    t.v2u   = 2 * t1.v2u;
+    t.v3u   = 2 * t1.v3u;
+    t.v4u   = 2 * t1.v4u;
+    t.f     = 2 * t1.f;
+    t.u     = 2 * t1.u;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = \(2 \* parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2 \* parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2 \* parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2 \* parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2 \* parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2 \* parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = \(2 \* parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(\(2 \* float3\(parameter\d+\.v3f\)\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = \(2 \* parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = \(2 \* parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(\(2 \* uint3\(parameter\d+\.v3u\)\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = \(2 \* parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = \(2 \* parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = \(2 \* parameter\d+\.u\);
+    t1.v2f.x = 2 * t2.v2f.x;
+    t1.v3f.x = 2 * t2.v3f.x;
+    t1.v4f.x = 2 * t2.v4f.x;
+    t1.v2u.x = 2 * t2.v2u.x;
+    t1.v3u.x = 2 * t2.v3u.x;
+    t1.v4u.x = 2 * t2.v4u.x;
+    t1.v2f   = 2 * t2.v2f;
+    t1.v3f   = 2 * t2.v3f;
+    t1.v4f   = 2 * t2.v4f;
+    t1.v2u   = 2 * t2.v2u;
+    t1.v3u   = 2 * t2.v3u;
+    t1.v4u   = 2 * t2.v4u;
+    t1.f     = 2 * t2.f;
+    t1.u     = 2 * t2.u;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = \(2 \* parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = \(2 \* parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = \(2 \* parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = \(2 \* parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = \(2 \* parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = \(2 \* parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = \(2 \* parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(\(2 \* parameter\d+\.v3f\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = \(2 \* parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = \(2 \* parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(\(2 \* parameter\d+\.v3u\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = \(2 \* parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = \(2 \* parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = \(2 \* parameter\d+\.u\);
+    t2.v2f.x = 2 * t.v2f.x;
+    t2.v3f.x = 2 * t.v3f.x;
+    t2.v4f.x = 2 * t.v4f.x;
+    t2.v2u.x = 2 * t.v2u.x;
+    t2.v3u.x = 2 * t.v3u.x;
+    t2.v4u.x = 2 * t.v4u.x;
+    t2.v2f   = 2 * t.v2f;
+    t2.v3f   = 2 * t.v3f;
+    t2.v4f   = 2 * t.v4f;
+    t2.v2u   = 2 * t.v2u;
+    t2.v3u   = 2 * t.v3u;
+    t2.v4u   = 2 * t.v4u;
+    t2.f     = 2 * t.f;
+    t2.u     = 2 * t.u;
+
+    return 0;
+}
+
+fn testUnaryOperations() -> i32
+{
+    // CHECK: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = -float3\(parameter\d+\.v3f\);
+    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    t.v2f.x = -t1.v2f.x;
+    t.v3f.x = -t1.v3f.x;
+    t.v4f.x = -t1.v4f.x;
+    t.v2f   = -t1.v2f;
+    t.v3f   = -t1.v3f;
+    t.v4f   = -t1.v4f;
+    t.f     = -t1.f;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(-float3\(parameter\d+\.v3f\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    t1.v2f.x = -t2.v2f.x;
+    t1.v3f.x = -t2.v3f.x;
+    t1.v4f.x = -t2.v4f.x;
+    t1.v2f   = -t2.v2f;
+    t1.v3f   = -t2.v3f;
+    t1.v4f   = -t2.v4f;
+    t1.f     = -t2.f;
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = -parameter\d+\.v2f\.x;
+    // CHECK-NEXT: parameter\d+\.v3f\.x = -parameter\d+\.v3f\.x;
+    // CHECK-NEXT: parameter\d+\.v4f\.x = -parameter\d+\.v4f\.x;
+    // CHECK-NEXT: parameter\d+\.v2f = -parameter\d+\.v2f;
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(-parameter\d+\.v3f\);
+    // CHECK-NEXT: parameter\d+\.v4f = -parameter\d+\.v4f;
+    // CHECK-NEXT: parameter\d+\.f = -parameter\d+\.f;
+    t2.v2f.x = -t.v2f.x;
+    t2.v3f.x = -t.v3f.x;
+    t2.v4f.x = -t.v4f.x;
+    t2.v2f   = -t.v2f;
+    t2.v3f   = -t.v3f;
+    t2.v4f   = -t.v4f;
+    t2.f     = -t.f;
+
+    return 0;
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
     _ = testUnpacked();
     _ = testAssignment();
     _ = testFieldAccess();
+    _ = testBinaryOperations();
+    _ = testUnaryOperations();
 }


### PR DESCRIPTION
#### dc79ccb4774148e246c2e5a637d047b96db87fc1
<pre>
[WGSL] Add support for binary and unary expressions with packed types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257818">https://bugs.webkit.org/show_bug.cgi?id=257818</a>
rdar://110410987

Reviewed by Dan Glastonbury.

Build onto PR#14736 and extend the support for packing/unpacking in binary and
unary expressions. Since not all binary and unary expressions are allowed on packed
types, we assume these expressions can only be performed on unpacked types. We
unpack the operand(s) and their result is always unpacked.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/264979@main">https://commits.webkit.org/264979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7701f0f30ee36849a61daddba21c983e9f6849a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11013 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9227 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12110 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10420 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11170 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7716 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8682 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9176 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8389 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12613 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->