### PR TITLE
Build fix for Debian Stable after 265057@main https://bugs.webkit.org/show_bug.cgi?id=257931

### DIFF
--- a/Source/WebCore/css/CSSWordBoundaryDetectionValue.cpp
+++ b/Source/WebCore/css/CSSWordBoundaryDetectionValue.cpp
@@ -40,7 +40,8 @@ CSSWordBoundaryDetectionValue::CSSWordBoundaryDetectionValue(WordBoundaryDetecti
 String CSSWordBoundaryDetectionValue::customCSSText() const
 {
     TextStream ts;
-    WTF::switchOn(value(), [&ts](WordBoundaryDetectionNormal) {
+    // FIXME: Explicit static_cast to work around issue on libstdc++-10. Undo when upgrading GCC from 10 to 11.
+    WTF::switchOn(static_cast<WordBoundaryDetectionType>(value()), [&ts](WordBoundaryDetectionNormal) {
         ts << "normal";
     }, [&ts](WordBoundaryDetectionManual) {
         ts << "manual";

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -375,7 +375,8 @@ TextBreakIterator::LineMode::Behavior TextUtil::lineBreakIteratorMode(LineBreak 
 
 TextBreakIterator::ContentAnalysis TextUtil::contentAnalysis(const WordBoundaryDetection& wordBoundaryDetection)
 {
-    return WTF::switchOn(wordBoundaryDetection, [](WordBoundaryDetectionNormal) {
+    // FIXME: Explicit static_cast to work around issue on libstdc++-10. Undo when upgrading GCC from 10 to 11.
+    return WTF::switchOn(static_cast<WordBoundaryDetectionType>(wordBoundaryDetection), [](WordBoundaryDetectionNormal) {
         return TextBreakIterator::ContentAnalysis::Mechanical;
     }, [](WordBoundaryDetectionManual) {
         return TextBreakIterator::ContentAnalysis::Mechanical;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1041,7 +1041,8 @@ TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak lineB
 
 TextBreakIterator::ContentAnalysis mapWordBoundaryDetectionToContentAnalysis(const WordBoundaryDetection& wordBoundaryDetection)
 {
-    return WTF::switchOn(wordBoundaryDetection, [](WordBoundaryDetectionNormal) {
+    // FIXME: Explicit static_cast to work around issue on libstdc++-10. Undo when upgrading GCC from 10 to 11.
+    return WTF::switchOn(static_cast<WordBoundaryDetectionType>(wordBoundaryDetection), [](WordBoundaryDetectionNormal) {
         return TextBreakIterator::ContentAnalysis::Mechanical;
     }, [](WordBoundaryDetectionManual) {
         return TextBreakIterator::ContentAnalysis::Mechanical;

--- a/Source/WebCore/rendering/style/WordBoundaryDetection.h
+++ b/Source/WebCore/rendering/style/WordBoundaryDetection.h
@@ -48,9 +48,12 @@ public:
     bool operator==(const WordBoundaryDetection&) const = default;
 };
 
+typedef std::variant<WordBoundaryDetectionNormal, WordBoundaryDetectionManual, WordBoundaryDetectionAuto> WordBoundaryDetectionType;
+
 inline WTF::TextStream& operator<<(TextStream& ts, WordBoundaryDetection wordBoundaryDetection)
 {
-    WTF::switchOn(wordBoundaryDetection, [&ts](WordBoundaryDetectionNormal) {
+    // FIXME: Explicit static_cast to work around issue on libstdc++-10. Undo when upgrading GCC from 10 to 11.
+    WTF::switchOn(static_cast<WordBoundaryDetectionType>(wordBoundaryDetection), [&ts](WordBoundaryDetectionNormal) {
         ts << "normal";
     }, [&ts](WordBoundaryDetectionManual) {
         ts << "manual";


### PR DESCRIPTION
#### 6ff8c5f88a558334ac0631c993947f0cc5883cb6
<pre>
Build fix for Debian Stable after 265057@main <a href="https://bugs.webkit.org/show_bug.cgi?id=257931">https://bugs.webkit.org/show_bug.cgi?id=257931</a>

Reviewed by Myles C. Maxfield.

Attempt to visit an inherited variant results into a compiler error in libstdc++-10.
See: <a href="https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90943">https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90943</a>

Refactor code to work around compiler error.

* Source/WebCore/css/CSSWordBoundaryDetectionValue.cpp:
(WebCore::CSSWordBoundaryDetectionValue::customCSSText const):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::contentAnalysis):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::mapWordBoundaryDetectionToContentAnalysis):
* Source/WebCore/rendering/style/WordBoundaryDetection.h:
(WebCore::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/265109@main">https://commits.webkit.org/265109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c67eee102d83db3428e12f9a9d3a11dc23bfb2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11509 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12509 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8355 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8942 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9091 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8754 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2358 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->