### PR TITLE
Upstream RuntimeApplicationChecks

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -192,6 +192,13 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::ScreenOrientationAPIEnabled);
     }
 
+    if (linkedBefore(dyld_fall_2023_os_versions, DYLD_IOS_VERSION_17_0, DYLD_MACOSX_VERSION_14_0)) {
+        disableBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContent);
+        disableBehavior(SDKAlignedBehavior::RunningBoardThrottling);
+        disableBehavior(SDKAlignedBehavior::PopoverAttributeEnabled);
+        disableBehavior(SDKAlignedBehavior::LiveRangeSelectionEnabledForAllApps);
+    }
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -85,6 +85,10 @@
 #define DYLD_IOS_VERSION_16_4 0x00100400
 #endif
 
+#ifndef DYLD_IOS_VERSION_17_0
+#define DYLD_IOS_VERSION_17_0 0x00200000
+#endif
+
 #ifndef DYLD_MACOSX_VERSION_10_13
 #define DYLD_MACOSX_VERSION_10_13 0x000A0D00
 #endif
@@ -129,6 +133,10 @@
 #define DYLD_MACOSX_VERSION_13_3 0x000d0300
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_14_0
+#define DYLD_MACOSX_VERSION_14_0 0x000e0000
+#endif
+
 #else
 
 typedef uint32_t dyld_platform_t;
@@ -159,6 +167,7 @@ typedef struct {
 #define DYLD_IOS_VERSION_15_4 0x000f0400
 #define DYLD_IOS_VERSION_16_0 0x00100000
 #define DYLD_IOS_VERSION_16_4 0x00100400
+#define DYLD_IOS_VERSION_17_0 0x00200000
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
 #define DYLD_MACOSX_VERSION_10_11 0x000A0B00
@@ -176,6 +185,7 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_12_3 0x000c0300
 #define DYLD_MACOSX_VERSION_13_0 0x000d0000
 #define DYLD_MACOSX_VERSION_13_3 0x000d0300
+#define DYLD_MACOSX_VERSION_14_0 0x000e0000
 
 #endif
 
@@ -255,6 +265,10 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_spring_2023_os_versions
 #define dyld_spring_2023_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_fall_2023_os_versions
+#define dyld_fall_2023_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 uint32_t dyld_get_program_sdk_version();

--- a/Source/WebCore/platform/NotImplemented.h
+++ b/Source/WebCore/platform/NotImplemented.h
@@ -50,6 +50,6 @@ WEBCORE_EXPORT WTFLogChannel* notImplementedLoggingChannel();
         } \
     } while (0)
 
-#endif // NDEBUG
+#endif // LOG_DISABLED
 
 #endif // NotImplemented_h


### PR DESCRIPTION
#### a420a9f3f6ab4c8d0c75aae3877d736d66affe36
<pre>
Upstream RuntimeApplicationChecks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257880">https://bugs.webkit.org/show_bug.cgi?id=257880</a>
rdar://110496563

Reviewed by Wenson Hsieh.

Upstream RunTimeApplicationChecks corresponding to iOS 17/MacOS Sonoma
(14).

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
(WTF::disableAdditionalSDKAlignedBehaviors): Deleted.
* Source/WTF/wtf/spi/darwin/dyldSPI.h:
* Source/WebCore/platform/NotImplemented.h:

Drive-by fix of an inconsistent macro name.

Canonical link: <a href="https://commits.webkit.org/265013@main">https://commits.webkit.org/265013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6056817943c9d2d05d5de1a93118b4a1939676c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11280 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16043 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12102 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9040 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7537 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9631 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8470 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12694 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/9880 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9031 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2425 "Passed tests") | 
<!--EWS-Status-Bubble-End-->