### PR TITLE
REGRESSION (264086@main): [iOS 17] Autocorrect highlight is sometimes incorrect in Mail compose

### DIFF
--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -61,7 +61,7 @@ template<typename ...T> auto makeSimpleRange(T&& ...arguments) -> decltype(makeS
 WEBCORE_EXPORT std::optional<SimpleRange> makeRangeSelectingNode(Node&);
 WEBCORE_EXPORT SimpleRange makeRangeSelectingNodeContents(Node&);
 
-bool operator==(const SimpleRange&, const SimpleRange&);
+WEBCORE_EXPORT bool operator==(const SimpleRange&, const SimpleRange&);
 
 template<TreeType = Tree> Node* commonInclusiveAncestor(const SimpleRange&);
 


### PR DESCRIPTION
#### ce1f5b1c5dd74c19b8833b169298249b915d0901
<pre>
REGRESSION (264086@main): [iOS 17] Autocorrect highlight is sometimes incorrect in Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=257830">https://bugs.webkit.org/show_bug.cgi?id=257830</a>
rdar://109582406

Reviewed by Megan Gardner and Aditya Keerthi.

The refactoring in 264086@main introduced a subtle behavior change in the case where the text
iterator emits spaces for soft line breaks in an `_editable` web view. When emitting text for a soft
line break, we previously appended the zero rect in the list of `textRects` for this character
range; however, after `264086@main`, we now skip the rect altogether, which causes the list of rects
to fall out of sync with the combined `contextBefore` + `selectedText` + `contextAfter` string.
Consequently, UIKit (which currently assumes that indices into the string correspond directly to
indices of rects in `textRects`) ends up using the wrong character layout rects.

This patch fixes the above by restoring preexisting behavior and appending a single empty rect in
the case where the text iterator finds (non-empty) text, but there are no character rects.

Additionally, I attempted to add a debug assertion to verify that the number of resulting text rects
is always consistent with the combined length of the context and selection strings; however, this
uncovered some bugs in the existing implementation, even prior the changes in 264086@main, where we
would sometimes end up with either too many or too few rects, when running the following three
layout tests:

• editing/selection/ios/update-selection-after-iframe-scroll.html
• editing/selection/ios/update-selection-after-overflow-scroll.html
• editing/selection/shift-click-includes-existing-selection.html

This patch fixes the assertion in `editing/selection/shift-click-includes-existing-selection.html`,
where we end up with too many text rects due to the fact that the text iterator advances to both the
upstream and downstream positions of a line break, emitting &quot;\n&quot; both times with the same rect. To
avoid this, we keep track of the last `SimpleRange` we observed, and avoid emitting a duplicate rect
in the case where we advance to the a range we just visited.

Test: DocumentEditingContext.CharacterRectsInEditableWebView

* Source/WebCore/dom/SimpleRange.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:

Canonical link: <a href="https://commits.webkit.org/264969@main">https://commits.webkit.org/264969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eed0ac0fe14cf44d18329fbd629d628148b0e171

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12062 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10368 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11109 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15926 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11964 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8338 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->