### PR TITLE
SharedMemory does not support creating a VM copy

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -92,12 +92,8 @@ void RemoteBufferProxy::copyFrom(std::span<const uint8_t> span, size_t offset)
 
     size_t actualCopySize = span.size() - offset;
     if (actualCopySize > maxCrossProcessResourceCopySize) {
-        auto sharedMemory = WebCore::SharedMemory::copySpan(span);
-        std::optional<WebCore::SharedMemoryHandle> handle;
-        if (sharedMemory)
-            handle = sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
-        auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::Copy(WTFMove(handle), offset), [sharedMemory = sharedMemory.copyRef(), handleHasValue = handle.has_value()](auto) mutable {
-            RELEASE_ASSERT(sharedMemory.get() || !handleHasValue);
+        auto handle = WebCore::SharedMemoryHandle::createCopy(span, WebCore::SharedMemory::Protection::ReadOnly);
+        auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::Copy(WTFMove(handle), offset), [](auto) {
         });
         UNUSED_VARIABLE(sendResult);
     } else {

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		7B7392EC28F84BD3007297FC /* IPCTestUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */; };
 		7B774906267CCE72009873B4 /* TestRunnerTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B774904267CCE68009873B4 /* TestRunnerTests.cpp */; };
 		7B7D096A2519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */; };
+		7B84864C2ED4465C00E34DC1 /* SharedMemoryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B84864B2ED4465C00E34DC1 /* SharedMemoryTests.cpp */; };
 		7B9FC39F28A26137007570E7 /* mainIOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CC16C4D80A00BA2BB1 /* mainIOS.mm */; };
 		7B9FC3A028A26137007570E7 /* mainMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E7765CE16C4D81100BA2BB1 /* mainMac.mm */; };
 		7B9FC3AA28A26137007570E7 /* libicucore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C83E0331D0A5F2700FEBCF3 /* libicucore.dylib */; };
@@ -3387,6 +3388,7 @@
 		7B7392EB28F84BD2007297FC /* IPCTestUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPCTestUtilities.cpp; sourceTree = "<group>"; };
 		7B774904267CCE68009873B4 /* TestRunnerTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TestRunnerTests.cpp; sourceTree = "<group>"; };
 		7B7D09692519F8F90017A078 /* WebGLNoCrashOnOtherThreadAccess.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebGLNoCrashOnOtherThreadAccess.mm; sourceTree = "<group>"; };
+		7B84864B2ED4465C00E34DC1 /* SharedMemoryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SharedMemoryTests.cpp; sourceTree = "<group>"; };
 		7B9FC57E28A26137007570E7 /* TestIPC */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestIPC; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B9FC58328A26792007570E7 /* StreamConnectionBufferTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StreamConnectionBufferTests.cpp; sourceTree = "<group>"; };
 		7B9FC58628A2682E007570E7 /* TestIPC.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = TestIPC.xcconfig; sourceTree = "<group>"; };
@@ -5318,6 +5320,7 @@
 				41973B5C1AF22875006C7B36 /* SharedBuffer.cpp */,
 				A17991891E1CA24100A505ED /* SharedBufferTest.cpp */,
 				A179918A1E1CA24100A505ED /* SharedBufferTest.h */,
+				7B84864B2ED4465C00E34DC1 /* SharedMemoryTests.cpp */,
 				ECA680CD1E68CC0900731D20 /* StringUtilities.mm */,
 				CE4D5DE51F6743BA0072CFC6 /* StringWithDirection.cpp */,
 				41E67A8425D16E83007B0A4C /* STUNMessageParsingTest.cpp */,
@@ -8032,6 +8035,7 @@
 				7C83E0521D0A641800FEBCF3 /* SharedBuffer.cpp in Sources */,
 				A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */,
 				A179918B1E1CA24100A505ED /* SharedBufferTest.cpp in Sources */,
