### PR TITLE
Web Inspector: Color swatch shouldn't show tooltip when read-only

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
@@ -195,13 +195,15 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
 
         switch (this._type) {
         case WI.InlineSwatch.Type.Color:
-            let title = WI.UIString("Click to select a color.");
-            if (this._allowChangingColorFormats())
-                title += "\n" + WI.UIString("Shift-click to switch color formats.");
-            if (InspectorFrontendHost.canPickColorFromScreen())
-                title += "\n" + WI.UIString("Option-click to pick color from screen.");
-
-            this._swatchElement.title = title;
+            if (!this._readOnly) {
+                let title = WI.UIString("Click to select a color.");
+                if (this._allowChangingColorFormats())
+                    title += "\n" + WI.UIString("Shift-click to switch color formats.");
+                if (InspectorFrontendHost.canPickColorFromScreen())
+                    title += "\n" + WI.UIString("Option-click to pick color from screen.");
+                
+                this._swatchElement.title = title;
+            }
             // fallthrough
 
         case WI.InlineSwatch.Type.Gradient:


### PR DESCRIPTION
#### 5753a82fef47a4cadce068c9c5e80b9ef59b1b03
<pre>
Web Inspector: Color swatch shouldn&apos;t show tooltip when read-only
<a href="https://bugs.webkit.org/show_bug.cgi?id=257764">https://bugs.webkit.org/show_bug.cgi?id=257764</a>
rdar://110409252

Reviewed by Patrick Angle.

Added a check to make sure inline color swatch is not read only before adding tooltips.

* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
(WI.InlineSwatch.prototype._updateSwatch):

Canonical link: <a href="https://commits.webkit.org/265039@main">https://commits.webkit.org/265039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70aec2bbe6262745978d4f2ff2699bda9e320713

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9156 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12037 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11075 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15912 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11942 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12540 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1097 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->