### PR TITLE
<feColorMatrix> filter doesn't work properly when defined inside then set directly on the <svg> element

### DIFF
--- a/LayoutTests/svg/filters/filter-specified-on-svg-root-expected.html
+++ b/LayoutTests/svg/filters/filter-specified-on-svg-root-expected.html
@@ -1,0 +1,7 @@
+<p>This test passes if the rectangle only contains a single shade of green.</p>
+
+<span>
+  <svg width="200" height="100">
+    <rect width="200" height="100" fill="green" fill-opacity="0.6" />
+  </svg>
+</span>

--- a/LayoutTests/svg/filters/filter-specified-on-svg-root.html
+++ b/LayoutTests/svg/filters/filter-specified-on-svg-root.html
@@ -1,0 +1,14 @@
+<p>This test passes if the rectangle only contains a single shade of green.</p>
+
+<span>
+  <svg filter="url(#fade)" width="100" height="100">
+    <filter id="fade">
+      <feComponentTransfer>
+        <feFuncA type="table" tableValues="0 0.6"/>
+      </feComponentTransfer>
+    </filter>
+    <rect width="100" height="100" fill="green" />
+  </svg><svg width="100" height="100">
+    <rect width="100" height="100" fill="green" fill-opacity="0.6" />
+  </svg>
+</span>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -884,7 +884,12 @@ bool RenderLayer::canRender3DTransforms() const
 
 bool RenderLayer::paintsWithFilters() const
 {
-    if (!renderer().hasFilter())
+    if (!hasFilter())
+        return false;
+
+    // The SVG rendering codepath should've already applied the filter to the SVG root,
+    // so do not apply the filter again.
+    if (renderer().isSVGRootOrLegacySVGRoot())
         return false;
 
     if (RenderLayerFilters::isIdentity(renderer()))
@@ -5570,14 +5575,13 @@ void RenderLayer::clearLayerScrollableArea()
 
 void RenderLayer::updateFiltersAfterStyleChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
-    if (!hasFilter()) {
+    if (!paintsWithFilters()) {
         clearLayerFilters();
         return;
     }
 
-    // Add the filter as a client to this renderer, unless we are a RenderLayer accommodating
-    // an SVG. In that case it takes care of its own resource management for filters.
-    if (renderer().style().filter().hasReferenceFilter() && !renderer().isSVGRootOrLegacySVGRoot()) {
+    // Add the filter as a client to this renderer.
+    if (renderer().style().filter().hasReferenceFilter()) {
         ensureLayerFilters();
         m_filters->updateReferenceFilterClients(renderer().style().filter());
     } else if (m_filters)
@@ -5623,7 +5627,7 @@ void RenderLayer::updateFilterPaintingStrategy()
         if (!renderer().style().filter().hasReferenceFilter())
             return;
     }
-    
+
     ensureLayerFilters();
     m_filters->setPreferredFilterRenderingModes(renderer().page().preferredFilterRenderingModes());
     m_filters->setFilterScale({ page().deviceScaleFactor(), page().deviceScaleFactor() });


### PR DESCRIPTION
#### 0dac14ca10cb771ef13516f2a82581b832f8a1c2
<pre>
&lt;feColorMatrix&gt; filter doesn&apos;t work properly when defined inside then set directly on the &lt;svg&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=225120">https://bugs.webkit.org/show_bug.cgi?id=225120</a>
rdar://77522728

Reviewed by Said Abou-Hallawa.

When a filter is specified on an SVG root, the SVG rendering codepath applies the
filter on the SVG root. Then, the RenderLayer of that SVG applies that filter again,
resulting in the filter being applied twice. Fix this by instructing RenderLayer not
to apply filters when rendering SVG roots.

Tests: LayoutTests/svg/filters/filter-specified-on-svg-root.html

* LayoutTests/svg/filters/filter-specified-on-svg-root-expected.html: Added.
* LayoutTests/svg/filters/filter-specified-on-svg-root.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintsWithFilters const):
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/265135@main">https://commits.webkit.org/265135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610c8946183ef52dadb47ff219133d5f831294e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9563 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12498 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11895 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16291 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12371 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9578 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8743 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2382 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->