### PR TITLE
[webkitcorepy] Create generic docker utilities

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -47,6 +47,7 @@ from webkitcorepy.file_lock import FileLock
 from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
+from webkitcorepy.docker import Docker
 
 version = Version(0, 14, 6)
 

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/docker.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/docker.py
@@ -1,0 +1,284 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import time
+
+from webkitcorepy import decorators, run
+
+
+class Docker(object):
+    _installed = None
+    _command = None
+    DOCKER_APP = '/Applications/Docker.app'
+    TIMEOUT = 10
+
+    class Container(object):
+        def __init__(self, image, name=None, tag='latest', remove=True, ports=None, port=None, volumes=None):
+            self.image = image
+            self.name = name or image
+            self.tag = tag
+
+            self.remove = remove
+            self.owner = False
+            self.ports = ports or {}
+            self.volumes = volumes or []
+            if port:
+                self.ports[port] = port
+
+        def __enter__(self, cached=True):
+            for volume in self.volumes:
+                volume.__enter__(cached=cached)
+
+            did_start = self.start(cached=cached)
+            self.owner = bool(did_start)
+            if did_start is False:
+                sys.stderr.write("Failed to start container '{}'\n".format(self.name))
+
+        def __exit__(self, *args, **kwargs):
+            cached = kwargs.get('cached', True)
+            if self.owner and self.stop(cached=cached) is False:
+                sys.stderr.write("Failed to stop container '{}'\n".format(self.name))
+            self.owner = False
+
+            for volume in self.volumes:
+                volume.__exit__(*args, **kwargs)
+
+        def download(self, cached=True, capture_output=True):
+            if self.downloaded(cached=cached):
+                return None
+            return not run(
+                [Docker.command(cached=cached), 'pull', '{}:{}'.format(self.image, self.tag)],
+                capture_output=capture_output,
+            ).returncode
+
+        def downloaded(self, cached=True):
+            return self.tag == Docker.images(cached=cached).get(self.image, {}).get('tag', None)
+
+        def created(self, cached=True):
+            return self.name in Docker.containers(cached=cached)
+
+        def create(self, cached=True, capture_output=True):
+            if self.created(cached=cached):
+                return None
+
+            args = ['--name', self.name]
+            if self.remove:
+                args.append('--rm')
+            for port, mapping in self.ports.items():
+                args.append('-p')
+                args.append('{}:{}'.format(port, mapping))
+            for volume in self.volumes:
+                args.append('--volume')
+                args.append(volume.name)
+
+            return not run(
+                [Docker.command(cached=cached), 'container', 'create'] + args + ['{}:{}'.format(self.image, self.tag)],
+                capture_output=capture_output,
+            ).returncode
+
+        def start(self, cached=True, capture_output=True):
+            if self.is_running(cached=cached):
+                return None
+            self.download(cached=cached, capture_output=capture_output)
+            self.create(cached=cached, capture_output=capture_output)
+            return not run(
+                [Docker.command(cached=cached), 'container', 'start', self.name],
+                capture_output=capture_output,
+            ).returncode
+
+        def stop(self, cached=True, capture_output=True):
+            if not self.is_running(cached=cached):
+                return None
+            return not run(
+                [Docker.command(cached=cached), 'container', 'stop', self.name],
+                capture_output=capture_output,
+            ).returncode
+
+        def is_running(self, cached=True):
+            return 'RUNNING' == Docker.containers(cached=cached).get(self.name, {}).get('state', 'STOPPED')
+
+    class Volume(object):
+        def __init__(self, name):
+            self.name = name
+            self.owner = False
+
+        def __enter__(self, cached=True):
+            did_create = self.create(cached=cached)
+            self.owner = bool(did_create)
+            if did_create is False:
+                sys.stderr.write("Failed to create volume '{}'\n".format(self.name))
+
+        def __exit__(self, *args, **kwargs):
+            cached = kwargs.get('cached', True)
+            if self.owner and self.remove(cached=cached) is False:
+                sys.stderr.write("Failed to remove volume '{}'\n".format(self.name))
+            self.owner = False
+
+        def exists(self, cached=True):
+            return bool(Docker.volumes(cached=cached).get(self.name, False))
+
+        def create(self, cached=True):
+            if self.exists():
+                return None
+            return not run(
+                [Docker.command(cached=cached), 'volume', 'create', self.name],
+                capture_output=True,
+            ).returncode
+
+        def remove(self, cached=True):
+            if not self.exists():
+                return None
+            return not run(
+                [Docker.command(cached=cached), 'volume', 'rm', self.name],
+                capture_output=True,
+            ).returncode
+
+    @classmethod
+    def command(cls, cached=True):
+        if cached and cls._command is not None:
+            return cls._command
+
+        from whichcraft import which
+        for candidate in [which('docker')]:
+            if candidate:
+                if cached:
+                    cls._command = candidate
+                return candidate
+        return None
+
+    @classmethod
+    def installed(cls, log=True, cached=True):
+        if cached and cls._installed is not None:
+            return cls._installed
+
+        result = False
+        if cls.command(cached=cached):
+            if not run([cls.command(cached=cached), '-v'], capture_output=True).returncode:
+                result = True
+        elif log:
+            sys.stderr.write('Nothing capable of running docker containers detected\n')
+
+        if cached:
+            cls._installed = result
+
+        return result
+
+    @classmethod
+    def opened(cls, cached=True):
+        return not run([cls.command(cached=cached), 'images'], capture_output=True).returncode
+
+    @classmethod
+    def open(cls, cached=True, timeout=10):
+        if cls.opened(cached=cached):
+            return
+
+        cmd = cls.command(cached=cached)
+        if not cmd:
+            raise RuntimeError('No Docker harness to open')
+
+        if sys.platform == 'darwin':
+            if 'docker' in cmd:
+                app = cls.DOCKER_APP
+            else:
+                raise NotImplementedError("'{}' is not recognized".format(cmd))
+            if not os.path.isdir(app):
+                raise OSError("'{}' is not installed".format(app))
+            if run(['open', app], capture_output=True).returncode:
+                raise RuntimeError("Failed to open '{}'".format(app))
+
+            # Wait until application has started
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                if cls.opened(cached=cached):
+                    return
+                time.sleep(0.1)
+            raise RuntimeError("Failed to verify '{}' has started".format(app))
+        raise NotImplementedError('Cannot start Docker on this platform')
+
+    @classmethod
+    def parse_output(cls, lines):
+        keys = ['']
+        length = [0]
+        whitespace_count = 0
+        if not lines:
+            return {}
+        for c in lines[0]:
+            if c.isspace():
+                whitespace_count += 1
+            elif whitespace_count == 1 and len(keys[-1]) < 7:
+                keys[-1] += ' ' + c.lower()
+                whitespace_count = 0
+            elif whitespace_count:
+                keys.append(c.lower())
+                length.append(0)
+                whitespace_count = 0
+            else:
+                keys[-1] += c.lower()
+            length[-1] += 1
+        length[-1] = 0
+
+        result = {}
+        for line in lines[1:]:
+            values = []
+            start = 0
+            for cnt in length:
+                if cnt:
+                    values.append(line[start:start + cnt].strip())
+                else:
+                    values.append(line[start:].strip())
+                start += cnt
+            if not values:
+                continue
+            key = values[0]
+            result[key] = {keys[cnt + 1]: values[cnt + 1] for cnt in range(len(keys) - 1)}
+        return result
+
+    @classmethod
+    def images(cls, cached=True):
+        proc = run([cls.command(cached=cached), 'images'], encoding='utf-8', capture_output=True)
+        if proc.returncode:
+            return {}
+        result = {}
+        for key, values in cls.parse_output(proc.stdout.splitlines()).items():
+            if ':' in key:
+                key, tag = key.split(':', 1)
+                values['tag'] = tag
+            if 'digest' in values:
+                values['digest'] = values['digest'].strip('.')
+            result[key] = values
+        return result
+
+    @classmethod
+    def containers(cls, cached=True):
+        proc = run([cls.command(cached=cached), 'container', 'ls', '-a'], encoding='utf-8', capture_output=True)
+        if proc.returncode:
+            return {}
+        return cls.parse_output(proc.stdout.splitlines())
+
+    @classmethod
+    def volumes(cls, cached=True):
+        proc = run([cls.command(cached=cached), 'volume', 'ls'], encoding='utf-8', capture_output=True)
+        if proc.returncode:
+            return {}
+        return cls.parse_output(proc.stdout.splitlines())

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py
@@ -145,8 +145,6 @@ class Subprocess(ContextStack):
             for completion in current.completions:
                 if completion.args[0] == program:
                     candidates.append(completion)
