### PR TITLE
Adopt PLATFORM(VISION) wherever PLATFORM(IOS) is used (Tools version)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -127,7 +127,7 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
 
 // FIXME: When can we enable this for non-Cocoa platforms?
 // FIXME: Can we enable this for watchOS and tvOS?
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
     result = KeyAgreementResponse::parse(convertBytesToVector(TestData::kCtapClientPinInvalidKeyAgreementResponse, sizeof(TestData::kCtapClientPinInvalidKeyAgreementResponse))); // The point is not on the curve.
     EXPECT_FALSE(result);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm
@@ -156,7 +156,7 @@ TEST(AVFoundationSoftLink, Constants)
     EXPECT_TRUE([AVContentKeyRequestProtocolVersionsKey isEqualToString:@"ProtocolVersionsKey"]);
 #endif
 
-#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(WATCHOS) || PLATFORM(APPLETV)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(WATCHOS) || PLATFORM(APPLETV) || PLATFORM(VISION)
     EXPECT_TRUE(PAL::canLoad_AVFoundation_AVVideoCodecTypeHEVCWithAlpha());
     EXPECT_TRUE([AVVideoCodecTypeHEVCWithAlpha isEqualToString:@"muxa"]);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/AGXCompilerService.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AGXCompilerService.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if WK_HAVE_C_SPI && PLATFORM(IOS)
+#if WK_HAVE_C_SPI && (PLATFORM(IOS) || PLATFORM(VISION))
 
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
@@ -48,4 +48,4 @@ TEST(WebKit, IOKitOpenSandboxAccessForDeviceWithAGXCompilerService)
 
 }
 
-#endif // WK_HAVE_C_SPI
+#endif // WK_HAVE_C_SPI && PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -488,7 +488,7 @@ TEST(WebKit, InterruptionBetweenSameProcessPages)
     TestWebKitAPI::Util::run(&done);
 
     done = false;
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     [webView1 stringByEvaluatingJavaScript:@"checkIsNotPlaying()"];
 #else
     [webView1 stringByEvaluatingJavaScript:@"checkIsPlaying()"];

--- a/Tools/TestWebKitAPI/Tests/WebKit/GrantAccessToMobileAssets.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GrantAccessToMobileAssets.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
@@ -39,4 +39,4 @@ TEST(WebKit, GrantAccessToMobileAssetsCrash)
     [webView _revokeAccessToAssetServices];
 }
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioBufferSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioBufferSize.mm
@@ -61,7 +61,7 @@ TEST(WebKit, AudioBufferSize)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm
@@ -137,7 +137,7 @@ TEST(Coding, WKWebView)
 
 #if PLATFORM(IOS_FAMILY)
     [a setAllowsLinkPreview:YES];
-#if PLATFORM(IOS) || PLATFORM(MACCATALYST)
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
     [a setFindInteractionEnabled:YES];
 #endif
 #else
@@ -157,7 +157,7 @@ TEST(Coding, WKWebView)
     EXPECT_EQ([a magnification], [b magnification]);
 #endif
 
-#if PLATFORM(IOS) || PLATFORM(MACCATALYST)
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
     EXPECT_EQ([a isFindInteractionEnabled], [b isFindInteractionEnabled]);
 #endif
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm
@@ -159,7 +159,7 @@ TEST(WebKit, CookieCachePruning)
 }
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/253387 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKit, DISABLED_CookieAccessFromPDFInAboutBlank)
 #else
 TEST(WebKit, CookieAccessFromPDFInAboutBlank)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm
@@ -127,7 +127,7 @@ TEST(WebKit, DISABLED_DataDetectionReferenceDate)
     expectLinkCount(webView.get(), @"yesterday at 6PM", 1);
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 TEST(WebKit, AddAndRemoveDataDetectors)
 {
@@ -174,6 +174,6 @@ TEST(WebKit, DoNotCrashWhenDetectingDataAfterWebProcessTerminates)
     [webView synchronouslyRemoveDataDetectedLinks];
 }
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -438,7 +438,7 @@ TEST(PrivateClickMeasurement, DatabaseLocation)
     EXPECT_EQ(webViewToKeepNetworkProcessAlive.get().configuration.websiteDataStore._networkProcessIdentifier, originalNetworkProcessPid);
 }
 
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 static RetainPtr<NSURL> testPCMDaemonLocation()
 {
@@ -647,7 +647,7 @@ TEST(PrivateClickMeasurement, NetworkProcessDebugMode)
 }
 #endif // PLATFORM(MAC)
 
