### PR TITLE
[WPE][Tools] Call repo with python3 explicitly

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -326,11 +326,11 @@ class YoctoCrossBuilder():
             if self._run_cmd('git init . && git add . && git commit -m "Initialize repository"') != 0:
                 _log.error('Error initializing git repository for repo tool')
                 return False
-            if self._run_cmd('./repo init -u {wdir} -m manifest.xml --depth 1'.format(wdir=self._workdir)) != 0:
+            if self._run_cmd('python3 ./repo init -u {wdir} -m manifest.xml --depth 1'.format(wdir=self._workdir)) != 0:
                 _log.error('Error initializing repo')
                 return False
             _log.info('Syncing repos... please wait')
-            if self._run_cmd('./repo sync -c') != 0:
+            if self._run_cmd('python3 ./repo sync -c') != 0:
                 _log.error('Error syncing repo')
                 return False
             # Apply patch if needed


### PR DESCRIPTION
#### dabb231e24dc7078e7d4db9e21a98c0f503e85b6
<pre>
[WPE][Tools] Call repo with python3 explicitly
<a href="https://bugs.webkit.org/show_bug.cgi?id=257850">https://bugs.webkit.org/show_bug.cgi?id=257850</a>

Reviewed by Carlos Alberto Lopez Perez.

WebKit already requires python3, so avoid the script bailing out when
relying on repo&apos;s unversioned python shebang.

* Tools/Scripts/cross-toolchain-helper:

Canonical link: <a href="https://commits.webkit.org/264984@main">https://commits.webkit.org/264984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec3ec692251be84840d65bee24141822400e0db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12116 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10427 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11176 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15976 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12619 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1069 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->