### PR TITLE
[WGSL] size and align attributes should not generate code

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -63,6 +63,8 @@ public:
     void visit(AST::GroupAttribute&) override;
     void visit(AST::BindingAttribute&) override;
     void visit(AST::WorkgroupSizeAttribute&) override;
+    void visit(AST::SizeAttribute&) override;
+    void visit(AST::AlignAttribute&) override;
 
     void visit(AST::Function&) override;
     void visit(AST::Structure&) override;
@@ -457,6 +459,18 @@ void FunctionDefinitionWriter::visit(AST::WorkgroupSizeAttribute&)
 {
     // This attribute shouldn't generate any code. The workgroup size is passed
     // to the API through the EntryPointInformation.
+}
+
+void FunctionDefinitionWriter::visit(AST::SizeAttribute&)
+{
+    // This attribute shouldn't generate any code. The size is used when serializing
+    // structs.
+}
+
+void FunctionDefinitionWriter::visit(AST::AlignAttribute&)
+{
+    // This attribute shouldn't generate any code. The alignment is used when
+    // serializing structs.
 }
 
 // Types

--- a/Source/WebGPU/WGSL/tests/valid/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/struct.wgsl
@@ -1,13 +1,20 @@
-// RUN: %wgslc
+// RUN: %metal-compile main
 
 struct S {
-    x: f32,
-    y: i32,
+    @size(16) x: f32,
+    @align(16) y: i32,
 }
 
-fn testStructConstructor()
+fn testStructConstructor() -> i32
 {
     _ = S(0, 0);
     _ = S(0.0, 0);
     _ = S(0f, 0i);
+    return 0;
+}
+
+@compute @workgroup_size(1)
+fn main()
+{
+    _ = testStructConstructor();
 }


### PR DESCRIPTION
#### 88ce5a35673023f55e9d057ee29614583476aa55
<pre>
[WGSL] size and align attributes should not generate code
<a href="https://bugs.webkit.org/show_bug.cgi?id=257901">https://bugs.webkit.org/show_bug.cgi?id=257901</a>
rdar://110539602

Reviewed by Dan Glastonbury.

The default visitor would cause the value of those attributes to be printed,
which result in invalid metal code. To fix it we simply have to override the
visitor with a no-op implementation.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/265110@main">https://commits.webkit.org/265110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f50b384d694a939f7cebf1ab795cf2452f301888

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9367 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12274 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11376 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7866 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16110 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12178 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7590 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8537 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2360 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9106 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->