### PR TITLE
Fix style invalidation of IDs within :nth-child/:nth-last-child

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1656,9 +1656,7 @@ imported/w3c/web-platform-tests/css/selectors/focus-within-004.html [ ImageOnlyF
 # :nth-child(n of S) invalidation
 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-of-has.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-of-in-ancestor.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-of-ids.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-last-child-of-has.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/selectors/invalidation/nth-last-child-of-ids.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/nth-last-child-of-in-ancestor.html [ ImageOnlyFailure ]
 
 # This test is bit heavy for debug

--- a/Source/WebCore/style/IdChangeInvalidation.cpp
+++ b/Source/WebCore/style/IdChangeInvalidation.cpp
@@ -29,7 +29,6 @@
 #include "ElementChildIteratorInlines.h"
 #include "ElementRareData.h"
 #include "StyleInvalidationFunctions.h"
-#include "StyleInvalidator.h"
 
 namespace WebCore {
 namespace Style {
@@ -69,13 +68,16 @@ void IdChangeInvalidation::invalidateStyle(const AtomString& changedId)
     else
         m_element.invalidateStyle();
 
-    // Invalidation rulesets exist for :has().
+    // Invalidation rulesets exist for :has() / :nth-child() / :nth-last-child.
     if (auto* invalidationRuleSets = ruleSets.idInvalidationRuleSets(changedId)) {
-        Invalidator::MatchElementRuleSets matchElementRuleSets;
         for (auto& invalidationRuleSet : *invalidationRuleSets)
-            Invalidator::addToMatchElementRuleSets(matchElementRuleSets, invalidationRuleSet);
-        Invalidator::invalidateWithMatchElementRuleSets(m_element, matchElementRuleSets);
+            Invalidator::addToMatchElementRuleSets(m_matchElementRuleSets, invalidationRuleSet);
     }
+}
+
+void IdChangeInvalidation::invalidateStyleWithRuleSets()
+{
+    Invalidator::invalidateWithMatchElementRuleSets(m_element, m_matchElementRuleSets);
 }
 
 }

--- a/Source/WebCore/style/IdChangeInvalidation.h
+++ b/Source/WebCore/style/IdChangeInvalidation.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Element.h"
+#include "StyleInvalidator.h"
 
 namespace WebCore {
 
@@ -38,11 +39,14 @@ public:
 
 private:
     void invalidateStyle(const AtomString&);
+    void invalidateStyleWithRuleSets();
 
     const bool m_isEnabled;
     Element& m_element;
 
     AtomString m_newId;
+
+    Invalidator::MatchElementRuleSets m_matchElementRuleSets;
 };
 
 inline IdChangeInvalidation::IdChangeInvalidation(Element& element, const AtomString& oldId, const AtomString& newId)
@@ -54,7 +58,9 @@ inline IdChangeInvalidation::IdChangeInvalidation(Element& element, const AtomSt
     if (oldId == newId)
         return;
     m_newId = newId;
+
     invalidateStyle(oldId);
+    invalidateStyleWithRuleSets();
 }
 
 inline IdChangeInvalidation::~IdChangeInvalidation()
@@ -62,6 +68,7 @@ inline IdChangeInvalidation::~IdChangeInvalidation()
     if (!m_isEnabled)
         return;
     invalidateStyle(m_newId);
+    invalidateStyleWithRuleSets();
 }
 
 }

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -224,7 +224,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             idsInRules.add(selector->value());
             if (matchElement == MatchElement::Parent || matchElement == MatchElement::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
-            else if (isHasPseudoClassMatchElement(matchElement))
+            else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling)
                 selectorFeatures.ids.append({ selector, matchElement, isNegation });
         } else if (selector->match() == CSSSelector::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });


### PR DESCRIPTION
#### 32756878ae2c401f8c7e9f68557b0e5caa2027c7
<pre>
Fix style invalidation of IDs within :nth-child/:nth-last-child
<a href="https://bugs.webkit.org/show_bug.cgi?id=257848">https://bugs.webkit.org/show_bug.cgi?id=257848</a>
rdar://110451692

Reviewed by Antti Koivisto.

When IDs change within :nth-child / :nth-last-child, we have to use ruleset invalidation, for this:

1. we collect the ID features when MatchElement is AnySibling in RuleFeatureSet (:nth-child/last-child selectors)
2. we store the match element rulesets on IdChangeInvalidation, since we&apos;ll want to run ruleset invalidation both
before &amp; after (ID changes can affect siblings even when the new ID is not in the CSS)

* LayoutTests/TestExpectations:
* Source/WebCore/style/IdChangeInvalidation.cpp:
(WebCore::Style::IdChangeInvalidation::invalidateStyle):
(WebCore::Style::IdChangeInvalidation::invalidateStyleWithRuleSets):
* Source/WebCore/style/IdChangeInvalidation.h:
(WebCore::Style::IdChangeInvalidation::IdChangeInvalidation):
(WebCore::Style::IdChangeInvalidation::~IdChangeInvalidation):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

Canonical link: <a href="https://commits.webkit.org/264986@main">https://commits.webkit.org/264986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efd11c5cc460896772d71975a29c7316501befc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11012 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9226 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12109 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10419 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11169 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15970 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8813 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7469 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8388 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2266 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8937 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->