### PR TITLE
Fix null pointer crash in WorkerScriptLoader::cancel()

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Launch a worker and terminate it before its service worker job is finished
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-worker.js
@@ -1,0 +1,2 @@
+navigator.serviceWorker.register("/WebKit/service-workers/resources/lengthy-pass.py?delay=0.5", { scope: "/WebKit/service-workers/resources/" });
+setTimeout(() => self.postMessage("ok"), 100);

--- a/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+<title>Service Worker cancel pending job</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const worker = new Worker("/WebKit/service-workers/service-worker-pending-job-cancel-worker.js");
+    await new Promise(resolve => worker.onmessage = resolve);
+    worker.terminate();
+}, "Launch a worker and terminate it before its service worker job is finished");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -173,8 +173,8 @@ void ServiceWorkerJob::notifyFinished()
 {
     ASSERT(m_creationThread.ptr() == &Thread::current());
     ASSERT(m_scriptLoader);
-    
-    auto scriptLoader = WTFMove(m_scriptLoader);
+
+    auto scriptLoader = std::exchange(m_scriptLoader, { });
 
     if (!scriptLoader->failed()) {
         m_client.jobFinishedLoadingScript(*this, scriptLoader->fetchResult());
@@ -189,8 +189,8 @@ void ServiceWorkerJob::notifyFinished()
 
 bool ServiceWorkerJob::cancelPendingLoad()
 {
-    if (auto loader = WTFMove(m_scriptLoader)) {
-        m_scriptLoader->cancel();
+    if (auto loader = std::exchange(m_scriptLoader, { })) {
+        loader->cancel();
         return true;
     }
     return false;


### PR DESCRIPTION
#### db0adb3f5ce1472cd25c86d7899d4d79f0925851
<pre>
Fix null pointer crash in WorkerScriptLoader::cancel()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257955">https://bugs.webkit.org/show_bug.cgi?id=257955</a>
rdar://110643539

Reviewed by David Kilzer.

Make sure to use the local variable loader instead of m_scriptLoader which is nullified just before.
Switch to std::exchange since it is more semantically correct.

* LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel-worker.js: Added.
* LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel.html: Added.
* Source/WebCore/workers/service/ServiceWorkerJob.cpp:
(WebCore::ServiceWorkerJob::notifyFinished):
(WebCore::ServiceWorkerJob::cancelPendingLoad):

Canonical link: <a href="https://commits.webkit.org/265070@main">https://commits.webkit.org/265070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f787a00c4a7580febb211d30697fc471a18a3e07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12410 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9871 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10713 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11536 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8831 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12314 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9475 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2329 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->