### PR TITLE
[Mac] Animation stutters when making a video full screen in Safari

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -747,6 +747,7 @@ static CAAnimation *zoomAnimation(const WebCore::FloatRect& initialFrame, const 
         scaleAnimation.toValue = scaleValue;
 
     scaleAnimation.duration = duration;
+    scaleAnimation.speed = speed;
     scaleAnimation.removedOnCompletion = NO;
     scaleAnimation.fillMode = kCAFillModeBoth;
     scaleAnimation.timingFunction = timingFunctionForDuration(duration);
@@ -783,6 +784,7 @@ static CAAnimation *maskAnimation(const WebCore::FloatRect& initialFrame, const 
     CAAnimationGroup *animation = [CAAnimationGroup animation];
     animation.animations = @[boundsAnimation, positionAnimation];
     animation.duration = duration;
+    animation.speed = speed;
     animation.removedOnCompletion = NO;
     animation.fillMode = kCAFillModeBoth;
     animation.timingFunction = timingFunctionForDuration(duration);


### PR DESCRIPTION
#### 7a59a6aafd1a403ec2341304fa9f8ed4e3299edc
<pre>
[Mac] Animation stutters when making a video full screen in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=257922">https://bugs.webkit.org/show_bug.cgi?id=257922</a>
rdar://109325226

Reviewed by Simon Fraser.

In some circumstances, there may be a significant delay between when fullscreen is initiated
through -[WKFullscreenWindowController beganEnterFullScreenWithInitialFrame], and when the
animation to enter fullscreen begins
via -window:startCustomAnimationToEnterFullScreenWithDuration:. In this case, the intent was to put
in place the animation&apos;s transformations, but with a speed of 0 (so that the animation would not
progress). However, the speed parameter to the animation methods was ignored, and the animation
would use the default speed of 1. When the delay between the two functions mentioned above occurrs,
it has the effect of making it look like the animation starts early and then &quot;restarts&quot;.

Actually obey the speed parameter in zoomAnimation() and maskAnimation().

* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(zoomAnimation):
(maskAnimation):

Canonical link: <a href="https://commits.webkit.org/265051@main">https://commits.webkit.org/265051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95152432273a7507f6dd9de823716ed075fb5393

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9400 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12324 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10619 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8186 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11435 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7914 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12229 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8570 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2312 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12791 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->