### PR TITLE
[GTK] No key modifier present in wheel event

### DIFF
--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-// FIXME: We should probably move to makeing the WebCore/PlatformFooEvents trivial classes so that
+// FIXME: We should probably move to making the WebCore/PlatformFooEvents trivial classes so that
 // we can use them as the event type.
 
 #include "WebEvent.h"

--- a/Source/WebKit/Shared/gtk/NativeWebWheelEventGtk.cpp
+++ b/Source/WebKit/Shared/gtk/NativeWebWheelEventGtk.cpp
@@ -37,8 +37,8 @@
 
 namespace WebKit {
 
-NativeWebWheelEvent::NativeWebWheelEvent(GdkEvent *event, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, const WebCore::FloatSize& delta, const WebCore::FloatSize& wheelTicks, WebWheelEvent::Phase phase, WebWheelEvent::Phase momentumPhase, bool hasPreciseDeltas)
-    : WebWheelEvent({ WebEventType::Wheel, { }, WallTime::now() }, position, globalPosition, delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, momentumPhase, hasPreciseDeltas)
+NativeWebWheelEvent::NativeWebWheelEvent(GdkEvent* event, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, const WebCore::FloatSize& delta, const WebCore::FloatSize& wheelTicks, WebWheelEvent::Phase phase, WebWheelEvent::Phase momentumPhase, bool hasPreciseDeltas)
+    : WebWheelEvent(WebEventFactory::createWebWheelEvent(event, position, globalPosition, delta, wheelTicks, phase, momentumPhase, hasPreciseDeltas))
     , m_nativeEvent(event ? constructNativeEvent(event) : nullptr)
 {
 }

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -298,4 +298,9 @@ WebTouchEvent WebEventFactory::createWebTouchEvent(const GdkEvent* event, Vector
 }
 #endif
 
+WebWheelEvent WebEventFactory::createWebWheelEvent(const GdkEvent* event, const WebCore::IntPoint& position, const WebCore::IntPoint& globalPosition, const WebCore::FloatSize& delta, const WebCore::FloatSize& wheelTicks, WebWheelEvent::Phase phase, WebWheelEvent::Phase momentumPhase, bool hasPreciseDeltas)
+{
+    return WebWheelEvent({ WebEventType::Wheel, modifiersForEvent(event), wallTimeForEvent(event) }, position, globalPosition, delta, wheelTicks, WebWheelEvent::ScrollByPixelWheelEvent, phase, momentumPhase, hasPreciseDeltas);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/gtk/WebEventFactory.h
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.h
@@ -28,6 +28,7 @@
 
 #include "WebKeyboardEvent.h"
 #include "WebMouseEvent.h"
+#include "WebWheelEvent.h"
 
 #if ENABLE(TOUCH_EVENTS)
 #include "WebTouchEvent.h"
@@ -50,6 +51,7 @@ public:
 #if ENABLE(TOUCH_EVENTS)
     static WebTouchEvent createWebTouchEvent(const GdkEvent*, Vector<WebPlatformTouchPoint>&&);
 #endif
+    static WebWheelEvent createWebWheelEvent(const GdkEvent*, const WebCore::IntPoint&, const WebCore::IntPoint&, const WebCore::FloatSize&, const WebCore::FloatSize&, WebWheelEvent::Phase, WebWheelEvent::Phase, bool hasPreciseDeltas);
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### c313668f2cf7dcce30a7bf265f0b363230927323
<pre>
[GTK] No key modifier present in wheel event
<a href="https://bugs.webkit.org/show_bug.cgi?id=257910">https://bugs.webkit.org/show_bug.cgi?id=257910</a>

Reviewed by Carlos Garcia Campos.

Pass the key modifier along with wheel events, rather than dropping it.
Thanks to Elie Donadio for debugging the problem, identifying the code
that needed fixed, and also providing a manual test case to confirm
the result.

This additionally passes along the wall time from the GdkEvent rather
than using current time.

* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/gtk/NativeWebWheelEventGtk.cpp:
(WebKit::NativeWebWheelEvent::NativeWebWheelEvent):
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::WebEventFactory::createWebWheelEvent):
* Source/WebKit/Shared/gtk/WebEventFactory.h:

Canonical link: <a href="https://commits.webkit.org/265104@main">https://commits.webkit.org/265104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4020a2386ac4060e3dfdcf09eb9d4d88ccb23ab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12413 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11541 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8015 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16238 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12316 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7729 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8657 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12882 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1116 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->