-#endif // PLATFORM(MAC) || PLATFORM(IOS)
+#endif // PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #if HAVE(UI_EVENT_ATTRIBUTION)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -237,7 +237,7 @@ static void swizzledSetAnalysis(VKCImageAnalysisInteraction *, SEL, VKCImageAnal
 namespace TestWebKitAPI {
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(FullscreenVideoTextRecognition, DISABLED_TogglePlaybackInElementFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
@@ -255,7 +255,7 @@ TEST(FullscreenVideoTextRecognition, TogglePlaybackInElementFullscreen)
 }
 
 // FIXME: re-enable for iOS when rdar://107476837 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(FullscreenVideoTextRecognition, DISABLED_AddVideoAfterEnteringFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
@@ -275,7 +275,7 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
 // FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
-#if PLATFORM(IOS) || !defined(NDEBUG)
+#if PLATFORM(IOS) || PLATFORM(VISION) || !defined(NDEBUG)
 TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -480,7 +480,7 @@ TEST(GPUProcess, CrashWhilePlayingAudioViaCreateMediaElementSource)
     EXPECT_EQ(webViewPID, [webView _webProcessIdentifier]);
 
     // FIXME: On iOS, video resumes after the GPU process crash but audio does not.
-#if !PLATFORM(IOS)
+#if !(PLATFORM(IOS) || PLATFORM(VISION))
     // Audio should resume playing.
     timeout = 0;
     while (![webView _isPlayingAudio] && timeout++ < 100)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
@@ -74,7 +74,7 @@ long long fileSizeAtPath(NSString *path)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_CheckpointsWALAutomatically)
 #else
 TEST(IndexedDB, CheckpointsWALAutomatically)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -52,7 +52,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexUpgradeToV2)
 #else
 TEST(IndexedDB, IndexUpgradeToV2)
@@ -118,7 +118,7 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexUpgradeToV2WithMultipleIndices)
 #else
 TEST(IndexedDB, IndexUpgradeToV2WithMultipleIndices)
@@ -128,7 +128,7 @@ TEST(IndexedDB, IndexUpgradeToV2WithMultipleIndices)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexUpgradeToV2WithMultipleIndicesHaveSameID)
 #else
 TEST(IndexedDB, IndexUpgradeToV2WithMultipleIndicesHaveSameID)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
@@ -52,7 +52,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBInPageCache)
 #else
 TEST(IndexedDB, IndexedDBInPageCache)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
@@ -53,7 +53,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBMultiProcess)
 #else
 TEST(IndexedDB, IndexedDBMultiProcess)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -57,7 +57,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBPersistence)
 #else
 TEST(IndexedDB, IndexedDBPersistence)
@@ -253,7 +253,7 @@ static void loadThirdPartyPageInWebView(WKWebView *webView, NSString *expectedRe
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBThirdPartyFrameHasAccess)
 #else
 TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
@@ -287,7 +287,7 @@ TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBThirdPartyDataRemoval)
 #else
 TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
@@ -342,7 +342,7 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBThirdPartyStorageLayout)
 #else
 TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
@@ -496,7 +496,7 @@ static const char* workerFrameBytes = R"TESTRESOURCE(
 )TESTRESOURCE";
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBThirdPartyWorkerHasAccess)
 #else
 TEST(IndexedDB, IndexedDBThirdPartyWorkerHasAccess)
@@ -579,7 +579,7 @@ indexedDB.databases().then(postDatabases);
 )TESTRESOURCE";
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBGetDatabases)
 #else
 TEST(IndexedDB, IndexedDBGetDatabases)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
@@ -72,7 +72,7 @@ static void keepNetworkProcessActive()
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBSuspendImminently)
 #else
 TEST(IndexedDB, IndexedDBSuspendImminently)
@@ -145,7 +145,7 @@ try {
 )TESTRESOURCE";
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_SuspendImminentlyForThirdPartyDatabases)
 #else
 TEST(IndexedDB, SuspendImminentlyForThirdPartyDatabases)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
@@ -54,7 +54,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBTempFileSize)
 #else
 TEST(IndexedDB, IndexedDBTempFileSize)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
@@ -52,7 +52,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_IndexedDBUserDelete)
 #else
 TEST(IndexedDB, IndexedDBUserDelete)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
@@ -90,7 +90,7 @@ static RetainPtr<WKWebView> createdWebView;
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WKWebView, DISABLED_LocalStorageProcessCrashes)
 #else
 TEST(WKWebView, LocalStorageProcessCrashes)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NoPauseWhenSwitchingTabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NoPauseWhenSwitchingTabs.mm
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 TEST(WebKit, NoPauseWhenSwitchingTabs)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     configuration.get().allowsInlineMediaPlayback = YES;
     configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NotificationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NotificationAPI.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if ENABLE(NOTIFICATIONS) && !PLATFORM(IOS)
