### PR TITLE
REGRESSION: Dynamic attribute updates partly broken for SVG

### DIFF
--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -80,8 +80,6 @@ String SVGAElement::title() const
 
 void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
     if (name == SVGNames::targetAttr) {
         m_target->setBaseValInternal(newValue);
         return;
@@ -89,6 +87,9 @@ void SVGAElement::attributeChanged(const QualifiedName& name, const AtomString& 
         if (m_relList)
             m_relList->associatedAttributeValueChanged(newValue);
     }
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGAElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -101,12 +101,12 @@ bool SVGAnimateMotionElement::hasValidAttributeName() const
 
 void SVGAnimateMotionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGAnimationElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::pathAttr) {
         m_path = buildPathFromString(newValue);
         updateAnimationPath();
     }
+
+    SVGAnimationElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
     
 SVGAnimateMotionElement::RotateMode SVGAnimateMotionElement::rotateMode() const

--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -56,13 +56,13 @@ bool SVGAnimateTransformElement::hasValidAttributeType() const
 
 void SVGAnimateTransformElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGAnimateElementBase::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::typeAttr) {
         m_type = SVGTransformable::parseTransformType(newValue).value_or(SVGTransformValue::SVG_TRANSFORM_UNKNOWN);
         if (m_type == SVGTransformValue::SVG_TRANSFORM_MATRIX)
             m_type = SVGTransformValue::SVG_TRANSFORM_UNKNOWN;
     }
+
+    SVGAnimateElementBase::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 String SVGAnimateTransformElement::animateRangeString(const String& string) const

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -165,9 +165,6 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
 
 void SVGAnimationElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGTests::parseAttribute(name, newValue);
-    SVGSMILElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     switch (name.nodeName()) {
     case AttributeNames::valuesAttr:
         // Per the SMIL specification, leading and trailing white space,
@@ -209,6 +206,9 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
     default:
         break;
     }
+
+    SVGTests::parseAttribute(name, newValue);
+    SVGSMILElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGAnimationElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -52,13 +52,13 @@ Ref<SVGClipPathElement> SVGClipPathElement::create(const QualifiedName& tagName,
 
 void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::clipPathUnitsAttr) {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_clipPathUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
     }
