### PR TITLE
[JSC] Revive DFG MovHintRemoval phase

### DIFF
--- a/JSTests/stress/dead-bytecode-local-ftl.js
+++ b/JSTests/stress/dead-bytecode-local-ftl.js
@@ -1,0 +1,16 @@
+//@ runDefault("--jitPolicyScale=0")
+function bar() {
+  return;
+  hello;
+}
+
+function foo() {
+  let j = 0;
+  let x = bar();
+  do {} while (j++ < 1000);
+  return x;
+}
+
+for (let i=0; i<1000; i++) {
+  foo();
+}

--- a/JSTests/stress/dead-bytecode-local.js
+++ b/JSTests/stress/dead-bytecode-local.js
@@ -1,0 +1,15 @@
+function bar() {
+  return;
+  hello;
+}
+
+function foo() {
+  let j = 0;
+  let x = bar();
+  do {} while (j++ < 1000);
+  return x;
+}
+
+for (let i=0; i<1000; i++) {
+  foo();
+}

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -386,6 +386,7 @@ dfg/DFGLoopPreHeaderCreationPhase.cpp
 dfg/DFGMayExit.cpp
 dfg/DFGMinifiedGraph.cpp
 dfg/DFGMinifiedNode.cpp
+dfg/DFGMovHintRemovalPhase.cpp
 dfg/DFGMultiGetByOffsetData.cpp
 dfg/DFGNode.cpp
 dfg/DFGNodeAbstractValuePair.cpp

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -444,6 +444,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
         
