### PR TITLE
Revert [264988@main] [macOS] Update ScreenCaptureKit API used

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
@@ -37,6 +37,10 @@
 #if __has_include(<ScreenCaptureKit/SCContentSharingPicker.h>)
 #import <ScreenCaptureKit/SCContentSharingPicker.h>
 #endif
+
+#if __has_include(<ScreenCaptureKit/SCContentSharingPicker_Private.h>)
+#import <ScreenCaptureKit/SCContentSharingPicker_Private.h>
+#endif
 #endif // HAVE(SC_CONTENT_SHARING_PICKER)
 
 #else // USE(APPLE_INTERNAL_SDK)
@@ -90,16 +94,6 @@ typedef NS_ENUM(NSInteger, SCContentFilterType) {
 - (instancetype)initWithSharingSession:(SCContentSharingSession *)session captureOutputProperties:(SCStreamConfiguration *)streamConfig delegate:(id<SCStreamDelegate>)delegate;
 @end
 
-NS_ASSUME_NONNULL_END
-
-#endif // USE(APPLE_INTERNAL_SDK)
-
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-
-// FIXME: Remove this section once the updated SDK is more widely available.
-
-NS_ASSUME_NONNULL_BEGIN
-
 @protocol SCContentSharingPickerDelegate <NSObject>
 @required
 @optional
@@ -115,11 +109,11 @@ typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
     SCContentSharingPickerAllowedModeSingleDisplay         = 1 << 3,
 };
 
-@interface SCContentSharingPickerConfiguration (Staging_110281298)
+@interface SCContentSharingPickerConfiguration : NSObject
 @property (nonatomic, assign) SCContentSharingAllowedPickerModes allowedPickingModes;
 @end
 
-@interface SCContentSharingPicker (Staging_110281298)
+@interface SCContentSharingPicker : NSObject
 @property (nonatomic, weak, nullable) id<SCContentSharingPickerDelegate> delegate;
 @property (nonatomic, nullable, strong) NSNumber *maxStreamCount;
 @property (nonatomic, nullable, copy) SCContentSharingPickerConfiguration *configuration;
@@ -127,6 +121,6 @@ typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
 
 NS_ASSUME_NONNULL_END
 
-#endif // HAVE(SC_CONTENT_SHARING_PICKER)
+#endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // HAVE(SCREEN_CAPTURE_KIT)


### PR DESCRIPTION
#### 194d0ea149c7ec599b6d25b5c2df06514f1d5f05
<pre>
Revert [264988@main] [macOS] Update ScreenCaptureKit API used
<a href="https://bugs.webkit.org/show_bug.cgi?id=257816">https://bugs.webkit.org/show_bug.cgi?id=257816</a>
rdar://110408877

Unreviewed revert.

Reverting commit casuing muliple build failures.

* Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper initWithCallback:]):
(-[WebDisplayMediaPromptHelper contentSharingPickerDidCancel:forStream:]):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didUpdateWithFilter:forStream:]):
(WebCore::ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didCancelForStream:]): Deleted.
(-[WebDisplayMediaPromptHelper startObservingPicker:]): Deleted.
(-[WebDisplayMediaPromptHelper stopObservingPicker:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/264989@main">https://commits.webkit.org/264989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1acb1a05379901413c1ffd55ea803417d8e4604

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9882 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/11036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9613 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/11036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9525 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8411 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12635 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1071 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->