### PR TITLE
Upstream form control styling for visionOS

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -496,10 +496,15 @@ input:is([type="date"], [type="time"], [type="datetime-local"], [type="month"], 
     overflow: hidden;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border: 1px solid -webkit-control-background;
-    background-color: -apple-system-opaque-secondary-fill;
     font-family: system-ui;
-    color: -apple-system-blue;
     padding: 0.2em 0.5em;
+#if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
+    background-color: rgba(0, 0, 0, 0.04);
+    color: CanvasText;
+#else
+    background-color: -apple-system-opaque-secondary-fill;
+    color: -apple-system-blue;
+#endif /*defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
 #else
     outline: none;
     font-variant-numeric: tabular-nums;
@@ -738,10 +743,6 @@ input::-webkit-list-button {
 }
 #endif
 
-select {
-    border-radius: 5px;
-}
-
 textarea {
     appearance: auto;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
@@ -860,9 +861,13 @@ input:is([type="button"], [type="submit"], [type="reset"]), input[type="file"]::
     padding: 0 1.0em;
     border: 1px solid -webkit-control-background;
     font: 11px system-ui;
-    background-color: -apple-system-opaque-secondary-fill;
     color: -apple-system-blue;
-#endif
+#if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
+    background-color: rgba(0, 0, 0, 0.05);
+#else
+    background-color: -apple-system-opaque-secondary-fill;
+#endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
+#endif /* (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY) */
     box-sizing: border-box;
 }
 
@@ -1072,8 +1077,13 @@ select {
     font: 11px system-ui;
     border: 1px solid -webkit-control-background;
     border-radius: initial;
-    background-color: -apple-system-opaque-secondary-fill;
+#if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
+    background-color: rgba(0, 0, 0, 0.04);
 #else
+    background-color: -apple-system-opaque-secondary-fill;
+#endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
+#else
+    border-radius: 5px;
     border: 1px solid;
 #if defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT
     color: CanvasText;
@@ -1081,7 +1091,7 @@ select {
 #else
     color: black;
     background-color: white;
-#endif
+#endif /* defined(HAVE_OS_DARK_MODE_SUPPORT) && HAVE_OS_DARK_MODE_SUPPORT */
 #endif
     align-items: center;
     white-space: pre;

--- a/Source/WebCore/style/InspectorCSSOMWrappers.cpp
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.cpp
@@ -138,9 +138,6 @@ void InspectorCSSOMWrappers::collectDocumentWrappers(ExtensionStyleSheets& exten
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
         collectFromStyleSheetContents(UserAgentStyle::legacyFormControlsIOSStyleSheet);
 #endif
-#if ENABLE(ALTERNATE_FORM_CONTROL_DESIGN)
-        collectFromStyleSheetContents(UserAgentStyle::alternateFormControlDesignStyleSheet);
-#endif
         collectFromStyleSheetContents(UserAgentStyle::plugInsStyleSheet);
         collectFromStyleSheetContents(UserAgentStyle::mediaQueryStyleSheet);
 

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -102,9 +102,6 @@ StyleSheetContents* UserAgentStyle::colorInputStyleSheet;
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
 StyleSheetContents* UserAgentStyle::legacyFormControlsIOSStyleSheet;
 #endif
-#if ENABLE(ALTERNATE_FORM_CONTROL_DESIGN)
-StyleSheetContents* UserAgentStyle::alternateFormControlDesignStyleSheet;
-#endif
 
 static const MQ::MediaQueryEvaluator& screenEval()
 {
@@ -269,13 +266,6 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
     if (!legacyFormControlsIOSStyleSheet && !element.document().settings().iOSFormControlRefreshEnabled()) {
         legacyFormControlsIOSStyleSheet = parseUASheet(StringImpl::createWithoutCopying(legacyFormControlsIOSUserAgentStyleSheet, sizeof(legacyFormControlsIOSUserAgentStyleSheet)));
         addToDefaultStyle(*legacyFormControlsIOSStyleSheet);
-    }
-#endif
-
-#if ENABLE(ALTERNATE_FORM_CONTROL_DESIGN)
-    if (!alternateFormControlDesignStyleSheet && element.document().settings().alternateFormControlDesignEnabled()) {
-        alternateFormControlDesignStyleSheet = parseUASheet(StringImpl::createWithoutCopying(alternateFormControlDesignUserAgentStyleSheet, sizeof(alternateFormControlDesignUserAgentStyleSheet)));
-        addToDefaultStyle(*alternateFormControlDesignStyleSheet);
     }
 #endif
 

--- a/Source/WebCore/style/UserAgentStyle.h
+++ b/Source/WebCore/style/UserAgentStyle.h
@@ -67,9 +67,6 @@ public:
 #if ENABLE(IOS_FORM_CONTROL_REFRESH)
     static StyleSheetContents* legacyFormControlsIOSStyleSheet;
 #endif
-#if ENABLE(ALTERNATE_FORM_CONTROL_DESIGN)
-    static StyleSheetContents* alternateFormControlDesignStyleSheet;
-#endif
 
     static void initDefaultStyleSheet();
     static void ensureDefaultStyleSheetsForElement(const Element&);


### PR DESCRIPTION
#### 9c4012488b1d2c4d5711227cd10421adcde75682
<pre>
Upstream form control styling for visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=257926">https://bugs.webkit.org/show_bug.cgi?id=257926</a>
rdar://110556097

Reviewed by Tim Nguyen.

* Source/WebCore/css/html.css:
(#if defined(ENABLE_DATE_AND_TIME_INPUT_TYPES) &amp;&amp; ENABLE_DATE_AND_TIME_INPUT_TYPES):
(#endif):
(input:is([type=&quot;button&quot;], [type=&quot;submit&quot;], [type=&quot;reset&quot;]), input[type=&quot;file&quot;]::file-selector-button, button):
(#endif // defined(ENABLE_INPUT_TYPE_COLOR) &amp;&amp; ENABLE_INPUT_TYPE_COLOR):
(textarea): Deleted.
* Source/WebCore/style/InspectorCSSOMWrappers.cpp:
(WebCore::Style::InspectorCSSOMWrappers::collectDocumentWrappers):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):
* Source/WebCore/style/UserAgentStyle.h:

Canonical link: <a href="https://commits.webkit.org/265054@main">https://commits.webkit.org/265054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f96af7ec95e4cf3f4a56193527a34d512fd665

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12336 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11454 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16163 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12240 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7631 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8585 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->