### PR TITLE
[CSS] Remove unused/broken CSSSelector equality operator

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -310,34 +310,6 @@ const CSSSelector* CSSSelector::firstInCompound() const
     return selector;
 }
 
-bool CSSSelector::operator==(const CSSSelector& other) const
-{
-    const CSSSelector* sel1 = this;
-    const CSSSelector* sel2 = &other;
-
-    while (sel1 && sel2) {
-        if (sel1->attribute() != sel2->attribute()
-            || sel1->relation() != sel2->relation()
-            || sel1->match() != sel2->match()
-            || sel1->value() != sel2->value()
-            || sel1->m_pseudoType != sel2->m_pseudoType
-            || sel1->argument() != sel2->argument()) {
-            return false;
-        }
-        if (sel1->match() == Tag) {
-            if (sel1->tagQName() != sel2->tagQName())
-                return false;
-        }
-        sel1 = sel1->tagHistory();
-        sel2 = sel2->tagHistory();
-    }
-
-    if (sel1 || sel2)
-        return false;
-
-    return true;
-}
-
 static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelector* selector)
 {
     switch (selector->pseudoClassType()) {

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -56,9 +56,6 @@ struct PossiblyQuotedIdentifier {
         // Re-create selector text from selector's data.
         String selectorText(StringView separator = { }, StringView rightSide = { }) const;
 
-        // Check if the 2 selectors (including sub selectors) agree.
-        bool operator==(const CSSSelector&) const;
-
         unsigned computeSpecificity() const;
         std::array<uint8_t, 3> computeSpecificityTuple() const;
         unsigned specificityForPage() const;


### PR DESCRIPTION
#### 50ddb4b4a4a91bc5bfe7f43fa3dc6923f5a6787b
<pre>
[CSS] Remove unused/broken CSSSelector equality operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=257886">https://bugs.webkit.org/show_bug.cgi?id=257886</a>
rdar://110518189

Reviewed by Antti Koivisto.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::operator== const): Deleted.
* Source/WebCore/css/CSSSelector.h:

Canonical link: <a href="https://commits.webkit.org/265014@main">https://commits.webkit.org/265014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8102d1d45bda0f189afb08a3e119172f4d04f30a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9521 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12239 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11330 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8659 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12145 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9296 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8498 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->