### PR TITLE
[Cocoa] colorSpace values missing from videoTrack.configuration with MP4s missing explicit color information

### DIFF
--- a/LayoutTests/media/track/video-track-configuration-mp4-default-colorspace-expected.txt
+++ b/LayoutTests/media/track/video-track-configuration-mp4-default-colorspace-expected.txt
@@ -1,0 +1,9 @@
+
+RUN(video.src = "../content/video-as-img.mp4")
+EVENT(canplay)
+EXPECTED (video.videoTracks.length == '1') OK
+EXPECTED (video.videoTracks[0].configuration.colorSpace.matrix != 'null') OK
+EXPECTED (video.videoTracks[0].configuration.colorSpace.primaries != 'null') OK
+EXPECTED (video.videoTracks[0].configuration.colorSpace.transfer != 'null') OK
+END OF TEST
+

--- a/LayoutTests/media/track/video-track-configuration-mp4-default-colorspace.html
+++ b/LayoutTests/media/track/video-track-configuration-mp4-default-colorspace.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>video-track-configuration-mp4-default-colorspace</title>
+	<script src="../video-test.js"></script>
+	<script>
+    window.addEventListener('load', async event => {
+      findMediaElement();
+      run('video.src = "../content/video-as-img.mp4"');
+      const timeout = 100;
+      await waitFor(video, 'canplay');
+      await testExpectedEventually('video.videoTracks.length', 1, '==', timeout);
+      await testExpectedEventually('video.videoTracks[0].configuration.colorSpace.matrix', null, '!=', timeout);
+      await testExpectedEventually('video.videoTracks[0].configuration.colorSpace.primaries', null, '!=', timeout);
+      await testExpectedEventually('video.videoTracks[0].configuration.colorSpace.transfer', null, '!=', timeout);
+      endTest();
+		});
+	</script>
+</head>
+<body>
+	<video controls></video>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.cpp
@@ -53,6 +53,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, VideoToolbox, VTCompressionSessionCompleteFra
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, VideoToolbox, VTCompressionSessionEncodeFrame, OSStatus, (VTCompressionSessionRef session, CVImageBufferRef imageBuffer, CMTime presentationTimeStamp, CMTime duration, CFDictionaryRef frameProperties, void* sourceFrameRefcon, VTEncodeInfoFlags* infoFlagsOut), (session, imageBuffer, presentationTimeStamp, duration, frameProperties, sourceFrameRefcon, infoFlagsOut))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, VideoToolbox, VTCompressionSessionPrepareToEncodeFrames, OSStatus, (VTCompressionSessionRef session), (session))
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, VideoToolbox, VTCompressionSessionInvalidate, void, (VTCompressionSessionRef session), (session))
+SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, VideoToolbox, VTGetDefaultColorAttributesWithHints, OSStatus, (OSType codecTypeHint, CFStringRef colorSpaceNameHint, size_t widthHint, size_t heightHint, CFStringRef* colorPrimariesOut, CFStringRef* transferFunctionOut, CFStringRef* yCbCrMatrixOut), (codecTypeHint, colorSpaceNameHint, widthHint, heightHint, colorPrimariesOut, transferFunctionOut, yCbCrMatrixOut))
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/VideoToolboxSoftLinkAdditionsImplementation.h>

--- a/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/VideoToolboxSoftLink.h
@@ -69,6 +69,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, VideoToolbox, VTCompressionSessionPrepareToEn
 #define VTCompressionSessionPrepareToEncodeFrames softLink_VideoToolbox_VTCompressionSessionPrepareToEncodeFrames
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, VideoToolbox, VTCompressionSessionInvalidate, void, (VTCompressionSessionRef session), (session))
 #define VTCompressionSessionInvalidate softLink_VideoToolbox_VTCompressionSessionInvalidate
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, VideoToolbox, VTGetDefaultColorAttributesWithHints, OSStatus, (OSType codecTypeHint, CFStringRef colorSpaceNameHint, size_t widthHint, size_t heightHint, CFStringRef* colorPrimariesOut, CFStringRef* transferFunctionOut, CFStringRef* yCbCrMatrixOut), (codecTypeHint, colorSpaceNameHint, widthHint, heightHint, colorPrimariesOut, transferFunctionOut, yCbCrMatrixOut))
+#define VTGetDefaultColorAttributesWithHints softLink_VideoToolbox_VTGetDefaultColorAttributesWithHints
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/VideoToolboxSoftLinkAdditions.h>


### PR DESCRIPTION
#### 41652ca1b8ff310d8f01acb27830c8ae31101145
<pre>
[Cocoa] colorSpace values missing from videoTrack.configuration with MP4s missing explicit color information
<a href="https://bugs.webkit.org/show_bug.cgi?id=257911">https://bugs.webkit.org/show_bug.cgi?id=257911</a>
rdar://110545901

Reviewed by Andy Estes.

Read the default colorspace values for a given codec and size from VideoToolbox.

* LayoutTests/media/track/video-track-configuration-mp4-default-colorspace-expected.txt: Added.
* LayoutTests/media/track/video-track-configuration-mp4-default-colorspace.html: Added.

Canonical link: <a href="https://commits.webkit.org/265053@main">https://commits.webkit.org/265053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7606e44c1d61d3c36b8442a257315155b54e922

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12334 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11451 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16165 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->