### PR TITLE
Generate serialization of WCUpdateInfo structures

### DIFF
--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -215,6 +215,10 @@ if (USE_GRAPHICS_LAYER_WC)
     list(APPEND WebKit_MESSAGES_IN_FILES
         GPUProcess/graphics/wc/RemoteWCLayerTreeHost
     )
+
+    list(APPEND WebKit_SERIALIZATION_IN_FILES
+        WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+    )
 endif ()
 
 if (USE_WPE_BACKEND_PLAYSTATION)

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -171,6 +171,10 @@ list(APPEND WebKit_MESSAGES_IN_FILES
     GPUProcess/graphics/wc/RemoteWCLayerTreeHost
 )
 
+list(APPEND WebKit_SERIALIZATION_IN_FILES
+    WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+)
+
 list(APPEND WebKit_PRIVATE_LIBRARIES
     comctl32
 )

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -43,31 +43,6 @@ struct WCTileUpdate {
     bool willRemove { false };
     WCBackingStore backingStore;
     WebCore::IntRect dirtyRect;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << index << willRemove;
-        if (!willRemove)
-            encoder << backingStore << dirtyRect;
-    }
-
-    template <class Decoder>
-    static std::optional<WCTileUpdate> decode(Decoder& decoder)
-    {
-        WCTileUpdate result;
-        if (!decoder.decode(result.index))
-            return std::nullopt;
-        if (!decoder.decode(result.willRemove))
-            return std::nullopt;
-        if (!result.willRemove) {
-            if (!decoder.decode(result.backingStore))
-                return std::nullopt;
-            if (!decoder.decode(result.dirtyRect))
-                return std::nullopt;
-        }
-        return result;
-    }
 };
 
 enum class WCLayerChange : uint32_t {
@@ -295,29 +270,6 @@ struct WCUpdateInfo {
     Vector<WebCore::PlatformLayerIdentifier> addedLayers;
     Vector<WebCore::PlatformLayerIdentifier> removedLayers;
     Vector<WCLayerUpdateInfo> changedLayers;
-
-    template<class Encoder>
-    void encode(Encoder& encoder) const
-    {
-        encoder << rootLayer;
-        encoder << addedLayers;
-        encoder << removedLayers;
-        encoder << changedLayers;
-    }
-
-    template <class Decoder>
-    static WARN_UNUSED_RETURN bool decode(Decoder& decoder, WCUpdateInfo& result)
-    {
-        if (!decoder.decode(result.rootLayer))
-            return false;
-        if (!decoder.decode(result.addedLayers))
-            return false;
-        if (!decoder.decode(result.removedLayers))
-            return false;
-        if (!decoder.decode(result.changedLayers))
-            return false;
-        return true;
-    }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
@@ -1,0 +1,41 @@
+# Copyright (C) 2023 Sony Interactive Entertainment Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(GRAPHICS_LAYER_WC)
+
+header: "WCUpdateInfo.h"
+
+[CustomHeader] struct WebKit::WCTileUpdate {
+    WebCore::TextureMapperSparseBackingStore::TileIndex index;
+    bool willRemove;
+    WebKit::WCBackingStore backingStore;
+    WebCore::IntRect dirtyRect;
+}
+
+struct WebKit::WCUpdateInfo {
+    WebCore::PlatformLayerIdentifier rootLayer;
+    Vector<WebCore::PlatformLayerIdentifier> addedLayers;
+    Vector<WebCore::PlatformLayerIdentifier> removedLayers;
+    Vector<WebKit::WCLayerUpdateInfo> changedLayers;
+}
+
+#endif


### PR DESCRIPTION
#### da98ff9957fb6271100ae900060ef9293868edea
<pre>
Generate serialization of WCUpdateInfo structures
<a href="https://bugs.webkit.org/show_bug.cgi?id=257839">https://bugs.webkit.org/show_bug.cgi?id=257839</a>

Reviewed by Fujii Hironori.

Add generated serializers of `WCTileUpdate` and `WCUpdateInfo`.

* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:
(WebKit::WCTileUpdate::encode const): Deleted.
(WebKit::WCTileUpdate::decode): Deleted.
(WebKit::WCUpdateInfo::encode const): Deleted.
(WebKit::WCUpdateInfo::decode): Deleted.
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/264968@main">https://commits.webkit.org/264968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdfc051800a4a572f8be4c95813cd018de0f457e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10970 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9549 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12077 "1 flakes 95 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9457 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11129 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9137 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1068 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->