### PR TITLE
Expose platform specific initialization of GPU Process

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -311,9 +311,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
     registerWithStateDumper("GPUProcess state"_s);
 #endif
 
-#if PLATFORM(COCOA)
     platformInitializeGPUProcess(parameters);
-#endif
 }
 
 void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -147,6 +147,7 @@ private:
 
     // Message Handlers
     void initializeGPUProcess(GPUProcessCreationParameters&&);
+    void platformInitializeGPUProcess(GPUProcessCreationParameters&);
     void updateGPUProcessPreferences(GPUProcessPreferences&&);
     void createGPUConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&, CompletionHandler<void()>&&);
     void updateWebGPUEnabled(WebCore::ProcessIdentifier, bool webGPUEnabled);
@@ -180,9 +181,6 @@ private:
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);
     void setScreenProperties(const WebCore::ScreenProperties&);
     void updateProcessName();
-#endif
-#if PLATFORM(COCOA)
-    void platformInitializeGPUProcess(GPUProcessCreationParameters&);
 #endif
 
 #if USE(OS_STATE)

--- a/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
+++ b/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
@@ -32,6 +32,10 @@
 
 namespace WebKit {
 
+void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
+{
+}
+
 void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameters&)
 {
 }

--- a/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
+++ b/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
@@ -32,6 +32,10 @@
 
 namespace WebKit {
 
+void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
+{
+}
+
 void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameters&)
 {
 }

--- a/Source/WebKit/GPUProcess/win/GPUProcessWin.cpp
+++ b/Source/WebKit/GPUProcess/win/GPUProcessWin.cpp
@@ -32,6 +32,10 @@
 
 namespace WebKit {
 
+void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
+{
+}
+
 void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameters&)
 {
 }


### PR DESCRIPTION
#### 4f6c2e880164c1d4dac1234d14b0dbee33c99dae
<pre>
Expose platform specific initialization of GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=257895">https://bugs.webkit.org/show_bug.cgi?id=257895</a>

Reviewed by Myles C. Maxfield.

Expose the method `GPUProcess::platformInitializeGPUProcess` for all
ports to do any platform specific routines at start up. This mirrors the
behavior of the Web and Network process.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/GPUProcess/win/GPUProcessWin.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):

Canonical link: <a href="https://commits.webkit.org/267572@main">https://commits.webkit.org/267572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7e89f7efef49ac869b67bf302c4e9ab23befe87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17486 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/18148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19621 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14808 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/22157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19935 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/16242 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16211 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/18582 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15370 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4332 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19733 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/19807 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16044 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/4190 "Passed tests") | 
<!--EWS-Status-Bubble-End-->