### PR TITLE
Use smart pointers with PageLoadStateObserverBase subclasses and instance variables

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,6 +24,7 @@
  */
 
 #import "PageLoadState.h"
+#import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
 
@@ -44,52 +45,52 @@ public:
 private:
     void willChangeIsLoading() override
     {
-        [m_object willChangeValueForKey:@"loading"];
+        [m_object.get() willChangeValueForKey:@"loading"];
     }
 
     void didChangeIsLoading() override
     {
-        [m_object didChangeValueForKey:@"loading"];
+        [m_object.get() didChangeValueForKey:@"loading"];
     }
 
     void willChangeTitle() override
     {
-        [m_object willChangeValueForKey:@"title"];
+        [m_object.get() willChangeValueForKey:@"title"];
     }
 
     void didChangeTitle() override
     {
-        [m_object didChangeValueForKey:@"title"];
+        [m_object.get() didChangeValueForKey:@"title"];
     }
 
     void willChangeActiveURL() override
     {
-        [m_object willChangeValueForKey:m_activeURLKey.get()];
+        [m_object.get() willChangeValueForKey:m_activeURLKey.get()];
     }
 
     void didChangeActiveURL() override
     {
-        [m_object didChangeValueForKey:m_activeURLKey.get()];
+        [m_object.get() didChangeValueForKey:m_activeURLKey.get()];
     }
 
     void willChangeHasOnlySecureContent() override
     {
-        [m_object willChangeValueForKey:@"hasOnlySecureContent"];
+        [m_object.get() willChangeValueForKey:@"hasOnlySecureContent"];
     }
 
     void didChangeHasOnlySecureContent() override
     {
-        [m_object didChangeValueForKey:@"hasOnlySecureContent"];
+        [m_object.get() didChangeValueForKey:@"hasOnlySecureContent"];
     }
 
     void willChangeEstimatedProgress() override
     {
-        [m_object willChangeValueForKey:@"estimatedProgress"];
+        [m_object.get() willChangeValueForKey:@"estimatedProgress"];
     }
 
     void didChangeEstimatedProgress() override
     {
-        [m_object didChangeValueForKey:@"estimatedProgress"];
+        [m_object.get() didChangeValueForKey:@"estimatedProgress"];
     }
 
     void willChangeCanGoBack() override { }
@@ -104,15 +105,15 @@ private:
 
     void willChangeWebProcessIsResponsive() override
     {
-        [m_object willChangeValueForKey:@"_webProcessIsResponsive"];
+        [m_object.get() willChangeValueForKey:@"_webProcessIsResponsive"];
     }
 
     void didChangeWebProcessIsResponsive() override
     {
-        [m_object didChangeValueForKey:@"_webProcessIsResponsive"];
+        [m_object.get() didChangeValueForKey:@"_webProcessIsResponsive"];
     }
 
