### PR TITLE
Upstream `defaultAlternateFormControlDesignEnabled` and `defaultVideoFullscreenRequiresElementFullscreen`

### DIFF
--- a/Source/WebCore/platform/ios/Device.cpp
+++ b/Source/WebCore/platform/ios/Device.cpp
@@ -42,6 +42,16 @@ bool deviceClassIsSmallScreen()
     return deviceClass == MGDeviceClassiPhone || deviceClass == MGDeviceClassiPod || deviceClass == MGDeviceClassWatch;
 }
 
+bool deviceClassIsReality()
+{
+#if PLATFORM(VISION)
+    static auto deviceClass = MGGetSInt32Answer(kMGQDeviceClassNumber, MGDeviceClassInvalid);
+    return deviceClass == MGDeviceClassRealityDevice;
+#else
+    return false;
+#endif
+}
+
 String deviceName()
 {
 #if ENABLE(MOBILE_GESTALT_DEVICE_NAME)

--- a/Source/WebCore/platform/ios/Device.h
+++ b/Source/WebCore/platform/ios/Device.h
@@ -38,6 +38,8 @@ String deviceName(); // Thread-safe.
 // If a check like this is needed, often currentUserInterfaceIdiomIsSmallScreen is preferred.
 WEBCORE_EXPORT bool deviceClassIsSmallScreen();
 
+WEBCORE_EXPORT bool deviceClassIsReality();
+
 // FIXME: How does this differ from !deviceClassIsSmallScreen()?
 WEBCORE_EXPORT bool deviceHasIPadCapability();
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -218,6 +218,7 @@ $(PROJECT_DIR)/Shared/TextFlags.serialization.in
 $(PROJECT_DIR)/Shared/TextRecognitionResult.serialization.in
 $(PROJECT_DIR)/Shared/TouchBarMenuItemData.serialization.in
 $(PROJECT_DIR)/Shared/UpdateInfo.serialization.in
+$(PROJECT_DIR)/Shared/UserInterfaceIdiom.serialization.in
 $(PROJECT_DIR)/Shared/WTFArgumentCoders.serialization.in
 $(PROJECT_DIR)/Shared/WebConnection.messages.in
 $(PROJECT_DIR)/Shared/WebCoreArgumentCoders.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -515,6 +515,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/TextFlags.serialization.in \
 	Shared/TextRecognitionResult.serialization.in \
 	Shared/TouchBarMenuItemData.serialization.in \
+	Shared/UserInterfaceIdiom.serialization.in \
 	Shared/WTFArgumentCoders.serialization.in \
 	Shared/WebCoreArgumentCoders.serialization.in \
 	Shared/WebExtensionContextParameters.serialization.in \

--- a/Source/WebKit/Shared/UserInterfaceIdiom.h
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.h
@@ -29,8 +29,18 @@
 
 namespace WebKit {
 
+enum class UserInterfaceIdiom : uint8_t {
+    Default,
+    SmallScreen,
+    Reality
+};
+
 bool currentUserInterfaceIdiomIsSmallScreen();
-void setCurrentUserInterfaceIdiomIsSmallScreen(bool);
+bool currentUserInterfaceIdiomIsReality();
+
+UserInterfaceIdiom currentUserInterfaceIdiom();
+void setCurrentUserInterfaceIdiom(UserInterfaceIdiom);
+
 bool updateCurrentUserInterfaceIdiom();
 
 }

--- a/Source/WebKit/Shared/UserInterfaceIdiom.mm
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.mm
@@ -30,43 +30,67 @@
 
 #import "UIKitSPI.h"
 #import <WebCore/Device.h>
-#import <wtf/TriState.h>
 
 namespace WebKit {
 
-static TriState idiomIsSmallScreen = TriState::Indeterminate;
+static std::optional<UserInterfaceIdiom> s_currentUserInterfaceIdiom;
 
 bool currentUserInterfaceIdiomIsSmallScreen()
 {
-    if (idiomIsSmallScreen == TriState::Indeterminate)
+    if (!s_currentUserInterfaceIdiom)
         updateCurrentUserInterfaceIdiom();
-    return idiomIsSmallScreen == TriState::True;
+    return s_currentUserInterfaceIdiom == UserInterfaceIdiom::SmallScreen;
 }
 
-void setCurrentUserInterfaceIdiomIsSmallScreen(bool isSmallScreen)
+bool currentUserInterfaceIdiomIsReality()
 {
-    idiomIsSmallScreen = TriState(isSmallScreen);
+    if (!s_currentUserInterfaceIdiom)
+        updateCurrentUserInterfaceIdiom();
+    return s_currentUserInterfaceIdiom == UserInterfaceIdiom::Reality;
+}
+
+UserInterfaceIdiom currentUserInterfaceIdiom()
+{
+    if (!s_currentUserInterfaceIdiom)
+        updateCurrentUserInterfaceIdiom();
+    return *s_currentUserInterfaceIdiom;
+}
+
+void setCurrentUserInterfaceIdiom(UserInterfaceIdiom idiom)
+{
+    s_currentUserInterfaceIdiom = idiom;
 }
 
 bool updateCurrentUserInterfaceIdiom()
 {
-    bool wasSmallScreen = idiomIsSmallScreen == TriState::True;
+    UserInterfaceIdiom oldIdiom = s_currentUserInterfaceIdiom.value_or(UserInterfaceIdiom::Default);
 
     // If we are in a daemon, we cannot use UIDevice. Fall back to checking the hardware itself.
     // Since daemons don't ever run in an iPhone-app-on-iPad jail, this will be accurate in the daemon case,
     // but is not sufficient in the application case.
-    bool isSmallScreen;
-    if (![UIApplication sharedApplication])
-        isSmallScreen = WebCore::deviceClassIsSmallScreen();
-    else {
-        auto idiom = [[UIDevice currentDevice] userInterfaceIdiom];
-        isSmallScreen = idiom == UIUserInterfaceIdiomPhone || idiom == UIUserInterfaceIdiomWatch;
-    }
+    UserInterfaceIdiom newIdiom = [&] {
+        if (![UIApplication sharedApplication]) {
+            if (WebCore::deviceClassIsSmallScreen())
+                return UserInterfaceIdiom::SmallScreen;
+            if (WebCore::deviceClassIsReality())
+                return UserInterfaceIdiom::Reality;
+        } else {
+            auto idiom = [[UIDevice currentDevice] userInterfaceIdiom];
+            if (idiom == UIUserInterfaceIdiomPhone || idiom == UIUserInterfaceIdiomWatch)
+                return UserInterfaceIdiom::SmallScreen;
+#if PLATFORM(VISION)
+            if (idiom == UIUserInterfaceIdiomReality)
+                return UserInterfaceIdiom::Reality;
+#endif
+        }
 
-    if (wasSmallScreen == isSmallScreen)
+        return UserInterfaceIdiom::Default;
+    }();
+
+    if (oldIdiom == newIdiom)
         return false;
 
-    setCurrentUserInterfaceIdiomIsSmallScreen(isSmallScreen);
+    setCurrentUserInterfaceIdiom(newIdiom);
     return true;
 }
 

--- a/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if PLATFORM(IOS_FAMILY)
+
+enum class WebKit::UserInterfaceIdiom : uint8_t {
+    Default,
+    SmallScreen,
+    Reality
+};
+
+#endif

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -68,17 +68,15 @@ bool defaultShouldPrintBackgrounds()
     return result;
 }
 
-#if !USE(APPLE_INTERNAL_SDK)
 bool defaultAlternateFormControlDesignEnabled()
 {
-    return false;
+    return currentUserInterfaceIdiomIsReality();
 }
 
 bool defaultVideoFullscreenRequiresElementFullscreen()
 {
-    return false;
+    return currentUserInterfaceIdiomIsReality();
 }
-#endif
 
 #endif
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include "TextCheckerState.h"
 #include "UserData.h"
+#include "UserInterfaceIdiom.h"
 #include "WebProcessDataStoreParameters.h"
 #include <WebCore/CrossOriginMode.h>
 #include <wtf/HashMap.h>
@@ -205,7 +206,7 @@ struct WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    bool currentUserInterfaceIdiomIsSmallScreen { false };
+    UserInterfaceIdiom currentUserInterfaceIdiom { UserInterfaceIdiom::Default };
     bool supportsPictureInPicture { false };
     WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -160,7 +160,7 @@ struct WebKit::WebProcessCreationParameters {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    bool currentUserInterfaceIdiomIsSmallScreen;
+    WebKit::UserInterfaceIdiom currentUserInterfaceIdiom;
     bool supportsPictureInPicture;
     WebCore::RenderThemeIOS::CSSValueToSystemColorMap cssValueToSystemColorMap;
     WebCore::Color focusRingColor;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -473,7 +473,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     parameters.strictSecureDecodingForAllObjCEnabled = IPC::strictSecureDecodingForAllObjCEnabled();
 
 #if PLATFORM(IOS_FAMILY)
-    parameters.currentUserInterfaceIdiomIsSmallScreen = currentUserInterfaceIdiomIsSmallScreen();
+    parameters.currentUserInterfaceIdiom = currentUserInterfaceIdiom();
     parameters.supportsPictureInPicture = supportsPictureInPicture();
     parameters.cssValueToSystemColorMap = RenderThemeIOS::cssValueToSystemColorMap();
     parameters.focusRingColor = RenderThemeIOS::systemFocusRingColor();
@@ -796,7 +796,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![UIApplication sharedApplication]) {
         m_applicationLaunchObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
             if (WebKit::updateCurrentUserInterfaceIdiom())
-                sendToAllProcesses(Messages::WebProcess::UserInterfaceIdiomDidChange(WebKit::currentUserInterfaceIdiomIsSmallScreen()));
+                sendToAllProcesses(Messages::WebProcess::UserInterfaceIdiomDidChange(WebKit::currentUserInterfaceIdiom()));
         }];
     }
 #endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4189,6 +4189,7 @@
 		2DA049B2180CCCD300AAFA9E /* PlatformCALayerRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCALayerRemote.h; sourceTree = "<group>"; };
 		2DA049B5180CCD0A00AAFA9E /* GraphicsLayerCARemote.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GraphicsLayerCARemote.mm; sourceTree = "<group>"; };
 		2DA049B6180CCD0A00AAFA9E /* GraphicsLayerCARemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicsLayerCARemote.h; sourceTree = "<group>"; };
+		2DA3E37D2A33C98900F7799D /* UserInterfaceIdiom.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserInterfaceIdiom.serialization.in; sourceTree = "<group>"; };
 		2DA6731920C754B1003CB401 /* DynamicViewportSizeUpdate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DynamicViewportSizeUpdate.h; path = ios/DynamicViewportSizeUpdate.h; sourceTree = "<group>"; };
 		2DA7FDCB18F88625008DDED0 /* FindIndicatorOverlayClientIOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FindIndicatorOverlayClientIOS.h; path = ios/FindIndicatorOverlayClientIOS.h; sourceTree = "<group>"; };
 		2DA944971884E4F000ED86DB /* NativeWebKeyboardEventIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = NativeWebKeyboardEventIOS.mm; path = ios/NativeWebKeyboardEventIOS.mm; sourceTree = "<group>"; };
@@ -8066,6 +8067,7 @@
 				5C9C5C022430535800BB6740 /* UserContentControllerParameters.h */,
 				1AC1336518565B5700F3EC05 /* UserData.cpp */,
 				1AC1336618565B5700F3EC05 /* UserData.h */,
