### PR TITLE
[CSSProperties.json] Fix missing "css-text-fill-and-stroke" and remove unused "css3-text" categories

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9926,16 +9926,15 @@
             "longname": "CSS Text Module",
             "url": "https://www.w3.org/TR/css-text-3/"
         },
+        "css-text-fill-and-stroke": {
+            "shortname": "CSS Text Fill and Stroke",
+            "longname": "CSS Text Fill and Stroke Module",
+            "url": "https://drafts.fxtf.org/paint/"
+        },
         "css-text-decor": {
             "shortname": "CSS Text Decoration",
             "longname": "CSS Text Decoration Module",
             "url": "https://www.w3.org/TR/css-text-decor-3/"
-        },
-        "css3-text": {
-            "shortname": "CSS3 Text",
-            "longname": "CSS3 Text Module",
-            "url": "https://www.w3.org/TR/2003/CR-css3-text-20030514/",
-            "status": "obsolete"
         },
         "css-transforms": {
             "shortname": "CSS Transforms",


### PR DESCRIPTION
#### 3a551112868ed61f9f1bc08c2d4a2d0786ba56c9
<pre>
[CSSProperties.json] Fix missing &quot;css-text-fill-and-stroke&quot; and remove unused &quot;css3-text&quot; categories
<a href="https://bugs.webkit.org/show_bug.cgi?id=257940">https://bugs.webkit.org/show_bug.cgi?id=257940</a>
rdar://110589992

Reviewed by Myles C. Maxfield.

* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/265058@main">https://commits.webkit.org/265058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2b2578ff040b6c38389213a164cb61299b013cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11318 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12357 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11477 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16185 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9417 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8603 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12826 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->