### PR TITLE
[JSC] Add global replace caching

### DIFF
--- a/JSTests/stress/v8-regexp-results-cache.js
+++ b/JSTests/stress/v8-regexp-results-cache.js
@@ -1,0 +1,79 @@
+// Copyright 2012 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+// Long string to trigger caching.
+var string =
+"Friends, Romans, countrymen, lend me your ears!  \
+ I come to bury Caesar, not to praise him.        \
+ The evil that men do lives after them,           \
+ The good is oft interred with their bones;       \
+ So let it be with Caesar. The noble Brutus       \
+ Hath told you Caesar was ambitious;              \
+ If it were so, it was a grievous fault,          \
+ And grievously hath Caesar answer'd it.          \
+ Here, under leave of Brutus and the rest-        \
+ For Brutus is an honorable man;                  \
+ So are they all, all honorable men-              \
+ Come I to speak in Caesar's funeral.             \
+ He was my friend, faithful and just to me;       \
+ But Brutus says he was ambitious,                \
+ And Brutus is an honorable man.                  \
+ He hath brought many captives home to Rome,      \
+ Whose ransoms did the general coffers fill.      \
+ Did this in Caesar seem ambitious?               \
+ When that the poor have cried, Caesar hath wept; \
+ Ambition should be made of sterner stuff:        \
+ Yet Brutus says he was ambitious,                \
+ And Brutus is an honorable man.                  \
+ You all did see that on the Lupercal             \
+ I thrice presented him a kingly crown,           \
+ Which he did thrice refuse. Was this ambition?   \
+ Yet Brutus says he was ambitious,                \
+ And sure he is an honorable man.                 \
+ I speak not to disprove what Brutus spoke,       \
+ But here I am to speak what I do know.           \
+ You all did love him once, not without cause;    \
+ What cause withholds you then to mourn for him?  \
+ O judgement, thou art fled to brutish beasts,    \
+ And men have lost their reason. Bear with me;    \
+ My heart is in the coffin there with Caesar,     \
+ And I must pause till it come back to me.";
+
+var replaced = string.replace(/\b\w+\b/g, function() { return "foo"; });
+for (var i = 0; i < 3; i++) {
+  assertEquals(replaced,
+               string.replace(/\b\w+\b/g, function() { return "foo"; }));
+}
+
+// Check that the result is in a COW array.
+var words = string.split(" ");
+assertEquals("Friends,", words[0]);
+words[0] = "Enemies,";
+words = string.split(" ");
+assertEquals("Friends,", words[0]);

