### PR TITLE
[WGSL] Add zero-initializer declarations

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -609,7 +609,7 @@ void TypeChecker::visit(AST::CallExpression& call)
             if (auto* structType = std::get_if<Types::Struct>(*targetType)) {
                 auto numberOfArguments = call.arguments().size();
                 auto numberOfFields = structType->fields.size();
-                if (numberOfArguments != numberOfFields) {
+                if (numberOfArguments && numberOfArguments != numberOfFields) {
                     const char* errorKind = numberOfArguments < numberOfFields ? "few" : "many";
                     typeError(call.span(), "struct initializer has too ", errorKind, " inputs: expected ", String::number(numberOfFields), ", found ", String::number(numberOfArguments));
                     return;
@@ -680,7 +680,8 @@ void TypeChecker::visit(AST::CallExpression& call)
                 typeError(call.span(), "array count must be greater than 0");
                 return;
             }
-            if (call.arguments().size() != elementCount) {
+            unsigned numberOfArguments = call.arguments().size();
+            if (numberOfArguments && numberOfArguments != elementCount) {
                 const char* errorKind = call.arguments().size() < elementCount ? "few" : "many";
                 typeError(call.span(), "array constructor has too ", errorKind, " elements: expected ", String::number(elementCount), ", found ", String::number(call.arguments().size()));
                 return;

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -105,6 +105,38 @@ operator :textureSampleBaseClampToEdge, {
   [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
 }
 
+# 16.1. Constructor Built-in Functions
+
+# 16.1.1. Zero Value Built-in Functions
+operator :bool, {
+    [].() => Bool,
+}
+operator :i32, {
+    [].() => I32,
+}
+operator :u32, {
+    [].() => U32,
+}
+operator :f32, {
+    [].() => F32,
+}
+operator :vec2, {
+    [T < ConcreteScalar].() => Vector[T, 2],
+}
+operator :vec3, {
+    [T < ConcreteScalar].() => Vector[T, 3],
+}
+operator :vec4, {
+    [T < ConcreteScalar].() => Vector[T, 4],
+}
+(2..4).each do |columns|
+    (2..4).each do |rows|
+        operator :"mat#{columns}x#{rows}", {
+            [T < ConcreteFloat].() => Matrix[T, columns, rows],
+        }
+    end
+end
+
 operator :vec2, {
     [T < Scalar].(T) => Vector[T, 2],
     [T < ConcreteScalar, S < Scalar].(Vector[S, 2]) => Vector[T, 2],

--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -4,8 +4,8 @@ fn testArrayLengthMismatch() {
   // CHECK-L: array count must be greater than 0
   let x1 = array<i32, 0>();
 
-  // CHECK-L: array constructor has too few elements: expected 1, found 0
-  let x2 = array<i32, 1>();
+  // CHECK-L: array constructor has too few elements: expected 2, found 1
+  let x2 = array<i32, 2>(0);
 
   // CHECK-L: array constructor has too many elements: expected 1, found 2
   let x3 = array<i32, 1>(0, 0);

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -568,6 +568,33 @@ fn testLogicalAnd()
     _ = vec4( true) & vec4( true);
 }
 
+// 16.1. Constructor Built-in Functions
+
+// 16.1.1. Zero Value Built-in Functions
+struct S { x: i32 };
+fn testZeroValueBuiltInFunctions()
+{
+    _ = bool();
+    _ = i32();
+    _ = u32();
+    _ = f32();
+
+    _ = vec2<f32>();
+    _ = vec3<f32>();
+    _ = vec4<f32>();
+
+    _ = mat2x2<f32>();
+    _ = mat2x3<f32>();
+    _ = mat2x4<f32>();
+    _ = mat3x2<f32>();
+    _ = mat3x3<f32>();
+    _ = mat3x4<f32>();
+    _ = mat4x2<f32>();
+    _ = mat4x3<f32>();
+    _ = mat4x4<f32>();
+    _ = S();
+    _ = array<f32, 1>();
+}
 
 // 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 


### PR DESCRIPTION
#### a9da0d20bb1c1e62953893d1a08211e7ba6ea0d9
<pre>
[WGSL] Add zero-initializer declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257902">https://bugs.webkit.org/show_bug.cgi?id=257902</a>
rdar://110540048

Reviewed by Dan Glastonbury.

Add declarations according to the spec[1]. Additionally, constructors for arrays
and structs are handled directly in the type checker, so that is also updated.

[1]: <a href="https://gpuweb.github.io/gpuweb/wgsl/#zero-value-builtin-function">https://gpuweb.github.io/gpuweb/wgsl/#zero-value-builtin-function</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/invalid/array.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/265108@main">https://commits.webkit.org/265108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cdbf41b5d621bcb42e16fd9739d44122f73f68c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12275 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11380 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7869 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16114 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12182 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8541 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2361 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12763 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->