-    id m_object;
+    WeakObjCPtr<id> m_object;
     RetainPtr<NSString> m_activeURLKey;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,22 +54,22 @@ namespace WebKit {
 
 struct WebNavigationDataStore;
 
-class NavigationState final : private PageLoadState::Observer, public CanMakeWeakPtr<NavigationState> {
+class NavigationState final : public PageLoadState::Observer {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit NavigationState(WKWebView *);
     ~NavigationState();
 
-    static NavigationState& fromWebPage(WebPageProxy&);
+    static NavigationState* fromWebPage(WebPageProxy&);
 
     UniqueRef<API::NavigationClient> createNavigationClient();
     UniqueRef<API::HistoryClient> createHistoryClient();
 
-    RetainPtr<id <WKNavigationDelegate> > navigationDelegate();
-    void setNavigationDelegate(id <WKNavigationDelegate>);
+    RetainPtr<id<WKNavigationDelegate>> navigationDelegate() const;
+    void setNavigationDelegate(id<WKNavigationDelegate>);
 
-    RetainPtr<id <WKHistoryDelegatePrivate> > historyDelegate();
-    void setHistoryDelegate(id <WKHistoryDelegatePrivate>);
+    RetainPtr<id<WKHistoryDelegatePrivate>> historyDelegate() const;
+    void setHistoryDelegate(id<WKHistoryDelegatePrivate>);
 
     // Called by the page client.
     void navigationGestureDidBegin();
@@ -201,8 +201,10 @@ private:
     void releaseNetworkActivityAfterLoadCompletion() { releaseNetworkActivity(NetworkActivityReleaseReason::LoadCompleted); }
 #endif
 
-    WKWebView *m_webView;
-    WeakObjCPtr<id <WKNavigationDelegate> > m_navigationDelegate;
+    RetainPtr<WKWebView> webView() const { return m_webView.get(); }
+
+    WeakObjCPtr<WKWebView> m_webView;
+    WeakObjCPtr<id<WKNavigationDelegate>> m_navigationDelegate;
 
     struct {
         bool webViewDecidePolicyForNavigationActionDecisionHandler : 1;
@@ -270,7 +272,7 @@ private:
 #endif
     } m_navigationDelegateMethods;
 
-    WeakObjCPtr<id <WKHistoryDelegatePrivate> > m_historyDelegate;
+    WeakObjCPtr<id<WKHistoryDelegatePrivate>> m_historyDelegate;
     struct {
         bool webViewDidNavigateWithNavigationData : 1;
         bool webViewDidPerformClientRedirectFromURLToURL : 1;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -105,6 +105,8 @@ public:
     WindowKind windowKind() final;
 
 protected:
+    RetainPtr<WKWebView> webView() const { return m_webView.get(); }
+
     WeakObjCPtr<WKWebView> m_webView;
     std::unique_ptr<WebCore::AlternativeTextUIController> m_alternativeTextUIController;
 };

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,13 +27,14 @@
 
 #include <WebCore/CertificateInfo.h>
 #include <wtf/URL.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
 
 class WebPageProxy;
 
-class PageLoadStateObserverBase {
+class PageLoadStateObserverBase : public CanMakeWeakPtr<PageLoadStateObserverBase> {
 public:
     virtual ~PageLoadStateObserverBase() = default;
 
@@ -203,7 +204,7 @@ private:
 
     void callObserverCallback(void (Observer::*)());
 
-    Vector<Observer*> m_observers;
+    WeakHashSet<Observer> m_observers;
 
     struct Data {
         State state { State::Finished };

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -612,8 +612,10 @@ void WebPageProxy::applicationDidEnterBackground()
 #if !PLATFORM(WATCHOS)
     // We normally delay process suspension when the app is backgrounded until the current page load completes. However,
     // we do not want to do so when the screen is locked for power reasons.
-    if (isSuspendedUnderLock)
-        NavigationState::fromWebPage(*this).releaseNetworkActivity(NavigationState::NetworkActivityReleaseReason::ScreenLocked);
+    if (isSuspendedUnderLock) {
+        if (auto* navigationState = NavigationState::fromWebPage(*this))
+            navigationState->releaseNetworkActivity(NavigationState::NetworkActivityReleaseReason::ScreenLocked);
+    }
 #endif
     m_process->send(Messages::WebPage::ApplicationDidEnterBackground(isSuspendedUnderLock), webPageID());
 }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -430,17 +430,17 @@ FloatRect PageClientImpl::convertToUserSpace(const FloatRect& rect)
 
 void PageClientImpl::pinnedStateWillChange()
 {
-    [m_webView willChangeValueForKey:@"_pinnedState"];
+    [webView() willChangeValueForKey:@"_pinnedState"];
 }
 
 void PageClientImpl::pinnedStateDidChange()
 {
-    [m_webView didChangeValueForKey:@"_pinnedState"];
+    [webView() didChangeValueForKey:@"_pinnedState"];
 }
 
 void PageClientImpl::drawPageBorderForPrinting(WebCore::FloatSize&& size)
 {
-    [m_webView drawPageBorderWithSize:size];
+    [webView() drawPageBorderWithSize:size];
 }
     
 IntPoint PageClientImpl::screenToRootView(const IntPoint& point)
@@ -507,12 +507,12 @@ Ref<WebContextMenuProxy> PageClientImpl::createContextMenuProxy(WebPageProxy& pa
 
 void PageClientImpl::didShowContextMenu()
 {
-    [m_webView _didShowContextMenu];
+    [webView() _didShowContextMenu];
 }
 
 void PageClientImpl::didDismissContextMenu()
 {
-    [m_webView _didDismissContextMenu];
+    [webView() _didDismissContextMenu];
 }
 
 #endif // ENABLE(CONTEXT_MENUS)
@@ -648,7 +648,7 @@ void PageClientImpl::selectionDidChange()
 
 bool PageClientImpl::showShareSheet(const ShareDataWithParsedURL& shareData, WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_impl->showShareSheet(shareData, WTFMove(completionHandler), m_webView.get().get());
+    m_impl->showShareSheet(shareData, WTFMove(completionHandler), webView().get());
     return true;
 }
 
@@ -815,20 +815,26 @@ void PageClientImpl::navigationGestureDidBegin()
 {
     m_impl->dismissContentRelativeChildWindowsWithAnimation(true);
 
-    if (auto webView = m_webView.get())
-        NavigationState::fromWebPage(*webView->_page).navigationGestureDidBegin();
+    if (auto webView = this->webView()) {
+        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+            navigationState->navigationGestureDidBegin();
+    }
 }
 
 void PageClientImpl::navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem& item)
 {
-    if (auto webView = m_webView.get())
-        NavigationState::fromWebPage(*webView->_page).navigationGestureWillEnd(willNavigate, item);
+    if (auto webView = this->webView()) {
+        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+            navigationState->navigationGestureWillEnd(willNavigate, item);
+    }
 }
 
 void PageClientImpl::navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem& item)
 {
-    if (auto webView = m_webView.get())
-        NavigationState::fromWebPage(*webView->_page).navigationGestureDidEnd(willNavigate, item);
+    if (auto webView = this->webView()) {
+        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+            navigationState->navigationGestureDidEnd(willNavigate, item);
+    }
 }
 
 void PageClientImpl::navigationGestureDidEnd()
@@ -837,14 +843,18 @@ void PageClientImpl::navigationGestureDidEnd()
 
 void PageClientImpl::willRecordNavigationSnapshot(WebBackForwardListItem& item)
 {
-    if (auto webView = m_webView.get())
-        NavigationState::fromWebPage(*webView->_page).willRecordNavigationSnapshot(item);
+    if (auto webView = this->webView()) {
+        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+            navigationState->willRecordNavigationSnapshot(item);
+    }
 }
 
 void PageClientImpl::didRemoveNavigationGestureSnapshot()
 {
-    if (auto webView = m_webView.get())
-        NavigationState::fromWebPage(*webView->_page).navigationGestureSnapshotWasRemoved();
+    if (auto webView = this->webView()) {
+        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        navigationState->navigationGestureSnapshotWasRemoved();
+    }
 }
 
 void PageClientImpl::didStartProvisionalLoadForMainFrame()
@@ -883,7 +893,7 @@ void PageClientImpl::didSameDocumentNavigationForMainFrame(SameDocumentNavigatio
 
 void PageClientImpl::handleControlledElementIDResponse(const String& identifier)
 {
-    [m_webView _handleControlledElementIDResponse:nsStringFromWebCoreString(identifier)];
+    [webView() _handleControlledElementIDResponse:nsStringFromWebCoreString(identifier)];
 }
 
 void PageClientImpl::didChangeBackgroundColor()


### PR DESCRIPTION
#### 946a761a0a7f9b63ceda7211a863527fa110883c
<pre>
Use smart pointers with PageLoadStateObserverBase subclasses and instance variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=257938">https://bugs.webkit.org/show_bug.cgi?id=257938</a>
&lt;rdar://110485192&gt;

Reviewed by Alex Christensen.

PageLoadStateObserverBase (a.k.a. PageLoadState::Observer) is stored as
a raw pointer in PageLoadState::m_observers, but subclass
NavigationState inherits CanMakeWeakPtr&lt;&gt;.  Be consistent by making
PageLoadStateObserverBase inherit CanMakeWeakPtr&lt;&gt; and propagate
necessary changes.

While here, make Cocoa instance variables in these classes use
WeakObjCPtr&lt;&gt; instead of raw pointers, and implement convenience
functions that return RetainPtr&lt;&gt; objects to avoid autoreleasing these
instance variables repeatedly for method calls.

* Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h:
- Store m_object using WeakObjCPtr&lt;&gt;, and use WeakObjCPtr&lt;&gt;::get() to
  avoid autoreleasing m_object on every method call.

* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
(WebKit::NavigationState):
- Change PageLoadState::Observer to public inheritance so
  CanMakeWeakPtr&lt;&gt; may be used from PageLoadState::Observer.
- Stop inheriting CanMakeWeakPtr&lt;&gt; from NavigationState.
(WebKit::NavigationState::fromWebPage):
- Must return a pointer because navigationStates() stores
  WeakPtr&lt;NavigationState&gt; values.
(WebKit::NavigationState::navigationDelegate const):
(WebKit::NavigationState::historyDelegate const):
- Add const modifier to methods.
(WebKit::NavigationState::webView const): Add.
- Store m_viewView as WeakObjCPtr&lt;WKWebView&gt;.

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::navigationStates):
- Change from HashMap&lt;&gt; to WeakHashMap&lt;&gt;.
(WebKit::NavigationState::NavigationState):
- Use `webView` parameter instead of m_webView to avoid autoreleasing
  the object.
(WebKit::NavigationState::~NavigationState):
(WebKit::NavigationState::fromWebPage):
- Update to return a pointer instead of a reference.
(WebKit::NavigationState::navigationDelegate const):
(WebKit::NavigationState::historyDelegate const):
- Add const modifier to methods.
(WebKit::NavigationState::navigationGestureDidBegin):
(WebKit::NavigationState::navigationGestureWillEnd):
(WebKit::NavigationState::navigationGestureDidEnd):
(WebKit::NavigationState::willRecordNavigationSnapshot):
(WebKit::NavigationState::navigationGestureSnapshotWasRemoved):
(WebKit::NavigationState::didRequestPasswordForQuickLookDocument):
(WebKit::NavigationState::didStopRequestingPasswordForQuickLookDocument):
(WebKit::NavigationState::didFirstPaint):
(WebKit::NavigationState::NavigationClient::didChangeBackForwardList):
(WebKit::NavigationState::NavigationClient::willGoToBackForwardListItem):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didStartProvisionalLoadForFrame):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::willPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didPerformClientRedirect):
(WebKit::NavigationState::NavigationClient::didCancelClientRedirect):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didCommitLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFinishDocumentLoad):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFinishLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailLoadDueToNetworkConnectionIntegrity):
(WebKit::NavigationState::NavigationClient::didChangeLookalikeCharacters):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didSameDocumentNavigation):
(WebKit::NavigationState::NavigationClient::renderingProgressDidChange):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
(WebKit::NavigationState::NavigationClient::shouldAllowLegacyTLS):
(WebKit::NavigationState::NavigationClient::didNegotiateModernTLS):
(WebKit::NavigationState::NavigationClient::processDidTerminate):
(WebKit::NavigationState::NavigationClient::processDidBecomeResponsive):
(WebKit::NavigationState::NavigationClient::processDidBecomeUnresponsive):
(WebKit::NavigationState::NavigationClient::webCryptoMasterKey):
(WebKit::NavigationState::NavigationClient::navigationActionDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::navigationResponseDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::contextMenuDidCreateDownload):
(WebKit::NavigationState::NavigationClient::didStartLoadForQuickLookDocumentInMainFrame):
(WebKit::NavigationState::NavigationClient::didFinishLoadForQuickLookDocumentInMainFrame):
(WebKit::NavigationState::NavigationClient::decidePolicyForSOAuthorizationLoad):
(WebKit::NavigationState::HistoryClient::didNavigateWithNavigationData):
(WebKit::NavigationState::HistoryClient::didPerformClientRedirect):
(WebKit::NavigationState::HistoryClient::didPerformServerRedirect):
(WebKit::NavigationState::HistoryClient::didUpdateHistoryTitle):
(WebKit::NavigationState::willChangeIsLoading):
(WebKit::NavigationState::didChangeIsLoading):
(WebKit::NavigationState::willChangeTitle):
(WebKit::NavigationState::didChangeTitle):
(WebKit::NavigationState::willChangeActiveURL):
(WebKit::NavigationState::didChangeActiveURL):
(WebKit::NavigationState::willChangeHasOnlySecureContent):
(WebKit::NavigationState::didChangeHasOnlySecureContent):
(WebKit::NavigationState::willChangeNegotiatedLegacyTLS):
(WebKit::NavigationState::didChangeNegotiatedLegacyTLS):
(WebKit::NavigationState::willChangeWasPrivateRelayed):
(WebKit::NavigationState::didChangeWasPrivateRelayed):
(WebKit::NavigationState::willChangeEstimatedProgress):
(WebKit::NavigationState::didChangeEstimatedProgress):
(WebKit::NavigationState::willChangeCanGoBack):
(WebKit::NavigationState::didChangeCanGoBack):
(WebKit::NavigationState::willChangeCanGoForward):
(WebKit::NavigationState::didChangeCanGoForward):
(WebKit::NavigationState::willChangeNetworkRequestsInProgress):
(WebKit::NavigationState::didChangeNetworkRequestsInProgress):
(WebKit::NavigationState::willChangeCertificateInfo):
(WebKit::NavigationState::didChangeCertificateInfo):
(WebKit::NavigationState::willChangeWebProcessIsResponsive):
(WebKit::NavigationState::didChangeWebProcessIsResponsive):
(WebKit::NavigationState::didSwapWebProcesses):
- Make use of navigationDelegate() convenience method instead of calling
  m_navigationDelegate.get().
