### PR TITLE
B3 Select instruction truncates vector operands

### DIFF
--- a/JSTests/wasm/stress/simd-select.js
+++ b/JSTests/wasm/stress/simd-select.js
@@ -1,0 +1,51 @@
+//@ requireOptions("--useWebAssemblySIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test_lower") (param i32 i32) (result i32) (local v128 v128)
+        v128.const i32x4 1 1 1 1
+        local.set 2
+        v128.const i32x4 2 2 2 2
+        local.set 3
+
+        local.get 2
+        local.get 3
+        local.get 0
+        local.get 1
+        i32.eq
+        select
+
+        i32x4.extract_lane 0
+    )
+
+    (func (export "test_upper") (param i32 i32) (result i32) (local v128 v128)
+        v128.const i32x4 1 1 1 1
+        local.set 2
+        v128.const i32x4 2 2 2 2
+        local.set 3
+
+        local.get 2
+        local.get 3
+        local.get 0
+        local.get 1
+        i32.eq
+        select
+
+        i32x4.extract_lane 3
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true });
+    const { test_lower, test_upper } = instance.exports;
+    assert.eq(test_lower(42, 42), 1);
+    assert.eq(test_lower(42, 43), 2);
+    assert.eq(test_upper(42, 42), 1);
+    assert.eq(test_upper(42, 43), 2);
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4469,6 +4469,26 @@ private:
         }
 
         case Select: {
+            if (m_value->type().isVector()) {
+                // Conditional moves aren't available for vectors on currently
+                // supported architectures, so we lower vector Select to a
+                // branching construct.
+
+                auto ifTrueBlock = newBlock();
+                Air::BasicBlock* beginBlock;
+                Air::BasicBlock* doneBlock;
+                splitBlock(beginBlock, doneBlock);
+
+                append(Air::MoveVector, tmp(m_value->child(2)), tmp(m_value));
+                append(createBranch(m_value->child(0)));
+                beginBlock->setSuccessors(ifTrueBlock, doneBlock);
+
+                ifTrueBlock->append(Air::MoveVector, m_value, tmp(m_value->child(1)), tmp(m_value));
+                ifTrueBlock->append(Air::Jump, m_value);
+                ifTrueBlock->setSuccessors(doneBlock);
+                return;
+            }
+
             MoveConditionallyConfig config;
             if (m_value->type().isInt()) {
                 config.moveConditionally32 = MoveConditionally32;


### PR DESCRIPTION
#### c4e675b3afdd1aa16c3d3d3bd38c503bece0df0f
<pre>
B3 Select instruction truncates vector operands
<a href="https://bugs.webkit.org/show_bug.cgi?id=257842">https://bugs.webkit.org/show_bug.cgi?id=257842</a>
rdar://108643371

Reviewed by Mark Lam, Justin Michaud and Yusuke Suzuki.

Fixes a bug where we would generate a double-precision conditional
move when lowering the Select B3 instruction on vector operands.
Since vector-sized conditional move isn&apos;t widely supported, we
transform the Select into a branch and moves during Air lowering
when the operands are vectors.

* JSTests/wasm/stress/simd-select.js: Added.
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:

Canonical link: <a href="https://commits.webkit.org/264996@main">https://commits.webkit.org/264996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c00b937df1d6ee2dfb1fede5d8d86b09ca7f8159

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11071 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12161 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9560 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11229 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8071 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12065 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9010 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9232 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9586 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2276 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9829 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8994 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2407 "Passed tests") | 
<!--EWS-Status-Bubble-End-->