### PR TITLE
Propagate errors out of the IPC Connection code

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -101,7 +101,7 @@ protected:
     virtual void platformWorkQueueInitialize(WebCore::GraphicsContextGLAttributes&&) { };
     void workQueueUninitialize();
     template<typename T>
-    bool send(T&& message) const { return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier); }
+    IPC::Error send(T&& message) const { return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier); }
 
     // GraphicsContextGL::Client overrides.
     void forceContextLost() final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -102,7 +102,7 @@ private:
     void workQueueUninitialize();
 
     template<typename T>
-    bool send(T&& message) const
+    IPC::Error send(T&& message) const
     {
         return m_streamConnection->send(WTFMove(message), m_identifier);
     }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -83,7 +83,10 @@ void ServiceWorkerDownloadTask::close()
 
 template<typename Message> bool ServiceWorkerDownloadTask::sendToServiceWorker(Message&& message)
 {
-    return m_serviceWorkerConnection ? m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) : false;
+    if (!m_serviceWorkerConnection)
+        return false;
+
+    return m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) == IPC::Error::NoError;
 }
 
 void ServiceWorkerDownloadTask::dispatch(Function<void()>&& function)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -127,12 +127,15 @@ ServiceWorkerFetchTask::~ServiceWorkerFetchTask()
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToServiceWorker(Message&& message)
 {
-    return m_serviceWorkerConnection ? m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) : false;
+    if (!m_serviceWorkerConnection)
+        return false;
+
+    return m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) == IPC::Error::NoError;
 }
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToClient(Message&& message)
 {
-    return m_loader.connectionToWebProcess().connection().send(std::forward<Message>(message), m_loader.coreIdentifier());
+    return m_loader.connectionToWebProcess().connection().send(std::forward<Message>(message), m_loader.coreIdentifier()) == IPC::Error::NoError;
 }
 
 void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorkerConnection)

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -36,14 +36,16 @@ bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOpti
 {
     auto* connection = messageSenderConnection();
     ASSERT(connection);
-    return connection->sendMessage(WTFMove(encoder), sendOptions);
+    // FIXME: Propagate errors out.
+    return connection->sendMessage(WTFMove(encoder), sendOptions) == Error::NoError;
 }
 
 bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncReplyHandler replyHandler, OptionSet<SendOption> sendOptions)
 {
     auto* connection = messageSenderConnection();
     ASSERT(connection);
-    return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions);
+    // FIXME: Propagate errors out.
+    return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -43,7 +43,7 @@ template<typename MessageType> inline auto MessageSender::sendSync(MessageType&&
     static_assert(MessageType::isSync);
     if (auto* connection = messageSenderConnection())
         return connection->sendSync(std::forward<MessageType>(message), destinationID, timeout, options);
-    return { };
+    return { nullptr, std::nullopt, Error::NoMessageSenderConnection };
 }
 
 template<typename MessageType, typename C> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> options)

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -74,7 +74,7 @@ public:
     void open(Connection::Client&, SerialFunctionDispatcher& = RunLoop::current());
     void invalidate();
 
-    template<typename T, typename U, typename V> bool send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout);
+    template<typename T, typename U, typename V> Error send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout);
 
     using AsyncReplyID = Connection::AsyncReplyID;
     template<typename T, typename C, typename U, typename V>
@@ -85,7 +85,7 @@ public:
     SendSyncResult<T> sendSync(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout);
 
     template<typename T, typename U, typename V>
-    bool waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V> destinationID, Timeout, OptionSet<WaitForOption> = { });
+    Error waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V> destinationID, Timeout, OptionSet<WaitForOption> = { });
 
     StreamClientConnectionBuffer& bufferForTesting();
     Connection& connectionForTesting();
@@ -97,7 +97,7 @@ private:
     bool trySendStream(std::span<uint8_t>&, T& message, AdditionalData&&...);
     template<typename T>
     std::optional<SendSyncResult<T>> trySendSyncStream(T& message, Timeout, std::span<uint8_t>&);
-    bool trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
+    Error trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout);
     void sendProcessOutOfStreamMessage(std::span<uint8_t>&&);
     using WakeUpServer = StreamClientConnectionBuffer::WakeUpServer;
     void wakeUpServerBatched(WakeUpServer);
@@ -126,34 +126,36 @@ private:
 };
 
 template<typename T, typename U, typename V>
-bool StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout)
+Error StreamClientConnection::send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout)
 {
     static_assert(!T::isSync, "Message is sync!");
-    if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
-        return false;
+    auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
+    if (error != Error::NoError)
+        return error;
+
     auto span = m_buffer.tryAcquire(timeout);
     if (!span)
-        return false;
+        return Error::FailedToAcquireBufferSpan;
     if constexpr(T::isStreamEncodable) {
         if (trySendStream(*span, message))
-            return true;
+            return Error::NoError;
     }
     sendProcessOutOfStreamMessage(WTFMove(*span));
-    if (!m_connection->send(WTFMove(message), destinationID, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply))
-        return false;
-    return true;
+    return m_connection->send(WTFMove(message), destinationID, IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
 }
 
 template<typename T, typename C, typename U, typename V>
 StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(T&& message, C&& completionHandler, ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout)
 {
     static_assert(!T::isSync, "Message is sync!");
-    if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
-        return { };
+    auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
+    if (error != Error::NoError)
+        return { }; // FIXME: Propagate errors.
 
     auto span = m_buffer.tryAcquire(timeout);
     if (!span)
-        return { };
+        return { }; // FIXME: Propagate errors.
+
     auto handler = Connection::makeAsyncReplyHandler<T>(WTFMove(completionHandler));
     auto replyID = handler.replyID;
     m_connection->addAsyncReplyHandler(WTFMove(handler));
@@ -161,11 +163,13 @@ StreamClientConnection::AsyncReplyID StreamClientConnection::sendWithAsyncReply(
         if (trySendStream(*span, message, replyID))
             return replyID;
     }
+
     sendProcessOutOfStreamMessage(WTFMove(*span));
     auto encoder = makeUniqueRef<Encoder>(T::name(), destinationID.toUInt64());
     encoder.get() << message.arguments() << replyID;
-    if (m_connection->sendMessage(WTFMove(encoder), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply, { }))
+    if (m_connection->sendMessage(WTFMove(encoder), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply, { }) == Error::NoError)
         return replyID;
+
     // replyHandlerToCancel might be already cancelled if invalidate() happened in-between.
     if (auto replyHandlerToCancel = m_connection->takeAsyncReplyHandler(replyID)) {
         // FIXME(https://bugs.webkit.org/show_bug.cgi?id=248947): Current contract is that completionHandler
@@ -197,11 +201,14 @@ template<typename T, typename U, typename V>
 StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& message, ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout)
 {
     static_assert(T::isSync, "Message is not sync!");
-    if (!trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout))
-        return { };
+    auto error = trySendDestinationIDIfNeeded(destinationID.toUInt64(), timeout);
+    if (error != Error::NoError)
+        return { nullptr, std::nullopt, error };
+
     auto span = m_buffer.tryAcquire(timeout);
     if (!span)
-        return { };
+        return { nullptr, std::nullopt, Error::FailedToAcquireBufferSpan };
+
     if constexpr(T::isStreamEncodable) {
         auto maybeSendResult = trySendSyncStream(message, timeout, *span);
         if (maybeSendResult)
@@ -212,7 +219,7 @@ StreamClientConnection::SendSyncResult<T> StreamClientConnection::sendSync(T&& m
 }
 
 template<typename T, typename U, typename V>
-bool StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
+Error StreamClientConnection::waitForAndDispatchImmediately(ObjectIdentifierGeneric<U, V> destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)
 {
     return m_connection->waitForAndDispatchImmediately<T>(destinationID, timeout, waitForOptions);
 }
@@ -226,20 +233,22 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
     if (!m_connection->pushPendingSyncRequestID(syncRequestID))
         return SendSyncResult<T> { };
 
-    auto decoderResult = [&]() -> std::optional<std::unique_ptr<Decoder>> {
+    auto decoderResult = [&]() -> std::optional<Connection::DecoderOrError> {
         StreamConnectionEncoder messageEncoder { T::name(), span.data(), span.size() };
         if (!(messageEncoder << syncRequestID << message.arguments()))
             return std::nullopt;
+
         auto wakeUpResult = m_buffer.release(messageEncoder.size());
         wakeUpServer(wakeUpResult);
         if constexpr(T::isReplyStreamEncodable) {
             auto replySpan = m_buffer.tryAcquireAll(timeout);
             if (!replySpan)
-                return std::unique_ptr<Decoder> { };
+                return Connection::DecoderOrError { Error::FailedToAcquireReplyBufferSpan };
+
             auto decoder = std::unique_ptr<Decoder> { new Decoder(replySpan->data(), replySpan->size(), m_currentDestinationID) };
             if (decoder->messageName() != MessageName::ProcessOutOfStreamMessage) {
                 ASSERT(decoder->messageName() == MessageName::SyncMessageReply);
-                return decoder;
+                return Connection::DecoderOrError { WTFMove(decoder) };
             }
         } else
             m_buffer.resetClientOffset();
@@ -252,31 +261,34 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
         return std::nullopt;
 
     SendSyncResult<T> result;
-    if (*decoderResult) {
-        auto& decoder = *decoderResult;
+    if (decoderResult->decoder) {
+        auto& decoder = decoderResult->decoder;
         *decoder >> result.replyArguments;
         if (result.replyArguments)
             result.decoder = WTFMove(decoder);
-    }
+    } else
+        result.error = decoderResult->error;
     return result;
 }
 
-inline bool StreamClientConnection::trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout timeout)
+inline Error StreamClientConnection::trySendDestinationIDIfNeeded(uint64_t destinationID, Timeout timeout)
 {
     if (destinationID == m_currentDestinationID)
-        return true;
+        return Error::NoError;
+
     auto span = m_buffer.tryAcquire(timeout);
     if (!span)
-        return false;
+        return Error::FailedToAcquireBufferSpan;
+
     StreamConnectionEncoder encoder { MessageName::SetStreamDestinationID, span->data(), span->size() };
     if (!(encoder << destinationID)) {
         ASSERT_NOT_REACHED(); // Size of the minimum allocation is incorrect. Likely an alignment issue.
-        return false;
+        return Error::StreamConnectionEncodingError;
     }
     auto wakeUpResult = m_buffer.release(encoder.size());
     wakeUpServer(wakeUpResult);
     m_currentDestinationID = destinationID;
-    return true;
+    return Error::NoError;
 }
 
 inline void StreamClientConnection::sendProcessOutOfStreamMessage(std::span<uint8_t>&& span)

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -85,7 +85,7 @@ public:
 
     void open(StreamConnectionWorkQueue&);
     void invalidate();
-    template<typename T> bool send(T&& message, const ObjectIdentifierGenericBase& destinationID);
+    template<typename T> Error send(T&& message, const ObjectIdentifierGenericBase& destinationID);
 
     template<typename T, typename... Arguments>
     void sendSyncReply(Connection::SyncRequestID, Arguments&&...);
@@ -130,7 +130,7 @@ private:
 };
 
 template<typename T>
-bool StreamServerConnection::send(T&& message, const ObjectIdentifierGenericBase& destinationID)
+Error StreamServerConnection::send(T&& message, const ObjectIdentifierGenericBase& destinationID)
 {
     return m_connection->send(WTFMove(message), destinationID);
 }

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -231,10 +231,10 @@ bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Optio
 
     case State::Running:
         if (asyncReplyHandler) {
-            if (connection()->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(*asyncReplyHandler), sendOptions))
+            if (connection()->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(*asyncReplyHandler), sendOptions) == IPC::Error::NoError)
                 return true;
         } else {
-            if (connection()->sendMessage(WTFMove(encoder), sendOptions))
+            if (connection()->sendMessage(WTFMove(encoder), sendOptions) == IPC::Error::NoError)
                 return true;
         }
         break;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -432,7 +432,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
     WeakPtr weakThis { *this };
     auto startTime = MonotonicTime::now();