+    case ZombieHint:
     case MovHint: {
         // Don't need to do anything. A MovHint only informs us about what would have happened
         // in bytecode, but this code is just concerned with what is actually happening during

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -523,6 +523,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
          
     case MovHint:
+    case ZombieHint:
     case ExitOK:
     case Upsilon:
     case Phi:

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -41,6 +41,7 @@ bool clobbersExitState(Graph& graph, Node* node)
     switch (node->op()) {
     case InitializeEntrypointArguments:
     case MovHint:
+    case ZombieHint:
     case PutHint:
     case KillStack:
         return true;

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -70,6 +70,7 @@ bool doesGC(Graph& graph, Node* node)
     case SetLocal:
     case MovHint:
     case InitializeEntrypointArguments:
+    case ZombieHint:
     case ExitOK:
     case Phantom:
     case Upsilon:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3083,6 +3083,7 @@ private:
         case LoopHint:
         case MovHint:
         case InitializeEntrypointArguments:
+        case ZombieHint:
         case ExitOK:
         case BottomValue:
         case TypeOf:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -66,6 +66,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case LoopHint:
     case Phi:
     case Upsilon:
+    case ZombieHint:
     case ExitOK:
     case BottomValue:
     case PutHint:

--- a/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DFGMovHintRemovalPhase.h"
+
+#if ENABLE(DFG_JIT)
+
+#include "DFGEpoch.h"
+#include "DFGForAllKills.h"
+#include "DFGGraph.h"
+#include "DFGInsertionSet.h"
+#include "DFGMayExit.h"
+#include "DFGPhase.h"
+#include "JSCJSValueInlines.h"
+#include "OperandsInlines.h"
+
+namespace JSC { namespace DFG {
+
+namespace {
+
+namespace DFGMovHintRemovalPhaseInternal {
+static constexpr bool verbose = false;
+}
+
+class MovHintRemovalPhase : public Phase {
+public:
+    MovHintRemovalPhase(Graph& graph)
+        : Phase(graph, "MovHint removal")
+        , m_insertionSet(graph)
+        , m_state(OperandsLike, graph.block(0)->variablesAtHead)
+        , m_changed(false)
+    {
+    }
+
+    bool run()
+    {
+        if (DFGMovHintRemovalPhaseInternal::verbose) {
+            dataLog("Graph before MovHint removal:\n");
+            m_graph.dump();
+        }
+
+        for (BasicBlock* block : m_graph.blocksInNaturalOrder())
+            handleBlock(block);
+
+        m_insertionSet.execute(m_graph.block(0));
+
+        return m_changed;
+    }
+
+private:
+    void handleBlock(BasicBlock* block)
+    {
+        if (DFGMovHintRemovalPhaseInternal::verbose)
+            dataLog("Handing block ", pointerDump(block), "\n");
+
+        // A MovHint is unnecessary if the local dies before it is used. We answer this question by
+        // maintaining the current exit epoch, and associating an epoch with each local. When a
+        // local dies, it gets the current exit epoch. If a MovHint occurs in the same epoch as its
+        // local, then it means there was no exit between the local's death and the MovHint - i.e.
+        // the MovHint is unnecessary.
+
+        Epoch currentEpoch = Epoch::first();
+
+        m_state.fill(Epoch());
+        m_graph.forAllLiveInBytecode(
+            block->terminal()->origin.forExit,
+            [&] (Operand reg) {
+                m_state.operand(reg) = currentEpoch;
+            });
+
+        if (DFGMovHintRemovalPhaseInternal::verbose)
+            dataLog("    Locals at ", block->terminal()->origin.forExit, ": ", m_state, "\n");
+
+        // Assume that blocks after we exit.
+        currentEpoch.bump();
+
+        for (unsigned nodeIndex = block->size(); nodeIndex--;) {
+            Node* node = block->at(nodeIndex);
+
+            if (node->op() == MovHint) {
+                Epoch localEpoch = m_state.operand(node->unlinkedOperand());
+                if (DFGMovHintRemovalPhaseInternal::verbose)
+                    dataLog("    At ", node, " (", node->unlinkedOperand(), "): current = ", currentEpoch, ", local = ", localEpoch, "\n");
+                if (!localEpoch || localEpoch == currentEpoch) {
+                    // Now, MovHint will put bottom value to dead locals. This means that if you insert a new DFG node which introduce
+                    // a new OSR exit, then it gets confused with the already-determined-dead locals. So this phase runs at very end of
+                    // DFG pipeline, and we do not insert a node having a new OSR exit (if it is existing OSR exit, or if it does not exit,
+                    // then it is totally fine).
+                    node->setOpAndDefaultFlags(ZombieHint);
+                    UseKind useKind = node->child1().useKind();
+                    Node* constant = m_constants.ensure(static_cast<std::underlying_type_t<UseKind>>(useKind), [&]() -> Node* {
+                        return m_insertionSet.insertBottomConstantForUse(0, m_graph.block(0)->at(0)->origin, useKind).node();
+                    }).iterator->value;
+                    node->child1() = Edge(constant, useKind);
+                    m_changed = true;
+                }
+                m_state.operand(node->unlinkedOperand()) = Epoch();
+            }
+
+            if (mayExit(m_graph, node) != DoesNotExit)
+                currentEpoch.bump();
+
+            if (nodeIndex) {
+                forAllKilledOperands(
+                    m_graph, block->at(nodeIndex - 1), node,
+                    [&] (Operand operand) {
+                        // This function is a bit sloppy - it might claim to kill a local even if
+                        // it's still live after. We need to protect against that.
+                        if (!!m_state.operand(operand))
+                            return;
+
+                        if (DFGMovHintRemovalPhaseInternal::verbose)
+                            dataLog("    Killed operand at ", node, ": ", operand, "\n");
+                        m_state.operand(operand) = currentEpoch;
+                    });
+            }
+        }
+    }
+
+    InsertionSet m_insertionSet;
+    HashMap<std::underlying_type_t<UseKind>, Node*, WTF::IntHash<std::underlying_type_t<UseKind>>, WTF::UnsignedWithZeroKeyHashTraits<std::underlying_type_t<UseKind>>> m_constants;
+    Operands<Epoch> m_state;
+    bool m_changed;
+};
+
+} // anonymous namespace
+
+bool performMovHintRemoval(Graph& graph)
+{
+    return runPhase<MovHintRemovalPhase>(graph);
+}
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)
+

--- a/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(DFG_JIT)
+
+namespace JSC { namespace DFG {
+
+class Graph;
+
+// Cleans up unnecessary MovHints. A MovHint is necessary if the variable dies before there is an
+// exit.
+
+bool performMovHintRemoval(Graph&);
+
+} } // namespace JSC::DFG
+
+#endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1037,6 +1037,7 @@ public:
     {
         switch (op()) {
         case MovHint:
+        case ZombieHint:
             return true;
         default:
             return false;
@@ -1079,6 +1080,7 @@ public:
         switch (op()) {
         case ExtractOSREntryLocal:
         case MovHint:
+        case ZombieHint:
         case KillStack:
             return true;
         default:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -82,6 +82,7 @@ namespace JSC { namespace DFG {
     macro(GetStack, NodeResultJS) \
     \
     macro(MovHint, NodeMustGenerate) \
+    macro(ZombieHint, NodeMustGenerate) \
     macro(ExitOK, NodeMustGenerate) /* Indicates that exit state is intact and it is safe to exit back to the beginning of the exit origin. */ \
     macro(Phantom, NodeMustGenerate) \
     macro(Check, NodeMustGenerate) /* Used if we want just a type check but not liveness. Non-checking uses will be removed. */\

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -270,7 +270,8 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
         break;
     }
 
-    case MovHint: {
+    case MovHint:
+    case ZombieHint: {
         m_availability.m_locals.operand(node->unlinkedOperand()).setNode(node->child1().node());
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp
@@ -102,9 +102,10 @@ private:
             
             switch (node->op()) {
             case MovHint:
+            case ZombieHint:
                 m_values.operand(node->unlinkedOperand()) = node->child1().node();
                 break;
-                
+
             case GetLocal:
             case SetArgumentDefinitely:
             case SetArgumentMaybe:

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -50,6 +50,7 @@
 #include "DFGLiveCatchVariablePreservationPhase.h"
 #include "DFGLivenessAnalysisPhase.h"
 #include "DFGLoopPreHeaderCreationPhase.h"
+#include "DFGMovHintRemovalPhase.h"
 #include "DFGOSRAvailabilityAnalysisPhase.h"
 #include "DFGOSREntrypointCreationPhase.h"
 #include "DFGObjectAllocationSinkingPhase.h"
@@ -428,6 +429,12 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         RUN_PHASE(performCFA);
         RUN_PHASE(performGlobalStoreBarrierInsertion);
         RUN_PHASE(performStoreBarrierClustering);
+
+        // MovHint removal happens based on the assumption that we no longer inserts random new nodes having new OSR exits.
+        // After this phase, you cannot insert a node having a new OSR exit. (If it does not cause OSR exit, or if it does
+        // not introduce a new OSR exit, then it is totally fine).
+        if (Options::useMovHintRemoval())
+            RUN_PHASE(performMovHintRemoval);
         RUN_PHASE(performCleanUp);
         RUN_PHASE(performDCE); // We rely on this to kill dead code that won't be recognized as dead by B3.
         RUN_PHASE(performStackLayout);

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1535,6 +1535,7 @@ private:
         case NotifyWrite:
         case ConstantStoragePointer:
         case MovHint:
+        case ZombieHint:
         case ExitOK:
         case VarargsLength:
         case LoadVarargs:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -529,6 +529,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PutStack:
     case KillStack:
     case MovHint:
+    case ZombieHint:
     case Upsilon:
     case Phi:
     case Flush:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2248,7 +2248,8 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case MovHint: {
+    case MovHint:
+    case ZombieHint: {
         compileMovHint(m_currentNode);
         noResult(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3118,12 +3118,13 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case MovHint: {
+    case MovHint:
+    case ZombieHint: {
         compileMovHint(m_currentNode);
         noResult(node);
         break;
     }
-        
+
     case ExitOK: {
         noResult(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGUseKind.h
+++ b/Source/JavaScriptCore/dfg/DFGUseKind.h
@@ -33,7 +33,7 @@
 
 namespace JSC { namespace DFG {
 
-enum UseKind {
+enum UseKind : uint8_t {
     // The DFG has 3 representations of values used:
 
     // 1. The JSValue representation for a JSValue that must be stored in a GP

--- a/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
@@ -270,6 +270,7 @@ private:
             // what gets read on OSR exit.
             switch (node->op()) {
             case MovHint:
+            case ZombieHint:
             case KillStack:
                 if (argumentsInvolveStackSlot(candidate, node->unlinkedOperand())) {
                     if (verbose)

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -51,6 +51,7 @@ inline CapabilityLevel canCompile(Node* node)
     case KillStack:
     case GetStack:
     case MovHint:
+    case ZombieHint:
     case ExitOK:
     case Phantom:
     case Flush:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -586,6 +586,7 @@ private:
 
         switch (node->op()) {
         case MovHint:
+        case ZombieHint:
         case JSConstant:
         case LazyJSConstant:
         case DoubleConstant:
@@ -1766,6 +1767,7 @@ private:
 
         case PhantomLocal:
         case MovHint:
+        case ZombieHint:
         case ExitOK:
         case PhantomNewObject:
         case PhantomNewFunction:

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -251,6 +251,7 @@ bool canUseWebAssemblyFastMemory();
     v(Unsigned, frequentCallThreshold, 2, Normal, nullptr) \
     v(Double, minimumCallToKnownRate, 0.51, Normal, nullptr) \
     v(Bool, createPreHeaders, true, Normal, nullptr) \
+    v(Bool, useMovHintRemoval, true, Normal, nullptr) \
     v(Bool, usePutStackSinking, true, Normal, nullptr) \
     v(Bool, useObjectAllocationSinking, true, Normal, nullptr) \
     v(Bool, useValueRepElimination, true, Normal, nullptr) \


### PR DESCRIPTION
#### ebb0ea427eeea3ec7f8a376b85a016a994a15c44
<pre>
[JSC] Revive DFG MovHintRemoval phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=257939">https://bugs.webkit.org/show_bug.cgi?id=257939</a>
rdar://110583931

Reviewed by Keith Miller.

This patch revives MovHintRemoval phase in DFG. We found that unnecessary MovHint exists in many cases (it is already dead),
and preventing us from adding further optimizations based on that nobody is referring to the unused DFG nodes. So this patch
paves the way to implementing that kind of optimization.
The major difference from previous MovHintRemoval is that ZombieHint no longer kills availability. Instead it always says
bottom value is stored. This makes availability analysis much simpler (we no longer need to consider wrong dead case).
So, MovHint and ZombieHint are now exact same in terms of semantics: ZombieHint is using its op to represent this is assumed
to be unused. And ZombieHint always refers to bottom value.

* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp: Added.
(JSC::DFG::performMovHintRemoval):
* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.h: Added.
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::containsMovHint):
(JSC::DFG::Node::hasUnlinkedOperand):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp:
(JSC::DFG::LocalOSRAvailabilityCalculator::executeNode):
* Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::validateAIState):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/265098@main">https://commits.webkit.org/265098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b20cc872c5521880e767f966cd3d65eeee7c90c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11469 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8329 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8907 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/8333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9184 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9320 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/9959 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8720 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12946 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10227 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1113 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9328 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2536 "Passed tests") | 
<!--EWS-Status-Bubble-End-->