### PR TITLE
REGRESSION(264622): some InteractionRegion occlusion layers are missing

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -9,12 +9,47 @@
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=1536 height=5013)
+      )
+      (children 3
+        (GraphicsLayer
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 1536.00 2008.00)
+              (event region
+                (rect (0,0) width=1536 height=2008)
 
-      (interaction regions [
-        (occlusion (0,0) width=1536 height=2008)
-        (borderRadius 0.00),
-        (occlusion (0,0) width=1536 height=5000)
-        (borderRadius 0.00)])
+              (interaction regions [
+                (occlusion (0,0) width=1536 height=2008)
+                (borderRadius 0.00)])
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1536.00 2008.00)
+          (opacity 0.50)
+          (contentsOpaque 1)
+          (event region
+            (rect (0,0) width=1536 height=2008)
+
+          (interaction regions [
+            (occlusion (0,0) width=1536 height=2008)
+            (borderRadius 0.00)])
+          )
+        )
+        (GraphicsLayer
+          (bounds 1536.00 5000.00)
+          (opacity 0.50)
+          (contentsOpaque 1)
+          (event region
+            (rect (0,0) width=1536 height=5000)
+
+          (interaction regions [
+            (occlusion (0,0) width=1536 height=5000)
+            (borderRadius 0.00)])
+          )
+        )
       )
     )
   )

--- a/LayoutTests/interaction-region/full-page-overlay.html
+++ b/LayoutTests/interaction-region/full-page-overlay.html
@@ -25,13 +25,24 @@
         .spacer {
             height: 5000px;
         }
+
+        #fixed-overlay {
+            position: fixed;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            background: rgba(0, 0, 0, 0.3);
+        }
     </style>
+    <script src="../resources/ui-helper.js"></script>
 </head>
 <body>
 <div class="tappable-overlay overlay"></div>
 <div class="spacer">
     <div id="dynamic" class="overlay"></div>
 </div>
+<div id="fixed-overlay"></div>
 
 <pre id="results"></pre>
 <script>
@@ -39,15 +50,21 @@ document.body.addEventListener("click", function(e) {
     console.log(e, "event delegation");
 });
 
-let dynamicallySizedOverlay = document.querySelector("#dynamic");
-dynamicallySizedOverlay.style.height = dynamicallySizedOverlay.parentElement.offsetHeight + "px";
-
-if (window.testRunner)
+if (window.testRunner) {
+    testRunner.waitUntilDone();
     testRunner.dumpAsText();
+}
 
 window.onload = async function () {
+    await UIHelper.renderingUpdate();
+    let dynamicallySizedOverlay = document.querySelector("#dynamic");
+    dynamicallySizedOverlay.style.height = dynamicallySizedOverlay.parentElement.offsetHeight + "px";
+    await UIHelper.renderingUpdate();
+
     if (window.internals)
        results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    if (window.testRunner)
+        testRunner.notifyDone();
 };
 </script>
 </body>

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1866,12 +1866,6 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
 
     bool hasPaintedContent = containsPaintedContent(contentsInfo);
 
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    // We need to clean-up existing Interaction Regions since we won't repaint.
-    if (!hasPaintedContent)
-        clearInteractionRegions();
-#endif
-
     // FIXME: we could refine this to only allocate backing for one of these layers if possible.
     m_graphicsLayer->setDrawsContent(hasPaintedContent);
     if (m_foregroundLayer)
@@ -2010,7 +2004,7 @@ void RenderLayerBacking::updateEventRegion()
 void RenderLayerBacking::clearInteractionRegions()
 {
     auto clearInteractionRegionsForLayer = [&](GraphicsLayer& graphicsLayer) {
-        if (graphicsLayer.eventRegion().isEmpty())
+        if (graphicsLayer.eventRegion().interactionRegions().isEmpty())
             return;
 
         EventRegion eventRegion = graphicsLayer.eventRegion();
@@ -3371,6 +3365,11 @@ void RenderLayerBacking::setRequiresOwnBackingStore(bool requiresOwnBacking)
     m_owningLayer.computeRepaintRectsIncludingDescendants();
 
     compositor().repaintInCompositedAncestor(m_owningLayer, compositedBounds());
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if (!requiresOwnBacking)
+        clearInteractionRegions();
+#endif
 }
 
 void RenderLayerBacking::setContentsNeedDisplay(GraphicsLayer::ShouldClipToLayer shouldClip)


### PR DESCRIPTION
#### 10ed5ca647f0b6e07cdf5d8c9715503ba4648e45
<pre>
REGRESSION(264622): some InteractionRegion occlusion layers are missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257952">https://bugs.webkit.org/show_bug.cgi?id=257952</a>
&lt;rdar://110631042&gt;

Reviewed by Simon Fraser.

Only clear InteractionRegions when the RenderLayerBacking stops
requiring its own backing.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateDrawsContent):
Remove the previous `clearInteractionRegions()` call.
(WebCore::RenderLayerBacking::clearInteractionRegions):
Early return when the EventRegion has no InteractionRegion.
(WebCore::RenderLayerBacking::setRequiresOwnBackingStore):
Clear InteractionRegions when `requiresOwnBaking` turns false.

* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/full-page-overlay.html:
Update test to cover the regression.

Canonical link: <a href="https://commits.webkit.org/265160@main">https://commits.webkit.org/265160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/196651b37e24c945bf3388bf1b819c4c700d7141

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11684 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12643 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12069 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16416 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9240 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12502 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8986 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2409 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->