+				7B84864C2ED4465C00E34DC1 /* SharedMemoryTests.cpp in Sources */,
 				411204CE2D3AAD8E009A8554 /* SharedVideoFrame.mm in Sources */,
 				71E88C4124B5299C00665160 /* ShareSheetTests.mm in Sources */,
 				51EB126324CA6B66000CB030 /* ShenzhenLongshengweiTechnologyGamepad.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+#include <WebCore/SharedMemory.h>
+#include <limits>
+
+#if PLATFORM(COCOA)
+#include <mach/mach.h>
+#endif
+
+namespace WebCore {
+
+void PrintTo(SharedMemory::Protection protection, ::std::ostream* o)
+{
+    if (protection == SharedMemory::Protection::ReadOnly)
+        *o << "ReadOnly";
+    else if (protection == SharedMemory::Protection::ReadWrite)
+        *o << "ReadWrite";
+    else
+        *o << "Unknown";
+}
+
+}
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+enum class MemorySource {
+    Malloc,
+    SharedMemory,
+#if PLATFORM(COCOA)
+    ExplicitMapping
+#endif
+};
+
+void PrintTo(MemorySource source, ::std::ostream* o)
+{
+    if (source == MemorySource::Malloc)
+        *o << "Malloc";
+    else if (source == MemorySource::SharedMemory)
+        *o << "SharedMemory";
+#if PLATFORM(COCOA)
+    else if (source == MemorySource::ExplicitMapping)
+        *o << "ExplicitMapping";
+#endif
+    else
+        *o << "Unknown";
+}
+
+static void fillTestPattern(std::span<uint8_t> data, size_t seed)
+{
+    for (size_t i = 0; i < 5 && i < data.size(); ++i)
+        data[i] = seed + i;
+    if (data.size() < 12)
+        return;
+    for (size_t i = 1; i < 6; ++i)
+        data[data.size() -  i] = seed + i + 77u;
+    auto mid = data.size() / 2;
+    data[mid] = seed + 99;
+}
+
+static void expectTestPattern(std::span<uint8_t> data, size_t seed)
+{
+    for (size_t i = 0; i < 5 && i < data.size(); ++i)
+        EXPECT_EQ(data[i], static_cast<uint8_t>(seed + i));
+    if (data.size() < 12)
+        return;
+    for (size_t i = 1; i < 6; ++i)
+        EXPECT_EQ(data[data.size() -  i], static_cast<uint8_t>(seed + i + 77u));
+    auto mid = data.size() / 2;
+    EXPECT_EQ(data[mid], static_cast<uint8_t>(seed + 99));
+}
+
+#if PLATFORM(COCOA)
+namespace {
+
+class VMAllocSpan {
+public:
+    VMAllocSpan() = default;
+    VMAllocSpan(std::span<uint8_t> data)
+        : m_data(data)
+    {
+    }
+    VMAllocSpan(VMAllocSpan&& other)
+    {
+        *this = WTFMove(other);
+    }
+    VMAllocSpan& operator=(VMAllocSpan&& other)
+    {
+        if (this != &other)
+            m_data = std::exchange(other.m_data, { });
+        return *this;
+    }
+    ~VMAllocSpan()
+    {
+        if (m_data.empty())
+            return;
+        kern_return_t kr = vm_deallocate(mach_task_self(), reinterpret_cast<uintptr_t>(m_data.data()), m_data.size());
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+    }
+private:
+    std::span<uint8_t> m_data;
+};
+
+}
+#endif
+
+class SharedMemoryFromMemoryTest : public testing::TestWithParam<std::tuple<uint64_t, size_t, MemorySource, SharedMemory::Protection>> {
+public:
+    auto memorySize() const { return std::get<0>(GetParam()); }
+    auto offset() const { return std::get<1>(GetParam()); }
+    auto memorySource() const { return std::get<2>(GetParam()); }
+    auto protection() const { return std::get<3>(GetParam()); }
+    std::span<uint8_t> allocate();
+protected:
+    static constexpr uint64_t sizeOkToSkip = sizeof(size_t) == 4 ? 2 * GB : 4 * GB;
+#if PLATFORM(COCOA)
+    using Source = std::variant<std::unique_ptr<uint8_t[]>, RefPtr<SharedMemory>, VMAllocSpan>;
+#else
+    using Source = std::variant<std::unique_ptr<uint8_t[]>, RefPtr<SharedMemory>>;
+#endif
+    Source m_source;
+};
+
+std::span<uint8_t> SharedMemoryFromMemoryTest::allocate()
+{
+    auto size = static_cast<size_t>(memorySize()) + offset();
+    std::span<uint8_t> data;
+    if (memorySource() == MemorySource::Malloc) {
+        if (auto source = std::unique_ptr<uint8_t[]> { new (std::nothrow) uint8_t[size] }) {
+            data = { source.get(), size };
+            m_source = WTFMove(source);
+        }
+    }
+    if (memorySource() == MemorySource::SharedMemory) {
+        if (auto shm = SharedMemory::allocate(size)) {
+            data = shm->mutableSpan();
+            m_source = WTFMove(shm);
+        }
+    }
+#if PLATFORM(COCOA)
+    if (memorySource() == MemorySource::ExplicitMapping) {
+        // Try to create a more complex vm region. The intention would be to to get multiple kernel-side
+        // memory objects.
+        // 1. allocate a full region
+        // 2. allocate one page at the start of the full region as named memory.
+        vm_address_t dataAddress = 0;
+        vm_prot_t vmProtection = VM_PROT_READ | VM_PROT_WRITE;
+        size = std::max(size, static_cast<size_t>(vm_page_size));
+        kern_return_t kr = vm_map(mach_task_self(), &dataAddress, size, 0, VM_FLAGS_ANYWHERE | VM_FLAGS_PURGABLE, 0, 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+        memory_object_size_t memoryObjectSize = vm_page_size;
+        mach_port_t port = MACH_PORT_NULL;
+        kr = mach_make_memory_entry_64(mach_task_self(), &memoryObjectSize, 0, vmProtection | MAP_MEM_NAMED_CREATE, &port, MACH_PORT_NULL);
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+        kr = vm_map(mach_task_self(), &dataAddress, vm_page_size, 0, VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE, port, 0, false, vmProtection, vmProtection, VM_INHERIT_NONE);
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+        kr = mach_port_deallocate(mach_task_self(), port);
+        ASSERT_UNUSED(kr, kr == KERN_SUCCESS);
+        data = { static_cast<uint8_t*>(reinterpret_cast<void*>(static_cast<uintptr_t>(dataAddress))), size };
+        m_source = VMAllocSpan { data };
+    }
+#endif
+    return data.subspan(offset(), static_cast<size_t>(memorySize()));
+}
+
+// Tests creating shared memory from a VM region.
+// Tests that:
+//   * The changes made to the VM region are visible through the shared memory object.
+//   * The changes made through the shared memory object are visible to the original.
+TEST_P(SharedMemoryFromMemoryTest, CreateHandleFromMemory)
+{
+    if (memorySize() > std::numeric_limits<size_t>::max())
+        return;
+    auto data = allocate();
+    if (data.empty() && memorySize() >= sizeOkToSkip)
+        return;
+    ASSERT_FALSE(data.empty());
+    ASSERT_EQ(data.size(), memorySize());
+    fillTestPattern(data, 1);
+    expectTestPattern(data, 1);
+
+    auto handle = SharedMemory::Handle::createVMShare(data, protection());
+#if !PLATFORM(COCOA)
+    // Remove when implemented.
+    if (!handle.has_value())
+        return;
+    ASSERT_FALSE(handle.has_value());
+#endif
+    ASSERT_TRUE(handle.has_value());
+    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    ASSERT_NOT_NULL(shm2);
+    auto data2 = shm2->mutableSpan();
+    expectTestPattern(data2, 1);
+    EXPECT_NE(data.data(), data2.data());
+    // Modify the orginal VM region and observe that the modification is visible
+    // through the shared object.
+    fillTestPattern(data, 2);
+    expectTestPattern(data2, 2);
+    if (protection() == SharedMemory::Protection::ReadWrite) {
+        // Modify through the shared object and observe that the change is visible
+        // in the original VM region.
+        fillTestPattern(data2, 3);
+        expectTestPattern(data2, 3);
+        expectTestPattern(data, 3);
+    }
+}
+
+// Tests creating shared memory from a VM copy of a VM region.
+// Tests that:
+//   * The changes made to the VM region are not visible through the shared memory object.
+//   * The changes made through the shared memory object are not visible to the original.
+TEST_P(SharedMemoryFromMemoryTest, CreateHandleVMCopyFromMemory)
+{
+    if (memorySize() > std::numeric_limits<size_t>::max())
+        return;
+    auto data = allocate();
+    if (data.empty() && memorySize() >= sizeOkToSkip)
+        return;
+    ASSERT_FALSE(data.empty());
+    ASSERT_EQ(data.size(), memorySize());
+    fillTestPattern(data, 1);
+    expectTestPattern(data, 1);
+
+    auto handle = SharedMemory::Handle::createVMCopy(data, protection());
+#if !PLATFORM(COCOA)
+    // Remove when implemented.
+    if (!handle.has_value())
+        return;
+    ASSERT_FALSE(handle.has_value());
+#endif
+    ASSERT_TRUE(handle.has_value());
+    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    ASSERT_NOT_NULL(shm2);
+    auto data2 = shm2->mutableSpan();
+    expectTestPattern(data2, 1);
+    fillTestPattern(data, 2);
+    expectTestPattern(data2, 1);
+    if (protection() == SharedMemory::Protection::ReadWrite) {
+        fillTestPattern(data2, 3);
+        expectTestPattern(data2, 3);
+        expectTestPattern(data, 2);
+    }
+}
+
+// Tests creating shared memory from a physical copy of a VM region.
+// Tests that:
+//   * The changes made to the VM region are not visible through the shared memory object.
+//   * The changes made through the shared memory object are not visible to the original.
+TEST_P(SharedMemoryFromMemoryTest, CreateHandleCopyFromMemory)
+{
+    if (memorySize() > std::numeric_limits<size_t>::max())
+        return;
+    auto data = allocate();
+    if (data.empty() && memorySize() >= sizeOkToSkip)
+        return;
+    ASSERT_FALSE(data.empty());
+    ASSERT_EQ(data.size(), memorySize());
+    fillTestPattern(data, 1);
+    expectTestPattern(data, 1);
+
+    auto handle = SharedMemory::Handle::createCopy(data, protection());
+    ASSERT_TRUE(handle.has_value());
+    auto shm2 = SharedMemory::map(WTFMove(*handle), protection());
+    ASSERT_NOT_NULL(shm2);
+    auto data2 = shm2->mutableSpan();
+    expectTestPattern(data2, 1);
+    fillTestPattern(data, 2);
+    expectTestPattern(data2, 1);
+    if (protection() == SharedMemory::Protection::ReadWrite) {
+        fillTestPattern(data2, 3);
+        expectTestPattern(data2, 3);
+        expectTestPattern(data, 2);
+    }
+}
+
+#if PLATFORM(COCOA)
+#define ANY_MEMORY_SOURCE testing::Values(MemorySource::Malloc, MemorySource::SharedMemory, MemorySource::ExplicitMapping)
+#else
+#define ANY_MEMORY_SOURCE testing::Values(MemorySource::Malloc, MemorySource::SharedMemory)
+#endif
+
+INSTANTIATE_TEST_SUITE_P(SharedMemoryTest,
+    SharedMemoryFromMemoryTest,
+    testing::Combine(
+        testing::Values(1, 2, KB, 100 * KB, 500 * MB, 4 * GB + 1, 20 * GB),
+        testing::Values(0, 1, 444, 4097),
+        ANY_MEMORY_SOURCE,
+        testing::Values(SharedMemory::Protection::ReadOnly, SharedMemory::Protection::ReadWrite)),
+    TestParametersToStringFormatter());
+
+}


### PR DESCRIPTION
#### 45d559f9b97534475612b4737a25d972ef167098
<pre>
SharedMemory does not support creating a VM copy
<a href="https://bugs.webkit.org/show_bug.cgi?id=257957">https://bugs.webkit.org/show_bug.cgi?id=257957</a>
<a href="https://rdar.apple.com/problem/110644611">rdar://problem/110644611</a>

Reviewed by Mike Wyrzykowski and Ben Nham.

Add SharedMemoryHandle::createCopy() which creates a SharedMemoryHandle
out of an existing VM region.

Also add SharedMemoryHandle::create() which shares the VM region itself.

These will be used in use-cases where large immutable strings are
passed across processes and to replace memory copies for sharing
large bitmaps.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemoryHandle::createCopy):
* Source/WebCore/platform/SharedMemory.h:
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm:
(WebCore::SharedMemoryHandle::create):
(WebCore::SharedMemoryHandle::createCopy):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/SharedMemoryTests.cpp: Added.
(WebCore::PrintTo):
(TestWebKitAPI::PrintTo):
(TestWebKitAPI::fillTestPattern):
(TestWebKitAPI::expectTestPattern):
(TestWebKitAPI::SharedMemoryFromMemoryTest::memorySize const):
(TestWebKitAPI::SharedMemoryFromMemoryTest::offset const):
(TestWebKitAPI::SharedMemoryFromMemoryTest::memorySource const):
(TestWebKitAPI::SharedMemoryFromMemoryTest::protection const):
(TestWebKitAPI::SharedMemoryFromMemoryTest::allocate):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/303597@main">https://commits.webkit.org/303597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70147f260d70eaaea1874cef698c311b68b1209d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140468 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/8b04aeea-8310-4722-a191-5457ce89b332) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/5846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68978 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/4d7c848c-dc91-419d-8be2-9dd6669a84b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135879 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119105 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/175b93e6-d480-43f0-bd23-ff175b0b5ddd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/3998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1610 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83701 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143121 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37805 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110028 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3913 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58668 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5157 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33722 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/4997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5247 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5115 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->