+				2DA3E37D2A33C98900F7799D /* UserInterfaceIdiom.serialization.in */,
 				419BD18F28E1A86C0089D7B7 /* VideoCodecType.h */,
 				2684054A18B866FF0022C38B /* VisibleContentRectUpdateInfo.cpp */,
 				2684054218B85A630022C38B /* VisibleContentRectUpdateInfo.h */,

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -156,6 +156,7 @@ struct WebsiteData;
 struct WebsiteDataStoreParameters;
 
 enum class RemoteWorkerType : uint8_t;
+enum class UserInterfaceIdiom : uint8_t;
 enum class WebsiteDataType : uint32_t;
 
 #if PLATFORM(IOS_FAMILY)
@@ -590,7 +591,7 @@ private:
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    void userInterfaceIdiomDidChange(bool);
+    void userInterfaceIdiomDidChange(UserInterfaceIdiom);
 
     bool shouldFreezeOnSuspension() const;
     void updateFreezerStatus();

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -117,7 +117,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    UserInterfaceIdiomDidChange(bool isPhoneOrWatch)
+    UserInterfaceIdiomDidChange(enum:uint8_t WebKit::UserInterfaceIdiom idiom)
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -366,7 +366,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     setEnhancedAccessibility(parameters.accessibilityEnhancedUserInterfaceEnabled);
 
 #if PLATFORM(IOS_FAMILY)
