### PR TITLE
Highlight appears behind dictated text

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -292,6 +292,16 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     return self;
 }
 
+- (void)setAllowsInlinePredictions:(BOOL)enabled
+{
+    _allowsInlinePredictions = enabled;
+}
+
+- (BOOL)allowsInlinePredictions
+{
+    return _allowsInlinePredictions;
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"<%@: %p; processPool = %@; preferences = %@>", NSStringFromClass(self.class), self, self.processPool, self.preferences];
@@ -1495,16 +1505,6 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 }
 
 - (BOOL)_markedTextInputEnabled
-{
-    return _allowsInlinePredictions;
-}
-
-- (void)setAllowsInlinePredictions:(BOOL)enabled
-{
-    _allowsInlinePredictions = enabled;
-}
-
-- (BOOL)allowsInlinePredictions
 {
     return _allowsInlinePredictions;
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5062,7 +5062,11 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
         if (underline.thick)
             mergedUnderlines.append(underline);
     }
-#else
+
+    if (mergedUnderlines.size())
+        return mergedUnderlines;
+#endif
+
     int length = string.string.length;
 
     for (int i = 0; i < length;) {
@@ -5081,7 +5085,6 @@ static Vector<WebCore::CompositionUnderline> compositionUnderlines(NSAttributedS
 
         i = range.location + range.length;
     }
-#endif
 
     return mergedUnderlines;
 }


### PR DESCRIPTION
#### 644d6535804c8d7a1ad1204e4203ba2462acf0a8
<pre>
Highlight appears behind dictated text
<a href="https://bugs.webkit.org/show_bug.cgi?id=257874">https://bugs.webkit.org/show_bug.cgi?id=257874</a>
radar://110492195

Reviewed by Aditya Keerthi.

264903@main introduced a regression where the following code:

  auto initialUnderlines = extractInitialUnderlines(string);
  underlines = !initialUnderlines.isEmpty() ? initialUnderlines : extractUnderlines(string);

was changed to:
  underlines = compositionUnderlines(string);

but compositionUnderlines doesn&apos;t populate the underlines when they are otherwise empty.

Re-introduce code removed from 264903@main and this issue appears resolved.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration setAllowsInlinePredictions:]):
(-[WKWebViewConfiguration allowsInlinePredictions]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::extractUnderlines):
(WebKit::WebViewImpl::setMarkedText):

Canonical link: <a href="https://commits.webkit.org/265031@main">https://commits.webkit.org/265031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b2d2ad681d1dc5e48490c4d4d592c0f6ec93c1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9317 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12218 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11305 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7814 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16056 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12121 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8482 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->