+#if ENABLE(NOTIFICATIONS) && !(PLATFORM(IOS) || PLATFORM(VISION))
 #import "DeprecatedGlobalValues.h"
 #import "PlatformUtilities.h"
 #import "TestWKWebView.h"
@@ -171,4 +171,4 @@ TEST(Notification, ParallelPermissionRequestsGranted)
 
 } // namespace TestWebKitAPI
 
-#endif // ENABLE(NOTIFICATIONS) && !PLATFORM(IOS)
+#endif // ENABLE(NOTIFICATIONS) && !(PLATFORM(IOS) || PLATFORM(VISION))

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -6947,7 +6947,7 @@ static bool hasOverlay(CALayer *layer)
 #endif
 
 // FIXME when rdar://106098852 is resolved
-#if PLATFORM(MAC) && (__MAC_OS_X_VERSION_MIN_REQUIRED > 130000) || PLATFORM(IOS)
+#if PLATFORM(MAC) && (__MAC_OS_X_VERSION_MIN_REQUIRED > 130000) || PLATFORM(IOS) || PLATFORM(VISION)
 TEST(ProcessSwap, DISABLED_PageOverlayLayerPersistence)
 #else
 TEST(ProcessSwap, PageOverlayLayerPersistence)
@@ -7002,7 +7002,7 @@ TEST(ProcessSwap, PageOverlayLayerPersistence)
 #endif
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
 TEST(ProcessSwap, QuickLookRequestsPasswordAfterSwap)
@@ -8224,7 +8224,7 @@ TEST(ProcessSwap, MemoryPressureDuringProcessSwap)
         TestWebKitAPI::Util::spinRunLoop(10);
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 TEST(ProcessSwap, CannotDisableLockdownModeWithoutBrowserEntitlement)
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm
@@ -278,7 +278,7 @@ static RetainPtr<WKWebView> runTestDecideBeforeLoading(QuickLookDelegate *delega
     return runTest(delegate, request, YES);
 }
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 static RetainPtr<WKWebView> runTestDecideAfterLoading(QuickLookDelegate *delegate, NSURLRequest *request)
 {
     return runTest(delegate, request, NO);
@@ -322,7 +322,7 @@ TEST(QuickLook, AllowResponseAfterLoadingPreview)
 
 @end
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, AsyncAllowResponseBeforeLoadingPreview)
 {
     auto delegate = adoptNS([[QuickLookAsyncDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() responsePolicy:WKNavigationResponsePolicyAllow]);
@@ -355,7 +355,7 @@ TEST(QuickLook, CancelResponseBeforeLoadingPreview)
     EXPECT_TRUE([delegate didFailNavigation]);
 }
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, CancelResponseAfterLoadingPreview)
 {
     auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyCancel]);
@@ -382,7 +382,7 @@ TEST(QuickLook, DownloadResponseBeforeLoadingPreview)
     [delegate verifyDownload];
 }
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, DownloadResponseAfterLoadingPreview)
 {
     auto delegate = adoptNS([[QuickLookDelegate alloc] initWithExpectedFileURL:pagesDocumentURL().get() previewMIMEType:pagesDocumentPreviewMIMEType responsePolicy:WKNavigationResponsePolicyDownload]);
@@ -409,7 +409,7 @@ TEST(QuickLook, DownloadResponseAfterLoadingPreview)
 
 @end
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, RequestPasswordBeforeLoadingPreview)
 {
     NSURL *passwordProtectedDocumentURL = [NSBundle.mainBundle URLForResource:@"password-protected" withExtension:@"pages" subdirectory:@"TestWebKitAPI.resources"];
@@ -479,7 +479,7 @@ TEST(QuickLook, ReloadAndSameDocumentNavigation)
 
 @end
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED > 130400) || PLATFORM(VISION)
 TEST(QuickLook, LegacyQuickLookContent)
 {
     WebKitInitialize();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -84,7 +84,7 @@ static void ensureITPFileIsCreated()
 }
 
 // FIXME when rdar://109481486 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(ResourceLoadStatistics, DISABLED_GrandfatherCallback)
 #else
 TEST(ResourceLoadStatistics, GrandfatherCallback)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -257,7 +257,7 @@ private:
     });
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 - (UIViewController *)_presentingViewControllerForWebView:(WKWebView *)webView
 {
     return nil;
@@ -268,7 +268,7 @@ private:
 
 #if PLATFORM(MAC)
 @interface TestSOAuthorizationViewController : NSViewController
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
 @interface TestSOAuthorizationViewController : UIViewController
 #endif
 @end
@@ -605,7 +605,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
 #if PLATFORM(MAC)
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     EXPECT_FALSE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #endif
 
@@ -613,7 +613,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed1)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -634,14 +634,14 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed2)
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
     [webView _loadRequest:[NSURLRequest requestWithURL:testURL] shouldOpenExternalURLs:YES];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
     checkAuthorizationOptions(false, emptyString(), 0);
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
     EXPECT_FALSE(policyForAppSSOPerformed); // The delegate isn't registered, so this won't be set.