--- a/JSTests/stress/v8-string-replace-cache.js
+++ b/JSTests/stress/v8-string-replace-cache.js
@@ -1,0 +1,303 @@
+//@ requireOptions("--thresholdForStringReplaceCache=0")
+// Copyright 2009 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @fileoverview Test String.prototype.replace
+ */
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+function replaceTest(result, subject, pattern, replacement) {
+  var name =
+    "\"" + subject + "\".replace(" + pattern + ", " + replacement + ")";
+  assertEquals(result, subject.replace(pattern, replacement), name);
+}
+
+
+var short = "xaxbxcx";
+
+replaceTest("axbxcx", short, "x", "");
+replaceTest("axbxcx", short, /x/, "");
+replaceTest("abc", short, /x/g, "");
+
+replaceTest("xaxxcx", short, "b", "");
+replaceTest("xaxxcx", short, /b/, "");
+replaceTest("xaxxcx", short, /b/g, "");
+
+
+replaceTest("[]axbxcx", short, "x", "[]");
+replaceTest("[]axbxcx", short, /x/, "[]");
+replaceTest("[]a[]b[]c[]", short, /x/g, "[]");
+
+replaceTest("xax[]xcx", short, "b", "[]");
+replaceTest("xax[]xcx", short, /b/, "[]");
+replaceTest("xax[]xcx", short, /b/g, "[]");
+
+
+replaceTest("[$]axbxcx", short, "x", "[$$]");
+replaceTest("[$]axbxcx", short, /x/, "[$$]");
+replaceTest("[$]a[$]b[$]c[$]", short, /x/g, "[$$]");
+
+replaceTest("xax[$]xcx", short, "b", "[$$]");
+replaceTest("xax[$]xcx", short, /b/, "[$$]");
+replaceTest("xax[$]xcx", short, /b/g, "[$$]");
+
+
+replaceTest("[]axbxcx", short, "x", "[$`]");
+replaceTest("[]axbxcx", short, /x/, "[$`]");
+replaceTest("[]a[xa]b[xaxb]c[xaxbxc]", short, /x/g, "[$`]");
+
+replaceTest("xax[xax]xcx", short, "b", "[$`]");
+replaceTest("xax[xax]xcx", short, /b/, "[$`]");
+replaceTest("xax[xax]xcx", short, /b/g, "[$`]");
+
+
+replaceTest("[x]axbxcx", short, "x", "[$&]");
+replaceTest("[x]axbxcx", short, /x/, "[$&]");
+replaceTest("[x]a[x]b[x]c[x]", short, /x/g, "[$&]");
+
+replaceTest("xax[b]xcx", short, "b", "[$&]");
+replaceTest("xax[b]xcx", short, /b/, "[$&]");
+replaceTest("xax[b]xcx", short, /b/g, "[$&]");
+
+
+replaceTest("[axbxcx]axbxcx", short, "x", "[$']");
+replaceTest("[axbxcx]axbxcx", short, /x/, "[$']");
+replaceTest("[axbxcx]a[bxcx]b[cx]c[]", short, /x/g, "[$']");
+
+replaceTest("xax[xcx]xcx", short, "b", "[$']");
+replaceTest("xax[xcx]xcx", short, /b/, "[$']");
+replaceTest("xax[xcx]xcx", short, /b/g, "[$']");
+
+
+replaceTest("[$1]axbxcx", short, "x", "[$1]");
+replaceTest("[$1]axbxcx", short, /x/, "[$1]");
+replaceTest("[]axbxcx", short, /x()/, "[$1]");
+replaceTest("[$1]a[$1]b[$1]c[$1]", short, /x/g, "[$1]");
+replaceTest("[]a[]b[]c[]", short, /x()/g, "[$1]");
+
+replaceTest("xax[$1]xcx", short, "b", "[$1]");
+replaceTest("xax[$1]xcx", short, /b/, "[$1]");
+replaceTest("xax[]xcx", short, /b()/, "[$1]");
+replaceTest("xax[$1]xcx", short, /b/g, "[$1]");
+replaceTest("xax[]xcx", short, /b()/g, "[$1]");
+
+// Bug 317 look-alikes. If "$e" has no meaning, the "$" must be retained.
+replaceTest("xax$excx", short, "b", "$e");
+replaceTest("xax$excx", short, /b/, "$e");
+replaceTest("xax$excx", short, /b/g, "$e");
+
+replaceTest("xaxe$xcx", short, "b", "e$");
+replaceTest("xaxe$xcx", short, /b/, "e$");
+replaceTest("xaxe$xcx", short, /b/g, "e$");
+
+
+replaceTest("[$$$1$$a1abb1bb0$002$3$03][$$$1$$b1bcc1cc0$002$3$03]c",
+            "abc", /(.)(?=(.))/g, "[$$$$$$1$$$$$11$01$2$21$02$020$002$3$03]");
+
+// Replace with functions.
+
+
+var ctr = 0;
+replaceTest("0axbxcx", short, "x", function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace('x',func) func-args");
+  assertEquals("x", m, "replace('x',func(m,..))");
+  assertEquals(0, i, "replace('x',func(..,i,..))");
+  assertEquals(short, s, "replace('x',func(..,s))");
+  return String(ctr++);
+});
+assertEquals(1, ctr, "replace('x',func) num-match");
+
+ctr = 0;
+replaceTest("0axbxcx", short, /x/, function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace(/x/,func) func-args");
+  assertEquals("x", m, "replace(/x/,func(m,..))");
+  assertEquals(0, i, "replace(/x/,func(..,i,..))");
+  assertEquals(short, s, "replace(/x/,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(1, ctr, "replace(/x/,func) num-match");
+
+ctr = 0;
+replaceTest("0a1b2c3", short, /x/g, function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace(/x/g,func) func-args");
+  assertEquals("x", m, "replace(/x/g,func(m,..))");
+  assertEquals(ctr * 2, i, "replace(/x/g,func(..,i,.))");
+  assertEquals(short, s, "replace(/x/g,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(4, ctr, "replace(/x/g,func) num-match");
+
+ctr = 0;
+replaceTest("0a1b2cx", short, /(x)(?=(.))/g, function r(m, c1, c2, i, s) {
+  assertEquals(5, arguments.length, "replace(/(x)(?=(.))/g,func) func-args");
+  assertEquals("x", m, "replace(/(x)(?=(.))/g,func(m,..))");
+  assertEquals("x", c1, "replace(/(x)(?=(.))/g,func(..,c1,..))");
+  assertEquals(["a","b","c"][ctr], c2, "replace(/(x)(?=(.))/g,func(..,c2,..))");
+  assertEquals(ctr * 2, i, "replace(/(x)(?=(.))/g,func(..,i,..))");
+  assertEquals(short, s, "replace(/(x)(?=(.))/g,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(3, ctr, "replace(/x/g,func) num-match");
+
+
+/*
+replaceTest("ABCD", "abcd", /(.)/g, function r(m, c1, i, s) {
+  assertEquals("d", RegExp.lastMatch);
+  assertEquals("d", RegExp.$1);
+  assertEquals("abc", RegExp.leftContext);
+  return m.toUpperCase();
+});
+*/
+
+
+var long = "";
+while (long.length < 0x2000) {
+  long += String.fromCharCode(65 + Math.random() * 26);
+}
+
+for (var i = 0; i < 3; i++) {
+  replaceTest(long.toLowerCase(), long, /(..)/g, function r(m, c1, i, s) {
+    var expected = long.substring(0x1ffe, 0x2000);
+    assertEquals(expected, RegExp.lastMatch);
+    assertEquals(expected, RegExp.$1);
+    assertEquals(long.substring(0, 0x1ffe), RegExp.leftContext);
+    return m.toLowerCase();
+  });
+}
+
+
+// Test special cases of replacement parts longer than 1<<11.
+var longstring = "xyzzy";
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+// longstring.length == 5 << 11
+
+replaceTest(longstring + longstring,
+            "<" + longstring + ">", /<(.*)>/g, "$1$1");
+
+replaceTest("string 42", "string x", /x/g, function() { return 42; });
+replaceTest("string 42", "string x", /x/, function() { return 42; });
+replaceTest("string 42", "string x", /[xy]/g, function() { return 42; });
+replaceTest("string 42", "string x", /[xy]/, function() { return 42; });
+replaceTest("string true", "string x", /x/g, function() { return true; });
+replaceTest("string null", "string x", /x/g, function() { return null; });
+replaceTest("string undefined", "string x", /x/g, function() { return undefined; });
+
+replaceTest("aundefinedbundefinedcundefined",
+            "abc", /(.)|(.)/g, function(m, m1, m2, i, s) { return m1+m2; });
+
+// Test nested calls to replace, including that it sets RegExp.$& correctly.
+
+var str = 'She sells seashells by the seashore.';
+var re = /sh/g;
+assertEquals('She sells sea$schells by the sea$schore.',
+             str.replace(re,"$$" + 'sch'))
+
+
+var replace_obj = { length: 0, toString: function() { return "x"; }};
+assertEquals("axc", "abc".replace(/b/, replace_obj));
+assertEquals("axc", "abc".replace(/b/g, replace_obj));
+
+var search_obj = { length: 1, toString: function() { return "b"; }};
+assertEquals("axc", "abc".replace(search_obj, function() { return "x"; }));
+
+var side_effect_flag = false;
+var replace_obj_side_effects = {
+    toString: function() { side_effect_flag = true; return "x" }
+}
+assertEquals("abc", "abc".replace(/z/g, replace_obj_side_effects));
+assertTrue(side_effect_flag);  // Side effect triggers even without a match.
+
+var regexp99pattern = "";
+var subject = "";
+for (var i = 0; i < 99; i++) {
+  regexp99pattern += "(.)";
+  subject += String.fromCharCode(i + 24);
+}
+
+function testIndices99(re) {
+  // Test $1 .. $99
+  for (var i = 1; i < 100; i++) {
+    assertEquals(String.fromCharCode(i + 23),
+                 subject.replace(re, "$" + i));
+  }
+
+  // Test $01 .. $09
+  for (var i = 1; i < 10; i++) {
+    assertEquals(String.fromCharCode(i + 23),
+                 subject.replace(re, "$0" + i));
+  }
+
+  assertEquals("$0", subject.replace(re, "$0"));
+  assertEquals("$00", subject.replace(re, "$00"));
+  assertEquals(String.fromCharCode(10 + 23) + "0",
+               subject.replace(re, "$100"));
+}
+
+testIndices99(new RegExp(regexp99pattern));
+testIndices99(new RegExp(regexp99pattern, "g"));
+
+var regexp59pattern = "";
+for (var i = 0; i < 59; i++) regexp59pattern += "(.)";
+
+function testIndices59(re) {
+  // Test $60 .. $99.  Captures reach up to 59.  Per spec, how to deal
+  // with this is implementation-dependent. We interpret $60 as $6
+  // followed by "0", $61 as $6, followed by "1" and so on.
+  var tail = subject.substr(59);
+  for (var i = 60; i < 100; i++) {
+    assertEquals(String.fromCharCode(i / 10 + 23) + (i % 10) + tail,
+                 subject.replace(re, "$" + i));
+  }
+}
+
+testIndices59(new RegExp(regexp59pattern));
+testIndices59(new RegExp(regexp59pattern, "g"));
+
+// Test that ToString(replace) is called.
+
+let replace_tostring_count = 0;
+const fake_replacer = {
+  [Symbol.toPrimitive]: () => { replace_tostring_count++; return "b"; }
+};
+
+"a".replace("x", fake_replacer);
+assertEquals(1, replace_tostring_count);
+
+"a".replace("a", fake_replacer);
+assertEquals(2, replace_tostring_count);

--- a/JSTests/stress/v8-string-replace.js
+++ b/JSTests/stress/v8-string-replace.js
@@ -1,0 +1,302 @@
+// Copyright 2009 the V8 project authors. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//     * Neither the name of Google Inc. nor the names of its
+//       contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @fileoverview Test String.prototype.replace
+ */
+
+load("./resources/v8-mjsunit.js", "caller relative");
+
+function replaceTest(result, subject, pattern, replacement) {
+  var name =
+    "\"" + subject + "\".replace(" + pattern + ", " + replacement + ")";
+  assertEquals(result, subject.replace(pattern, replacement), name);
+}
+
+
+var short = "xaxbxcx";
+
+replaceTest("axbxcx", short, "x", "");
+replaceTest("axbxcx", short, /x/, "");
+replaceTest("abc", short, /x/g, "");
+
+replaceTest("xaxxcx", short, "b", "");
+replaceTest("xaxxcx", short, /b/, "");
+replaceTest("xaxxcx", short, /b/g, "");
+
+
+replaceTest("[]axbxcx", short, "x", "[]");
+replaceTest("[]axbxcx", short, /x/, "[]");
+replaceTest("[]a[]b[]c[]", short, /x/g, "[]");
+
+replaceTest("xax[]xcx", short, "b", "[]");
+replaceTest("xax[]xcx", short, /b/, "[]");
+replaceTest("xax[]xcx", short, /b/g, "[]");
+
+
+replaceTest("[$]axbxcx", short, "x", "[$$]");
+replaceTest("[$]axbxcx", short, /x/, "[$$]");
+replaceTest("[$]a[$]b[$]c[$]", short, /x/g, "[$$]");
+
+replaceTest("xax[$]xcx", short, "b", "[$$]");
+replaceTest("xax[$]xcx", short, /b/, "[$$]");
+replaceTest("xax[$]xcx", short, /b/g, "[$$]");
+
+
+replaceTest("[]axbxcx", short, "x", "[$`]");
+replaceTest("[]axbxcx", short, /x/, "[$`]");
+replaceTest("[]a[xa]b[xaxb]c[xaxbxc]", short, /x/g, "[$`]");
+
+replaceTest("xax[xax]xcx", short, "b", "[$`]");
+replaceTest("xax[xax]xcx", short, /b/, "[$`]");
+replaceTest("xax[xax]xcx", short, /b/g, "[$`]");
+
+
+replaceTest("[x]axbxcx", short, "x", "[$&]");
+replaceTest("[x]axbxcx", short, /x/, "[$&]");
+replaceTest("[x]a[x]b[x]c[x]", short, /x/g, "[$&]");
+
+replaceTest("xax[b]xcx", short, "b", "[$&]");
+replaceTest("xax[b]xcx", short, /b/, "[$&]");
+replaceTest("xax[b]xcx", short, /b/g, "[$&]");
+
+
+replaceTest("[axbxcx]axbxcx", short, "x", "[$']");
+replaceTest("[axbxcx]axbxcx", short, /x/, "[$']");
+replaceTest("[axbxcx]a[bxcx]b[cx]c[]", short, /x/g, "[$']");
+
+replaceTest("xax[xcx]xcx", short, "b", "[$']");
+replaceTest("xax[xcx]xcx", short, /b/, "[$']");
+replaceTest("xax[xcx]xcx", short, /b/g, "[$']");
+
+
+replaceTest("[$1]axbxcx", short, "x", "[$1]");
+replaceTest("[$1]axbxcx", short, /x/, "[$1]");
+replaceTest("[]axbxcx", short, /x()/, "[$1]");
+replaceTest("[$1]a[$1]b[$1]c[$1]", short, /x/g, "[$1]");
+replaceTest("[]a[]b[]c[]", short, /x()/g, "[$1]");
+
+replaceTest("xax[$1]xcx", short, "b", "[$1]");
+replaceTest("xax[$1]xcx", short, /b/, "[$1]");
+replaceTest("xax[]xcx", short, /b()/, "[$1]");
+replaceTest("xax[$1]xcx", short, /b/g, "[$1]");
+replaceTest("xax[]xcx", short, /b()/g, "[$1]");
+
+// Bug 317 look-alikes. If "$e" has no meaning, the "$" must be retained.
+replaceTest("xax$excx", short, "b", "$e");
+replaceTest("xax$excx", short, /b/, "$e");
+replaceTest("xax$excx", short, /b/g, "$e");
+
+replaceTest("xaxe$xcx", short, "b", "e$");
+replaceTest("xaxe$xcx", short, /b/, "e$");
+replaceTest("xaxe$xcx", short, /b/g, "e$");
+
+
+replaceTest("[$$$1$$a1abb1bb0$002$3$03][$$$1$$b1bcc1cc0$002$3$03]c",
+            "abc", /(.)(?=(.))/g, "[$$$$$$1$$$$$11$01$2$21$02$020$002$3$03]");
+
+// Replace with functions.
+
+
+var ctr = 0;
+replaceTest("0axbxcx", short, "x", function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace('x',func) func-args");
+  assertEquals("x", m, "replace('x',func(m,..))");
+  assertEquals(0, i, "replace('x',func(..,i,..))");
+  assertEquals(short, s, "replace('x',func(..,s))");
+  return String(ctr++);
+});
+assertEquals(1, ctr, "replace('x',func) num-match");
+
+ctr = 0;
+replaceTest("0axbxcx", short, /x/, function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace(/x/,func) func-args");
+  assertEquals("x", m, "replace(/x/,func(m,..))");
+  assertEquals(0, i, "replace(/x/,func(..,i,..))");
+  assertEquals(short, s, "replace(/x/,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(1, ctr, "replace(/x/,func) num-match");
+
+ctr = 0;
+replaceTest("0a1b2c3", short, /x/g, function r(m, i, s) {
+  assertEquals(3, arguments.length, "replace(/x/g,func) func-args");
+  assertEquals("x", m, "replace(/x/g,func(m,..))");
+  assertEquals(ctr * 2, i, "replace(/x/g,func(..,i,.))");
+  assertEquals(short, s, "replace(/x/g,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(4, ctr, "replace(/x/g,func) num-match");
+
+ctr = 0;
+replaceTest("0a1b2cx", short, /(x)(?=(.))/g, function r(m, c1, c2, i, s) {
+  assertEquals(5, arguments.length, "replace(/(x)(?=(.))/g,func) func-args");
+  assertEquals("x", m, "replace(/(x)(?=(.))/g,func(m,..))");
+  assertEquals("x", c1, "replace(/(x)(?=(.))/g,func(..,c1,..))");
+  assertEquals(["a","b","c"][ctr], c2, "replace(/(x)(?=(.))/g,func(..,c2,..))");
+  assertEquals(ctr * 2, i, "replace(/(x)(?=(.))/g,func(..,i,..))");
+  assertEquals(short, s, "replace(/(x)(?=(.))/g,func(..,s))");
+  return String(ctr++);
+});
+assertEquals(3, ctr, "replace(/x/g,func) num-match");
+
+
+/*
+replaceTest("ABCD", "abcd", /(.)/g, function r(m, c1, i, s) {
+  assertEquals("d", RegExp.lastMatch);
+  assertEquals("d", RegExp.$1);
+  assertEquals("abc", RegExp.leftContext);
+  return m.toUpperCase();
+});
+*/
+
+
+var long = "";
+while (long.length < 0x2000) {
+  long += String.fromCharCode(65 + Math.random() * 26);
+}
+
+for (var i = 0; i < 3; i++) {
+  replaceTest(long.toLowerCase(), long, /(..)/g, function r(m, c1, i, s) {
+    var expected = long.substring(0x1ffe, 0x2000);
+    assertEquals(expected, RegExp.lastMatch);
+    assertEquals(expected, RegExp.$1);
+    assertEquals(long.substring(0, 0x1ffe), RegExp.leftContext);
+    return m.toLowerCase();
+  });
+}
+
+
+// Test special cases of replacement parts longer than 1<<11.
+var longstring = "xyzzy";
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+longstring = longstring + longstring;
+// longstring.length == 5 << 11
+
+replaceTest(longstring + longstring,
+            "<" + longstring + ">", /<(.*)>/g, "$1$1");
+
+replaceTest("string 42", "string x", /x/g, function() { return 42; });
+replaceTest("string 42", "string x", /x/, function() { return 42; });
+replaceTest("string 42", "string x", /[xy]/g, function() { return 42; });
+replaceTest("string 42", "string x", /[xy]/, function() { return 42; });
+replaceTest("string true", "string x", /x/g, function() { return true; });
+replaceTest("string null", "string x", /x/g, function() { return null; });
+replaceTest("string undefined", "string x", /x/g, function() { return undefined; });
+
+replaceTest("aundefinedbundefinedcundefined",
+            "abc", /(.)|(.)/g, function(m, m1, m2, i, s) { return m1+m2; });
+
+// Test nested calls to replace, including that it sets RegExp.$& correctly.
+
+var str = 'She sells seashells by the seashore.';
+var re = /sh/g;
+assertEquals('She sells sea$schells by the sea$schore.',
+             str.replace(re,"$$" + 'sch'))
+
+
+var replace_obj = { length: 0, toString: function() { return "x"; }};
+assertEquals("axc", "abc".replace(/b/, replace_obj));
+assertEquals("axc", "abc".replace(/b/g, replace_obj));
+
+var search_obj = { length: 1, toString: function() { return "b"; }};
+assertEquals("axc", "abc".replace(search_obj, function() { return "x"; }));
+
+var side_effect_flag = false;
+var replace_obj_side_effects = {
+    toString: function() { side_effect_flag = true; return "x" }
+}
+assertEquals("abc", "abc".replace(/z/g, replace_obj_side_effects));
+assertTrue(side_effect_flag);  // Side effect triggers even without a match.
+
+var regexp99pattern = "";
+var subject = "";
+for (var i = 0; i < 99; i++) {
+  regexp99pattern += "(.)";
+  subject += String.fromCharCode(i + 24);
+}
+
+function testIndices99(re) {
+  // Test $1 .. $99
+  for (var i = 1; i < 100; i++) {
+    assertEquals(String.fromCharCode(i + 23),
+                 subject.replace(re, "$" + i));
+  }
+
+  // Test $01 .. $09
+  for (var i = 1; i < 10; i++) {
+    assertEquals(String.fromCharCode(i + 23),
+                 subject.replace(re, "$0" + i));
+  }
+
+  assertEquals("$0", subject.replace(re, "$0"));
+  assertEquals("$00", subject.replace(re, "$00"));
+  assertEquals(String.fromCharCode(10 + 23) + "0",
+               subject.replace(re, "$100"));
+}
+
+testIndices99(new RegExp(regexp99pattern));
+testIndices99(new RegExp(regexp99pattern, "g"));
+
+var regexp59pattern = "";
+for (var i = 0; i < 59; i++) regexp59pattern += "(.)";
+
+function testIndices59(re) {
+  // Test $60 .. $99.  Captures reach up to 59.  Per spec, how to deal
+  // with this is implementation-dependent. We interpret $60 as $6
+  // followed by "0", $61 as $6, followed by "1" and so on.
+  var tail = subject.substr(59);
+  for (var i = 60; i < 100; i++) {
+    assertEquals(String.fromCharCode(i / 10 + 23) + (i % 10) + tail,
+                 subject.replace(re, "$" + i));
+  }
+}
+
+testIndices59(new RegExp(regexp59pattern));
+testIndices59(new RegExp(regexp59pattern, "g"));
+
+// Test that ToString(replace) is called.
+
+let replace_tostring_count = 0;
+const fake_replacer = {
+  [Symbol.toPrimitive]: () => { replace_tostring_count++; return "b"; }
+};
+
+"a".replace("x", fake_replacer);
+assertEquals(1, replace_tostring_count);
+
+"a".replace("a", fake_replacer);
+assertEquals(2, replace_tostring_count);

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1209,6 +1209,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/StackFrame.h
     runtime/StringObject.h
     runtime/StringPrototype.h
+    runtime/StringReplaceCache.h
     runtime/StringSplitCache.h
     runtime/Structure.h
     runtime/StructureCache.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1880,6 +1880,8 @@
 		E355D38F22446877008F1AD6 /* GlobalExecutable.h in Headers */ = {isa = PBXBuildFile; fileRef = E355D38D2244686B008F1AD6 /* GlobalExecutable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E356987222841187008CDCCB /* PackedCellPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = E356987122841183008CDCCB /* PackedCellPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35A0B9D220AD87A00AC4474 /* ExecutableBaseInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E35B36072A2E981E004EC264 /* StringReplaceCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */; };
+		E35B36082A2E981E004EC264 /* StringReplaceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E35B36062A2E981E004EC264 /* StringReplaceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E35CA1521DBC3A5600F83516 /* DOMJITHeapRange.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35CA1561DBC3A5F00F83516 /* DOMJITAbstractHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = E35CA1501DBC3A5600F83516 /* DOMJITAbstractHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E35E89FD25C50F870071EE1E /* BigInt64Array.h in Headers */ = {isa = PBXBuildFile; fileRef = E35E89FB25C50F860071EE1E /* BigInt64Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5370,6 +5372,8 @@
 		E355D38E2244686C008F1AD6 /* GlobalExecutable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalExecutable.cpp; sourceTree = "<group>"; };
 		E356987122841183008CDCCB /* PackedCellPtr.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PackedCellPtr.h; sourceTree = "<group>"; };
 		E35A0B9C220AD87A00AC4474 /* ExecutableBaseInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExecutableBaseInlines.h; sourceTree = "<group>"; };
+		E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCacheInlines.h; sourceTree = "<group>"; };
+		E35B36062A2E981E004EC264 /* StringReplaceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringReplaceCache.h; sourceTree = "<group>"; };
 		E35C88C42984F411005A3CDA /* WasmCallsiteCollection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCallsiteCollection.cpp; sourceTree = "<group>"; };
 		E35CA14F1DBC3A5600F83516 /* DOMJITAbstractHeap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMJITAbstractHeap.cpp; sourceTree = "<group>"; };
 		E35CA1501DBC3A5600F83516 /* DOMJITAbstractHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMJITAbstractHeap.h; sourceTree = "<group>"; };
@@ -8261,6 +8265,8 @@
 				E325A35F2221158A007349A1 /* StringPrototypeInlines.h */,
 				93345A8712D838C400302BE3 /* StringRecursionChecker.cpp */,
 				93345A8812D838C400302BE3 /* StringRecursionChecker.h */,
+				E35B36062A2E981E004EC264 /* StringReplaceCache.h */,
+				E35B36052A2E981E004EC264 /* StringReplaceCacheInlines.h */,
 				E36706292A2705DB00CF892F /* StringSplitCache.h */,
 				E36706282A2705DB00CF892F /* StringSplitCacheInlines.h */,
 				BCDE3AB00E6C82CF001453A7 /* Structure.cpp */,
@@ -11098,6 +11104,8 @@
 				BC18C4680E16F5CD00B34460 /* StringObject.h in Headers */,
 				BC18C46A0E16F5CD00B34460 /* StringPrototype.h in Headers */,
 				E325A36022211590007349A1 /* StringPrototypeInlines.h in Headers */,
+				E35B36082A2E981E004EC264 /* StringReplaceCache.h in Headers */,
+				E35B36072A2E981E004EC264 /* StringReplaceCacheInlines.h in Headers */,
 				E367062B2A2705DB00CF892F /* StringSplitCache.h in Headers */,
 				E367062A2A2705DB00CF892F /* StringSplitCacheInlines.h in Headers */,
 				142E313B134FF0A600AFADB5 /* Strong.h in Headers */,

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2183,6 +2183,7 @@ void Heap::finalize()
         vm().jsonAtomStringCache.clear();
     vm().keyAtomStringCache.clear();
     vm().stringSplitCache.clear();
+    vm().stringReplaceCache.clear();
     vm().numericStrings.clearOnGarbageCollection();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -273,9 +273,9 @@ public:
         
     JS_EXPORT_PRIVATE void getSlice(int startIndex, ArgList& result) const;
 
-private:
     EncodedJSValue* data() const { return m_args; }
 
+private:
     EncodedJSValue* m_args { nullptr };
     int m_argCount { 0 };
 };

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp
@@ -236,4 +236,14 @@ JSImmutableButterfly* JSImmutableButterfly::createFromString(JSGlobalObject* glo
     return result;
 }
 
+JSImmutableButterfly* JSImmutableButterfly::tryCreateFromArgList(VM& vm, ArgList argList)
+{
+    JSImmutableButterfly* result = JSImmutableButterfly::tryCreate(vm, vm.immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].get(), argList.size());
+    if (UNLIKELY(!result))
+        return nullptr;
+    gcSafeMemcpy(bitwise_cast<EncodedJSValue*>(result->toButterfly()->contiguous().data()), argList.data(), argList.size() * sizeof(EncodedJSValue));
+    vm.writeBarrier(result);
+    return result;
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -137,6 +137,7 @@ public:
     static JSImmutableButterfly* createFromDirectArguments(JSGlobalObject*, DirectArguments*);
     static JSImmutableButterfly* createFromScopedArguments(JSGlobalObject*, ScopedArguments*);
     static JSImmutableButterfly* createFromString(JSGlobalObject*, JSString*);
+    static JSImmutableButterfly* tryCreateFromArgList(VM&, ArgList);
 
     unsigned publicLength() const { return m_header.publicLength(); }
     unsigned vectorLength() const { return m_header.vectorLength(); }

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -556,6 +556,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpCompilerConstructionSite, false, Normal, nullptr) \
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
+    v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
     \
     /* Feature Flags */\
     \

--- a/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
@@ -90,4 +90,11 @@ ALWAYS_INLINE void RegExpGlobalData::recordMatch(VM& vm, JSGlobalObject* owner, 
     m_cachedResult.record(vm, owner, regExp, string, result);
 }
 
+inline void RegExpGlobalData::resetResultFromCache(JSGlobalObject* owner, RegExp* regExp, JSString* string, Vector<int>&& vector)
+{
+    MatchResult result(vector[0], vector[1]);
+    m_ovector = WTFMove(vector);
+    m_cachedResult.record(getVM(owner), owner, regExp, string, result);
+}
+
 }

--- a/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2012 the V8 project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StringReplaceCache.h"
+
+namespace JSC {
+
+inline StringReplaceCache::Entry* StringReplaceCache::get(const String& subject, RegExp* regExp)
+{
+    DisallowGC disallowGC;
+    if (!subject.impl() || !subject.impl()->isAtom())
+        return nullptr;
+    ASSERT(regExp->global());
+    ASSERT(subject.length() >= Options::thresholdForStringReplaceCache());
+
+    auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
+    unsigned index = subjectImpl->hash() & (cacheSize - 1);
+    {
+        auto& entry = m_entries[index];
+        if (entry.m_subject == subjectImpl && entry.m_regExp == regExp)
+            return &entry;
+    }
+    {
+        auto& entry = m_entries[(index + 1) & (cacheSize - 1)];
+        if (entry.m_subject == subjectImpl && entry.m_regExp == regExp)
+            return &entry;
+    }
+    return nullptr;
+}
+
+inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImmutableButterfly* result, const Vector<int>& lastMatch)
+{
+    DisallowGC disallowGC;
+    if (!subject.impl() || !subject.impl()->isAtom())
+        return;
+
+    auto* subjectImpl = static_cast<AtomStringImpl*>(subject.impl());
+    unsigned index = subjectImpl->hash() & (cacheSize - 1);
+    {
+        auto& entry1 = m_entries[index];
+        if (!entry1.m_subject) {
+            entry1.m_subject = subjectImpl;
+            entry1.m_regExp = regExp;
+            entry1.m_lastMatch = lastMatch;
+            entry1.m_result = result;
+        } else {
+            auto& entry2 = m_entries[(index + 1) & (cacheSize - 1)];
+            if (!entry2.m_subject) {
+                entry2.m_subject = subjectImpl;
+                entry2.m_regExp = regExp;
+                entry2.m_lastMatch = lastMatch;
+                entry2.m_result = result;
+            } else {
+                entry2 = { };
+                entry1.m_subject = subjectImpl;
+                entry1.m_regExp = regExp;
+                entry1.m_lastMatch = lastMatch;
+                entry1.m_result = result;
+            }
+        }
+    }
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -51,6 +51,7 @@
 #include "NumericStrings.h"
 #include "SlotVisitorMacros.h"
 #include "SmallStrings.h"
+#include "StringReplaceCache.h"
 #include "StringSplitCache.h"
 #include "Strong.h"
 #include "SubspaceAccess.h"
@@ -571,6 +572,7 @@ public:
     KeyAtomStringCache keyAtomStringCache;
     StringSplitCache stringSplitCache;
     Vector<unsigned> stringSplitIndice;
+    StringReplaceCache stringReplaceCache;
 
     AtomStringTable* atomStringTable() const { return m_atomStringTable; }
     WTF::SymbolRegistry& symbolRegistry() { return m_symbolRegistry; }


### PR DESCRIPTION
#### 0e3fcb9531e248c468366393fd4f2127ea5dcb56
<pre>
[JSC] Add global replace caching
<a href="https://bugs.webkit.org/show_bug.cgi?id=257826">https://bugs.webkit.org/show_bug.cgi?id=257826</a>
rdar://110417641

Reviewed by Michael Saboff.

This patch adds String.replace(/regexp-global/g, func) result cache, which is in the same fashion to V8&apos;s cache.
We cache the result only when the subject string length is &gt;= 0x1000, aligned to V8&apos;s behavior.
This cache is cleared on every GC, so it does not affect on memory usage in practice: once GC happens, everything gets cleared,
so it is not retaining things.

* JSTests/stress/v8-regexp-results-cache.js: Added.
* JSTests/stress/v8-string-replace-cache.js: Added.
(replaceTest):
(r):
(i.r):
(string_appeared_here.string_appeared_here.replace_obj.toString):
(search_obj.toString):
(replace_obj_side_effects.toString):
(testIndices99):
(testIndices59):
(const.fake_replacer.Symbol.toPrimitive):
* JSTests/stress/v8-string-replace.js: Added.
(replaceTest):
(r):
(i.r):
(string_appeared_here.string_appeared_here.replace_obj.toString):
(search_obj.toString):
(replace_obj_side_effects.toString):
(testIndices99):
(testIndices59):
(const.fake_replacer.Symbol.toPrimitive):
* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/ArgList.h:
* Source/JavaScriptCore/runtime/JSImmutableButterfly.cpp:
(JSC::JSImmutableButterfly::tryCreateFromArgList):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
(JSC::RegExpGlobalData::ovector const):
* Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h:
(JSC::RegExpGlobalData::resetResultFromCache):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearchWithCache):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/runtime/StringReplaceCache.h: Copied from Source/JavaScriptCore/runtime/RegExpGlobalData.h.
(JSC::StringReplaceCache::clear):
* Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h: Added.
(JSC::StringReplaceCache::get):
(JSC::StringReplaceCache::set):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/264967@main">https://commits.webkit.org/264967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9b5b56f5f1404eae0c2fa1c10e293a9bd29a799

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12059 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10366 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11106 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15929 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7966 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11968 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9462 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8336 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12560 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9702 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1067 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8881 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2382 "Passed tests") | 
<!--EWS-Status-Bubble-End-->