### PR TITLE
Safari Tab shows speaker icon indicating tab is playing audio even though it is paused

### DIFF
--- a/LayoutTests/media/video-is-playing-audio-after-load-expected.txt
+++ b/LayoutTests/media/video-is-playing-audio-after-load-expected.txt
@@ -1,0 +1,13 @@
+
+RUN(video.src = findMediaFile("video", "content/audio-tracks"))
+EVENT(canplay)
+EXPECTED (video.audioTracks.length > '1') OK
+RUN(video.play())
+EVENT(playing)
+EXPECTED (internals.pageMediaState().includes("IsPlayingAudio") == 'true') OK
+RUN(video.src = "")
+RUN(video.load())
+EVENT(emptied)
+EXPECTED (internals.pageMediaState().includes("IsPlayingAudio") == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/video-is-playing-audio-after-load.html
+++ b/LayoutTests/media/video-is-playing-audio-after-load.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>video-is-playing-audio-after-load</title>
+        <script src=video-test.js></script>
+        <script src=media-file.js></script>
+        <script>
+        async function runTest() {
+            findMediaElement();
+            run('video.src = findMediaFile("video", "content/audio-tracks")');
+            await waitFor(video, 'canplay');
+
+            testExpected('video.audioTracks.length', '1', '>');
+            runWithKeyDown('video.play()');
+            await waitFor(video, 'playing');
+
+            testExpected('internals.pageMediaState().includes("IsPlayingAudio")', true);
+
+            run('video.src = ""');
+            run('video.load()');
+
+            await waitFor(video, 'emptied');
+            testExpected('internals.pageMediaState().includes("IsPlayingAudio")', false);
+        };
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        });
+        </script>
+    </head>
+    <body>
+        <video loop></video>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1271,6 +1271,7 @@ void HTMLMediaElement::prepareForLoad()
 
         // 6.6 - If the paused attribute is false, then set it to true.
         setPaused(true);
+        setPlaying(false);
 
         // 6.7 - If seeking is true, set it to false.
         clearSeeking();


### PR DESCRIPTION
#### a14e6af69efe7727482e7bac49caa4f059a22eb8
<pre>
Safari Tab shows speaker icon indicating tab is playing audio even though it is paused
<a href="https://bugs.webkit.org/show_bug.cgi?id=257919">https://bugs.webkit.org/show_bug.cgi?id=257919</a>
rdar://110019966

Reviewed by Eric Carlson.

The value of m_playing is not reset when a client resets via load(), leading to
a stale &quot;IsPlayingAudio&quot; flag being returned from mediaState().

* LayoutTests/media/video-is-playing-audio-after-load-expected.txt: Added.
* LayoutTests/media/video-is-playing-audio-after-load.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::prepareForLoad):

Canonical link: <a href="https://commits.webkit.org/265052@main">https://commits.webkit.org/265052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31238e2dd3bb805b8434007f97dd2d8733daaa5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11265 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12313 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11424 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12219 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2313 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->