### PR TITLE
MS Teams browser meeting IncomingAudioMediaStreamTrackRendererUnit crashes with failed: Bad bounds passed to std::clamp

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -110,6 +110,7 @@
 		7A6EBA3420746C34004F9C44 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A6EBA3320746C34004F9C44 /* MachSendRight.cpp */; };
 		7AF023B52061E17000A8EFD6 /* ProcessPrivilege.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AF023B42061E16F00A8EFD6 /* ProcessPrivilege.cpp */; };
 		7AFEC6B11EB22B5900DADE36 /* UUID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7AFEC6B01EB22B5900DADE36 /* UUID.cpp */; };
+		7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		8134013815B092FD001FF0B8 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
 		8348BA0E21FBC0D500FD3054 /* ObjectIdentifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8348BA0D21FBC0D400FD3054 /* ObjectIdentifier.cpp */; };
 		93853DD328755A6C00FF4E2B /* EscapedFormsForJSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 93853DD228755A6600FF4E2B /* EscapedFormsForJSON.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1215,6 +1216,7 @@
 		7AFEC6B01EB22B5900DADE36 /* UUID.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UUID.cpp; sourceTree = "<group>"; };
 		7B2739DC2624DAAA0040F182 /* ThreadSafetyAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadSafetyAnalysis.h; sourceTree = "<group>"; };
 		7B2739F12632A8940040F182 /* ThreadAssertions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadAssertions.h; sourceTree = "<group>"; };
+		7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SequenceLocked.h; sourceTree = "<group>"; };
 		7C137941222326C700D7A824 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
 		7C137942222326D500D7A824 /* ieee.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ieee.h; sourceTree = "<group>"; };
 		7C137943222326D500D7A824 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -2282,6 +2284,7 @@
 				0FA6F38E20CC580E00A03DCD /* SegmentedVector.cpp */,
 				A8A47306151A825B004123FF /* SegmentedVector.h */,
 				A8A47307151A825B004123FF /* SentinelLinkedList.h */,
+				7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */,
 				A8A4731A151A825B004123FF /* SetForScope.h */,
 				A8A47308151A825B004123FF /* SHA1.cpp */,
 				A8A47309151A825B004123FF /* SHA1.h */,
@@ -3241,6 +3244,7 @@
 				DDF306DD27C08654006A526F /* SecuritySPI.h in Headers */,
 				DD3DC99227A4BF8E007E5B61 /* SegmentedVector.h in Headers */,
 				DD3DC8C127A4BF8E007E5B61 /* SentinelLinkedList.h in Headers */,
+				7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */,
 				DD3DC88627A4BF8E007E5B61 /* SetForScope.h in Headers */,
 				DD3DC8BB27A4BF8E007E5B61 /* SHA1.h in Headers */,
 				DD3DC88B27A4BF8E007E5B61 /* SharedTask.h in Headers */,