-    setCurrentUserInterfaceIdiomIsSmallScreen(parameters.currentUserInterfaceIdiomIsSmallScreen);
+    setCurrentUserInterfaceIdiom(parameters.currentUserInterfaceIdiom);
     setLocalizedDeviceModel(parameters.localizedDeviceModel);
     setContentSizeCategory(parameters.contentSizeCategory);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -1085,9 +1085,9 @@ void WebProcess::releaseSystemMallocMemory()
 
 #if PLATFORM(IOS_FAMILY)
 
-void WebProcess::userInterfaceIdiomDidChange(bool isSmallScreen)
+void WebProcess::userInterfaceIdiomDidChange(UserInterfaceIdiom idiom)
 {
-    WebKit::setCurrentUserInterfaceIdiomIsSmallScreen(isSmallScreen);
+    WebKit::setCurrentUserInterfaceIdiom(idiom);
 }
 
 bool WebProcess::shouldFreezeOnSuspension() const


### PR DESCRIPTION
#### c976622eda347ae0d2691521cad71e40d6ae5acf
<pre>
Upstream `defaultAlternateFormControlDesignEnabled` and `defaultVideoFullscreenRequiresElementFullscreen`
<a href="https://bugs.webkit.org/show_bug.cgi?id=257908">https://bugs.webkit.org/show_bug.cgi?id=257908</a>
rdar://110544922