@@ -667,7 +667,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
     [webView _loadRequest:[NSURLRequest requestWithURL:testURL] shouldOpenExternalURLs:YES];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
 #endif
@@ -675,7 +675,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed3)
     EXPECT_TRUE(gAuthorization.enableEmbeddedAuthorizationViewController);
 #if PLATFORM(MAC)
     checkAuthorizationOptions(false, emptyString(), 0);
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
     EXPECT_TRUE(policyForAppSSOPerformed);
@@ -710,7 +710,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceed4)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -760,7 +760,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookie)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -794,7 +794,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithCookies)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Set-Cookie" : @"sessionid=38afes7a8, qwerty=219ffwef9w0f, id=a3fWa;", @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -821,14 +821,14 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithRedirectionAndCookie)
     URL testURL { "https://www.example.com"_str };
 #if PLATFORM(MAC)
     [webView loadRequest:[NSURLRequest requestWithURL:testURL]];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     // Here we force RedirectSOAuthorizationSession to go to the with user gestures route.
     [webView evaluateJavaScript: [NSString stringWithFormat:@"location = '%@'", (id)testURL.string()] completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
 #if PLATFORM(MAC)
     checkAuthorizationOptions(false, emptyString(), 0);
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     checkAuthorizationOptions(true, "null"_s, 0);
 #endif
     EXPECT_TRUE(policyForAppSSOPerformed);
@@ -898,7 +898,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -957,7 +957,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithActiveSessionDidMoveWindow)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -988,7 +988,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedTwice)
         auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
         [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
         Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
         navigationCompleted = false;
         Util::run(&navigationCompleted);
 #endif
@@ -1025,7 +1025,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressActiveSession)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -1067,7 +1067,7 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -1239,7 +1239,7 @@ TEST(SOAuthorizationRedirect, SOAuthorizationLoadPolicyAllowAsync)
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
     Util::run(&navigationCompleted);
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     navigationCompleted = false;
     Util::run(&navigationCompleted);
 #endif
@@ -1681,7 +1681,7 @@ TEST(SOAuthorizationPopUp, NoInterceptions)
     navigationCompleted = false;
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&newWindowCreated);
@@ -1755,7 +1755,7 @@ TEST(SOAuthorizationPopUp, InterceptionError)
     [delegate setShouldOpenExternalSchemes:true];
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1795,7 +1795,7 @@ TEST(SOAuthorizationPopUp, InterceptionCancel)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1831,7 +1831,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByItself)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1869,7 +1869,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByParent)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1907,7 +1907,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedCloseByWebKit)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1942,7 +1942,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithOtherHttpStatusCode)
     [delegate setShouldOpenExternalSchemes:true];
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -1986,7 +1986,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedWithCookie)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -2027,7 +2027,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedTwice)
         policyForAppSSOPerformed = false;
 #if PLATFORM(MAC)
         [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
         [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
         Util::run(&authorizationPerformed);
@@ -2064,7 +2064,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -2088,7 +2088,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedSuppressActiveSession)
     policyForAppSSOPerformed = false;
 #if PLATFORM(MAC)
     [newWebView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [newWebView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationCancelled);
@@ -2134,7 +2134,7 @@ TEST(SOAuthorizationPopUp, InterceptionSucceedNewWindowNavigation)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -2167,7 +2167,7 @@ TEST(SOAuthorizationPopUp, AuthorizationOptions)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -2193,7 +2193,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnore)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&newWindowCreated);
@@ -2224,7 +2224,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyAllowAsync)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&authorizationPerformed);
@@ -2260,7 +2260,7 @@ TEST(SOAuthorizationPopUp, SOAuthorizationLoadPolicyIgnoreAsync)
 
 #if PLATFORM(MAC)
     [webView sendClicksAtPoint:NSMakePoint(200, 200) numberOfClicks:1];
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
     [webView evaluateJavaScript: @"clickMe()" completionHandler:nil];
 #endif
     Util::run(&newWindowCreated);
@@ -2552,7 +2552,7 @@ TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyIgnore)
 }
 
 // FIX ME WHEN rdar://107855114 is resolved. 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(SOAuthorizationSubFrame, DISABLED_SOAuthorizationLoadPolicyAllowAsync)
 #else
 TEST(SOAuthorizationSubFrame, SOAuthorizationLoadPolicyAllowAsync)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -2383,7 +2383,7 @@ TEST(ServiceWorkers, ChangeOfServerCertificate)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(ServiceWorkers, DISABLED_ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
 #else
 TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
@@ -52,7 +52,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_StoreBlobThenRemoveData)
 #else
 TEST(IndexedDB, StoreBlobThenRemoveData)