--- a/Source/WTF/wtf/SequenceLocked.h
+++ b/Source/WTF/wtf/SequenceLocked.h
@@ -1,0 +1,141 @@
+//
+// Copyright 2020 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <type_traits>
+#include <wtf/Compiler.h>
+
+namespace WTF {
+
+// A SequenceLock implements lock-free reads. A sequence counter is incremented
+// before and after each write, and readers access the counter before and after
+// accessing the protected data. If the counter is verified to not change during
+// the access, and the sequence counter value was even, then the reader knows
+// that the read was race-free and valid.
+//
+// Works best with types T that are initialized to zeros.
+//
+// The memory reads and writes protected by this lock must use the provided
+// `load()` and `store()` functions.
+// As an implementation detail, the protected data must be an array of
+// `std::atomic<uint64_t>`. This is to comply with the C++ standard, which
+// considers data races on non-atomic objects to be undefined behavior. See "Can
+// Seqlocks Get Along With Programming Language Memory Models?"[1] by Hans J.
+// Boehm for more details.
+//
+// [1] https://www.hpl.hp.com/techreports/2012/HPL-2012-68.pdf
+template<typename T>
+class SequenceLocked {
+public:
+    static_assert(std::atomic<uint64_t>::is_always_lock_free);
+    static_assert(std::is_trivially_copyable_v<T>);
+
+    // Copy T from store and return it, protected as a read-side
+    // critical section of the sequence lock.
+    T load() const
+    {
+        T result;
+        for (;;) {
+            // Acquire barrier ensures that no loads are reordered
+            // above the first load of the sequence counter.
+            uint64_t versionBefore = m_version.load(std::memory_order_acquire);
+            if (UNLIKELY((versionBefore & 1) == 1))
+                continue;
+            relaxedCopyFromAtomic(&result, m_storage.data(), sizeof(T));
+            // Another acquire fence ensures that the load of 'm_version' below is
+            // strictly ordered after the RelaxedCopyToAtomic call above.
+            std::atomic_thread_fence(std::memory_order_acquire);
+            uint64_t versionAfter = m_version.load(std::memory_order_relaxed);
+            if (LIKELY(versionBefore == versionAfter))
+                break;
+        }
+        return result;
+    }
+
+    // Copy value to store as a write-side critical section
+    // of the sequence lock. Any concurrent readers will be forced to retry
+    // until they get a read that does not conflict with this write.
+    //
+    // This call must be externally synchronized against other calls to write,
+    // but may proceed concurrently with reads.
+    void store(const T& value)
+    {
+        // We can use relaxed instructions to increment the counter since we
+        // are extenally synchronized. The std::atomic_thread_fence below
+        // ensures that the counter updates don't get interleaved with the
+        // copy to the data.
+        uint64_t version = m_version.load(std::memory_order_relaxed);
+        m_version.store(version + 1, std::memory_order_relaxed);
+
+        // We put a release fence between update to m_version and writes to shared data.
+        // Thus all stores to shared data are effectively release operations and
+        // update to m_version above cannot be re-ordered past any of them. Note that
+        // this barrier is not for the fetch_add above. A release barrier for the
+        // fetch_add would be before it, not after.
+        std::atomic_thread_fence(std::memory_order_release);
+        relaxedCopyToAtomic(m_storage.data(), &value, sizeof(T));
+        // "Release" semantics ensure that none of the writes done by
+        // relaxedCopyToAtomic() can be reordered after the following modification.
+        m_version.store(version + 2, std::memory_order_release);
+    }
+
+private:
+    // Perform the equivalent of "memcpy(dst, src, size)", but using relaxed
+    // atomics.
+    static void relaxedCopyFromAtomic(void* dst, const std::atomic<uint64_t>* src, size_t size)
+    {
+        char* dstChar = static_cast<char*>(dst);
+        for (;size >= sizeof(uint64_t); size -= sizeof(uint64_t)) {
+            uint64_t word = src->load(std::memory_order_relaxed);
+            std::memcpy(dstChar, &word, sizeof(uint64_t));
+            dstChar += sizeof(uint64_t);
+            src++;
+        }
+        if (size) {
+            uint64_t word = src->load(std::memory_order_relaxed);
+            std::memcpy(dstChar, &word, size);
+        }
+    }
+
+    // Perform the equivalent of "memcpy(dst, src, size)", but using relaxed
+    // atomics.
+    static void relaxedCopyToAtomic(std::atomic<uint64_t>* dst, const void* src, size_t size)
+    {
+        const char* srcByte = static_cast<const char*>(src);
+        for (;size >= sizeof(uint64_t); size -= sizeof(uint64_t)) {
+            uint64_t word;
+            std::memcpy(&word, srcByte, sizeof(word));
+            dst->store(word, std::memory_order_relaxed);
+            srcByte += sizeof(word);
+            dst++;
+        }
+        if (size) {
+            uint64_t word = 0;
+            std::memcpy(&word, srcByte, size);
+            dst->store(word, std::memory_order_relaxed);
+        }
+    }
+
+    std::atomic<uint64_t> m_version { 0 };
+    using Storage = std::array<std::atomic<uint64_t>, (sizeof(T) + sizeof(uint64_t) - 1) / sizeof(std::atomic<uint64_t>)>;
+    Storage m_storage { };
+};
+
+}
+
+using WTF::SequenceLocked;

--- a/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
+++ b/Source/WebCore/platform/audio/cocoa/CARingBuffer.h
@@ -32,6 +32,7 @@
 #include <optional>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/Lock.h>
+#include <wtf/SequenceLocked.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 
@@ -77,11 +78,7 @@ protected:
     WEBCORE_EXPORT static CheckedSize computeSizeForBuffers(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams);
 
     virtual void* data() = 0;