Reviewed by Megan Gardner and Aditya Keerthi.

* Source/WebCore/platform/ios/Device.cpp:
(WebCore::deviceClassIsReality):
* Source/WebCore/platform/ios/Device.h:
* Source/WebKit/Shared/UserInterfaceIdiom.h:
* Source/WebKit/Shared/UserInterfaceIdiom.mm:
(WebKit::currentUserInterfaceIdiomIsSmallScreen):
(WebKit::currentUserInterfaceIdiomIsReality):
(WebKit::currentUserInterfaceIdiom):
(WebKit::setCurrentUserInterfaceIdiom):
(WebKit::updateCurrentUserInterfaceIdiom):
(WebKit::setCurrentUserInterfaceIdiomIsSmallScreen): Deleted.
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::userInterfaceIdiomDidChange):
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/UserInterfaceIdiom.h:
* Source/WebKit/Shared/UserInterfaceIdiom.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
Extend our existing UserInterfaceIdiom mechanism to support the new idiom.

* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultAlternateFormControlDesignEnabled):
(WebKit::defaultVideoFullscreenRequiresElementFullscreen):
Adopt it to implement these two preferences.

Canonical link: <a href="https://commits.webkit.org/265038@main">https://commits.webkit.org/265038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de3f31cd41eee61edc74b85153b8ce4e9ee30be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11243 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9799 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12297 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9734 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11402 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/7891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12199 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1096 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->