@@ -137,7 +137,7 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_StoreBlobThenDeleteDatabase)
 #else
 TEST(IndexedDB, StoreBlobThenDeleteDatabase)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if PLATFORM(IOS) && USE(SYSTEM_PREVIEW)
+#if (PLATFORM(IOS) || PLATFORM(VISION)) && USE(SYSTEM_PREVIEW)
 
 #import "TestWKWebView.h"
 #import "Utilities.h"
@@ -175,4 +175,4 @@ TEST(WebKit, SystemPreviewTriggeredOnDetachedElement)
 
 }
 
-#endif // PLATFORM(IOS) && USE(SYSTEM_PREVIEW)
+#endif // (PLATFORM(IOS) || PLATFORM(VISION)) && USE(SYSTEM_PREVIEW)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -50,7 +50,7 @@
 #import <Carbon/Carbon.h>
 #endif
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 #import "ClassMethodSwizzler.h"
 #import "UIKitSPI.h"
 #endif
@@ -395,7 +395,7 @@ TEST(WebKit, InjectedBundleNodeHandleIsSelectElement)
     TestWebKitAPI::Util::run(&done);
 }
 
-#if PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
+#if (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) || PLATFORM(VISION)
 
 static int presentViewControllerCallCount = 0;
 
@@ -550,7 +550,7 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:WebKitLockdownModeAlertShownKey];
 }
 
-#endif // PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000
+#endif // (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) || PLATFORM(VISION)
 
 #if PLATFORM(IOS_FAMILY)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #import "DragAndDropSimulator.h"
 #import "InstanceMethodSwizzler.h"
@@ -2769,4 +2769,4 @@ TEST(WKAttachmentTestsIOS, PasteRichTextCopiedFromNotes)
 
 } // namespace TestWebKitAPI
 
-#endif // PLATFORM(MAC) || PLATFORM(IOS)
+#endif // PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm
@@ -43,14 +43,14 @@
 #import <Carbon/Carbon.h>
 #endif
 
-#if PLATFORM(IOS) || PLATFORM(MAC)
+#if PLATFORM(IOS) || PLATFORM(MAC) || PLATFORM(VISION)
 static NSData *pdfData()
 {
     return [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"pdf" subdirectory:@"TestWebKitAPI.resources"]];
 }
 #endif
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 @interface PDFHostViewController : UIViewController
 + (void)createHostView:(void(^)(id hostViewController))callback forExtensionIdentifier:(NSString *)extensionIdentifier;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm
@@ -128,7 +128,7 @@ TEST(WKWebViewCloseAllMediaPresentationsInternal, PictureInPicture)
 #if ENABLE(FULLSCREEN_API)
 
 // FIXME rdar://109155883 is resolved.
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WKWebViewCloseAllMediaPresentations, DISABLED_VideoFullscreen)
 # else
 TEST(WKWebViewCloseAllMediaPresentations, VideoFullscreen)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -357,7 +357,7 @@ TEST(WebKit, EvaluateJavaScriptInAttachments)
 }
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/207874 is resolved
-#if !PLATFORM(IOS)
+#if !(PLATFORM(IOS) || PLATFORM(VISION))
 TEST(WebKit, AllowsContentJavaScript)
 {
     RetainPtr<TestWKWebView> webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -99,7 +99,7 @@ namespace TestWebKitAPI {
 
 
 // FIXME: Re-enable this test once webkit.org/b/208451 is resolved.
-#if !PLATFORM(IOS)
+#if !(PLATFORM(IOS) || PLATFORM(VISION))
 TEST(WKWebsiteDataStore, RemoveAndFetchData)
 {
     readyToContinue = false;
@@ -115,7 +115,7 @@ TEST(WKWebsiteDataStore, RemoveAndFetchData)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 }
-#endif // !PLATFORM(IOS)
+#endif // !(PLATFORM(IOS) || PLATFORM(VISION))
 
 TEST(WKWebsiteDataStore, RemoveEphemeralData)
 {
@@ -640,7 +640,7 @@ TEST(WKWebsiteDataStore, ListIdentifiers)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WKWebsiteDataStorePrivate, DISABLED_FetchWithSize)
 #else
 TEST(WKWebsiteDataStorePrivate, FetchWithSize)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
@@ -57,7 +57,7 @@ static bool masterKeyCalled = false;
 namespace TestWebKitAPI {
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKit, DISABLED_WebCryptoNilMasterKey)
 #else
 TEST(WebKit, WebCryptoNilMasterKey)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
@@ -52,7 +52,7 @@
 @end
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_WebProcessKillIDBCleanup)
 #else
 TEST(IndexedDB, WebProcessKillIDBCleanup)
@@ -94,7 +94,7 @@ TEST(IndexedDB, WebProcessKillIDBCleanup)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(IndexedDB, DISABLED_KillWebProcessWithOpenConnection)
 #else
 TEST(IndexedDB, KillWebProcessWithOpenConnection)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -268,7 +268,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithoutPrewarming)
 #else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