- Make use of new webView() convenience method to avoid autoreleasing
  m_webView each time.  Add nil checks as needed.
- Remove unneeded RetainPtr&lt;&gt;::get() calls.
- Change C-style casts to static_cast&lt;&gt;() for consistency.

* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
(WebKit::PageClientImplCocoa::webView const): Add.

* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::~PageLoadState):
(WebKit::PageLoadState::addObserver):
(WebKit::PageLoadState::removeObserver):
(WebKit::PageLoadState::callObserverCallback):
- Update to work with m_observers storing WeakPtr&lt;Observer&gt;.

* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadStateObserverBase):
- Inherit from CanMakeWeakPtr&lt;&gt;.
- Change m_observers from Vector&lt;Observer*&gt; to WeakHashSet&lt;Observer&gt;.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(MESSAGE_CHECK):
- Update to use webView().
(WebKit::PageClientImpl::isViewVisible):
(WebKit::PageClientImpl::isViewInWindow):
(WebKit::PageClientImpl::decidePolicyForGeolocationPermissionRequest):
(WebKit::PageClientImpl::didStartProvisionalLoadForMainFrame):
(WebKit::PageClientImpl::didFailProvisionalLoadForMainFrame):
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
(WebKit::PageClientImpl::minimumZoomScale const):
(WebKit::PageClientImpl::showSafeBrowsingWarning):
(WebKit::PageClientImpl::clearSafeBrowsingWarning):
(WebKit::PageClientImpl::clearSafeBrowsingWarningIfForMainFrameNavigation):
(WebKit::PageClientImpl::effectiveAppearanceIsDark const):
(WebKit::PageClientImpl::effectiveUserInterfaceLevelIsElevated const):
(WebKit::PageClientImpl::takeViewSnapshot):
(WebKit::PageClientImpl::couldNotRestorePageState):
(WebKit::PageClientImpl::restorePageState):
(WebKit::PageClientImpl::restorePageCenterAndScale):
(WebKit::PageClientImpl::closeFullScreenManager):
(WebKit::PageClientImpl::isFullScreen):
(WebKit::PageClientImpl::enterFullScreen):
(WebKit::PageClientImpl::exitFullScreen):
(WebKit::PageClientImpl::lockFullscreenOrientation):
(WebKit::PageClientImpl::unlockFullscreenOrientation):
(WebKit::PageClientImpl::beganEnterFullScreen):
(WebKit::PageClientImpl::beganExitFullScreen):
(WebKit::PageClientImpl::didFinishLoadingDataForCustomContentProvider):
(WebKit::PageClientImpl::mimeTypesWithCustomContentProviders):
(WebKit::PageClientImpl::navigationGestureDidBegin):
(WebKit::PageClientImpl::navigationGestureWillEnd):
(WebKit::PageClientImpl::navigationGestureDidEnd):
(WebKit::PageClientImpl::willRecordNavigationSnapshot):
(WebKit::PageClientImpl::didRemoveNavigationGestureSnapshot):
(WebKit::PageClientImpl::didFinishNavigation):
(WebKit::PageClientImpl::didFailNavigation):
(WebKit::PageClientImpl::didSameDocumentNavigationForMainFrame):
(WebKit::PageClientImpl::didChangeBackgroundColor):
(WebKit::PageClientImpl::videoControlsManagerDidChange):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::applicationDidEnterBackground):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::pinnedStateWillChange):
(WebKit::PageClientImpl::pinnedStateDidChange):
(WebKit::PageClientImpl::drawPageBorderForPrinting):
(WebKit::PageClientImpl::didShowContextMenu):
(WebKit::PageClientImpl::didDismissContextMenu):
(WebKit::PageClientImpl::showShareSheet):
(WebKit::PageClientImpl::navigationGestureDidBegin):
(WebKit::PageClientImpl::navigationGestureWillEnd):
(WebKit::PageClientImpl::navigationGestureDidEnd):
(WebKit::PageClientImpl::willRecordNavigationSnapshot):
(WebKit::PageClientImpl::didRemoveNavigationGestureSnapshot):
(WebKit::PageClientImpl::handleControlledElementIDResponse):
- Make use of new webView() convenience method to avoid autoreleasing
  m_webView each time.  Add nil checks as needed.
- Add nullptr checks after calling NavigationState::fromWebPage() since
  it now returns a pointer instead of a reference.

Canonical link: <a href="https://commits.webkit.org/265120@main">https://commits.webkit.org/265120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdc0a4aacfcd619eedef340ff5b4fda9ebdc0547

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9560 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12494 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11893 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8107 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16290 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12370 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9573 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7789 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12962 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1122 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->