### PR TITLE
Non-MSE blob urls don't work for <source> 'src' attribute

### DIFF
--- a/LayoutTests/media/video-source-element-with-blob-url-expected.txt
+++ b/LayoutTests/media/video-source-element-with-blob-url-expected.txt
@@ -1,0 +1,4 @@
+This tests that a video element can load a non-MSE blob URL in an <source> element.
+
+END OF TEST
+

--- a/LayoutTests/media/video-source-element-with-blob-url.html
+++ b/LayoutTests/media/video-source-element-with-blob-url.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=media-file.js></script>
+        <script src=video-test.js></script>
+        <script>
+            async function runTest() {
+                const video = document.querySelectorAll('video')[0];
+
+                video.onloadedmetadata = endTest;
+                video.onerror = () => {
+                    failTest(`loading failed`);
+                }
+
+                const url = findMediaFile('video', 'content/long-test');
+                const request = new XMLHttpRequest();
+                request.open('GET', url, true);
+                request.responseType = 'blob';
+
+                request.onload = () => {
+                    const reader = new FileReader();
+                    reader.onload = event => {
+                        video.src = event.target.result;
+                    };
+                    reader.readAsDataURL(request.response);
+                };
+                request.send();
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <div>
+            This tests that a video element can load a non-MSE blob URL in an &lt;source> element.
+        </div>
+        <video controls></video>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5234,7 +5234,7 @@ URL HTMLMediaElement::selectNextSourceChild(ContentType* contentType, String* ke
             parameters.type = ContentType(type);
             parameters.url = mediaURL;
 #if ENABLE(MEDIA_SOURCE)
-            parameters.isMediaSource = mediaURL.protocolIs(mediaSourceBlobProtocol);
+            parameters.isMediaSource = mediaURL.protocolIs(mediaSourceBlobProtocol) && MediaSource::lookup(mediaURL.string());
 #endif
             parameters.requiresRemotePlayback = !!m_remotePlaybackConfiguration;
             if (!document().settings().allowMediaContentTypesRequiringHardwareSupportAsFallback() || Traversal<HTMLSourceElement>::nextSkippingChildren(source))


### PR DESCRIPTION
#### bf0aa014e8913031073b6d93ccaa725ce1df1501
<pre>
Non-MSE blob urls don&apos;t work for &lt;source&gt; &apos;src&apos; attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=257918">https://bugs.webkit.org/show_bug.cgi?id=257918</a>
rdar://110423496

Reviewed by Jer Noble.

Don&apos;t assume every blob url is for MSE.

* LayoutTests/media/video-source-element-with-blob-url-expected.txt: Added.
* LayoutTests/media/video-source-element-with-blob-url.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::selectNextSourceChild):

Canonical link: <a href="https://commits.webkit.org/265045@main">https://commits.webkit.org/265045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d343f9bf438a6e13400b984375d0f78a9c16ae79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12309 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11419 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16138 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12212 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2307 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->