@@ -278,7 +278,7 @@ TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithPrewarming)
 #else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)
@@ -497,7 +497,7 @@ TEST(WebKit, WebsiteDataStoreIfExists)
 }
 
 // FIXME when rdar://109725221 is resolved
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKit, DISABLED_WebsiteDataStoreRenameOriginForIndexedDatabase)
 #else
 TEST(WebKit, WebsiteDataStoreRenameOriginForIndexedDatabase)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -351,7 +351,7 @@ static void checkFrameInfo(WKFrameInfo *frame, bool isMainFrame, NSString *url, 
     EXPECT_EQ(frame.webView, webView);
 }
 
-#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 bool addKeyToKeychain(const String& privateKeyBase64, const String& rpId, const String& userHandleBase64, bool synchronizable = false)
 {
@@ -401,7 +401,7 @@ void cleanUpKeychain(const String& rpId)
     SecItemDelete((__bridge CFDictionaryRef)deleteQuery);
 }
 
-#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 } // namesapce;
 
@@ -1269,7 +1269,7 @@ TEST(WebAuthenticationPanel, MultipleAccounts)
 
 // For macOS, only internal builds can sign keychain entitlemnets
 // which are required to run local authenticator tests.
-#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 TEST(WebAuthenticationPanel, LAError)
 {
@@ -1478,7 +1478,7 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 
 #endif // PLATFORM(MAC)
 
-#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 {
@@ -1738,7 +1738,7 @@ TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
 
 // For macOS, only internal builds can sign keychain entitlemnets
 // which are required to run local authenticator tests.
-#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebAuthenticationPanel, MakeCredentialLA)
 {
     reset();
@@ -1946,7 +1946,7 @@ TEST(WebAuthenticationPanel, GetAssertionSPITimeout)
 
 // For macOS, only internal builds can sign keychain entitlemnets
 // which are required to run local authenticator tests.
-#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#if USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebAuthenticationPanel, GetAssertionLA)
 {
     reset();
@@ -2427,7 +2427,7 @@ TEST(WebAuthenticationPanel, DeleteOneCredential)
     EXPECT_NOT_NULL(credentials);
     EXPECT_EQ([credentials count], 0lu);
 }
-#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS)
+#endif // USE(APPLE_INTERNAL_SDK) || PLATFORM(IOS) || PLATFORM(VISION)
 
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if PLATFORM(IOS) || PLATFORM(MACCATALYST)
+#if PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)
 
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
@@ -796,4 +796,4 @@ TEST(iOSMouseSupport, MouseAlwaysConnected)
 
 #endif // PLATFORM(MACCATALYST)
 
-#endif // PLATFORM(IOS) || PLATFORM(MACCATALYST)
+#endif // PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 #import "PlatformUtilities.h"
 #import "Test.h"
@@ -174,4 +174,4 @@ TEST(iOSStylusSupport, StylusDisconnectedTimeoutCancel)
 
 #endif // HAVE(STYLUS_DEVICE_OBSERVATION)
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm
@@ -81,7 +81,7 @@ static AVAudioSessionRouteSharingPolicy routeSharingPolicyLongFormAudio()
 }
 
 // FIXME Re-enable when https://bugs.webkit.org/show_bug.cgi?id=237125 is resovled 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKitLegacy, DISABLED_AudioSessionCategoryIOS)
 #else
 TEST(WebKitLegacy, AudioSessionCategoryIOS)

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm
@@ -83,7 +83,7 @@ IGNORE_WARNINGS_END
 namespace TestWebKitAPI {
 
 // FIXME Re-enable when https://bugs.webkit.org/show_bug.cgi?id=237125 is resovled 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKitLegacy, DISABLED_PreemptVideoFullscreen)
 #else
 TEST(WebKitLegacy, PreemptVideoFullscreen)

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm
@@ -75,7 +75,7 @@ IGNORE_WARNINGS_END
 namespace TestWebKitAPI {
 
 // FIXME Re-enable when https://bugs.webkit.org/show_bug.cgi?id=237125 is resovled 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 TEST(WebKitLegacy, DISABLED_ScrollingDoesNotPauseMedia)
 #else
 TEST(WebKitLegacy, ScrollingDoesNotPauseMedia)

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm
@@ -37,7 +37,7 @@
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
 #import <OpenGL/OpenGL.h>
-#elif PLATFORM(IOS)
+#elif PLATFORM(IOS) || PLATFORM(VISION)
 #import <OpenGLES/EAGL.h>
 #endif
 
@@ -64,7 +64,7 @@ class SetContextCGL {
 };
 #endif
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 class SetContextEAGL {
 public:
     SetContextEAGL()

--- a/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm
@@ -41,7 +41,7 @@
 
 typedef void (^DataLoadCompletionBlock)(NSData *, NSError *);
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 static void checkJSONWithLogging(NSString *jsonString, NSDictionary *expected)
 {
@@ -79,7 +79,7 @@ static _UIDataOwner gLastKnownDataOwner = _UIDataOwnerUndefined;
 
 @end
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 namespace TestWebKitAPI {
 
@@ -195,7 +195,7 @@ TEST(UIPasteboardTests, PasteWithCompletionHandler)
     EXPECT_WK_STREQ("https://www.apple.com/", [webView stringByEvaluatingJavaScript:@"textData.textContent"]);
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 TEST(UIPasteboardTests, DataTransferGetDataWhenPastingURL)
 {
@@ -473,7 +473,7 @@ TEST(UIPasteboardTests, PerformAsDataOwnerWithManagedURL)
     }
 }
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 } // namespace TestWebKitAPI
 

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #import <wtf/RetainPtr.h>
 #import <wtf/spi/darwin/XPCSPI.h>
@@ -45,5 +45,5 @@ void registerPlistWithLaunchD(NSDictionary<NSString *, id> *plist, NSURL *tempDi
 
 } // namespace TestWebKitAPI
 
-#endif // PLATFORM(MAC) || PLATFORM(IOS)
+#endif // PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -26,14 +26,14 @@
 #import "config.h"
 #import "DaemonTestUtilities.h"
 
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 
 #import <mach-o/dyld.h>
 #import <wtf/Vector.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 @interface NSTask : NSObject
 - (instancetype)init;
 - (void)launch;
@@ -65,7 +65,7 @@ RetainPtr<NSURL> currentExecutableDirectory()
     return [currentExecutableLocation() URLByDeletingLastPathComponent];
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 static RetainPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
     auto xpc = adoptNS(xpc_array_create(nullptr, 0));
@@ -109,7 +109,7 @@ static RetainPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, i
 void registerPlistWithLaunchD(NSDictionary<NSString *, id> *plist, NSURL *tempDir)
 {
     NSError *error = nil;
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     auto xpcPlist = convertDictionaryToXPC(plist);
     xpc_dictionary_set_string(xpcPlist.get(), "_ManagedBy", "TestWebKitAPI");
     xpc_dictionary_set_bool(xpcPlist.get(), "RootedSimulatorPath", true);
@@ -178,7 +178,7 @@ void killFirstInstanceOfDaemon(NSString *daemonExecutableName)
     [task waitUntilExit];
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 BOOL restartService(NSString *, NSString *daemonExecutableName)
 {
@@ -205,4 +205,4 @@ BOOL restartService(NSString *serviceName, NSString *)
 
 NS_ASSUME_NONNULL_END
 
-#endif // PLATFORM(MAC) || PLATFORM(IOS)
+#endif // PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)

--- a/Tools/TestWebKitAPI/config.h
+++ b/Tools/TestWebKitAPI/config.h
@@ -118,7 +118,7 @@
 #endif
 
 // FIXME: Move this to PlatformHave.h.
-#if PLATFORM(MAC) || PLATFORM(IOS)
+#if PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(VISION)
 #define HAVE_PDFKIT 1
 #endif
 

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -58,13 +58,13 @@ IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 #import <UIKit/UIWebView_Private.h>
 IGNORE_WARNINGS_END
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 @protocol UIDragSession;
 @class UIDragInteraction;
 @class UIDragItem;
 #import <UIKit/NSItemProvider+UIKitAdditions_Private.h>
 #import <UIKit/UIDragInteraction_Private.h>
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 #else // USE(APPLE_INTERNAL_SDK)
 
@@ -336,13 +336,13 @@ typedef NS_ENUM(NSInteger, _UITextSearchMatchMethod) {
 - (BOOL)_shouldSuppressSoftwareKeyboard;
 @end
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 
 @protocol UIDropInteractionDelegate_Private <UIDropInteractionDelegate>
 - (void)_dropInteraction:(UIDropInteraction *)interaction delayedPreviewProviderForDroppingItem:(UIDragItem *)item previewProvider:(void(^)(UITargetedDragPreview *preview))previewProvider;
 @end
 
-#endif // PLATFORM(IOS)
+#endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
     _UIClickInteractionEventBegan = 0,

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/ActivateFontsCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/ActivateFontsCocoa.mm
@@ -140,7 +140,7 @@ void installFakeHelvetica(WKStringRef configuration)
     NSURL *resourceURL = [resourcesDirectoryURL() URLByAppendingPathComponent:[NSString stringWithFormat:@"FakeHelvetica-%@.ttf", configurationString.get()] isDirectory:NO];
     CFErrorRef error = nullptr;
     if (!CTFontManagerRegisterFontsForURL((__bridge CFURLRef)resourceURL, kCTFontManagerScopeProcess, &error)) {
-#if PLATFORM(MAC) || (PLATFORM(IOS) && !PLATFORM(IOS_FAMILY_SIMULATOR))
+#if PLATFORM(MAC) || ((PLATFORM(IOS) || PLATFORM(VISION)) && !PLATFORM(IOS_FAMILY_SIMULATOR))
         // Registering shadow fonts is only supported on macOS Mojave and iOS 12 or newer, but not iOS Simulator. See Bugs 180062 & 194761.
         NSLog(@"Failed to activate fake Helvetica: %@", error);
 #endif

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -393,7 +393,7 @@ void TestController::handleQueryPermission(WKStringRef string, WKSecurityOriginR
     WKQueryPermissionResultCallbackCompleteWithPrompt(callback);
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 static void lockScreenOrientationCallback(WKPageRef, WKScreenOrientationType orientation)
 {
     TestController::singleton().lockScreenOrientation(orientation);
@@ -973,7 +973,7 @@ void TestController::createWebViewWithOptions(const TestOptions& options)
         decidePolicyForMediaKeySystemPermissionRequest,
         nullptr, // requestWebAuthenticationNoGesture
         queryPermission,
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
         lockScreenOrientationCallback,
         unlockScreenOrientationCallback
 #else

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -402,7 +402,7 @@ public:
 
     void handleQueryPermission(WKStringRef, WKSecurityOriginRef, WKQueryPermissionResultCallbackRef);
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
     void lockScreenOrientation(WKScreenOrientationType);
     void unlockScreenOrientation();
 #endif

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -515,7 +515,7 @@ UIPasteboardConsistencyEnforcer *TestController::pasteboardConsistencyEnforcer()
     return m_pasteboardConsistencyEnforcer.get();
 }
 
-#if PLATFORM(IOS)
+#if PLATFORM(IOS) || PLATFORM(VISION)
 void TestController::lockScreenOrientation(WKScreenOrientationType orientation)
 {
     TestRunnerWKWebView *webView = mainWebView()->platformView();


### PR DESCRIPTION
#### 70f1cbcc20e8912f4f6b1cbc1a4f0fbd699f435d
<pre>
Adopt PLATFORM(VISION) wherever PLATFORM(IOS) is used (Tools version)
<a href="https://bugs.webkit.org/show_bug.cgi?id=257837">https://bugs.webkit.org/show_bug.cgi?id=257837</a>
rdar://110427723

Reviewed by Megan Gardner and Aditya Keerthi.

* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/AVFoundationSoftLinkTest.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/AGXCompilerService.mm:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/GrantAccessToMobileAssets.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/AudioBufferSize.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Coding.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CookiePrivateBrowsing.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NoPauseWhenSwitchingTabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NotificationAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/QuickLook.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAttachmentTests.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPDFView.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCloseAllMediaPresentations.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSStylusSupport.mm:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/AudioSessionCategoryIOS.mm:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/PreemptVideoFullscreen.mm:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/ScrollingDoesNotPauseMedia.mm:
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/WebGLNoCrashOnOtherThreadAccess.mm:
* Tools/TestWebKitAPI/Tests/ios/UIPasteboardTests.mm:
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.h:
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm:
(TestWebKitAPI::registerPlistWithLaunchD):
* Tools/TestWebKitAPI/config.h:
* Tools/TestWebKitAPI/ios/UIKitSPI.h:
* Tools/WebKitTestRunner/InjectedBundle/cocoa/ActivateFontsCocoa.mm:
(WTR::installFakeHelvetica):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createWebViewWithOptions):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:

Canonical link: <a href="https://commits.webkit.org/264963@main">https://commits.webkit.org/264963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26f2f8a877d34f96dc7829e7e0ccdb4a42a020bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9307 "Failed to checkout and rebase branch from PR 14766") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/9588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/9815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10969 "Failed to checkout and rebase branch from PR 14766") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9317 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/11572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9548 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/10969 "Failed to checkout and rebase branch from PR 14766") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9456 "Failed to checkout and rebase branch from PR 14766") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/11572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/9815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/11572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/9815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/11572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/9815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/9815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1064 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/8899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->