### PR TITLE
[WGSL] Distinguish between value and type bindings

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -6,7 +6,7 @@ fn f2() {
     // CHECK-L: type in function call does not match parameter type: expected 'f32', found 'i32'
     _ = f1(0i);
 
-    // CHECK-L: Cannot call value of type: 'i32'
+    // CHECK-L: cannot call value of type 'i32'
     let f3: i32 = 0;
     _ = f3();
 

--- a/Source/WebGPU/WGSL/tests/invalid/types-vs-values.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/types-vs-values.wgsl
@@ -1,0 +1,22 @@
+// RUN: %not %wgslc | %check
+
+struct S { x: i32 }
+
+var<private> s : S;
+
+// CHECK-L: cannot use value 's' as type
+fn f() -> s
+{
+    // CHECK-NEXT-L: unresolved type 'undefined'
+    var x : undefined;
+
+    let s = S(42);
+    // CHECK-NEXT-L: cannot call value of type 'S'
+    _ = s(42);
+
+    // CHECK-NEXT-L: cannot use type 'S' as value
+    _ = S;
+
+    // CHECK-NEXT-L: unresolved identifier 'undefined'
+    _ = undefined;
+}


### PR DESCRIPTION
#### eb76ee09c3fc574a8c8bc7e3d8a9cbf8bdeee99f
<pre>
[WGSL] Distinguish between value and type bindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=257883">https://bugs.webkit.org/show_bug.cgi?id=257883</a>
rdar://110515257

Reviewed by Dan Glastonbury.

When the type checker looks up types for identifiers it needs to distinguish
between types and values. e.g.

struct S { x: i32 };
var s: S;

Currently, we have no way of distinguishing between `s` and `S`, as they both
return the same struct type. To fix it, instead of adding `Type*`s directly to
the typing context, we wrap types in a struct `Binding`, which indicates whether
the binding is a value or a type.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitStructMembers):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visitFunctionBody):
(WGSL::TypeChecker::introduceType):
(WGSL::TypeChecker::introduceValue):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl:

Canonical link: <a href="https://commits.webkit.org/265112@main">https://commits.webkit.org/265112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff30cdb08f728338b796257046fd368bb4f78edc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11534 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10837 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8143 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9112 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9613 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8774 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2363 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->