### PR TITLE
InteractionRegions: refine the overlay heuristic

### DIFF
--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -16,6 +16,42 @@
         (occlusion (0,200) width=200 height=100)
         (borderRadius 0.00)])
       )
+      (children 2
+        (GraphicsLayer
+          (position 0.00 400.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (drawsContent 1)
+              (event region
+                (rect (0,0) width=200 height=200)
+
+              (interaction regions [
+                (occlusion (0,0) width=200 height=200)
+                (borderRadius 0.00)])
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 600.00 0.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (contentsOpaque 1)
+              (event region
+                (rect (0,0) width=200 height=200)
+
+              (interaction regions [
+                (occlusion (0,0) width=200 height=200)
+                (borderRadius 0.00)])
+              )
+            )
+          )
+        )
+      )
     )
   )
 )

--- a/LayoutTests/interaction-region/overlay.html
+++ b/LayoutTests/interaction-region/overlay.html
@@ -13,11 +13,40 @@
         pointer-events: none;
         background-color: red;
     }
+    #fixed-container {
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        pointer-events: none;
+    }
+    #fixed {
+        position: fixed;
+        right: 0;
+        top: 0;
+    }
+    .paints {
+        width: 200px;
+        height: 200px;
+        background: blue;
+        pointer-events: auto;
+    }
+    .child {
+        width: 50px;
+        height: 50px;
+        background: red;
+    }
 </style>
 <body>
 <div class="overlay"></div>
 <div class="overlay" id="not-occlusion"></div>
 <div class="overlay" onclick="click()"></div>
+<div id="fixed-container">
+    <div class="paints">
+        <div class="child"></div>
+        <div class="child"></div>
+    </div>
+</div>
+<div id="fixed" class="paints"></div>
 
 <pre id="results"></pre>
 <script>


### PR DESCRIPTION
#### c749494c731ac6dde55999f9a65983d053bf8197
<pre>
InteractionRegions: refine the overlay heuristic
<a href="https://bugs.webkit.org/show_bug.cgi?id=257851">https://bugs.webkit.org/show_bug.cgi?id=257851</a>
&lt;rdar://109538187&gt;

Reviewed by Tim Horton.

Use `position: fixed` as a signal for InteractionRegion occlusion
layers, as fixed content can easily be overlaid on other regions.
It might come from an ancestor that doesn&apos;t paint. To avoid generating
occlusion layers for every element in a `position: fixed` container, we
only look at ancestors with the same absolute content box.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
(WebCore::isOverlay):
Extract the overlay detection in its own function.

* LayoutTests/interaction-region/overlay-expected.txt:
* LayoutTests/interaction-region/overlay.html:
Update test to cover all heuristics.

Canonical link: <a href="https://commits.webkit.org/264990@main">https://commits.webkit.org/264990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d90e641b23eb79c40bb7fb43aa5dcd87ce759999

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10428 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11177 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15978 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12024 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7478 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8444 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2271 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->