### PR TITLE
[Cocoa] Create "NonVisualMode" to avoid visual operations for embedders that don't need it

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6697,3 +6697,9 @@ imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-f
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-first-003.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-002.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-inline/baseline-source/baseline-source-last-003.html [ Pass Failure ]
+
+# These tests are only expected to work on some ports.
+fast/dom/non-visual-mode.html [ Pass ImageOnlyFailure ]
+fast/images/non-visual-mode.html [ Pass ImageOnlyFailure ]
+fast/text/non-visual-mode.html [ Pass ImageOnlyFailure ]
+fast/transforms/non-visual-mode.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/fast/dom/non-visual-mode-expected-mismatch.html
+++ b/LayoutTests/fast/dom/non-visual-mode-expected-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div style="background: black; width: 200px; height: 200px;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/dom/non-visual-mode.html
+++ b/LayoutTests/fast/dom/non-visual-mode.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    window.internals.settings.setNonVisualModeEnabled(true);
+</script>
+</head>
+<body>
+<div style="background: black; width: 200px; height: 200px;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/images/non-visual-mode-expected-mismatch.html
+++ b/LayoutTests/fast/images/non-visual-mode-expected-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<img src="resources/green.jpg">
+</body>
+</html>

--- a/LayoutTests/fast/images/non-visual-mode.html
+++ b/LayoutTests/fast/images/non-visual-mode.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    window.internals.settings.setNonVisualModeEnabled(true);
+</script>
+</head>
+<body>
+<img src="resources/green.jpg">
+</body>
+</html>

--- a/LayoutTests/fast/text/non-visual-mode-expected-mismatch.html
+++ b/LayoutTests/fast/text/non-visual-mode-expected-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+Hello
+</body>
+</html>

--- a/LayoutTests/fast/text/non-visual-mode.html
+++ b/LayoutTests/fast/text/non-visual-mode.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    window.internals.settings.setNonVisualModeEnabled(true);
+</script>
+</head>
+<body>
+Hello
+</body>
+</html>

--- a/LayoutTests/fast/transforms/non-visual-mode-expected-mismatch.html
+++ b/LayoutTests/fast/transforms/non-visual-mode-expected-mismatch.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<div style="transform: translateZ(0); will-change: transform;">
+Hello
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/transforms/non-visual-mode.html
+++ b/LayoutTests/fast/transforms/non-visual-mode.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+    window.internals.settings.setNonVisualModeEnabled(true);
+</script>
+</head>
+<body>
+<div style="transform: translateZ(0); will-change: transform;">
+Hello
+</div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4604,3 +4604,9 @@ imported/w3c/web-platform-tests/css/filter-effects/effect-reference-feimage-001.
 imported/w3c/web-platform-tests/css/filter-effects/effect-reference-feimage-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/filter-function/filter-function-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects/svg-image-root-filter.html [ ImageOnlyFailure ]
+
+# These tests are only expected to work on some ports.
+fast/dom/non-visual-mode.html [ Pass ]
+fast/images/non-visual-mode.html [ Pass ]
+fast/text/non-visual-mode.html [ Pass ]
+fast/transforms/non-visual-mode.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2878,3 +2878,9 @@ webkit.org/b/261531 [ Monterey ] imported/w3c/web-platform-tests/css/css-transfo
 webkit.org/b/261531 [ Monterey ] imported/w3c/web-platform-tests/css/css-transforms/transform3d-sorting-003.html [ ImageOnlyFailure ]
 webkit.org/b/261531 [ Monterey ] imported/w3c/web-platform-tests/css/css-transforms/transform3d-scale-004.html [ ImageOnlyFailure ]
 webkit.org/b/261531 [ Monterey ] imported/w3c/web-platform-tests/css/css-transforms/preserve3d-and-filter-no-perspective.html [ ImageOnlyFailure ]
