### PR TITLE
Update handling of negative radius for feMorphology

### DIFF
--- a/LayoutTests/svg/filters/feMorphology-negative-radius-expected.html
+++ b/LayoutTests/svg/filters/feMorphology-negative-radius-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<svg>
+    <filter id="dilate">
+        <feMorphology operator="dilate" radius="0"/>
+    </filter>
+    <rect width="100" height="100" fill="green" filter="url(#dilate)"/>
+
+    <filter id="erode">
+        <feMorphology operator="erode" radius="0"/>
+    </filter>
+    <rect width="100" height="100" fill="green" filter="url(#erode)" x="100"/>
+</svg>

--- a/LayoutTests/svg/filters/feMorphology-negative-radius.html
+++ b/LayoutTests/svg/filters/feMorphology-negative-radius.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<svg>
+    <filter id="dilate">
+        <feMorphology operator="dilate" radius="-1"/>
+    </filter>
+    <rect width="100" height="100" fill="green" filter="url(#dilate)"/>
+
+    <filter id="erode">
+        <feMorphology operator="erode" radius="-1"/>
+    </filter>
+    <rect width="100" height="100" fill="green" filter="url(#erode)" x="100"/>
+</svg>

--- a/LayoutTests/svg/filters/feMorphology-radius-cases.svg
+++ b/LayoutTests/svg/filters/feMorphology-radius-cases.svg
@@ -25,13 +25,13 @@
 
     <!-- negative radius case -->
     <g>
-      <rect x="140" y="10" width="100" height="100" fill="lime"/>
-      <rect x="140" y="10" width="100" height="100" fill="red" filter="url(#Erode-1)"/>
+      <rect x="140" y="10" width="100" height="100" fill="red"/>
+      <rect x="140" y="10" width="100" height="100" fill="lime" filter="url(#Erode-1)"/>
     </g>
 
     <g>
-      <rect x="140" y="130" width="100" height="100" fill="lime"/>
-      <rect x="140" y="130" width="100" height="100" fill="red" filter="url(#Dilate-1)"/>
+      <rect x="140" y="130" width="100" height="100" fill="red"/>
+      <rect x="140" y="130" width="100" height="100" fill="lime" filter="url(#Dilate-1)"/>
     </g>
     
     <!-- zero radius case -->

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
@@ -5,6 +5,7 @@
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -39,8 +40,8 @@ Ref<FEMorphology> FEMorphology::create(MorphologyOperatorType type, float radius
 FEMorphology::FEMorphology(MorphologyOperatorType type, float radiusX, float radiusY)
     : FilterEffect(FilterEffect::Type::FEMorphology)
     , m_type(type)
-    , m_radiusX(radiusX)
-    , m_radiusY(radiusY)
+    , m_radiusX(std::max(0.0f, radiusX))
+    , m_radiusY(std::max(0.0f, radiusY))
 {
 }
 
@@ -62,6 +63,7 @@ bool FEMorphology::setMorphologyOperator(MorphologyOperatorType type)
 
 bool FEMorphology::setRadiusX(float radiusX)
 {
+    radiusX = std::max(0.0f, radiusX);
     if (m_radiusX == radiusX)
         return false;
     m_radiusX = radiusX;
@@ -70,6 +72,7 @@ bool FEMorphology::setRadiusX(float radiusX)
 
 bool FEMorphology::setRadiusY(float radiusY)
 {
+    radiusY = std::max(0.0f, radiusY);
     if (m_radiusY == radiusY)
         return false;
     m_radiusY = radiusY;

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2009 Dirk Schulze <krit@webkit.org>
  * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2014 Google Inc. All rights reserved.
+ * Copyright (C) 2014-2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -113,7 +113,7 @@ void SVGFEMorphologyElement::svgAttributeChanged(const QualifiedName& attrName)
 
 bool SVGFEMorphologyElement::isIdentity() const
 {
-    return !radiusX() && !radiusY();
+    return !std::max(0.0f, radiusX()) && !std::max(0.0f, radiusY());
 }
 
 IntOutsets SVGFEMorphologyElement::outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const
@@ -124,9 +124,10 @@ IntOutsets SVGFEMorphologyElement::outsets(const FloatRect& targetBoundingBox, S
 
 RefPtr<FilterEffect> SVGFEMorphologyElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const
 {
-    if (radiusX() < 0 || radiusY() < 0)
-        return nullptr;
-
+    // "A negative or zero value disables the effect of the given filter
+    // primitive (i.e., the result is the filter input image)."
+    // https://drafts.fxtf.org/filters/#element-attrdef-femorphology-radius
+    // This is handled by FEMorphology.
     return FEMorphology::create(svgOperator(), radiusX(), radiusY());
 }
 


### PR DESCRIPTION
#### e7825a0cbca5b51b5fd45c8be7a9a07802cffa98
<pre>
Update handling of negative radius for feMorphology

<a href="https://bugs.webkit.org/show_bug.cgi?id=257838">https://bugs.webkit.org/show_bug.cgi?id=257838</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=202644

Spec[1] states:

&quot;A negative or zero value disables the effect of the given filter
  primitive (i.e., the result is the filter input image).&quot;

So this changes FEMorphology to clamp radii to non-negative and stop treating
as an error in SVGFEMorphologyElement::createFilterEffect.

[1] <a href="https://drafts.fxtf.org/filters/#element-attrdef-femorphology-radius">https://drafts.fxtf.org/filters/#element-attrdef-femorphology-radius</a>

* Source/WebCore/platform/graphics/filters/FEMorphology.cpp:
(FEMorphology::FEMorphology): clamp &apos;m_radiusX&apos; and &apos;m_radiusY&apos;
(FEMorphology::setRadiusX): clamp &apos;radiusX&apos;
(FEMorphology::setRadiusY): clamp &apos;radiusY&apos;
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(SVGFEMorphologyElement::isIdentity): clamp return as per commit
(SVGFEMorphologyElement::createFilterEffect): Remove condition to return &apos;nullptr&apos; on negative radius
* LayoutTests/svg/filters/feMorphology-negative-radius.html: Add Test Case
* LayoutTests/svg/filters/feMorphology-negative-radius-expected.html: Add Test Case Expectation
* LayoutTests/svg/filters/feMorphology-radius-cases.svg: Rebaselined

Canonical link: <a href="https://commits.webkit.org/265007@main">https://commits.webkit.org/265007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f744d96a58804a182c974002de386db32efbe0a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11105 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10497 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11262 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16036 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9257 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8462 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8513 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2280 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9020 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->