-                if current.ordered:
-                    break
             current = current.previous
 
         if candidates:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/docker_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/docker_unittest.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitcorepy import Docker, OutputCapture, mocks
+
+
+class DockerTest(unittest.TestCase):
+    DOCKER = mocks.Subprocess(
+        mocks.Subprocess.Route(
+            '/bin/docker', '-v',
+            completion=mocks.ProcessCompletion(
+                returncode=0,
+                stdout='Docker version 20.10.17, build 100c701',
+            ),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'images', completion=mocks.ProcessCompletion(
+                returncode=0,
+                stdout='REPOSITORY     TAG    IMAGE ID     CREATED     SIZE\n'
+                       'cassandra      latest 7772bea61223 3 weeks ago 146MB\n'
+                       'redis          latest ea30bef6a142 3 weeks ago 39MB\n',
+            ),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'pull', 'nginx:latest', completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'pull', completion=mocks.ProcessCompletion(returncode=1),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'container', 'ls', '-a',
+            completion=mocks.ProcessCompletion(
+                returncode=0,
+                stdout='ID        IMAGE            OS    ARCH  STATE\n'
+                       'cassandra cassandra:latest linux arm64 RUNNING\n'
+                       'redis     redis:latest     linux arm64 STOPPED\n',
+            ),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'container', 'create', '--name', 'nginx', '--rm', 'nginx:latest',
+            completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'container', 'start', 'redis', completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'container', 'stop', 'cassandra', completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'container', completion=mocks.ProcessCompletion(returncode=1),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'volume', 'ls', completion=mocks.ProcessCompletion(
+                returncode=0,
+                stdout='NAME          METADATA OPTIONS\n'
+                       'cassandradata          {"format":"ext4"}\n',
+            ),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'volume', 'create', 'redisdata', completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'volume', 'rm', 'cassandradata', completion=mocks.ProcessCompletion(returncode=0),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', 'volume', completion=mocks.ProcessCompletion(returncode=1),
+        ), mocks.Subprocess.Route(
+            '/bin/docker', completion=mocks.ProcessCompletion(returncode=0),
+        ), ordered=True,
+    )
+
+    @classmethod
+    def mock_which(cls, **programs):
+        from mock import patch
+        return patch('whichcraft.which', new=lambda arg: programs.get(arg, None))
+
+    def test_command(self):
+        with self.mock_which():
+            self.assertIsNone(Docker.command(cached=False))
+
+        with self.mock_which(docker='/bin/docker'):
+            self.assertEqual('/bin/docker', Docker.command(cached=False))
+
+    def test_installed(self):
+        with OutputCapture() as captured, self.mock_which(), self.DOCKER:
+            self.assertFalse(Docker.installed(cached=False))
+        self.assertEqual('Nothing capable of running docker containers detected\n', captured.stderr.getvalue())
+
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.installed(cached=False))
+
+    def test_images(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertDictEqual(Docker.images(cached=False), dict(
+                cassandra={
+                    'created': '3 weeks ago',
+                    'image id': '7772bea61223',
+                    'size': '146MB',
+                    'tag': 'latest',
+                }, redis={
+                    'created': '3 weeks ago',
+                    'image id': 'ea30bef6a142',
+                    'size': '39MB',
+                    'tag': 'latest',
+                },
+            ))
+
+    def test_downloaded(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.Container('cassandra').downloaded(cached=False))
+            self.assertTrue(Docker.Container('redis').downloaded(cached=False))
+            self.assertFalse(Docker.Container('nginx').downloaded(cached=False))
+
+    def test_download(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertIsNone(Docker.Container('cassandra').download(cached=False))
+            self.assertTrue(Docker.Container('nginx').download(cached=False))
+            self.assertFalse(Docker.Container('python3').download(cached=False))
+
+    def test_containers(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertDictEqual(Docker.containers(cached=False), dict(
+                cassandra=dict(
+                    image='cassandra:latest',
+                    arch='arm64',
+                    os='linux',
+                    state='RUNNING',
+                ), redis=dict(
+                    image='redis:latest',
+                    arch='arm64',
+                    os='linux',
+                    state='STOPPED',
+                ),
+            ))
+
+    def test_created(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.Container('cassandra').created(cached=False))
+            self.assertTrue(Docker.Container('redis').created(cached=False))
+            self.assertFalse(Docker.Container('nginx').created(cached=False))
+
+    def test_create(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertIsNone(Docker.Container('cassandra').create(cached=False))
+            self.assertTrue(Docker.Container('nginx').create(cached=False))
+            self.assertFalse(Docker.Container('python3').create(cached=False))
+
+    def test_running(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.Container('cassandra').is_running(cached=False))
+            self.assertFalse(Docker.Container('redis').is_running(cached=False))
+            self.assertFalse(Docker.Container('nginx').is_running(cached=False))
+
+    def test_start(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertIsNone(Docker.Container('cassandra').start(cached=False))
+            self.assertTrue(Docker.Container('redis').start(cached=False))
+            self.assertFalse(Docker.Container('nginx').start(cached=False))
+
+    def test_stop(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.Container('cassandra').stop(cached=False))
+            self.assertIsNone(Docker.Container('redis').stop(cached=False))
+            self.assertIsNone(Docker.Container('nginx').stop(cached=False))
+
+    def test_container_decorator(self):
+        with OutputCapture() as captured, self.mock_which(docker='/bin/docker'), self.DOCKER:
+            container = Docker.Container('cassandra')
+            container.__enter__(cached=False)
+            self.assertFalse(container.owner)
+            container.__exit__(cached=False)
+
+            container = Docker.Container('redis')
+            container.__enter__(cached=False)
+            self.assertTrue(container.owner)
+            container.__exit__(cached=False)
+            self.assertFalse(container.owner)
+
+            container = Docker.Container('nginx')
+            container.__enter__(cached=False)
+            container.__exit__(cached=False)
+
+        self.assertEqual("Failed to start container 'nginx'\n", captured.stderr.getvalue())
+
+    def test_volume(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertDictEqual(Docker.volumes(cached=False), dict(
+                cassandradata=dict(
+                    metadata='',
+                    options='{"format":"ext4"}',
+                ),
+            ))
+
+    def test_volume_create(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertIsNone(Docker.Volume('cassandradata').create(cached=False))
+            self.assertTrue(Docker.Volume('redisdata').create(cached=False))
+
+    def test_volume_remove(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            self.assertTrue(Docker.Volume('cassandradata').remove(cached=False))
+            self.assertIsNone(Docker.Volume('redisdata').remove(cached=False))
+
+    def test_volume_decorator(self):
+        with self.mock_which(docker='/bin/docker'), self.DOCKER:
+            volume = Docker.Volume('cassandradata')
+            volume.__enter__(cached=False)
+            self.assertFalse(volume.owner)
+            volume.__exit__(cached=False)
+
+            volume = Docker.Volume('redisdata')
+            volume.__enter__(cached=False)
+            self.assertTrue(volume.owner)
+            volume.__exit__(cached=False)
+            self.assertFalse(volume.owner)


### PR DESCRIPTION
#### 9677cac049358081971a5113e5c64de74ab7fbe8
<pre>
[webkitcorepy] Create generic docker utilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=257815">https://bugs.webkit.org/show_bug.cgi?id=257815</a>
rdar://110408458

Reviewed by NOBODY (OOPS!).

Create a generic set of Docker utilities for our various Python services.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/docker.py: Added.
(Docker.Container): Object representing a specific docker container managed from Python.
(Docker.Volume): Object representing a specific docker volume managed from Python.
(Docker.command): Return path to Docker command, if it exists.
(Docker.installed): Check if Docker is installed.
(Docker.opened): Check if Docker application is running.
(Docker.open): Start the Docker application.
(Docker.parse_output): Parse list output from various Docker commands.
(Docker.images): List all downloaded images.
(Docker.containers): List all created containers.
(Docker.volumes): List all volumes.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/mocks/subprocess.py:
(Subprocess.completion_generator_for):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/docker_unittest.py: Added.
(DockerTest.mock_which):
(DockerTest.test_command):
(DockerTest.test_installed):
(DockerTest.test_images):
(DockerTest.test_downloaded):
(DockerTest.test_download):
(DockerTest.test_containers):
(DockerTest.test_created):
(DockerTest.test_create):
(DockerTest.test_running):
(DockerTest.test_start):
(DockerTest.test_stop):
(DockerTest.test_container_decorator):
(DockerTest.test_volume):
(DockerTest.test_volume_create):
(DockerTest.test_volume_remove):
(DockerTest.test_volume_decorator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9677cac049358081971a5113e5c64de74ab7fbe8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9385 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9257 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12141 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11203 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9504 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15999 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12046 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7497 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/9325 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8970 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->