+
+# These tests are only expected to work on some ports.
+fast/dom/non-visual-mode.html [ Pass ]
+fast/images/non-visual-mode.html [ Pass ]
+fast/text/non-visual-mode.html [ Pass ]
+fast/transforms/non-visual-mode.html [ Pass ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4812,6 +4812,19 @@ NeedsStorageAccessFromFileURLsQuirk:
     WebCore:
       default: true
 
+NonVisualModeEnabled:
+  type: bool
+  status: embedder
+  humanReadableName: "Enables non-visual mode"
+  humanReadableDescription: "Enables a mode that doesn't show anything visually (painting, compositing, etc.)"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 NotificationEventEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4794,6 +4794,11 @@ void LocalFrameView::didPaintContents(GraphicsContext& context, const IntRect& d
 
 void LocalFrameView::paintContents(GraphicsContext& context, const IntRect& dirtyRect, SecurityOriginPaintPolicy securityOriginPaintPolicy, RegionContext* regionContext)
 {
+    if (auto* document = m_frame->document()) {
+        if (document->settings().nonVisualModeEnabled())
+            return;
+    }
+
 #ifndef NDEBUG
     bool fillWithWarningColor;
     if (m_frame->document()->printing())

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -356,7 +356,7 @@ void GraphicsLayer::setMasksToBounds(bool b)
 void GraphicsLayer::setDrawsContent(bool b)
 {
     ASSERT_IMPLIES(m_type == Type::Structural, false);
-    m_drawsContent = b;
+    m_drawsContent = b && !client().nonVisualModeEnabled();
 }
 
 const TransformationMatrix& GraphicsLayer::transform() const
@@ -575,7 +575,8 @@ void GraphicsLayer::paintGraphicsLayerContents(GraphicsContext& context, const F
         clipRect.move(offset);
     }
 
-    client().paintContents(this, context, clipRect, layerPaintBehavior);
+    if (!client().nonVisualModeEnabled())
+        client().paintContents(this, context, clipRect, layerPaintBehavior);
 }
 
 FloatRect GraphicsLayer::adjustCoverageRectForMovement(const FloatRect& coverageRect, const FloatRect& previousVisibleRect, const FloatRect& currentVisibleRect)

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -133,6 +133,8 @@ public:
     virtual TransformationMatrix transformMatrixForProperty(AnimatedProperty) const { return { }; }
 
     virtual bool layerContainsBitmapOnly(const GraphicsLayer*) const { return false; }
+
+    virtual bool nonVisualModeEnabled() { return false; }
 
 #ifndef NDEBUG
     // RenderLayerBacking overrides this to verify that it is not

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -710,8 +710,11 @@ void GraphicsLayerCA::setDrawsContent(bool drawsContent)
     if (drawsContent == m_drawsContent)
         return;
 
+    auto oldDrawsContent = this->drawsContent();
     GraphicsLayer::setDrawsContent(drawsContent);
-    noteLayerPropertyChanged(DrawsContentChanged | DebugIndicatorsChanged);
+    auto newDrawsContent = this->drawsContent();
+    if (oldDrawsContent != newDrawsContent)
+        noteLayerPropertyChanged(DrawsContentChanged | DebugIndicatorsChanged);
 }
 
 void GraphicsLayerCA::setContentsVisible(bool contentsVisible)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4290,4 +4290,9 @@ TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProp
     return matrix;
 }
 
+bool RenderLayerBacking::nonVisualModeEnabled()
+{
+    return m_owningLayer.page().settings().nonVisualModeEnabled();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -409,6 +409,8 @@ private:
     LayoutRect computePrimaryGraphicsLayerRect(const RenderLayer* compositedAncestor, const LayoutRect& parentGraphicsLayerRect) const;
 
     bool shouldSetContentsDisplayDelegate() const;
+
+    bool nonVisualModeEnabled() final;
 
     RenderLayer& m_owningLayer;
     

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -5323,6 +5323,11 @@ void RenderLayerCompositor::updateScrollSnapPropertiesWithFrameView(const LocalF
 Page& RenderLayerCompositor::page() const
 {
     return m_renderView.page();
+}
+
+bool RenderLayerCompositor::nonVisualModeEnabled()
+{
+    return page().settings().nonVisualModeEnabled();
 }
 
 TextStream& operator<<(TextStream& ts, CompositingUpdateType updateType)

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -565,6 +565,8 @@ private:
     bool isRootFrameCompositor() const;
 
     void updateCompositingForLayerTreeAsTextDump();
+
+    bool nonVisualModeEnabled() final;
 
     RenderView& m_renderView;
     Timer m_updateCompositingLayersTimer;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1394,6 +1394,16 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 - (BOOL)_appNapEnabled
 {
     return _preferences->pageVisibilityBasedProcessSuppressionEnabled();
+}
+
+- (void)_setNonVisualModeEnabled:(BOOL)enabled
+{
+    _preferences->setNonVisualModeEnabled(enabled);
+}
+
+- (BOOL)_nonVisualModeEnabled
+{
+    return _preferences->nonVisualModeEnabled();
 }
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -235,6 +235,7 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setWantsBalancedSetDefersLoadingBehavior:) BOOL _wantsBalancedSetDefersLoadingBehavior WK_API_AVAILABLE(macos(10.14));
 @property (nonatomic, setter=_setAggressiveTileRetentionEnabled:) BOOL _aggressiveTileRetentionEnabled WK_API_AVAILABLE(macos(10.14));
 @property (nonatomic, setter=_setAppNapEnabled:) BOOL _appNapEnabled WK_API_AVAILABLE(macos(10.15));
+@property (nonatomic, setter=_setNonVisualModeEnabled:) BOOL _nonVisualModeEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA));
 #endif
 
 @end