-    static constexpr unsigned boundsBufferSize { 32 };
-    struct TimeBoundsBuffer {
-        TimeBounds buffer[boundsBufferSize];
-        Atomic<unsigned> index { 0 };
-    };
+    using TimeBoundsBuffer = SequenceLocked<TimeBounds>;
     virtual TimeBoundsBuffer& timeBoundsBuffer() = 0;
 
 private:
@@ -120,6 +117,8 @@ class InProcessCARingBuffer final : public CARingBuffer {
 public:
     WEBCORE_EXPORT static std::unique_ptr<InProcessCARingBuffer> allocate(const WebCore::CAAudioStreamDescription& format, size_t frameCount);
     WEBCORE_EXPORT ~InProcessCARingBuffer();
+
+    TimeBoundsBuffer& timeBoundsBufferForTesting() { return timeBoundsBuffer(); }
 
 protected:
     WEBCORE_EXPORT InProcessCARingBuffer(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStreams, Vector<uint8_t>&& buffer);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		0794742D25CB33FD00C597ED /* webrtc-remote-iframe.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */; };
 		0799C34B1EBA3301003B7532 /* disableGetUserMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */; };
 		079D45F22A2A6BBE003830C7 /* Viewport.mm in Sources */ = {isa = PBXBuildFile; fileRef = 079D45F12A2A6BBE003830C7 /* Viewport.mm */; };
-		07C046CA1E4262A8007201E7 /* CARingBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBuffer.cpp */; };
+		07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07C046C91E42573E007201E7 /* CARingBufferTest.cpp */; };
 		07CE1CF31F06A7E000BF89F5 /* GetUserMediaNavigation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07CE1CF21F06A7E000BF89F5 /* GetUserMediaNavigation.mm */; };
 		07E1F6A21FFC44FA0096C7EC /* getDisplayMedia.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 07E1F6A11FFC44F90096C7EC /* getDisplayMedia.html */; };
 		07E499911F9E56DF002F1EF3 /* GetUserMediaReprompt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E499901F9E56A1002F1EF3 /* GetUserMediaReprompt.mm */; };
@@ -574,6 +574,7 @@
 		7AE9E5091AE5AE8B00CF874B /* test.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AE9E5081AE5AE8B00CF874B /* test.pdf */; };
 		7AEAD47F1E20116C00416EFE /* CrossPartitionFileSchemeAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */; };
 		7AEAD4811E20122700416EFE /* CrossPartitionFileSchemeAccess.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */; };
+		7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */; };
 		7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */; };
 		7B2739F32632AB640040F182 /* ThreadAssertionsTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */; };
 		7B2950E22972AFDE008CC225 /* StreamConnectionEncoderTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */; };
@@ -1981,7 +1982,7 @@
 		0794742C25CB33B000C597ED /* webrtc-remote-iframe.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "webrtc-remote-iframe.html"; sourceTree = "<group>"; };
 		0799C34A1EBA32F4003B7532 /* disableGetUserMedia.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = disableGetUserMedia.html; sourceTree = "<group>"; };
 		079D45F12A2A6BBE003830C7 /* Viewport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Viewport.mm; sourceTree = "<group>"; };
-		07C046C91E42573E007201E7 /* CARingBuffer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBuffer.cpp; sourceTree = "<group>"; };
+		07C046C91E42573E007201E7 /* CARingBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CARingBufferTest.cpp; sourceTree = "<group>"; };
 		07CC7DFD2266330800E39181 /* MediaBufferingPolicy.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MediaBufferingPolicy.mm; sourceTree = "<group>"; };
 		07CD32F52065B5420064A4BE /* AVFoundationPreference.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AVFoundationPreference.mm; sourceTree = "<group>"; };
 		07CD32F72065B72A0064A4BE /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
@@ -2791,6 +2792,7 @@
 		7AE9E5081AE5AE8B00CF874B /* test.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = test.pdf; sourceTree = "<group>"; };
 		7AEAD47C1E20113800416EFE /* CrossPartitionFileSchemeAccess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CrossPartitionFileSchemeAccess.mm; sourceTree = "<group>"; };
 		7AEAD47D1E20114E00416EFE /* CrossPartitionFileSchemeAccess.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = CrossPartitionFileSchemeAccess.html; path = Tests/mac/CrossPartitionFileSchemeAccess.html; sourceTree = SOURCE_ROOT; };
+		7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequenceLockedTest.cpp; sourceTree = "<group>"; };
 		7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferTests.cpp; sourceTree = "<group>"; };
 		7B2739F22632AB640040F182 /* ThreadAssertionsTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ThreadAssertionsTest.cpp; sourceTree = "<group>"; };
 		7B2950DA2972AFDD008CC225 /* StreamConnectionEncoderTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionEncoderTests.cpp; sourceTree = "<group>"; };
@@ -4267,7 +4269,7 @@
 				DF6580922722168900B3F1C1 /* ASN1Utilities.cpp */,
 				DF6580932722168900B3F1C1 /* ASN1Utilities.h */,
 				93A720E518F1A0E800A848E1 /* CalculationValue.cpp */,
