### PR TITLE
Implemented relaxed_swizzle SIMD opcode.

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-swizzle.js
@@ -1,0 +1,37 @@
+//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param $sz i32) (result i32)
+        (i32.const 9)
+        (drop)
+        (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)
+        (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+        (i8x16.relaxed_swizzle)
+        (return (i8x16.extract_lane_u 1))
+    )
+    (func (export "test2") (param $sz i32) (result i32)
+        (i32.const 9)
+        (drop)
+        (v128.const i8x16 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16)
+        (v128.const i8x16 0 8 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+        (i8x16.relaxed_swizzle)
+        (return (i8x16.extract_lane_u 1))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 2);
+        assert.eq(test2(42), 9);
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4326,6 +4326,10 @@ private:
             }
             return;
 
+        case B3::VectorRelaxedSwizzle:
+            emitSIMDMonomorphicBinaryOp(Air::VectorSwizzle);
+            return;
+
         case Fence: {
             FenceValue* fence = m_value->as<FenceValue>();
             if (!fence->write && !fence->read)

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -537,6 +537,9 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorShiftByVector:
         out.print("VectorShiftByVector");
         return;
+    case VectorRelaxedSwizzle:
+        out.print("VectorRelaxedSwizzle");
+        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -417,6 +417,10 @@ enum Opcode : uint8_t {
     VectorMulSat,
     VectorSwizzle,
 
+    // Relaxed SIMD
+
+    VectorRelaxedSwizzle,
+
     // Currently only some architectures support this.
     // FIXME: Expand this to identical instructions for the other architectures as a macro.
     VectorMulByElement,

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -95,6 +95,7 @@ public:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorDotProduct:
+        case VectorRelaxedSwizzle:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -670,6 +670,17 @@ public:
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::v128, ("At ", *value));
                 VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
                 break;
+
+            // Relaxed SIMD
+            case VectorRelaxedSwizzle:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
+                break;
+
             case CCall:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() >= 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -736,6 +736,7 @@ Effects Value::effects() const
     case VectorSwizzle:
     case VectorMulByElement:
     case VectorShiftByVector:
+    case VectorRelaxedSwizzle:
         break;
     case Div:
     case UDiv:
@@ -982,6 +983,7 @@ ValueKey Value::key() const
     case VectorMulSat:
     case VectorAvgRound:
     case VectorShiftByVector:
+    case VectorRelaxedSwizzle:
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1));
     case VectorReplaceLane:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -540,6 +540,7 @@ protected:
         case VectorAvgRound:
         case VectorMulByElement:
         case VectorShiftByVector:
+        case VectorRelaxedSwizzle:
             return 2 * sizeof(Value*);
         case Select:
         case AtomicWeakCAS:
@@ -758,6 +759,7 @@ private:
         case VectorAvgRound:
         case VectorMulByElement:
         case VectorShiftByVector:
+        case VectorRelaxedSwizzle:
             if (UNLIKELY(numArgs != 2))
                 badKind(kind, numArgs);
             return Two;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -230,6 +230,7 @@ namespace JSC { namespace B3 {
     case VectorExtaddPairwise: \
     case VectorMulSat: \
     case VectorSwizzle: \
+    case VectorRelaxedSwizzle: \
     case VectorMulByElement: \
     case VectorShiftByVector: \
         return MACRO(SIMDValue); \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -184,6 +184,7 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorMulSat:
     case VectorAvgRound:
     case VectorShiftByVector:
+    case VectorRelaxedSwizzle:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1));
     case VectorReplaceLane:
     case VectorMulByElement:

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -577,6 +577,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing.") \
     v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
+    v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \
     v(Bool, useWebAssemblyTailCalls, false, Normal, "Allow the new instructions from the wasm tail calls spec.") \
 
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -520,6 +520,11 @@ public:
         AIR_OP_CASE(SubSat)
         AIR_OP_CASE(Max)
         AIR_OP_CASE(Min)