### PR DESCRIPTION
#### fe6185621fb591bc747d1859c0ec216920a8fadc
<pre>
[Cocoa] Create &quot;NonVisualMode&quot; to avoid visual operations for embedders that don&apos;t need it
<a href="https://bugs.webkit.org/show_bug.cgi?id=257948">https://bugs.webkit.org/show_bug.cgi?id=257948</a>
rdar://110625441

Reviewed by NOBODY (OOPS!).

This is a mode for embedders who don&apos;t actually visually look at the web view - e.g.
embedders who only interact with the web view programmatically. For those embedders,
there&apos;s no point actually painting anything, since no one will actually view it.
In fact, painting can actually be harmful, because it takes time to do so. If we can
make WebKit faster by just avoiding painting (which is unnecessary anyway for these
embedders) then the performance improvements could be significantly valuable.

Traditionally, the way to have a non-visual mode was to just not parent the WKWebView.
However, this has a bunch of negative repercussions like throttling timers, etc.
This new mode is intended to be used with a parented WKWebView - it just avoids
painting / compositing into it.

This patch just hooks up this setting to painting operations, but in the future it
could/should be hooked up to compositing, IOSurface creation etc. This patch starts
small, though.

Beware that painting triggers full layout. When programmatically interacting with
the page, we *should* perform enough layouts to answer whatever question we are
being asked, but it&apos;s totally possible that we missed some spots, but never caught
it because they were being masked by the fact that we&apos;re painting all the time. So
it&apos;s possible that, by avoiding painting, it makes it more likely for embedders to
hit preexisting missing layout bugs, if they exist.

Tests: fast/dom/non-visual-mode.html
       fast/images/non-visual-mode.html
       fast/text/non-visual-mode.html
       fast/transforms/non-visual-mode.html

* LayoutTests/TestExpectations:
* LayoutTests/fast/dom/non-visual-mode-expected-mismatch.html: Added.
* LayoutTests/fast/dom/non-visual-mode.html: Added.
* LayoutTests/fast/images/non-visual-mode-expected-mismatch.html: Added.
* LayoutTests/fast/images/non-visual-mode.html: Added.
* LayoutTests/fast/text/non-visual-mode-expected-mismatch.html: Added.
* LayoutTests/fast/text/non-visual-mode.html: Added.
* LayoutTests/fast/transforms/non-visual-mode-expected-mismatch.html: Added.
* LayoutTests/fast/transforms/non-visual-mode.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::GraphicsLayer):
(WebCore::GraphicsLayer::paintGraphicsLayerContents):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::nonVisualModeEnabled const):
(WebCore::GraphicsLayer::setNonVisualModeEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setNonVisualModeEnabled:]):
(-[WKPreferences _nonVisualModeEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::createGraphicsLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe6185621fb591bc747d1859c0ec216920a8fadc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/18413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/19344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/20262 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/17240 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/22057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/19144 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/16038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/21141 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/16049 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/23274 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/15964 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/17069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/21161 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/17701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/17540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14880 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/21773 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16621 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/5327 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20988 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/23013 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/17379 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/5175 "Passed tests") | 
<!--EWS-Status-Bubble-End-->