### PR TITLE
Fix typo in WC class names

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -34,7 +34,7 @@
 #include "RemoteWCLayerTreeHostMessages.h"
 #include "StreamConnectionWorkQueue.h"
 #include "WCScene.h"
-#include "WCUpateInfo.h"
+#include "WCUpdateInfo.h"
 
 namespace WebKit {
 
@@ -96,7 +96,7 @@ uint64_t RemoteWCLayerTreeHost::messageSenderDestinationID() const
     return m_identifier.toUInt64();
 }
 
-void RemoteWCLayerTreeHost::update(WCUpateInfo&& update, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
+void RemoteWCLayerTreeHost::update(WCUpdateInfo&& update, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
 {
     remoteGraphicsStreamWorkQueue().dispatch([this, weakThis = WeakPtr(*this), scene = m_scene.get(), update = WTFMove(update), completionHandler = WTFMove(completionHandler)]() mutable {
         auto updateInfo = scene->update(WTFMove(update));

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
@@ -38,7 +38,7 @@ namespace WebKit {
 class GPUConnectionToWebProcess;
 class UpdateInfo;
 class WCScene;
-struct WCUpateInfo;
+struct WCUpdateInfo;
 
 class RemoteWCLayerTreeHost : public IPC::MessageReceiver, private IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
@@ -47,7 +47,7 @@ public:
     RemoteWCLayerTreeHost(GPUConnectionToWebProcess&, WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);
     ~RemoteWCLayerTreeHost();
     // message handlers
-    void update(WCUpateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
+    void update(WCUpdateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in
@@ -23,7 +23,7 @@
 #if USE(GRAPHICS_LAYER_WC)
 
 messages -> RemoteWCLayerTreeHost NotRefCounted {
-    Update(struct WebKit::WCUpateInfo updateInfo) -> (std::optional<WebKit::UpdateInfo> updateInfo)
+    Update(struct WebKit::WCUpdateInfo updateInfo) -> (std::optional<WebKit::UpdateInfo> updateInfo)
 }
 
 #endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -32,7 +32,7 @@
 #include "WCContentBuffer.h"
 #include "WCContentBufferManager.h"
 #include "WCSceneContext.h"
-#include "WCUpateInfo.h"
+#include "WCUpdateInfo.h"
 #include <WebCore/TextureMapperGLHeaders.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TextureMapperPlatformLayer.h>
@@ -83,7 +83,7 @@ WCScene::~WCScene()
     m_textureMapper = nullptr;
 }
 
-std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
+std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
 {
     if (!m_context->makeContextCurrent())
         return std::nullopt;

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.h
@@ -44,7 +44,7 @@ class TextureMapperTiledBackingStore;
 namespace WebKit {
 
 class WCSceneContext;
-struct WCUpateInfo;
+struct WCUpdateInfo;
 
 class WCScene {
     WTF_MAKE_FAST_ALLOCATED;
@@ -52,7 +52,7 @@ public:
     WCScene(WebCore::ProcessIdentifier, bool usesOffscreenRendering);
     ~WCScene();
     void initialize(WCSceneContext&);
-    std::optional<UpdateInfo> update(WCUpateInfo&&);
+    std::optional<UpdateInfo> update(WCUpdateInfo&&);
 
 private:
     struct Layer;

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp
@@ -31,7 +31,7 @@
 #include "GPUConnectionToWebProcess.h"
 #include "MessageSenderInlines.h"
 #include "RemoteWCLayerTreeHostMessages.h"
-#include "WCUpateInfo.h"
+#include "WCUpdateInfo.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 
@@ -84,7 +84,7 @@ uint64_t RemoteWCLayerTreeHostProxy::messageSenderDestinationID() const
     return wcLayerTreeHostIdentifier().toUInt64();
 }
 
-void RemoteWCLayerTreeHostProxy::update(WCUpateInfo&& updateInfo, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
+void RemoteWCLayerTreeHostProxy::update(WCUpdateInfo&& updateInfo, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::RemoteWCLayerTreeHost::Update(updateInfo), WTFMove(completionHandler));
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-struct WCUpateInfo;
+struct WCUpdateInfo;
 
 class RemoteWCLayerTreeHostProxy
     : private IPC::MessageSender
@@ -46,7 +46,7 @@ public:
     RemoteWCLayerTreeHostProxy(WebPage&, bool usesOffscreenRendering);
     ~RemoteWCLayerTreeHostProxy();
 
-    void update(WCUpateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
+    void update(WCUpdateInfo&&, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&&);
 
     void ref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::ref(); }
     void deref() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RemoteWCLayerTreeHostProxy>::deref(); }

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -193,7 +193,7 @@ void DrawingAreaWC::triggerRenderingUpdate()
     m_updateRenderingTimer.startOneShot(0_s);
 }
 
-static void flushLayerImageBuffers(WCUpateInfo& info)
+static void flushLayerImageBuffers(WCUpdateInfo& info)
 {
     for (auto& layerInfo : info.changedLayers) {
         if (layerInfo.changes & WCLayerChange::Background) {
@@ -363,7 +363,7 @@ void DrawingAreaWC::graphicsLayerRemoved(GraphicsLayerWC& layer)
     m_updateInfo.removedLayers.append(layer.primaryLayerID());
 }
 
-void DrawingAreaWC::commitLayerUpateInfo(WCLayerUpateInfo&& info)
+void DrawingAreaWC::commitLayerUpdateInfo(WCLayerUpdateInfo&& info)
 {
     m_updateInfo.changedLayers.append(WTFMove(info));
 }

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -67,7 +67,7 @@ private:
     // GraphicsLayerWC::Observer
     void graphicsLayerAdded(GraphicsLayerWC&) override;
     void graphicsLayerRemoved(GraphicsLayerWC&) override;
-    void commitLayerUpateInfo(WCLayerUpateInfo&&) override;
+    void commitLayerUpdateInfo(WCLayerUpdateInfo&&) override;
     RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize) override;
 
     bool isCompositingMode();
@@ -86,7 +86,7 @@ private:
     bool m_inUpdateRendering { false };
     bool m_waitDidUpdate { false };
     bool m_isForceRepaintCompletionHandlerDeferred { false };
-    WCUpateInfo m_updateInfo;
+    WCUpdateInfo m_updateInfo;
     Ref<WebCore::GraphicsLayer> m_rootLayer;
     RefPtr<WebCore::GraphicsLayer> m_contentLayer;
     RefPtr<WebCore::GraphicsLayer> m_viewOverlayRootLayer;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -42,7 +42,7 @@ public:
     WCTiledBacking(GraphicsLayerWC& owner)
         : m_owner(owner) { }
 
-    bool paintAndFlush(WCLayerUpateInfo& update)
+    bool paintAndFlush(WCLayerUpdateInfo& update)
     {
         bool repainted = false;
         for (auto& entry : m_tileGrid.tiles()) {
@@ -510,7 +510,7 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
 {
     if (!m_uncommittedChanges)
         return;
-    WCLayerUpateInfo update;
+    WCLayerUpdateInfo update;
     update.id = primaryLayerID();
     update.changes = std::exchange(m_uncommittedChanges, { });
     if (update.changes & WCLayerChange::Children) {
@@ -591,7 +591,7 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
             update.contentBufferIdentifiers = static_cast<WCPlatformLayerGCGL*>(m_platformLayer)->takeContentBufferIdentifiers();
 #endif
     }
-    m_observer->commitLayerUpateInfo(WTFMove(update));
+    m_observer->commitLayerUpdateInfo(WTFMove(update));
 }
 
 TiledBacking* GraphicsLayerWC::tiledBacking() const

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -27,7 +27,7 @@
 
 #if USE(GRAPHICS_LAYER_WC)
 
-#include "WCUpateInfo.h"
+#include "WCUpdateInfo.h"
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
 #include <wtf/DoublyLinkedList.h>
 
@@ -43,7 +43,7 @@ public:
     struct Observer {
         virtual void graphicsLayerAdded(GraphicsLayerWC&) = 0;
         virtual void graphicsLayerRemoved(GraphicsLayerWC&) = 0;
-        virtual void commitLayerUpateInfo(WCLayerUpateInfo&&) = 0;
+        virtual void commitLayerUpdateInfo(WCLayerUpdateInfo&&) = 0;
         virtual RefPtr<WebCore::ImageBuffer> createImageBuffer(WebCore::FloatSize) = 0;
     };
 

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -93,7 +93,7 @@ enum class WCLayerChange : uint32_t {
     PlatformLayer           = 1 << 19,
 };
 
-struct WCLayerUpateInfo {
+struct WCLayerUpdateInfo {
     WebCore::PlatformLayerIdentifier id;
     OptionSet<WCLayerChange> changes;
     Vector<WebCore::PlatformLayerIdentifier> children;
@@ -178,7 +178,7 @@ struct WCLayerUpateInfo {
     }
 
     template <class Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCLayerUpateInfo& result)
+    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCLayerUpdateInfo& result)
     {
         if (!decoder.decode(result.id))
             return false;
@@ -290,11 +290,11 @@ struct WCLayerUpateInfo {
     }
 };
 
-struct WCUpateInfo {
+struct WCUpdateInfo {
     WebCore::PlatformLayerIdentifier rootLayer;
     Vector<WebCore::PlatformLayerIdentifier> addedLayers;
     Vector<WebCore::PlatformLayerIdentifier> removedLayers;
-    Vector<WCLayerUpateInfo> changedLayers;
+    Vector<WCLayerUpdateInfo> changedLayers;
 
     template<class Encoder>
     void encode(Encoder& encoder) const
@@ -306,7 +306,7 @@ struct WCUpateInfo {
     }
 
     template <class Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCUpateInfo& result)
+    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCUpdateInfo& result)
     {
         if (!decoder.decode(result.rootLayer))
             return false;


### PR DESCRIPTION
#### 6f3d38914686251c5a708c2532307a3f3f9c98d8
<pre>
Fix typo in WC class names
<a href="https://bugs.webkit.org/show_bug.cgi?id=257835">https://bugs.webkit.org/show_bug.cgi?id=257835</a>

Reviewed by Fujii Hironori.

Rename `WCUpateInfo` -&gt; `WCUpdateInfo` and `WCLayerUpateInfo` -&gt;
`WCLayerUpdateInfo`. Rename the file as well.

* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::RemoteWCLayerTreeHost::update):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h:
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.messages.in:
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):
* Source/WebKit/GPUProcess/graphics/wc/WCScene.h:
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.cpp:
(WebKit::RemoteWCLayerTreeHostProxy::update):
* Source/WebKit/WebProcess/GPU/graphics/wc/RemoteWCLayerTreeHostProxy.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::flushLayerImageBuffers):
(WebKit::DrawingAreaWC::commitLayerUpdateInfo):
(WebKit::DrawingAreaWC::commitLayerUpateInfo): Deleted.
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::flushCompositingStateForThisLayerOnly):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h: Renamed from Source/WebKit/WebProcess/WebPage/wc/WCUpateInfo.h.
(WebKit::WCLayerUpdateInfo::decode):
(WebKit::WCUpdateInfo::decode):

Canonical link: <a href="https://commits.webkit.org/264964@main">https://commits.webkit.org/264964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39516e0a69ec784a285fe4ee142b2ad5905061e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10960 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9448 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11119 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1065 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->