+
+        // Relaxed SIMD redirecting to non-relaxed:
+
+        else if (op == SIMDLaneOperation::RelaxedSwizzle) airOp = B3::Air::VectorSwizzle;
+
         result = tmpForType(Types::V128);
 
         if (isX86() && airOp == B3::Air::VectorMulSat) {

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -535,6 +535,7 @@ public:
         B3_OP_CASE(Pmin)
         B3_OP_CASE(Or)
         B3_OP_CASE(Swizzle)
+        B3_OP_CASE(RelaxedSwizzle)
         B3_OP_CASE(Xor)
         B3_OP_CASE(Narrow)
         B3_OP_CASE(AddSat)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -9176,6 +9176,9 @@ public:
                 return fixupOutOfBoundsIndicesForSwizzle(leftLocation, rightLocation, resultLocation);
             m_jit.vectorSwizzle(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
             return { };
+        case SIMDLaneOperation::RelaxedSwizzle:
+            m_jit.vectorSwizzle(leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
+            return { };
         case SIMDLaneOperation::Xor:
             m_jit.vectorXor(info, leftLocation.asFPR(), rightLocation.asFPR(), resultLocation.asFPR());
             return { };

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -691,6 +691,9 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         return { };
     };
 
+    if (isRelaxedSIMDOperation(op))
+        WASM_PARSER_FAIL_IF(!Options::useWebAssemblyRelaxedSIMD(), "relaxed simd instructions not supported");
+
     switch (op) {
     case SIMDLaneOperation::Const: {
         v128_t constant;
@@ -1144,6 +1147,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::Pmin:
     case SIMDLaneOperation::Or:
     case SIMDLaneOperation::Swizzle:
+    case SIMDLaneOperation::RelaxedSwizzle:
     case SIMDLaneOperation::Xor:
     case SIMDLaneOperation::Narrow:
     case SIMDLaneOperation::AddSat:

--- a/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
+++ b/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
@@ -109,6 +109,9 @@ enum class SIMDLaneOperation : uint8_t {
     Bitmask,
     Neg,
     MulSat,
+
+    // relaxed SIMD
+    RelaxedSwizzle,
 };
 
 #define FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -350,7 +353,8 @@ macro(I64x2ShrU,                  0xcd,  Shr,                 SIMDLane::i64x2,  
 macro(I64x2ExtmulLowI32x4S,       0xdc,  ExtmulLow,           SIMDLane::i64x2,  SIMDSignMode::Signed) \
 macro(I64x2ExtmulHighI32x4S,      0xdd,  ExtmulHigh,          SIMDLane::i64x2,  SIMDSignMode::Signed) \
 macro(I64x2ExtmulLowI32x4U,       0xde,  ExtmulLow,           SIMDLane::i64x2,  SIMDSignMode::Unsigned) \
-macro(I64x2ExtmulHighI32x4U,      0xdf,  ExtmulHigh,          SIMDLane::i64x2,  SIMDSignMode::Unsigned)
+macro(I64x2ExtmulHighI32x4U,      0xdf,  ExtmulHigh,          SIMDLane::i64x2,  SIMDSignMode::Unsigned) \
+macro(I8x16RelaxedSwizzle,        0x100, RelaxedSwizzle,      SIMDLane::i8x16,  SIMDSignMode::None)
 
 #define FOR_EACH_WASM_EXT_SIMD_OP(macro) \
 FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -436,9 +440,17 @@ static void dumpSIMDLaneOperation(PrintStream& out, SIMDLaneOperation op)
     case SIMDLaneOperation::Bitmask: out.print("Bitmask"); break;
     case SIMDLaneOperation::Neg: out.print("Neg"); break;
     case SIMDLaneOperation::MulSat: out.print("MulSat"); break;
+    case SIMDLaneOperation::RelaxedSwizzle: out.print("RelaxedSwizzle"); break;
     }
 }
 MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperation);
+
+// Relaxed SIMD
+
+inline bool isRelaxedSIMDOperation(SIMDLaneOperation op)
+{
+    return (op == SIMDLaneOperation::RelaxedSwizzle);
+}
 
 }
 #endif // ENABLE(WEBASSEMBLY)


### PR DESCRIPTION
#### e1ec14877b7db64cf484cbd62480417029127c05
<pre>
Implemented relaxed_swizzle SIMD opcode.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257878">https://bugs.webkit.org/show_bug.cgi?id=257878</a>
rdar://problem/110495643

Reviewed by Justin Michaud.

Added support for relaxed_swizzle as part of implementing relaxed SIMD functionality.

* JSTests/wasm/stress/simd-const-swizzle.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.i32.i32.const.9.drop.v128.const.i8x16.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.v128.const.i8x16.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.i8x16.relaxed_swizzle.return.i8x16.extract_lane_u.1.async test):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addSIMDV_VV):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSIMDV_VV):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h:
(JSC::dumpSIMDLaneOperation):
(JSC::isRelaxedSIMDOperation):
* JSTests/wasm/libwabt.js:
(WabtModule.):
(WabtModule):
(set get if): Deleted.
* JSTests/wasm/stress/simd-const-relaxed-swizzle.js: Renamed from JSTests/wasm/stress/simd-const-swizzle.js.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.i32.i32.const.9.drop.v128.const.i8x16.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.v128.const.i8x16.0.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.i8x16.relaxed_swizzle.return.i8x16.extract_lane_u.1.func.export.string_appeared_here.param.sz.i32.result.i32.i32.const.9.drop.v128.const.i8x16.1.2.3.4.5.6.7.8.9.10.11.12.13.14.15.16.v128.const.i8x16.0.8.2.3.4.5.6.7.8.9.10.11.12.13.14.15.i8x16.relaxed_swizzle.return.i8x16.extract_lane_u.1.async test):
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:

Canonical link: <a href="https://commits.webkit.org/265075@main">https://commits.webkit.org/265075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60953701bdc30fbc513b0b11bf64a908f5fbd3a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9611 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12323 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16150 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8183 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12227 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9376 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7618 "5 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9767 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8567 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2405 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12788 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10024 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9150 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2467 "Passed tests") | 
<!--EWS-Status-Bubble-End-->