-				07C046C91E42573E007201E7 /* CARingBuffer.cpp */,
+				07C046C91E42573E007201E7 /* CARingBufferTest.cpp */,
 				57303BC220071E2200355965 /* CBORReaderTest.cpp */,
 				57303BAC2006C56000355965 /* CBORValueTest.cpp */,
 				57303BAB2006C55400355965 /* CBORWriterTest.cpp */,
@@ -5229,6 +5231,7 @@
 				1A3524AC1D63A4FB0031729B /* Scope.cpp */,
 				DC69AA621CF77C6500C6272F /* ScopedLambda.cpp */,
 				E3FCFB7E274B70D5000E6B69 /* SentinelLinkedList.cpp */,
+				7B06F95E2A377E23000DFC95 /* SequenceLockedTest.cpp */,
 				0BCD85691485C98B00EA2003 /* SetForScope.cpp */,
 				CD5393C91757BAC400C07123 /* SHA1.cpp */,
 				E3953F951F2CF32100A76A2E /* Signals.cpp */,
@@ -6201,6 +6204,7 @@
 				1A3524AE1D63A4FB0031729B /* Scope.cpp in Sources */,
 				7C83DF121D0A590C00FEBCF3 /* ScopedLambda.cpp in Sources */,
 				E3FCFB7F274B70D5000E6B69 /* SentinelLinkedList.cpp in Sources */,
+				7B06F95F2A377E23000DFC95 /* SequenceLockedTest.cpp in Sources */,
 				7C83DF3D1D0A590C00FEBCF3 /* SetForScope.cpp in Sources */,
 				7C83DF2A1D0A590C00FEBCF3 /* SHA1.cpp in Sources */,
 				E373D7911F2CF35200C6FAAF /* Signals.cpp in Sources */,
@@ -6294,7 +6298,7 @@
 				7CCE7EB61A411A7E00447C4C /* CancelLoadFromResourceLoadDelegate.mm in Sources */,
 				7C83E0411D0A63F200FEBCF3 /* CandidateTests.mm in Sources */,
 				7CCE7EE71A411AE600447C4C /* CanHandleRequest.cpp in Sources */,