+
+    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGClipPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -53,10 +53,10 @@ Ref<SVGFEComponentTransferElement> SVGFEComponentTransferElement::create(const Q
 
 void SVGFEComponentTransferElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(newValue);
+
+    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFEComponentTransferElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -116,11 +116,11 @@ void SVGFEImageElement::buildPendingResource()
 
 void SVGFEImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::preserveAspectRatioAttr)
         m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { newValue });
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFEImageElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
@@ -50,10 +50,10 @@ Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(const QualifiedName& ta
 
 void SVGFEMergeNodeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(newValue);
+
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFEMergeNodeElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -51,8 +51,6 @@ Ref<SVGFEOffsetElement> SVGFEOffsetElement::create(const QualifiedName& tagName,
 
 void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     switch (name.nodeName()) {
     case AttributeNames::dxAttr:
         m_dx->setBaseValInternal(newValue.toFloat());
@@ -66,6 +64,8 @@ void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomS
     default:
         break;
     }
+
+    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFEOffsetElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFETileElement.cpp
+++ b/Source/WebCore/svg/SVGFETileElement.cpp
@@ -48,10 +48,10 @@ Ref<SVGFETileElement> SVGFETileElement::create(const QualifiedName& tagName, Doc
 
 void SVGFETileElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::inAttr)
         m_in1->setBaseValInternal(newValue);
+
+    SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFETileElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -74,8 +74,6 @@ Ref<SVGFontFaceElement> SVGFontFaceElement::create(const QualifiedName& tagName,
 
 void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     CSSPropertyID propertyId = cssPropertyIdForSVGAttributeName(name);
     if (propertyId > 0) {
         // FIXME: Parse using the @font-face descriptor grammars, not the property grammars.
@@ -95,6 +93,8 @@ void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomS
         rebuildFontFace();
         return;
     }
+
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 unsigned SVGFontFaceElement::unitsPerEm() const

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -68,9 +68,10 @@ Ref<CSSFontFaceSrcResourceValue> SVGFontFaceUriElement::createSrcValue() const
 
 void SVGFontFaceUriElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
     if (name == SVGNames::hrefAttr || name == XLinkNames::hrefAttr)
         loadFont();
+
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGFontFaceUriElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -135,13 +135,13 @@ bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
 
 void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::pathLengthAttr) {
         m_pathLength->setBaseValInternal(newValue.toFloat());
         if (m_pathLength->baseVal() < 0)
             document().accessSVGExtensions().reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }
+
+    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGGeometryElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -63,9 +63,6 @@ static float parseFloat(const AtomString& value)
 
 void SVGGlyphRefElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     // FIXME: Is the error handling in parseFloat correct for these attributes?
     switch (name.nodeName()) {
     case AttributeNames::xAttr:
@@ -83,6 +80,9 @@ void SVGGlyphRefElement::attributeChanged(const QualifiedName& name, const AtomS
     default:
         break;
     }
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGGlyphRefElement::setX(float x)

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -52,9 +52,6 @@ SVGGradientElement::SVGGradientElement(const QualifiedName& tagName, Document& d
 
 void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     switch (name.nodeName()) {
     case AttributeNames::gradientUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
@@ -74,6 +71,9 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
     default:
         break;
     }
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGGradientElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -132,11 +132,11 @@ AffineTransform* SVGGraphicsElement::ensureSupplementalTransform()
 
 void SVGGraphicsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGTests::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::transformAttr)
         m_transform->baseVal()->parse(newValue);
+
+    SVGTests::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGGraphicsElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -92,9 +92,6 @@ bool SVGImageElement::renderingTaintsOrigin() const
 
 void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     SVGParsingError parseError = NoError;
     switch (name.nodeName()) {
     case AttributeNames::preserveAspectRatioAttr:
@@ -116,6 +113,9 @@ void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomStri
         break;
     }
     reportAttributeParsingError(parseError, name, newValue);
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -62,9 +62,6 @@ AffineTransform SVGMarkerElement::viewBoxToViewTransform(float viewWidth, float 
 
 void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGFitToViewBox::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     SVGParsingError parseError = NoError;
     switch (name.nodeName()) {
     case AttributeNames::markerUnitsAttr: {
@@ -95,6 +92,9 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
         break;
     }
     reportAttributeParsingError(parseError, name, newValue);
+
+    SVGFitToViewBox::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGMarkerElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -67,10 +67,6 @@ Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Documen
 
 void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGTests::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
-
     SVGParsingError parseError = NoError;
     switch (name.nodeName()) {
     case AttributeNames::maskUnitsAttr: {
@@ -101,6 +97,9 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
         break;
     }
     reportAttributeParsingError(parseError, name, newValue);
+
+    SVGTests::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGMaskElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -55,11 +55,12 @@ Ref<SVGPathElement> SVGPathElement::create(const QualifiedName& tagName, Documen
 
 void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
     if (name == SVGNames::dAttr) {
         if (!m_pathSegList->baseVal()->parse(newValue))
             document().accessSVGExtensions().reportError("Problem parsing d=\"" + newValue + "\"");
     }
+
+    SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -73,28 +73,23 @@ Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, D
 
 void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGURIReference::parseAttribute(name, newValue);
-    SVGTests::parseAttribute(name, newValue);
-    SVGFitToViewBox::parseAttribute(name, newValue);
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     SVGParsingError parseError = NoError;
     switch (name.nodeName()) {
     case AttributeNames::patternUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_patternUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
+        break;
     }
     case AttributeNames::patternContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_patternContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
+        break;
     }
     case AttributeNames::patternTransformAttr: {
         m_patternTransform->baseVal()->parse(newValue);
-        return;
+        break;
     }
     case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
@@ -112,6 +107,11 @@ void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomSt
         break;
     }
     reportAttributeParsingError(parseError, name, newValue);
+
+    SVGURIReference::parseAttribute(name, newValue);
+    SVGTests::parseAttribute(name, newValue);
+    SVGFitToViewBox::parseAttribute(name, newValue);
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGPatternElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -45,12 +45,12 @@ SVGPolyElement::SVGPolyElement(const QualifiedName& tagName, Document& document)
 
 void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::pointsAttr) {
         if (!m_points->baseVal()->parse(newValue))
             document().accessSVGExtensions().reportError("Problem parsing points=\"" + newValue + "\"");
     }
+
+    SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGPolyElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -167,10 +167,6 @@ void SVGSVGElement::updateCurrentTranslate()
 
 void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGFitToViewBox::parseAttribute(name, newValue);
-    SVGZoomAndPan::parseAttribute(name, newValue);
-    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (!nearestViewportElement() && isConnected()) {
         // For these events, the outermost <svg> element works like a <body> element does,
         // setting certain event handlers directly on the window object.
@@ -231,6 +227,10 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
         break;
     }
     reportAttributeParsingError(parseError, name, newValue);
+
+    SVGFitToViewBox::parseAttribute(name, newValue);
+    SVGZoomAndPan::parseAttribute(name, newValue);
+    SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGSVGElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -52,14 +52,14 @@ Ref<SVGStopElement> SVGStopElement::create(const QualifiedName& tagName, Documen
 
 void SVGStopElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     if (name == SVGNames::offsetAttr) {
         if (newValue.endsWith('%'))
             m_offset->setBaseValInternal(newValue.string().left(newValue.length() - 1).toFloat() / 100.0f);
         else
             m_offset->setBaseValInternal(newValue.toFloat());
     }
+
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGStopElement::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -94,8 +94,6 @@ String SVGStyleElement::title() const
 
 void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-
     switch (name.nodeName()) {
     case AttributeNames::titleAttr:
         if (sheet() && !isInShadowTree())
@@ -110,6 +108,8 @@ void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomStri
     default:
         break;
     }
+
+    SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void SVGStyleElement::finishParsingChildren()


### PR DESCRIPTION
#### a0c0c14bfa2185765e469bdbcdf06ca79cddbf6f
<pre>
REGRESSION: Dynamic attribute updates partly broken for SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=257900">https://bugs.webkit.org/show_bug.cgi?id=257900</a>

[LBSE] REGRESSION: Transform repainting/relayout broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=257692">https://bugs.webkit.org/show_bug.cgi?id=257692</a>

Reviewed by Rob Buis.

SVGElement::attributeChanged() need to be called _after_ changing
the class and/or base class members. attributeChanged() calls
svgAttributeChanged(), which assumes the class members have been
updated due to an attribute change before.

This also fixes the regression seen in LBSE, where &apos;transform&apos;
updates no longer have any effect.

Covered by existing tests.

* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::attributeChanged):
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::attributeChanged):
* Source/WebCore/svg/SVGAnimateTransformElement.cpp:
(WebCore::SVGAnimateTransformElement::attributeChanged):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeChanged):
* Source/WebCore/svg/SVGClipPathElement.cpp:
(WebCore::SVGClipPathElement::attributeChanged):
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::attributeChanged):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::attributeChanged):
* Source/WebCore/svg/SVGFEMergeNodeElement.cpp:
(WebCore::SVGFEMergeNodeElement::attributeChanged):
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::attributeChanged):
* Source/WebCore/svg/SVGFETileElement.cpp:
(WebCore::SVGFETileElement::attributeChanged):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::attributeChanged):
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::attributeChanged):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/SVGGlyphRefElement.cpp:
(WebCore::SVGGlyphRefElement::attributeChanged):
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::attributeChanged):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::attributeChanged):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::attributeChanged):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::attributeChanged):
* Source/WebCore/svg/SVGStopElement.cpp:
(WebCore::SVGStopElement::attributeChanged):
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/265069@main">https://commits.webkit.org/265069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4f8481380f91474484b46ace051f3cdda7433e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12271 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11374 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16115 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12183 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7587 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8535 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2330 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12757 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->