-    while (process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives)) {
+    while (process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError) {
         if (!weakThis || activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= m_activityStateChangeID)
             return;
     }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1365,11 +1365,11 @@ void WebProcessProxy::renderTreeAsText(WebCore::ProcessIdentifier destinationPro
     if (!webProcessProxy)
         return completionHandler({ });
 
-    auto reply = webProcessProxy->sendSync(Messages::WebProcess::RenderTreeAsText(frameIdentifier, baseIndent, behavior), 0);
-    if (!reply)
+    auto sendResult = webProcessProxy->sendSync(Messages::WebProcess::RenderTreeAsText(frameIdentifier, baseIndent, behavior), 0);
+    if (!sendResult.succeeded())
         return completionHandler({ });
 
-    auto [result] = reply.takeReply();
+    auto [result] = sendResult.takeReply();
     completionHandler(result);
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2772,7 +2772,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _isWaitingOnPositionInformation = YES;
     if (![self _hasValidOutstandingPositionInformationRequest:request])
         [self requestAsynchronousPositionInformationUpdate:request];
-    bool receivedResponse = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageID(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+    bool receivedResponse = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageID(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
     _hasValidPositionInformation = receivedResponse && _positionInformation.canBeValid;
     return _hasValidPositionInformation;
 }
@@ -5240,7 +5240,7 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
     if (!useSyncRequest)
         return;
 
-    if (!_page->process().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting))
+    if (_page->process().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
         RELEASE_LOG(TextInput, "Timed out while waiting for autocorrection context.");
 
     if (_autocorrectionContextNeedsUpdate)

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -190,7 +190,7 @@
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
         if (auto* connection = _page->process().connection()) {
-            bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(_page->webPageID(), Seconds::fromMilliseconds(500));
+            bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(_page->webPageID(), 500_ms) == IPC::Error::NoError;
             if (!receivedReply)
                 _state = WebKit::ImmediateActionState::TimedOut;
         }

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -376,7 +376,7 @@ bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEven
         return false;
 
     send(Messages::WebPage::RequestAcceptsFirstMouse(eventNumber, event), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
-    bool receivedReply = m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+    bool receivedReply = m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
 
     if (!receivedReply)
         return false;

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -82,7 +82,7 @@ bool WebPaymentCoordinator::canMakePayments()
     auto now = MonotonicTime::now();
     if (now - m_timestampOfLastCanMakePaymentsRequest > 1_min || !m_lastCanMakePaymentsResult) {
         auto sendResult = sendSync(Messages::WebPaymentCoordinatorProxy::CanMakePayments());
-        if (!sendResult)
+        if (!sendResult.succeeded())
             return false;
         auto [canMakePayments] = sendResult.takeReply();
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -306,8 +306,8 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
 bool GPUProcessConnection::waitForDidInitialize()
 {
     if (!m_hasInitialized) {
-        bool result = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
-        if (!result) {
+        auto result = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
+        if (result != IPC::Error::NoError) {
             invalidate();
             return false;
         }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -384,7 +384,7 @@ protected:
 
     static inline Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return m_streamConnection->send(WTFMove(message), m_graphicsContextGLIdentifier, defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -35,7 +35,7 @@ void RemoteGraphicsContextGLProxy::activeTexture(GCGLenum texture)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -46,7 +46,7 @@ void RemoteGraphicsContextGLProxy::attachShader(PlatformGLObject program, Platfo
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -57,7 +57,7 @@ void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -68,7 +68,7 @@ void RemoteGraphicsContextGLProxy::bindBuffer(GCGLenum target, PlatformGLObject 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -79,7 +79,7 @@ void RemoteGraphicsContextGLProxy::bindFramebuffer(GCGLenum target, PlatformGLOb
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -90,7 +90,7 @@ void RemoteGraphicsContextGLProxy::bindRenderbuffer(GCGLenum target, PlatformGLO
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -101,7 +101,7 @@ void RemoteGraphicsContextGLProxy::bindTexture(GCGLenum target, PlatformGLObject
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -112,7 +112,7 @@ void RemoteGraphicsContextGLProxy::blendColor(GCGLclampf red, GCGLclampf green, 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -123,7 +123,7 @@ void RemoteGraphicsContextGLProxy::blendEquation(GCGLenum mode)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -134,7 +134,7 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparate(GCGLenum modeRGB, GCGLe
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -145,7 +145,7 @@ void RemoteGraphicsContextGLProxy::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -156,7 +156,7 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparate(GCGLenum srcRGB, GCGLenum d
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -167,7 +167,7 @@ GCGLenum RemoteGraphicsContextGLProxy::checkFramebufferStatus(GCGLenum target)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CheckFramebufferStatus(target));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -180,7 +180,7 @@ void RemoteGraphicsContextGLProxy::clear(GCGLbitfield mask)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Clear(mask));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -191,7 +191,7 @@ void RemoteGraphicsContextGLProxy::clearColor(GCGLclampf red, GCGLclampf green, 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -202,7 +202,7 @@ void RemoteGraphicsContextGLProxy::clearDepth(GCGLclampf depth)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -213,7 +213,7 @@ void RemoteGraphicsContextGLProxy::clearStencil(GCGLint s)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -224,7 +224,7 @@ void RemoteGraphicsContextGLProxy::colorMask(GCGLboolean red, GCGLboolean green,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -235,7 +235,7 @@ void RemoteGraphicsContextGLProxy::compileShader(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -246,7 +246,7 @@ void RemoteGraphicsContextGLProxy::copyTexImage2D(GCGLenum target, GCGLint level
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -257,7 +257,7 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage2D(GCGLenum target, GCGLint le
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -268,7 +268,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createBuffer()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateBuffer());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -281,7 +281,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createFramebuffer()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateFramebuffer());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -294,7 +294,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createProgram()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateProgram());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -307,7 +307,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createRenderbuffer()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateRenderbuffer());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -320,7 +320,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createShader(GCGLenum arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateShader(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -333,7 +333,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createTexture()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTexture());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -346,7 +346,7 @@ void RemoteGraphicsContextGLProxy::cullFace(GCGLenum mode)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -357,7 +357,7 @@ void RemoteGraphicsContextGLProxy::deleteBuffer(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -368,7 +368,7 @@ void RemoteGraphicsContextGLProxy::deleteFramebuffer(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -379,7 +379,7 @@ void RemoteGraphicsContextGLProxy::deleteProgram(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -390,7 +390,7 @@ void RemoteGraphicsContextGLProxy::deleteRenderbuffer(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -401,7 +401,7 @@ void RemoteGraphicsContextGLProxy::deleteShader(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -412,7 +412,7 @@ void RemoteGraphicsContextGLProxy::deleteTexture(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -423,7 +423,7 @@ void RemoteGraphicsContextGLProxy::depthFunc(GCGLenum func)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -434,7 +434,7 @@ void RemoteGraphicsContextGLProxy::depthMask(GCGLboolean flag)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -445,7 +445,7 @@ void RemoteGraphicsContextGLProxy::depthRange(GCGLclampf zNear, GCGLclampf zFar)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -456,7 +456,7 @@ void RemoteGraphicsContextGLProxy::destroyEGLImage(GCEGLImage handle)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DestroyEGLImage(static_cast<uint64_t>(reinterpret_cast<intptr_t>(handle))));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -467,7 +467,7 @@ void RemoteGraphicsContextGLProxy::detachShader(PlatformGLObject arg0, PlatformG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -478,7 +478,7 @@ void RemoteGraphicsContextGLProxy::disable(GCGLenum cap)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Disable(cap));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -489,7 +489,7 @@ void RemoteGraphicsContextGLProxy::disableVertexAttribArray(GCGLuint index)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -500,7 +500,7 @@ void RemoteGraphicsContextGLProxy::drawArrays(GCGLenum mode, GCGLint first, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -511,7 +511,7 @@ void RemoteGraphicsContextGLProxy::drawElements(GCGLenum mode, GCGLsizei count, 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -522,7 +522,7 @@ void RemoteGraphicsContextGLProxy::enable(GCGLenum cap)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Enable(cap));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -533,7 +533,7 @@ void RemoteGraphicsContextGLProxy::enableVertexAttribArray(GCGLuint index)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -544,7 +544,7 @@ void RemoteGraphicsContextGLProxy::finish()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Finish());
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -555,7 +555,7 @@ void RemoteGraphicsContextGLProxy::flush()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Flush());
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -566,7 +566,7 @@ void RemoteGraphicsContextGLProxy::framebufferRenderbuffer(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -577,7 +577,7 @@ void RemoteGraphicsContextGLProxy::framebufferTexture2D(GCGLenum target, GCGLenu
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -588,7 +588,7 @@ void RemoteGraphicsContextGLProxy::frontFace(GCGLenum mode)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -599,7 +599,7 @@ void RemoteGraphicsContextGLProxy::generateMipmap(GCGLenum target)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -610,7 +610,7 @@ bool RemoteGraphicsContextGLProxy::getActiveAttrib(PlatformGLObject program, GCG
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveAttrib(program, index));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -624,7 +624,7 @@ bool RemoteGraphicsContextGLProxy::getActiveUniform(PlatformGLObject program, GC
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniform(program, index));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -638,7 +638,7 @@ GCGLint RemoteGraphicsContextGLProxy::getAttribLocation(PlatformGLObject arg0, c
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetAttribLocation(arg0, name));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -651,7 +651,7 @@ GCGLint RemoteGraphicsContextGLProxy::getBufferParameteri(GCGLenum target, GCGLe
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferParameteri(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -664,7 +664,7 @@ String RemoteGraphicsContextGLProxy::getString(GCGLenum name)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetString(name));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -677,7 +677,7 @@ void RemoteGraphicsContextGLProxy::getFloatv(GCGLenum pname, std::span<GCGLfloat
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFloatv(pname, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -690,7 +690,7 @@ void RemoteGraphicsContextGLProxy::getIntegerv(GCGLenum pname, std::span<GCGLint
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegerv(pname, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -703,7 +703,7 @@ void RemoteGraphicsContextGLProxy::getIntegeri_v(GCGLenum pname, GCGLuint index,
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetIntegeri_v(pname, index));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -716,7 +716,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64(GCGLenum pname)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64(pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -729,7 +729,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64i(GCGLenum pname, GCGLuint i
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64i(pname, index));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -742,7 +742,7 @@ GCGLint RemoteGraphicsContextGLProxy::getProgrami(PlatformGLObject program, GCGL
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgrami(program, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -755,7 +755,7 @@ void RemoteGraphicsContextGLProxy::getBooleanv(GCGLenum pname, std::span<GCGLboo
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBooleanv(pname, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -768,7 +768,7 @@ GCGLint RemoteGraphicsContextGLProxy::getFramebufferAttachmentParameteri(GCGLenu
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFramebufferAttachmentParameteri(target, attachment, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -781,7 +781,7 @@ String RemoteGraphicsContextGLProxy::getProgramInfoLog(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetProgramInfoLog(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -794,7 +794,7 @@ GCGLint RemoteGraphicsContextGLProxy::getRenderbufferParameteri(GCGLenum target,
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetRenderbufferParameteri(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -807,7 +807,7 @@ GCGLint RemoteGraphicsContextGLProxy::getShaderi(PlatformGLObject arg0, GCGLenum
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderi(arg0, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -820,7 +820,7 @@ String RemoteGraphicsContextGLProxy::getShaderInfoLog(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderInfoLog(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -833,7 +833,7 @@ void RemoteGraphicsContextGLProxy::getShaderPrecisionFormat(GCGLenum shaderType,
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderPrecisionFormat(shaderType, precisionType));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -848,7 +848,7 @@ String RemoteGraphicsContextGLProxy::getShaderSource(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetShaderSource(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -861,7 +861,7 @@ GCGLfloat RemoteGraphicsContextGLProxy::getTexParameterf(GCGLenum target, GCGLen
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameterf(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -874,7 +874,7 @@ GCGLint RemoteGraphicsContextGLProxy::getTexParameteri(GCGLenum target, GCGLenum
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTexParameteri(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -887,7 +887,7 @@ void RemoteGraphicsContextGLProxy::getUniformfv(PlatformGLObject program, GCGLin
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformfv(program, location, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -900,7 +900,7 @@ void RemoteGraphicsContextGLProxy::getUniformiv(PlatformGLObject program, GCGLin
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformiv(program, location, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -913,7 +913,7 @@ void RemoteGraphicsContextGLProxy::getUniformuiv(PlatformGLObject program, GCGLi
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformuiv(program, location, value.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -926,7 +926,7 @@ GCGLint RemoteGraphicsContextGLProxy::getUniformLocation(PlatformGLObject arg0, 
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformLocation(arg0, name));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -939,7 +939,7 @@ GCGLsizeiptr RemoteGraphicsContextGLProxy::getVertexAttribOffset(GCGLuint index,
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetVertexAttribOffset(index, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -952,7 +952,7 @@ void RemoteGraphicsContextGLProxy::hint(GCGLenum target, GCGLenum mode)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -963,7 +963,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isBuffer(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsBuffer(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -976,7 +976,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isEnabled(GCGLenum cap)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsEnabled(cap));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -989,7 +989,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isFramebuffer(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsFramebuffer(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1002,7 +1002,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isProgram(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsProgram(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1015,7 +1015,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isRenderbuffer(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsRenderbuffer(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1028,7 +1028,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isShader(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsShader(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1041,7 +1041,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isTexture(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTexture(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1054,7 +1054,7 @@ void RemoteGraphicsContextGLProxy::lineWidth(GCGLfloat arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1065,7 +1065,7 @@ void RemoteGraphicsContextGLProxy::linkProgram(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1076,7 +1076,7 @@ void RemoteGraphicsContextGLProxy::pixelStorei(GCGLenum pname, GCGLint param)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1087,7 +1087,7 @@ void RemoteGraphicsContextGLProxy::polygonOffset(GCGLfloat factor, GCGLfloat uni
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1098,7 +1098,7 @@ void RemoteGraphicsContextGLProxy::renderbufferStorage(GCGLenum target, GCGLenum
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1109,7 +1109,7 @@ void RemoteGraphicsContextGLProxy::sampleCoverage(GCGLclampf value, GCGLboolean 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1120,7 +1120,7 @@ void RemoteGraphicsContextGLProxy::scissor(GCGLint x, GCGLint y, GCGLsizei width
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1131,7 +1131,7 @@ void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const Str
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1142,7 +1142,7 @@ void RemoteGraphicsContextGLProxy::stencilFunc(GCGLenum func, GCGLint ref, GCGLu
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1153,7 +1153,7 @@ void RemoteGraphicsContextGLProxy::stencilFuncSeparate(GCGLenum face, GCGLenum f
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1164,7 +1164,7 @@ void RemoteGraphicsContextGLProxy::stencilMask(GCGLuint mask)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1175,7 +1175,7 @@ void RemoteGraphicsContextGLProxy::stencilMaskSeparate(GCGLenum face, GCGLuint m
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1186,7 +1186,7 @@ void RemoteGraphicsContextGLProxy::stencilOp(GCGLenum fail, GCGLenum zfail, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1197,7 +1197,7 @@ void RemoteGraphicsContextGLProxy::stencilOpSeparate(GCGLenum face, GCGLenum fai
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1208,7 +1208,7 @@ void RemoteGraphicsContextGLProxy::texParameterf(GCGLenum target, GCGLenum pname
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1219,7 +1219,7 @@ void RemoteGraphicsContextGLProxy::texParameteri(GCGLenum target, GCGLenum pname
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1230,7 +1230,7 @@ void RemoteGraphicsContextGLProxy::uniform1f(GCGLint location, GCGLfloat x)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1241,7 +1241,7 @@ void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1252,7 +1252,7 @@ void RemoteGraphicsContextGLProxy::uniform1i(GCGLint location, GCGLint x)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1263,7 +1263,7 @@ void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1274,7 +1274,7 @@ void RemoteGraphicsContextGLProxy::uniform2f(GCGLint location, GCGLfloat x, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1285,7 +1285,7 @@ void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1296,7 +1296,7 @@ void RemoteGraphicsContextGLProxy::uniform2i(GCGLint location, GCGLint x, GCGLin
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1307,7 +1307,7 @@ void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1318,7 +1318,7 @@ void RemoteGraphicsContextGLProxy::uniform3f(GCGLint location, GCGLfloat x, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1329,7 +1329,7 @@ void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1340,7 +1340,7 @@ void RemoteGraphicsContextGLProxy::uniform3i(GCGLint location, GCGLint x, GCGLin
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1351,7 +1351,7 @@ void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1362,7 +1362,7 @@ void RemoteGraphicsContextGLProxy::uniform4f(GCGLint location, GCGLfloat x, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1373,7 +1373,7 @@ void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1384,7 +1384,7 @@ void RemoteGraphicsContextGLProxy::uniform4i(GCGLint location, GCGLint x, GCGLin
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1395,7 +1395,7 @@ void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, std::span<const 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1406,7 +1406,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolea
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1417,7 +1417,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolea
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1428,7 +1428,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolea
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1439,7 +1439,7 @@ void RemoteGraphicsContextGLProxy::useProgram(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1450,7 +1450,7 @@ void RemoteGraphicsContextGLProxy::validateProgram(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1461,7 +1461,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1f(GCGLuint index, GCGLfloat x)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1472,7 +1472,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, std::span<con
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1483,7 +1483,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2f(GCGLuint index, GCGLfloat x, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1494,7 +1494,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, std::span<con
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1505,7 +1505,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3f(GCGLuint index, GCGLfloat x, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1516,7 +1516,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, std::span<con
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1527,7 +1527,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4f(GCGLuint index, GCGLfloat x, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1538,7 +1538,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, std::span<con
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1549,7 +1549,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribPointer(GCGLuint index, GCGLint s
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1560,7 +1560,7 @@ void RemoteGraphicsContextGLProxy::viewport(GCGLint x, GCGLint y, GCGLsizei widt
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1571,7 +1571,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLsizeiptr arg1
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1582,7 +1582,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, std::span<const u
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1593,7 +1593,7 @@ void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr off
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1604,7 +1604,7 @@ void RemoteGraphicsContextGLProxy::readPixelsBufferObject(WebCore::IntRect arg0,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadPixelsBufferObject(arg0, format, type, static_cast<uint64_t>(offset), alignment, rowLength));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1615,7 +1615,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1626,7 +1626,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1637,7 +1637,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1648,7 +1648,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1659,7 +1659,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1670,7 +1670,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1681,7 +1681,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1692,7 +1692,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1703,7 +1703,7 @@ void RemoteGraphicsContextGLProxy::drawArraysInstanced(GCGLenum mode, GCGLint fi
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1714,7 +1714,7 @@ void RemoteGraphicsContextGLProxy::drawElementsInstanced(GCGLenum mode, GCGLsize
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1725,7 +1725,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribDivisor(GCGLuint index, GCGLuint 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1736,7 +1736,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createVertexArray()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateVertexArray());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1749,7 +1749,7 @@ void RemoteGraphicsContextGLProxy::deleteVertexArray(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1760,7 +1760,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isVertexArray(PlatformGLObject arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsVertexArray(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -1773,7 +1773,7 @@ void RemoteGraphicsContextGLProxy::bindVertexArray(PlatformGLObject arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1784,7 +1784,7 @@ void RemoteGraphicsContextGLProxy::copyBufferSubData(GCGLenum readTarget, GCGLen
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1795,7 +1795,7 @@ void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr 
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -1808,7 +1808,7 @@ void RemoteGraphicsContextGLProxy::blitFramebuffer(GCGLint srcX0, GCGLint srcY0,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1819,7 +1819,7 @@ void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1830,7 +1830,7 @@ void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, std::s
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1841,7 +1841,7 @@ void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, std
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1852,7 +1852,7 @@ void RemoteGraphicsContextGLProxy::readBuffer(GCGLenum src)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1863,7 +1863,7 @@ void RemoteGraphicsContextGLProxy::renderbufferStorageMultisample(GCGLenum targe
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1874,7 +1874,7 @@ void RemoteGraphicsContextGLProxy::texStorage2D(GCGLenum target, GCGLsizei level
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1885,7 +1885,7 @@ void RemoteGraphicsContextGLProxy::texStorage3D(GCGLenum target, GCGLsizei level
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1896,7 +1896,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1907,7 +1907,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1918,7 +1918,7 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1929,7 +1929,7 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1940,7 +1940,7 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage3D(GCGLenum target, GCGLint le
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1951,7 +1951,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1962,7 +1962,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1973,7 +1973,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1984,7 +1984,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -1995,7 +1995,7 @@ GCGLint RemoteGraphicsContextGLProxy::getFragDataLocation(PlatformGLObject progr
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetFragDataLocation(program, name));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2008,7 +2008,7 @@ void RemoteGraphicsContextGLProxy::uniform1ui(GCGLint location, GCGLuint v0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2019,7 +2019,7 @@ void RemoteGraphicsContextGLProxy::uniform2ui(GCGLint location, GCGLuint v0, GCG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2030,7 +2030,7 @@ void RemoteGraphicsContextGLProxy::uniform3ui(GCGLint location, GCGLuint v0, GCG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2041,7 +2041,7 @@ void RemoteGraphicsContextGLProxy::uniform4ui(GCGLint location, GCGLuint v0, GCG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2052,7 +2052,7 @@ void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, std::span<const
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2063,7 +2063,7 @@ void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, std::span<const
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2074,7 +2074,7 @@ void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, std::span<const
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2085,7 +2085,7 @@ void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, std::span<const
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2096,7 +2096,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2107,7 +2107,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2118,7 +2118,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2129,7 +2129,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2140,7 +2140,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2151,7 +2151,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLbool
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2162,7 +2162,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4i(GCGLuint index, GCGLint x, GC
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2173,7 +2173,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, std::span<co
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2184,7 +2184,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4ui(GCGLuint index, GCGLuint x, 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2195,7 +2195,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, std::span<c
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2206,7 +2206,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribIPointer(GCGLuint index, GCGLint 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2217,7 +2217,7 @@ void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint sta
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2228,7 +2228,7 @@ void RemoteGraphicsContextGLProxy::drawBuffers(std::span<const GCGLenum> bufs)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2239,7 +2239,7 @@ void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbu
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2250,7 +2250,7 @@ void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawb
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2261,7 +2261,7 @@ void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbu
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2272,7 +2272,7 @@ void RemoteGraphicsContextGLProxy::clearBufferfi(GCGLenum buffer, GCGLint drawbu
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2283,7 +2283,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQuery()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQuery());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2296,7 +2296,7 @@ void RemoteGraphicsContextGLProxy::deleteQuery(PlatformGLObject query)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2307,7 +2307,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isQuery(PlatformGLObject query)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQuery(query));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2320,7 +2320,7 @@ void RemoteGraphicsContextGLProxy::beginQuery(GCGLenum target, PlatformGLObject 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2331,7 +2331,7 @@ void RemoteGraphicsContextGLProxy::endQuery(GCGLenum target)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2342,7 +2342,7 @@ GCGLint RemoteGraphicsContextGLProxy::getQuery(GCGLenum target, GCGLenum pname)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQuery(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2355,7 +2355,7 @@ GCGLuint RemoteGraphicsContextGLProxy::getQueryObjectui(PlatformGLObject query, 
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui(query, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2368,7 +2368,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createSampler()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateSampler());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2381,7 +2381,7 @@ void RemoteGraphicsContextGLProxy::deleteSampler(PlatformGLObject sampler)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2392,7 +2392,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isSampler(PlatformGLObject sampler)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSampler(sampler));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2405,7 +2405,7 @@ void RemoteGraphicsContextGLProxy::bindSampler(GCGLuint unit, PlatformGLObject s
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2416,7 +2416,7 @@ void RemoteGraphicsContextGLProxy::samplerParameteri(PlatformGLObject sampler, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2427,7 +2427,7 @@ void RemoteGraphicsContextGLProxy::samplerParameterf(PlatformGLObject sampler, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2438,7 +2438,7 @@ GCGLfloat RemoteGraphicsContextGLProxy::getSamplerParameterf(PlatformGLObject sa
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameterf(sampler, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2451,7 +2451,7 @@ GCGLint RemoteGraphicsContextGLProxy::getSamplerParameteri(PlatformGLObject samp
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSamplerParameteri(sampler, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2464,7 +2464,7 @@ GCGLsync RemoteGraphicsContextGLProxy::fenceSync(GCGLenum condition, GCGLbitfiel
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::FenceSync(condition, flags));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2477,7 +2477,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isSync(GCGLsync arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2490,7 +2490,7 @@ void RemoteGraphicsContextGLProxy::deleteSync(GCGLsync arg0)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2501,7 +2501,7 @@ GCGLenum RemoteGraphicsContextGLProxy::clientWaitSync(GCGLsync arg0, GCGLbitfiel
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ClientWaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<uint64_t>(timeout)));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2514,7 +2514,7 @@ void RemoteGraphicsContextGLProxy::waitSync(GCGLsync arg0, GCGLbitfield flags, G
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2525,7 +2525,7 @@ GCGLint RemoteGraphicsContextGLProxy::getSynci(GCGLsync arg0, GCGLenum pname)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetSynci(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2538,7 +2538,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createTransformFeedback()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTransformFeedback());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2551,7 +2551,7 @@ void RemoteGraphicsContextGLProxy::deleteTransformFeedback(PlatformGLObject id)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2562,7 +2562,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isTransformFeedback(PlatformGLObject i
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsTransformFeedback(id));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2575,7 +2575,7 @@ void RemoteGraphicsContextGLProxy::bindTransformFeedback(GCGLenum target, Platfo
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2586,7 +2586,7 @@ void RemoteGraphicsContextGLProxy::beginTransformFeedback(GCGLenum primitiveMode
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2597,7 +2597,7 @@ void RemoteGraphicsContextGLProxy::endTransformFeedback()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2608,7 +2608,7 @@ void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject pr
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2619,7 +2619,7 @@ void RemoteGraphicsContextGLProxy::getTransformFeedbackVarying(PlatformGLObject 
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTransformFeedbackVarying(program, index));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -2632,7 +2632,7 @@ void RemoteGraphicsContextGLProxy::pauseTransformFeedback()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2643,7 +2643,7 @@ void RemoteGraphicsContextGLProxy::resumeTransformFeedback()
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2654,7 +2654,7 @@ void RemoteGraphicsContextGLProxy::bindBufferBase(GCGLenum target, GCGLuint inde
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2665,7 +2665,7 @@ void RemoteGraphicsContextGLProxy::bindBufferRange(GCGLenum target, GCGLuint ind
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2676,7 +2676,7 @@ Vector<GCGLuint> RemoteGraphicsContextGLProxy::getUniformIndices(PlatformGLObjec
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformIndices(program, uniformNames));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2689,7 +2689,7 @@ Vector<GCGLint> RemoteGraphicsContextGLProxy::getActiveUniforms(PlatformGLObject
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniforms(program, uniformIndices, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2702,7 +2702,7 @@ GCGLuint RemoteGraphicsContextGLProxy::getUniformBlockIndex(PlatformGLObject pro
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetUniformBlockIndex(program, uniformBlockName));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2715,7 +2715,7 @@ String RemoteGraphicsContextGLProxy::getActiveUniformBlockName(PlatformGLObject 
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockName(program, uniformBlockIndex));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2728,7 +2728,7 @@ void RemoteGraphicsContextGLProxy::uniformBlockBinding(PlatformGLObject program,
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2739,7 +2739,7 @@ void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(GCGLuint program, GCG
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetActiveUniformBlockiv(program, uniformBlockIndex, pname, params.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -2752,7 +2752,7 @@ String RemoteGraphicsContextGLProxy::getTranslatedShaderSourceANGLE(PlatformGLOb
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetTranslatedShaderSourceANGLE(arg0));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2765,7 +2765,7 @@ void RemoteGraphicsContextGLProxy::drawBuffersEXT(std::span<const GCGLenum> bufs
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2776,7 +2776,7 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQueryEXT()
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQueryEXT());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2789,7 +2789,7 @@ void RemoteGraphicsContextGLProxy::deleteQueryEXT(PlatformGLObject query)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQueryEXT(query));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2800,7 +2800,7 @@ GCGLboolean RemoteGraphicsContextGLProxy::isQueryEXT(PlatformGLObject query)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::IsQueryEXT(query));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2813,7 +2813,7 @@ void RemoteGraphicsContextGLProxy::beginQueryEXT(GCGLenum target, PlatformGLObje
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQueryEXT(target, query));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2824,7 +2824,7 @@ void RemoteGraphicsContextGLProxy::endQueryEXT(GCGLenum target)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQueryEXT(target));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2835,7 +2835,7 @@ void RemoteGraphicsContextGLProxy::queryCounterEXT(PlatformGLObject query, GCGLe
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::QueryCounterEXT(query, target));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2846,7 +2846,7 @@ GCGLint RemoteGraphicsContextGLProxy::getQueryiEXT(GCGLenum target, GCGLenum pna
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryiEXT(target, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2859,7 +2859,7 @@ GCGLint RemoteGraphicsContextGLProxy::getQueryObjectiEXT(PlatformGLObject query,
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectiEXT(query, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2872,7 +2872,7 @@ GCGLuint64 RemoteGraphicsContextGLProxy::getQueryObjectui64EXT(PlatformGLObject 
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetQueryObjectui64EXT(query, pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2885,7 +2885,7 @@ GCGLint64 RemoteGraphicsContextGLProxy::getInteger64EXT(GCGLenum pname)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInteger64EXT(pname));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -2898,7 +2898,7 @@ void RemoteGraphicsContextGLProxy::enableiOES(GCGLenum target, GCGLuint index)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2909,7 +2909,7 @@ void RemoteGraphicsContextGLProxy::disableiOES(GCGLenum target, GCGLuint index)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2920,7 +2920,7 @@ void RemoteGraphicsContextGLProxy::blendEquationiOES(GCGLuint buf, GCGLenum mode
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2931,7 +2931,7 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparateiOES(GCGLuint buf, GCGLe
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2942,7 +2942,7 @@ void RemoteGraphicsContextGLProxy::blendFunciOES(GCGLuint buf, GCGLenum src, GCG
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2953,7 +2953,7 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparateiOES(GCGLuint buf, GCGLenum 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2964,7 +2964,7 @@ void RemoteGraphicsContextGLProxy::colorMaskiOES(GCGLuint buf, GCGLboolean red, 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2975,7 +2975,7 @@ void RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE(GCGLenum
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2986,7 +2986,7 @@ void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceAN
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -2997,7 +2997,7 @@ void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum provokeMode)
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(provokeMode));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -3008,7 +3008,7 @@ void RemoteGraphicsContextGLProxy::polygonOffsetClampEXT(GCGLfloat factor, GCGLf
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffsetClampEXT(factor, units, clamp));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -3019,7 +3019,7 @@ void RemoteGraphicsContextGLProxy::renderbufferStorageMultisampleANGLE(GCGLenum 
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -3030,7 +3030,7 @@ void RemoteGraphicsContextGLProxy::blitFramebufferANGLE(GCGLint srcX0, GCGLint s
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebufferANGLE(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -3041,7 +3041,7 @@ void RemoteGraphicsContextGLProxy::getInternalformativ(GCGLenum target, GCGLenum
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetInternalformativ(target, internalformat, pname, params.size()));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }
@@ -3054,7 +3054,7 @@ void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::Des
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace(arg0));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }
@@ -3065,7 +3065,7 @@ RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResults
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -3078,7 +3078,7 @@ bool RemoteGraphicsContextGLProxy::destroyEGLSync(GCEGLSync arg0)
     if (isContextLost())
         return { };
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::DestroyEGLSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -3091,7 +3091,7 @@ void RemoteGraphicsContextGLProxy::clientWaitEGLSyncWithFlush(GCEGLSync arg0, ui
     if (isContextLost())
         return;
     auto sendResult = send(Messages::RemoteGraphicsContextGL::ClientWaitEGLSyncWithFlush(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), timeout));
-    if (!sendResult) {
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -77,6 +77,8 @@ public:
 
     ~RemoteRenderingBackendProxy();
 
+    const RemoteRenderingBackendCreationParameters& parameters() const { return m_parameters; }
+
     RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }
 
     void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp
@@ -58,7 +58,7 @@ void RemoteAdapterProxy::requestDevice(const PAL::WebGPU::DeviceDescriptor& desc
     auto identifier = WebGPUIdentifier::generate();
     auto queueIdentifier = WebGPUIdentifier::generate();
     auto sendResult = sendSync(Messages::RemoteAdapter::RequestDevice(*convertedDescriptor, identifier, queueIdentifier));
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return;
 
     auto [supportedFeatures, supportedLimits] = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -67,7 +67,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -63,7 +63,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -51,7 +51,7 @@ RemoteCompositorIntegrationProxy::~RemoteCompositorIntegrationProxy()
 Vector<MachSendRight> RemoteCompositorIntegrationProxy::recreateRenderBuffers(int height, int width)
 {
     auto sendResult = sendSync(Messages::RemoteCompositorIntegration::RecreateRenderBuffers(height, width));
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return { };
 
     auto [renderBuffers] = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -69,7 +69,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -64,7 +64,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -65,7 +65,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -115,7 +115,7 @@ void RemoteGPUProxy::waitUntilInitialized()
 {
     if (m_didInitialize)
         return;
-    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing, defaultSendTimeout))
+    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing, defaultSendTimeout) == IPC::Error::NoError)
         return;
     m_lost = true;
 }
@@ -136,7 +136,7 @@ void RemoteGPUProxy::requestAdapter(const PAL::WebGPU::RequestAdapterOptions& op
 
     auto identifier = WebGPUIdentifier::generate();
     auto sendResult = sendSync(Messages::RemoteGPU::RequestAdapter(*convertedOptions, identifier));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         m_lost = true;
         callback(nullptr);
         return;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -89,7 +89,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -66,7 +66,7 @@ private:
 
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -63,7 +63,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -64,7 +64,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -65,7 +65,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -62,7 +62,7 @@ private:
     
     static inline constexpr Seconds defaultSendTimeout = 30_s;
     template<typename T>
-    WARN_UNUSED_RETURN bool send(T&& message)
+    WARN_UNUSED_RETURN IPC::Error send(T&& message)
     {
         return root().streamClientConnection().send(WTFMove(message), backing(), defaultSendTimeout);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
@@ -165,7 +165,7 @@ std::optional<WebCore::GraphicsContextGL::ExternalImageAttachResult> RemoteGraph
     if (isContextLost())
         return std::nullopt;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateAndBindExternalImage(target, source));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return std::nullopt;
     }
@@ -181,7 +181,7 @@ GCEGLSync RemoteGraphicsContextGLProxyCocoa::createEGLSync(ExternalEGLSyncEvent 
         return { };
     auto [eventHandle, signalValue] = syncEvent;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateEGLSync(eventHandle, signalValue));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return { };
     }
@@ -195,7 +195,7 @@ void RemoteGraphicsContextGLProxyCocoa::prepareForDisplay()
         return;
     IPC::Semaphore finishedSignaller;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay(finishedSignaller));
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/wc/RemoteGraphicsContextGLProxyWC.cpp
@@ -91,7 +91,7 @@ void RemoteGraphicsContextGLProxyWC::prepareForDisplay()
     if (isContextLost())
         return;
     auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PrepareForDisplay());
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         markContextLost();
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1036,7 +1036,7 @@ RefPtr<WebCore::VideoFrame> MediaPlayerPrivateRemote::videoFrameForCurrentTime()
         return { };
 
     auto sendResult = connection().sendSync(Messages::RemoteMediaPlayerProxy::VideoFrameForCurrentTimeIfChanged(), m_id);
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return nullptr;
 
     auto [result, changed] = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
@@ -204,7 +204,7 @@ void RemoteImageDecoderAVF::setData(const FragmentedSharedBuffer& data, bool all
         return;
 
     auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteImageDecoderAVFProxy::SetData(m_identifier, IPC::SharedBufferReference(data), allDataReceived), 0);
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return;
     auto [frameCount, size, hasTrack, frameInfos] = sendResult.takeReply();
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -88,7 +88,7 @@ RefPtr<Uint8Array> RemoteLegacyCDMSession::generateKeyRequest(const String& mime
     auto sendResult = m_factory->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMSessionProxy::GenerateKeyRequest(mimeType, ipcInitData), m_identifier);
 
     RefPtr<SharedBuffer> ipcNextMessage;
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(ipcNextMessage, destinationURL, errorCode, systemCode) = sendResult.takeReply();
 
     if (!ipcNextMessage)
@@ -116,7 +116,7 @@ bool RemoteLegacyCDMSession::update(Uint8Array* keyData, RefPtr<Uint8Array>& nex
 
     bool succeeded { false };
     RefPtr<SharedBuffer> ipcNextMessage;
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(succeeded, ipcNextMessage, errorCode, systemCode) = sendResult.takeReply();
 
     if (ipcNextMessage)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp
@@ -118,7 +118,7 @@ CVPixelBufferRef RemoteVideoFrameProxy::pixelBuffer() const
             semaphore.wait();
         } else {
             auto sendResult = m_connection->sendSync(Messages::RemoteVideoFrameObjectHeap::PixelBuffer(newReadReference()), 0, defaultTimeout);
-            if (sendResult)
+            if (sendResult.succeeded())
                 std::tie(m_pixelBuffer) = sendResult.takeReply();
         }
     }

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -228,7 +228,7 @@ void SourceBufferPrivateRemote::evictCodedFrames(uint64_t newDataSize, uint64_t 
         return;
 
     auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteSourceBufferProxy::EvictCodedFrames(newDataSize, maximumBufferSize, currentTime, isEnded), m_remoteSourceBufferIdentifier);
-    if (sendResult) {
+    if (sendResult.succeeded()) {
         PlatformTimeRanges buffered;
         std::tie(buffered, m_totalTrackBufferSizeInBytes) = sendResult.takeReply();
         setBufferedRanges(WTFMove(buffered));

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -161,7 +161,7 @@ RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(con
         return nullptr;
 
     auto sendResult = connection.sendSync(Messages::RemoteVideoFrameObjectHeap::ConvertFrameBuffer { *frame }, 0, GPUProcessConnection::defaultTimeout);
-    if (!sendResult) {
+    if (!sendResult.succeeded()) {
         m_sharedVideoFrameWriter.disable();
         return nullptr;
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -140,7 +140,7 @@ void InjectedBundle::postSynchronousMessage(const String& messageName, API::Obje
 {
     auto& webProcess = WebProcess::singleton();
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebProcessPool::HandleSynchronousMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
-    if (sendResult) {
+    if (sendResult.succeeded()) {
         auto [returnUserData] = sendResult.takeReply();
         returnData = webProcess.transformHandlesToObjects(returnUserData.object());
     } else

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
@@ -80,7 +80,7 @@ void WebMDNSRegister::registerMDNSName(ScriptExecutionContextIdentifier identifi
 
     // FIXME: Use async reply.
     auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
-    if (!connection.send(Messages::NetworkMDNSRegister::RegisterMDNSName { requestIdentifier, identifier, ipAddress }, 0))
+    if (connection.send(Messages::NetworkMDNSRegister::RegisterMDNSName { requestIdentifier, identifier, ipAddress }, 0) != IPC::Error::NoError)
         finishedRegisteringMDNSName(requestIdentifier, { }, MDNSRegisterError::Internal);
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -80,7 +80,7 @@ static bool sendMessage(WebPage* page, const Function<bool(IPC::Connection&, uin
 template<typename U> static bool sendNotificationMessage(U&& message, WebPage* page)
 {
     return sendMessage(page, [&] (auto& connection, auto destinationIdentifier) {
-        return connection.send(WTFMove(message), destinationIdentifier);
+        return connection.send(WTFMove(message), destinationIdentifier) == IPC::Error::NoError;
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -333,7 +333,7 @@ Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& win
     WebFrame* webFrame = WebFrame::fromCoreFrame(frame);
 
     auto sendResult = webProcess.parentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(webFrame->info(), webFrame->page()->webPageProxyIdentifier(), navigationAction.resourceRequest(), windowFeatures, navigationActionData), m_page.identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages, IPC::SendSyncOption::InformPlatformProcessWillSuspend });
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return nullptr;
 
     auto [newPageID, parameters] = sendResult.takeReply();
@@ -547,7 +547,7 @@ bool WebChromeClient::runJavaScriptPrompt(LocalFrame& frame, const String& messa
     IPC::UnboundedSynchronousIPCScope unboundedSynchronousIPCScope;
 
     auto sendResult = m_page.sendSyncWithDelayedReply(Messages::WebPageProxy::RunJavaScriptPrompt(webFrame->frameID(), webFrame->info(), message, defaultValue), IPC::SendSyncOption::MaintainOrderingWithAsyncMessages);
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return false;
 
     std::tie(result) = sendResult.takeReply();
@@ -1397,7 +1397,7 @@ void WebChromeClient::handleAutoplayEvent(AutoplayEvent event, OptionSet<Autopla
 bool WebChromeClient::wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>& wrappedKey) const
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::WrapCryptoKey(key), m_page.identifier());
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return false;
 
     bool succeeded;
@@ -1408,7 +1408,7 @@ bool WebChromeClient::wrapCryptoKey(const Vector<uint8_t>& key, Vector<uint8_t>&
 bool WebChromeClient::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Vector<uint8_t>& key) const
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::UnwrapCryptoKey(wrappedKey), m_page.identifier());
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return false;
 
     bool succeeded;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -522,7 +522,7 @@ void WebEditorClient::checkGrammarOfString(StringView text, Vector<WebCore::Gram
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::CheckGrammarOfString(text.toStringWithoutCopying()));
     int32_t resultLocation = -1;
     int32_t resultLength = 0;
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(grammarDetails, resultLocation, resultLength) = sendResult.takeReply();
     *badGrammarLocation = resultLocation;
     *badGrammarLength = resultLength;
@@ -571,7 +571,7 @@ bool WebEditorClient::spellingUIIsShowing()
 void WebEditorClient::getGuessesForWord(const String& word, const String& context, const VisibleSelection& currentSelection, Vector<String>& guesses)
 {
     auto sendResult = m_page->sendSync(Messages::WebPageProxy::GetGuessesForWord(word, context, insertionPointFromCurrentSelection(currentSelection)));
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(guesses) = sendResult.takeReply();
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -149,8 +149,8 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     // Notify the UIProcess.
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {
         auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(m_frame->frameID(), m_frame->isMainFrame(), m_frame->info(), requestIdentifier, documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.resourceRequest(), request, IPC::FormDataReference { request.httpBody() }, redirectResponse));
-        if (!sendResult) {
-            WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC");
+        if (!sendResult.succeeded()) {
+            WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
             m_frame->didReceivePolicyDecision(listenerID, PolicyDecision { requestIdentifier });
             return;
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -130,7 +130,7 @@ void WebPlatformStrategies::getTypes(Vector<String>& types, const String& pasteb
         return;
 
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(pasteboardName, pageIdentifier(context)), 0);
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(types) = sendResult.takeReply();
 }
 
@@ -151,7 +151,7 @@ void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const
 {
     Vector<SandboxExtension::Handle> sandboxExtensionsHandleArray;
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardPathnamesForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(pathnames, sandboxExtensionsHandleArray) = sendResult.takeReply();
     ASSERT(pathnames.size() == sandboxExtensionsHandleArray.size());
     SandboxExtension::consumePermanently(sandboxExtensionsHandleArray);
@@ -256,7 +256,7 @@ String WebPlatformStrategies::urlStringSuitableForLoading(const String& pasteboa
 {
     String url;
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::URLStringSuitableForLoading(pasteboardName, pageIdentifier(context)), 0);
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(url, title) = sendResult.takeReply();
     return url;
 }
@@ -351,7 +351,7 @@ int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
 void WebPlatformStrategies::getTypes(Vector<String>& types)
 {
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(), 0);
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(types) = sendResult.takeReply();
 }
 
@@ -435,7 +435,7 @@ URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pas
 {
     String urlString;
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadURLFromPasteboard(index, pasteboardName, pageIdentifier(context)), 0);
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(urlString, title) = sendResult.takeReply();
     return URL({ }, urlString);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -84,11 +84,11 @@ void WebRemoteFrameClient::changeLocation(WebCore::FrameLoadRequest&& request)
 
 String WebRemoteFrameClient::renderTreeAsText(WebCore::ProcessIdentifier processIdentifier, WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior)
 {
-    auto reply = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebProcessProxy::RenderTreeAsText(processIdentifier, frameIdentifier, baseIndent, behavior), 0);
-    if (!reply)
+    auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebProcessProxy::RenderTreeAsText(processIdentifier, frameIdentifier, baseIndent, behavior), 0);
+    if (!sendResult.succeeded())
         return { };
 
-    auto [result] = reply.takeReply();
+    auto [result] = sendResult.takeReply();
     return result;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -69,7 +69,7 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
         return;
 
     auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(resultItems) = sendResult.takeReply();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -154,7 +154,7 @@ const WebBackForwardListCounts& WebBackForwardListProxy::cacheListCountsIfNecess
         WebBackForwardListCounts backForwardListCounts;
         if (m_page) {
             auto sendResult = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebPageProxy::BackForwardListCounts(), m_page->identifier());
-            if (sendResult)
+            if (sendResult.succeeded())
                 std::tie(backForwardListCounts) = sendResult.takeReply();
         }
         m_cachedBackForwardListCounts = backForwardListCounts;

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -50,7 +50,7 @@ String WebCookieCache::cookiesForDOM(const URL& firstParty, const SameSiteInfo& 
         auto host = url.host().toString();
         bool subscribeToCookieChangeNotifications = true;
         auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::DomCookiesForHost(url, subscribeToCookieChangeNotifications), 0);
-        if (!sendResult)
+        if (!sendResult.succeeded())
             return { };
 
         auto& [cookies] = sendResult.reply();

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -223,7 +223,7 @@ std::pair<String, WebCore::SecureCookiesAccessed> WebCookieJar::cookieRequestHea
 #endif
 
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::CookieRequestHeaderFieldValue(firstParty, sameSiteInfo, url, frameID, pageID, includeSecureCookies, applyTrackingPreventionInNetworkProcess, shouldRelaxThirdPartyCookieBlocking(webFrame)), 0);
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return { };
 
     auto [cookieString, secureCookiesAccessed] = sendResult.takeReply();
@@ -242,7 +242,7 @@ bool WebCookieJar::getRawCookies(const WebCore::Document& document, const URL& u
     std::optional<FrameIdentifier> frameID = webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt;
     std::optional<PageIdentifier> pageID = webFrame && webFrame->page() ? std::make_optional(webFrame->page()->identifier()) : std::nullopt;
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::GetRawCookies(document.firstPartyForCookies(), sameSiteInfo(document), url, frameID, pageID, applyTrackingPreventionInNetworkProcess, shouldRelaxThirdPartyCookieBlocking(webFrame)), 0);
-    if (!sendResult)
+    if (!sendResult.succeeded())
         return false;
 
     std::tie(rawCookies) = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7565,7 +7565,7 @@ void WebPage::postSynchronousMessageForTesting(const String& messageName, API::O
     auto& webProcess = WebProcess::singleton();
 
     auto sendResult = sendSync(Messages::WebPageProxy::HandleSynchronousMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), Seconds::infinity(), IPC::SendSyncOption::UseFullySynchronousModeForTesting);
-    if (sendResult) {
+    if (sendResult.succeeded()) {
         auto& [returnUserData] = sendResult.reply();
         returnData = webProcess.transformHandlesToObjects(returnUserData.object());
     } else

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
@@ -68,7 +68,7 @@ void WebURLSchemeHandlerProxy::loadSynchronously(WebCore::ResourceLoaderIdentifi
 {
     data.shrink(0);
     auto sendResult = m_webPage.sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
-    if (sendResult)
+    if (sendResult.succeeded())
         std::tie(response, error, data) = sendResult.takeReply();
     else
         error = failedCustomProtocolSyncLoad(request);

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1167,8 +1167,8 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
     NetworkProcessConnectionInfo connectionInfo;
     auto requestConnection = [&]() -> bool {
         auto sendResult = connection.sendSync(Messages::WebProcessProxy::GetNetworkProcessConnection(), 0);
-        if (!sendResult) {
-            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message");
+        if (!sendResult.succeeded()) {
+            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message: error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
             failedToGetNetworkProcessConnection();
         }
         std::tie(connectionInfo) = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1401,7 +1401,7 @@ void WebProcess::didWriteToPasteboardAsynchronously(const String& pasteboardName
 void WebProcess::waitForPendingPasteboardWritesToFinish(const String& pasteboardName)
 {
     while (m_pendingPasteboardWriteCounts.contains(pasteboardName)) {
-        if (!parentProcessConnection()->waitForAndDispatchImmediately<Messages::WebProcess::DidWriteToPasteboardAsynchronously>(0, 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives)) {
+        if (parentProcessConnection()->waitForAndDispatchImmediately<Messages::WebProcess::DidWriteToPasteboardAsynchronously>(0, 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) != IPC::Error::NoError) {
             m_pendingPasteboardWriteCounts.removeAll(pasteboardName);
             break;
         }

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -624,21 +624,21 @@ class webkit_ipc_cpp_proxy_impl(object):
         if is_async:
             self.call_stmts += [
                 f"auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
+                "if (sendResult != IPC::Error::NoError) {",
             ]
         else:
             self.call_stmts += [
-                f"auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));"
+                f"auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
+                "if (!sendResult.succeeded()) {",
             ]
         if self.return_type.is_void():
             self.call_stmts += [
-                "if (!sendResult) {",
                 "    markContextLost();",
                 "    return;",
                 "}",
             ]
         else:
             self.call_stmts += [
-                "if (!sendResult) {",
                 "    markContextLost();",
                 "    return { };",
                 "}",

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -305,14 +305,14 @@ TEST_P(StreamMessageTest, Send)
 {
     auto cleanup = localReferenceBarrier();
     for (uint64_t i = 0u; i < 55u; ++i) {
-        auto success = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
-        EXPECT_TRUE(success);
+        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
+        EXPECT_EQ(result, IPC::Error::NoError);
     }
     serverQueue().dispatch([&] {
         assertIsCurrent(serverQueue());
         for (uint64_t i = 100u; i < 160u; ++i) {
-            auto success = m_serverConnection->send(MockTestMessage1 { }, ObjectIdentifier<TestObjectIdentifierTag>(i));
-            EXPECT_TRUE(success);
+            auto result = m_serverConnection->send(MockTestMessage1 { }, ObjectIdentifier<TestObjectIdentifierTag>(i));
+            EXPECT_EQ(result, IPC::Error::NoError);
         }
     });
     for (uint64_t i = 100u; i < 160u; ++i) {
@@ -346,11 +346,11 @@ TEST_P(StreamMessageTest, SendWithSwitchingDestinationIDs)
     });
 
     for (uint64_t i = 0u; i < 777u; ++i) {
-        auto success = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
-        EXPECT_TRUE(success);
+        auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
+        EXPECT_EQ(result, IPC::Error::NoError);
         if (i % 77) {
-            success = m_clientConnection->send(MockStreamTestMessage1 { }, other, defaultSendTimeout);
-            EXPECT_TRUE(success);
+            result = m_clientConnection->send(MockStreamTestMessage1 { }, other, defaultSendTimeout);
+            EXPECT_EQ(result, IPC::Error::NoError);
         }
     }
     for (uint64_t i = 0u; i < 777u; ++i) {


### PR DESCRIPTION
#### c9d50e24bf89596f3f456db76eab951f945c424c
<pre>
Propagate errors out of the IPC Connection code
<a href="https://bugs.webkit.org/show_bug.cgi?id=257934">https://bugs.webkit.org/show_bug.cgi?id=257934</a>
rdar://110563735

Reviewed by Kimmo Kinnunen and Mike Wyrzykowski.

Add an IPC::Error enum to hold various error values, and have Connection and StreamClientConnection
return these error values from their core functions. Change callers to check for Error::NoError instead
of the existing bool return value.

Add a `DecoderOrError` struct in IPC::Connection to hold a Decoder or error (I chose to avoid the complexity
of std::variant code).

Currently Connection::sendWithAsyncReply() still indicates failure by returning a zero AsyncReplyID.

Currently MessageSender converts the errors to a bool value as before, but the errors could be propagated
out further in future.

Adjust some existing release logging to log the error values.

Add release logging in RemoteRenderingBackendProxy::waitForDidCreateImageBufferBackend() which logs the
specific error value to assist with debugging GPUProcess-related issues. Also enhance the release
logging in RemoteImageBufferProxy::ensureBackendCreated().

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
(WebKit::RemoteGraphicsContextGL::send const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sendToServiceWorker):
(WebKit::ServiceWorkerFetchTask::sendToClient):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::sendSyncReply):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::didFailToSendSyncMessage):
(IPC::errorAsString):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::ConnectionSendSyncResult::succeeded const):
(IPC::Connection::DecoderOrError::DecoderOrError):
(IPC::Connection::send):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::waitForMessageForTesting):
(IPC::ConnectionSendSyncResult::operator bool const): Deleted.
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::sendMessage):
(IPC::MessageSender::sendMessageWithAsyncReply):
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendSync):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::waitForAndDispatchImmediately):
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
(IPC::StreamServerConnection::send):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::sendMessage):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::renderTreeAsText):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::acceptsFirstMouse):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::canMakePayments):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::waitForDidInitialize):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::markContextChanged):
(WebKit::RemoteGraphicsContextGLProxy::ensureExtensionEnabled):
(WebKit::RemoteGraphicsContextGLProxy::reshape):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToCanvas):
(WebKit::RemoteGraphicsContextGLProxy::paintCompositedResultsToVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::getErrors):
(WebKit::RemoteGraphicsContextGLProxy::simulateEventForTesting):
(WebKit::RemoteGraphicsContextGLProxy::readPixels):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::send):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::activeTexture):
(WebKit::RemoteGraphicsContextGLProxy::attachShader):
[snip]
(WebKit::RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace):
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer):
(WebKit::RemoteGraphicsContextGLProxy::destroyEGLSync):
(WebKit::RemoteGraphicsContextGLProxy::clientWaitEGLSyncWithFlush):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::ensureBackendCreated const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::waitForDidCreateImageBufferBackend):
(WebKit::RemoteRenderingBackendProxy::getPixelBufferForImageBuffer):
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::parameters const):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.cpp:
(WebKit::WebGPU::RemoteAdapterProxy::requestDevice):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp:
(WebKit::WebGPU::RemoteCompositorIntegrationProxy::recreateRenderBuffers):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::waitUntilInitialized):
(WebKit::RemoteGPUProxy::requestAdapter):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::videoFrameForCurrentTime):
* Source/WebKit/WebProcess/GPU/media/RemoteImageDecoderAVF.cpp:
(WebKit::RemoteImageDecoderAVF::setData):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::generateKeyRequest):
(WebKit::RemoteLegacyCDMSession::update):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoFrameProxy.cpp:
(WebKit::RemoteVideoFrameProxy::pixelBuffer const):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::evictCodedFrames):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::postSynchronousMessage):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp:
(WebKit::WebMDNSRegister::registerMDNSName):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendNotificationMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):
(WebKit::WebChromeClient::runJavaScriptPrompt):
(WebKit::WebChromeClient::wrapCryptoKey const):
(WebKit::WebChromeClient::unwrapCryptoKey const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::checkGrammarOfString):
(WebKit::WebEditorClient::getGuessesForWord):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::getTypes):
(WebKit::WebPlatformStrategies::getPathnamesForType):
(WebKit::WebPlatformStrategies::urlStringSuitableForLoading):
(WebKit::WebPlatformStrategies::readURLFromPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::renderTreeAsText):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::sendSyncMessageWithJSArguments):
(WebKit::IPCTestingAPI::waitForMessageWithJSArguments):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::cacheListCountsIfNecessary const):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookieRequestHeaderFieldValue const):
(WebKit::WebCookieJar::getRawCookies const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::postSynchronousMessageForTesting):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::loadSynchronously):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::getNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::waitForPendingPasteboardWritesToFinish):
* Tools/Scripts/generate-gpup-webgl:
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/265125@main">https://commits.webkit.org/265125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/822559b453989e926f2b3333813f11cfb9bc88d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12499 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11896 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16293 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9579 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7792 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8744 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2372 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->