### PR TITLE
[ macOS ] 2 http/tests/media/FairPlay tests are broken.

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-hls.html
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-hls.html
@@ -14,6 +14,7 @@
     async function startTest() {
         findMediaElement();
         video.src = 'content/prog_index.m3u8';
+        waitFor(video, 'error').then(failTest);
         var event = await waitFor(video, 'webkitneedkey');
 
         let keys = await startLegacyEME({
@@ -28,8 +29,8 @@
         let initDataArray = this.concatInitDataIdAndCertificate(event.initData, contentId, certificate);
 
         let keySession = keys.createSession('application/vnd.apple.mpegurl', initDataArray);
-        waitFor(keySession, 'webkitkeyerror').then(() => {
-            consoleWrite('FAIL: update() failed');
+        waitFor(keySession, 'webkitkeyerror').then(event => {
+            consoleWrite(`FAIL: update() failed with code: ${ event.code }, systemCode: ${ event.systemCode }`);
             endTest();
         });
         event = await waitFor(keySession, 'webkitkeymessage');

--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2.html
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2.html
@@ -15,6 +15,13 @@
 
     async function startTest() {
         let video = document.querySelector('video');
+        waitFor(video, 'error').then(failTest);
+
+        let keys = await startLegacyEME({
+            video: video,
+            protocolVersion: 2,
+            mimeType: 'video/mp4'
+        });
 
         let mediaSource = new MediaSource;
         video.srcObject = mediaSource;
@@ -28,16 +35,10 @@
         let updateEndPromise = fetchAndAppend(sourceBuffer, 'content/elementary-stream-video-header-keyid-1.m4v', true);
         event = await waitFor(video, 'webkitneedkey');
 
-        let keys = await startLegacyEME({
-            video: video,
-            protocolVersion: 2,
-            mimeType: 'video/mp4'
-        });
-
         let initDataArray = stringToUInt8Array('skd://twelve');
         let keySession = keys.createSession('video/mp4', initDataArray);
-        waitFor(keySession, 'webkitkeyerror').then(() => {
-            consoleWrite('FAIL: update() failed');
+        waitFor(keySession, 'webkitkeyerror').then(event => {
+            consoleWrite(`FAIL: update() failed with code: ${ event.code }, systemCode: ${ event.systemCode }`);
             endTest();
         });
         event = await waitFor(keySession, 'webkitkeymessage');

--- a/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3.html
+++ b/LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3.html
@@ -15,6 +15,13 @@
 
     async function startTest() {
         let video = document.querySelector('video');
+        waitFor(video, 'error').then(failTest);
+
+        let keys = await startLegacyEME({
+            video: video,
+            protocolVersion: 3,
+            mimeType: 'video/mp4'
+        });
 
         let mediaSource = new MediaSource;
         video.srcObject = mediaSource;
@@ -28,15 +35,9 @@
         let updateEndPromise = fetchAndAppend(sourceBuffer, 'content/elementary-stream-video-header-keyid-1.m4v', true);
         event = await waitFor(video, 'webkitneedkey');
 
-        let keys = await startLegacyEME({
-            video: video,
-            protocolVersion: 3,
-            mimeType: 'video/mp4'
-        });
-
         let keySession = keys.createSession('video/mp4', event.initData);
-        waitFor(keySession, 'webkitkeyerror').then(() => {
-            consoleWrite('FAIL: update() failed');
+        waitFor(keySession, 'webkitkeyerror').then(event => {
+            consoleWrite(`FAIL: update() failed with code: ${ event.code }, systemCode: ${ event.systemCode }`);
             endTest();
         });
         event = await waitFor(keySession, 'webkitkeymessage');

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1964,9 +1964,9 @@ webkit.org/b/222422 imported/w3c/web-platform-tests/media-source/mediasource-dur
 
 webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
-# webkit.org/b/255294  2 http/tests/media/FairPlay tests are broken.
-http/tests/media/fairplay/legacy-fairplay-mse-v2.html [ Skip ]
-http/tests/media/fairplay/legacy-fairplay-mse-v3.html [ Skip ]
+# webkit.org/b/255294  2 http/tests/media/FairPlay tests are flakey.
+http/tests/media/fairplay/legacy-fairplay-mse-v2.html [ Pass Failure ]
+http/tests/media/fairplay/legacy-fairplay-mse-v3.html [ Pass Failure ]
 
 webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeout ]
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1022,8 +1022,18 @@ void MediaSource::openIfDeferredOpen()
     onReadyStateChange(ReadyState::Closed, ReadyState::Open);
 }
 
+void MediaSource::setAsSrcObject(bool set)
+{
+    m_sourceopenPending = set;
+}
+
 bool MediaSource::virtualHasPendingActivity() const
 {
+    // Mark this object as hasPendingActivity if it has been set as the srcObject
+    // of a HTMLMediaElement, but has not yet fired the "sourceopen" event.
+    if (m_sourceopenPending)
+        return true;
+
     return m_private || m_associatedRegistryCount;
 }
 
@@ -1055,6 +1065,7 @@ void MediaSource::onReadyStateChange(ReadyState oldState, ReadyState newState)
         buffer->readyStateChanged();
 
     if (isOpen()) {
+        m_sourceopenPending = false;
         scheduleEvent(eventNames().sourceopenEvent);
         monitorSourceBuffers();
         return;

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -133,6 +133,8 @@ public:
     void memoryPressure();
 #endif
 
+    void setAsSrcObject(bool);
+
 protected:
     explicit MediaSource(ScriptExecutionContext&);
 
@@ -183,6 +185,7 @@ private:
     MediaTime m_pendingSeekTime;
     ReadyState m_readyState { ReadyState::Closed };
     bool m_openDeferred { false };
+    bool m_sourceopenPending { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const void* m_logIdentifier { nullptr };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1117,6 +1117,13 @@ void HTMLMediaElement::setSrcObject(MediaProvider&& mediaProvider)
 #endif
     m_blob = nullptr;
 
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaProvider && std::holds_alternative<RefPtr<MediaSource>>(*m_mediaProvider)) {
+        auto mediaSource = std::get<RefPtr<MediaSource>>(*m_mediaProvider);
+        mediaSource->setAsSrcObject(true);
+    }
+#endif
+
     prepareForLoad();
 }
 
@@ -3778,6 +3785,11 @@ double HTMLMediaElement::duration() const
 
 MediaTime HTMLMediaElement::durationMediaTime() const
 {
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaSource)
+        return m_mediaSource->duration();
+#endif
+
     if (m_player && m_readyState >= HAVE_METADATA)
         return m_player->duration();
 
@@ -4175,6 +4187,7 @@ void HTMLMediaElement::detachMediaSource()
         return;
 
     m_mediaSource->detachFromElement(*this);
+    m_mediaSource->setAsSrcObject(false);
     m_mediaSource = nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -129,10 +129,17 @@ CDMSessionAVContentKeySession::CDMSessionAVContentKeySession(Vector<int>&& proto
 
 CDMSessionAVContentKeySession::~CDMSessionAVContentKeySession()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     [m_contentKeySessionDelegate invalidate];
 
-    for (auto& sourceBuffer : m_sourceBuffers)
-        removeParser(sourceBuffer->streamDataParser());
+    if (hasContentKeySession()) {
+        for (auto& sourceBuffer : m_sourceBuffers) {
+            sourceBuffer->flush();
+            removeParser(sourceBuffer->streamDataParser());
+        }
+
+        [contentKeySession() expire];
+    }
 }
 
 bool CDMSessionAVContentKeySession::isAvailable()

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -371,6 +371,13 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     m_libWebRTCCodecsProxy = nullptr;
 #endif
+#if ENABLE(ENCRYPTED_MEDIA)
+    if (m_cdmFactoryProxy)
+        m_cdmFactoryProxy->clear();
+#endif
+#if ENABLE(LEGACY_ENCRYPTED_MEDIA)
+    RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
+#endif
     gpuProcess().connectionToWebProcessClosed(connection);
     gpuProcess().removeGPUConnectionToWebProcess(*this); // May destroy |this|.
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -45,7 +45,15 @@ RemoteCDMFactoryProxy::RemoteCDMFactoryProxy(GPUConnectionToWebProcess& connecti
 {
 }
 
-RemoteCDMFactoryProxy::~RemoteCDMFactoryProxy() = default;
+RemoteCDMFactoryProxy::~RemoteCDMFactoryProxy()
+{
+    clear();
+}
+
+void RemoteCDMFactoryProxy::clear()
+{
+    m_proxies.clear();
+}
 
 static CDMFactory* factoryForKeySystem(const String& keySystem)
 {

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -50,6 +50,8 @@ public:
     RemoteCDMFactoryProxy(GPUConnectionToWebProcess&);
     virtual ~RemoteCDMFactoryProxy();
 
+    void clear();
+
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
     bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
     void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp
@@ -48,13 +48,21 @@ RemoteLegacyCDMFactoryProxy::RemoteLegacyCDMFactoryProxy(GPUConnectionToWebProce
 
 RemoteLegacyCDMFactoryProxy::~RemoteLegacyCDMFactoryProxy()
 {
+    clear();
+}
+
+void RemoteLegacyCDMFactoryProxy::clear()
+{
+    auto proxies = std::exchange(m_proxies, { });
+    auto sessions = std::exchange(m_sessions, { });
+
     if (!m_gpuConnectionToWebProcess)
         return;
 
-    for (auto const& session : m_sessions)
+    for (auto const& session : sessions)
         m_gpuConnectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMSessionProxy::messageReceiverName(), session.key.toUInt64());
 
-    for (auto const& proxy : m_proxies)
+    for (auto const& proxy : proxies)
         m_gpuConnectionToWebProcess->messageReceiverMap().removeMessageReceiver(Messages::RemoteLegacyCDMProxy::messageReceiverName(), proxy.key.toUInt64());
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -48,6 +48,8 @@ public:
     RemoteLegacyCDMFactoryProxy(GPUConnectionToWebProcess&);
     virtual ~RemoteLegacyCDMFactoryProxy();
 
+    void clear();
+
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
     bool didReceiveSyncMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) { return didReceiveSyncMessage(connection, decoder, encoder); }
     void didReceiveCDMMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in
@@ -26,6 +26,7 @@
 messages -> RemoteLegacyCDMFactoryProxy NotRefCounted {
     CreateCDM(String keySystem, std::optional<WebCore::MediaPlayerIdentifier> playerId) -> (WebKit::RemoteLegacyCDMIdentifier identifier) Synchronous
     SupportsKeySystem(String keySystem, std::optional<String> mimeType) -> (bool result) Synchronous
+    RemoveSession(WebKit::RemoteLegacyCDMSessionIdentifier identifier)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -121,16 +121,17 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
     return remoteCDM;
 }
 
-void RemoteLegacyCDMFactory::addSession(RemoteLegacyCDMSessionIdentifier identifier, std::unique_ptr<RemoteLegacyCDMSession>&& session)
+void RemoteLegacyCDMFactory::addSession(RemoteLegacyCDMSessionIdentifier identifier, RemoteLegacyCDMSession& session)
 {
     ASSERT(!m_sessions.contains(identifier));
-    m_sessions.set(identifier, WTFMove(session));
+    m_sessions.set(identifier, WeakPtr { session });
 }
 
 void RemoteLegacyCDMFactory::removeSession(RemoteLegacyCDMSessionIdentifier identifier)
 {
     ASSERT(m_sessions.contains(identifier));
     m_sessions.remove(identifier);
+    gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMFactoryProxy::RemoveSession(identifier), { });
 }
 
 RemoteLegacyCDM* RemoteLegacyCDMFactory::findCDM(CDMPrivateInterface* privateInterface) const
@@ -140,12 +141,6 @@ RemoteLegacyCDM* RemoteLegacyCDMFactory::findCDM(CDMPrivateInterface* privateInt
             return cdm.get();
     }
     return nullptr;
-}
-
-void RemoteLegacyCDMFactory::didReceiveSessionMessage(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    if (auto* session = m_sessions.get(ObjectIdentifier<RemoteLegacyCDMSessionIdentifierType>(decoder.destinationID())))
-        session->didReceiveMessage(connection, decoder);
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -71,9 +71,7 @@ public:
 
     GPUProcessConnection& gpuProcessConnection();
 
-    void didReceiveSessionMessage(IPC::Connection&, IPC::Decoder&);
-
-    void addSession(RemoteLegacyCDMSessionIdentifier, std::unique_ptr<RemoteLegacyCDMSession>&&);
+    void addSession(RemoteLegacyCDMSessionIdentifier, RemoteLegacyCDMSession&);
     void removeSession(RemoteLegacyCDMSessionIdentifier);
 
     RemoteLegacyCDM* findCDM(WebCore::CDMPrivateInterface*) const;
@@ -83,7 +81,7 @@ private:
     bool supportsKeySystemAndMimeType(const String&, const String&);
     std::unique_ptr<WebCore::CDMPrivateInterface> createCDM(WebCore::LegacyCDM*);
 
-    HashMap<RemoteLegacyCDMSessionIdentifier, std::unique_ptr<RemoteLegacyCDMSession>> m_sessions;
+    HashMap<RemoteLegacyCDMSessionIdentifier, WeakPtr<RemoteLegacyCDMSession>> m_sessions;
     HashMap<RemoteLegacyCDMIdentifier, WeakPtr<RemoteLegacyCDM>> m_cdms;
     HashMap<String, bool> m_supportsKeySystemCache;
     HashMap<std::pair<String, String>, bool> m_supportsKeySystemAndMimeTypeCache;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -67,7 +67,10 @@ static RefPtr<SharedBuffer> convertToSharedBuffer(T array)
 
 std::unique_ptr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(WeakPtr<RemoteLegacyCDMFactory> factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
 {
-    return std::unique_ptr<RemoteLegacyCDMSession>(new RemoteLegacyCDMSession(WTFMove(factory), WTFMove(identifier), client));
+    auto session = std::unique_ptr<RemoteLegacyCDMSession>(new RemoteLegacyCDMSession(WTFMove(factory), WTFMove(identifier), client));
+    if (session->m_factory)
+        session->m_factory->addSession(identifier, *session);
+    return session;
 }
 
 RemoteLegacyCDMSession::RemoteLegacyCDMSession(WeakPtr<RemoteLegacyCDMFactory> factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)
@@ -77,7 +80,11 @@ RemoteLegacyCDMSession::RemoteLegacyCDMSession(WeakPtr<RemoteLegacyCDMFactory> f
 {
 }
 
-RemoteLegacyCDMSession::~RemoteLegacyCDMSession() = default;
+RemoteLegacyCDMSession::~RemoteLegacyCDMSession()
+{
+    if (m_factory)
+        m_factory->removeSession(m_identifier);
+}
 
 RefPtr<Uint8Array> RemoteLegacyCDMSession::generateKeyRequest(const String& mimeType, Uint8Array* initData, String& destinationURL, unsigned short& errorCode, uint32_t& systemCode)
 {


### PR DESCRIPTION
#### 46b462205dd97be0f9eaa729085860c288436be1
<pre>
[ macOS ] 2 http/tests/media/FairPlay tests are broken.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255294">https://bugs.webkit.org/show_bug.cgi?id=255294</a>
rdar://107891205

Reviewed by Ryosuke Niwa.

Fixing 4 related issues which keep these tests from passing consistentely:

1. When adding a MediaSource to a HTMLMediaElement via the element&apos;s .srcObject
   property, sometimes the MediaSource wrapper will be collected before the element
   has fully attached, and before the &quot;sourceopen&quot; event is fired. Mitigate this
   by returning true from virtualHasPendingActivity() in the time between when
   the MediaSource is set as srcObject and when it fires the &quot;sourceopen&quot; event.

2. HTMLMediaElement&apos;s own virtualHasPendingActivity() method will check whether
   the element is in the &quot;ended&quot; state. To do so, it calls m_player-&gt;duration(),
   which in the case of MediaSource, makes a call through a WeakPtr back up to
   the MediaSource to return _its_ duration. However, virtualHasPendingActivity()
   will be called on a background thread, and the WeakPtr accessor will throw
   an assertion. Rather than bounce down to MediaPlayer and back up to MediaSource,
   just query MediaSource directly.

   This will address the narrow issue of duration(), but the rest of the calls
   in virtualHasPendingActivity() may be non-thread-safe and further investigation
   and analysis is warranted.

3. Sometimes tests would fail with &quot;decode&quot; errors if ran back-to-back. One
   cause may be that CDM proxy objects in the GPU process are not consistently
   destroyed when their objects in the WebContent process are destroyed. Fix the
   RemoteLegacyCDMFactory to keep a WeakPtr map of CDM objects, and to track as
   those objects are created and destroyed, sending a message to the GPU process
   for its proxy to remove proxy objects.

   When the GPUConnectionToWebProcess closes, explicitly clear both the
   RemoteLegacyCDMFactory and RemoteCDMFactory objects, rather than wait for the
   connections refcount to go to zero.

   When destroying the CDMSessionAVContentKeySession, explicitly flush all
   attached SourceBufferPrivate objects, as well as removing the parser from
   the AVContentKeySession. Also explicitly expire the session before releasing
   it.

   This should cause system resources dedicated to protected playback to be more
   consistently freed after a test ends.

4. Add an explicit handler in the legacy tests which will fail the test (rather than
   time out) if the video throws an error. This will make the tests complete faster
   when video decoding fails, generating failed tests rather than time out results.

* LayoutTests/http/tests/media/fairplay/legacy-fairplay-hls.html:
* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v2.html:
* LayoutTests/http/tests/media/fairplay/legacy-fairplay-mse-v3.html:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setAsSrcObject):
(WebCore::MediaSource::virtualHasPendingActivity const):
(WebCore::MediaSource::onReadyStateChange):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSrcObject):
(WebCore::HTMLMediaElement::durationMediaTime const):
(WebCore::HTMLMediaElement::detachMediaSource):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::~CDMSessionAVContentKeySession):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::~RemoteCDMFactoryProxy):
(WebKit::RemoteCDMFactoryProxy::clear):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.cpp:
(WebKit::RemoteLegacyCDMFactoryProxy::~RemoteLegacyCDMFactoryProxy):
(WebKit::RemoteLegacyCDMFactoryProxy::clear):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::addSession):
(WebKit::RemoteLegacyCDMFactory::removeSession):
(WebKit::RemoteLegacyCDMFactory::didReceiveSessionMessage): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp:
(WebKit::RemoteLegacyCDMSession::create):
(WebKit::RemoteLegacyCDMSession::~RemoteLegacyCDMSession):

Canonical link: <a href="https://commits.webkit.org/265252@main">https://commits.webkit.org/265252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3315461f7ce8944bf3d87edd14cbfadb3e350db4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11927 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9894 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12313 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16589 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9461 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12710 "6 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9912 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8043 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9751 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->