-				07C046CA1E4262A8007201E7 /* CARingBuffer.cpp in Sources */,
+				07C046CA1E4262A8007201E7 /* CARingBufferTest.cpp in Sources */,
 				57303BCB2008376500355965 /* CBORReaderTest.cpp in Sources */,
 				57303BC9200824D300355965 /* CBORValueTest.cpp in Sources */,
 				57303BCA20082C0100355965 /* CBORWriterTest.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/SequenceLockedTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SequenceLockedTest.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <wtf/Scope.h>
+#include <wtf/SequenceLocked.h>
+#include <wtf/Threading.h>
+
+namespace TestWebKitAPI {
+
+namespace {
+class SequenceLockedTest : public testing::Test {
+public:
+    virtual void SetUp()
+    {
+        WTF::initializeMainThread();
+    }
+};
+
+struct Tester {
+    unsigned a;
+    unsigned b;
+    unsigned c;
+    unsigned d;
+};
+
+}
+
+TEST_F(SequenceLockedTest, Works)
+{
+    SequenceLocked<Tester> tester;
+    static_assert(sizeof(tester) - sizeof(uint64_t) == sizeof(Tester));
+    std::atomic<bool> done = false;
+    auto thread = Thread::create("SequenceLocked test", [&] {
+        unsigned i = 0;
+        while (!done) {
+            tester.store({ i, i, i, i });
+            ++i;
+        }
+    }, ThreadType::Audio, Thread::QOS::UserInteractive);
+    auto threadCleanup = makeScopeExit([&] {
+        thread->waitForCompletion();
+    });
+    unsigned maxValue = 0;
+    for (int i = 0; i < 10000000; ++i) {
+        auto t = tester.load();
+        EXPECT_EQ(t.a, t.b);
+        EXPECT_EQ(t.b, t.c);
+        EXPECT_EQ(t.c, t.d);
+        EXPECT_LE(maxValue, t.a);
+        maxValue = t.a;
+    }
+    done = true;
+}
+
+TEST_F(SequenceLockedTest, DISABLED_WithoutSequenceLockedFails)
+{
+    Tester tester;
+    std::atomic<bool> done = false;
+    auto thread = Thread::create("SequenceLocked test", [&] {
+        unsigned i = 0;
+        while (!done) {
+            tester = { i, i, i, i };
+            ++i;
+        }
+    }, ThreadType::Audio, Thread::QOS::UserInteractive);
+    auto threadCleanup = makeScopeExit([&] {
+        thread->waitForCompletion();
+    });
+    unsigned maxValue = 0;
+    for (int i = 0; i < 10000000; ++i) {
+        auto t = tester;
+        EXPECT_EQ(t.a, t.b) << "a:" << t.a << " b:" << t.b << " c:" << t.c << " d:" << t.d;
+        EXPECT_EQ(t.b, t.c) << "a:" << t.a << " b:" << t.b << " c:" << t.c << " d:" << t.d;
+        EXPECT_EQ(t.c, t.d) << "a:" << t.a << " b:" << t.b << " c:" << t.c << " d:" << t.d;
+        EXPECT_LE(maxValue, t.a);
+        maxValue = t.a;
+    }
+    done = true;
+}
+
+}


### PR DESCRIPTION
#### 6dc46a71a3e1df409099e57aea286d5d8db49110
<pre>
MS Teams browser meeting IncomingAudioMediaStreamTrackRendererUnit crashes with failed: Bad bounds passed to std::clamp
<a href="https://bugs.webkit.org/show_bug.cgi?id=257892">https://bugs.webkit.org/show_bug.cgi?id=257892</a>
rdar://110382833

Reviewed by Andy Estes.

CARingBuffer start, end frame bounds were used in non-thread safe
fashion with a ad hoc ringbuffer:
  - write buffer[i] = {start, end} in non-atomic way to index i
  - atomic write index i

  - atomic load index i
  - read bounds from buffer[i]

The buffer was 32 entry ring buffer.
Presumably this was done to avoid needing 128-bit atomic primitives.

The writer might wraparound the ring buffer between the index load
and bounds load. The loads would end up happening in relaxed manner from
memory that is updated in relaxed manner during the load.
For each load, writer might wrap around the ring buffer arbitrary number
of times.

This has two problems:
- Since the bounds value load is non-atomic, it might load a value from
the distant future writes, and then subsequent later loads might load
values from near future. This would mean that strictly monotonic
increases in bounds would appear to be non-monotonic, essentially
random.
- Since the start and end loads are distinct, one load, say start, might
come from distant future write, where as the other load, end, might come
from near future write. This would mean that start might be larger than
end. This would cause the crash.

The bug contains the simpilified C++ reproductions of the problems.

Instead, adapt SequenceLocked from abseil sequence_lock.h. Seqlock is
an algorithm designed for atomic updates of larger data sections.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/SequenceLocked.h: Added.
(WTF::SequenceLocked::load const):
(WTF::SequenceLocked::store):
(WTF::SequenceLocked::relaxedCopyFromAtomic):
(WTF::SequenceLocked::relaxedCopyToAtomic):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.cpp:
(WebCore::CARingBuffer::setTimeBounds):
(WebCore::CARingBuffer::getFetchTimeBounds):
* Source/WebCore/platform/audio/cocoa/CARingBuffer.h:
* Tools/TestWebKitAPI/Tests/WebCore/CARingBuffer.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/265117@main">https://commits.webkit.org/265117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebcef77f248d4d0b9ce8d4cb2e379f8942d11eff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12519 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11907 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16298 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8361 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9100 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12378 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9369 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9599 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10011 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8848 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2368 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12986 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10280 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9374 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2550 "Passed tests") | 
<!--EWS-Status-Bubble-End-->