### PR TITLE
Web Inspector: Resizing Debugger Resource/Scope Chain column doesn't survive the change of tab

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js
@@ -89,6 +89,9 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
         console.assert(sidebarPanel.navigationItem);
         this._navigationBar.insertNavigationItem(sidebarPanel.navigationItem, index);
 
+        if (this.collapsed)
+            return;
+
         this._recalculateWidth();   
     }
 
@@ -99,6 +102,9 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
 
         console.assert(sidebarPanel.navigationItem);
         this._navigationBar.removeNavigationItem(sidebarPanel.navigationItem);
+
+        if (this.collapsed)
+            return;
 
         this._recalculateWidth();
     }
@@ -174,6 +180,8 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
 
     _recalculateWidth(newWidth = this.width)
     {
+        console.assert(newWidth);
+
         // Need to add 1 because of the 1px border-inline-start or border-inline-end.
         newWidth = Math.ceil(Number.constrain(newWidth, this.minimumWidth + 1, this.maximumWidth));
         this.element.style.width = `${newWidth}px`;


### PR DESCRIPTION
#### 8303e810a6809f7f2439fb5c389329c0b7cbd1af
<pre>
Web Inspector: Resizing Debugger Resource/Scope Chain column doesn&apos;t survive the change of tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=256691">https://bugs.webkit.org/show_bug.cgi?id=256691</a>
rdar://109253229

Reviewed by Devin Rousso.

The width of the details sidebar for the Sources tab resets to its minimum width when navigating
to a tab without sidebar panels (Console, Network) or to a tab with a collapsed details sidebar (Graphics, Storage).

Navigating between tabs with visible details sidebar (Sources, Elements) doesn&apos;t reset the sidebar width.

TL;DR:

Adding and removing sidebar panels triggers `SingleSidebar._recalculateWidth(newWidth = this.width)`
without passing `newWidth` which therefore uses the default `this.width`.

While the sidebar is collapsed, `this.width` is zero (the sidebar DOM element&apos;s `offsetWidth`).

These calls clobber any previously set `width` on the sidebar with zero.
But there&apos;s a clamp function in `SingleSidebar._recalculateWidth()` which picks
the `SingleSidebar.minimumWidth` for the sidebar. This resets the sidebar width.

Detailed explantion:

--- Symptom 1

When a tab without visible sidebar panels is selected, the details sidebar gets collapsed:
- [TabBrowser._showDetailsSidebarPanelsForTabContentView():L471-L473](<a href="https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/TabBrowser.js#L471-L473)">https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/TabBrowser.js#L471-L473)</a>
- [ContentBrowserTabContentView.showDetailsSidebarPanels():L195-L196](<a href="https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js#L195-L196)">https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js#L195-L196)</a>

--- Symptom 2

The `width` getter for `SingleSidebar` returns it from the corresponding DOM node:
```
get width()
{
    return this.element.offsetWidth;
}
```

The `width` setter calls `SingleSidebar._recalculateWidth(newWidth = this.width)`:

[SingleSidebar._recalculateWidth():L175-L192](<a href="https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js#L175C5-L192)">https://github.com/WebKit/WebKit/blob/fc2cbdef688b134951ca32f386632379ea8cf49f/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js#L175C5-L192)</a>

That default function parameter, `newWidth = this.width`, is the source of the issue.

--- Explanation of issue:

When the sidebar is collapsed, the layout step is skipped in `SingleSidebar._recalculateWidth()`:

```
if (this.collapsed)
    return;

if (this._navigationBar)
    this._navigationBar.needsLayout(WI.View.LayoutReason.Resize);

if (this.selectedSidebarPanel)
    this.selectedSidebarPanel.needsLayout(WI.View.LayoutReason.Resize);
```

That means that, even though, there&apos;s a non-zero `newWidth` on the element,
the `.collapsed` CSS class on the sidebar makes its `offsetWidth` equal to zero.

When sidebar panels are added in `ContentBrowserTabContentView.showDetailsSidebarPanels()`,
they trigger layout via this call chain:

`SingleSidebar.insertSidebarPanel()`
-&gt; `SingleSidebar.didInsertSidebarPanel()`
-&gt; `SingleSidebar._recalculateWidth(newWidth = this.width)`

But in this call there is no value for `newWidth`, so it uses the default function paramter
which calls the `SingleSidebar.width` getter that returns zero (the DOM node&apos;s actual `offsetWidth`).

Luckily, there&apos;s also an immutable minimum width on the sidebar styles set by `SingleSidebar._recalculateWidth():

```
    this.element.style.width = `${newWidth}px`; // this is 0px
    this.element.style.minWidth = `${this.minimumWidth}px`; // this is 250px
```

This allows the sidebar content to be shown but at a different size than the one set when resizing the sidebar.

--- Solution:

Prevent calling `SingleSidebar._recalculateWidth()` when sidebar panels are inserted or removed
while the sidebar is collapsed. This avoids overwriting the element&apos;s inline style `width` to zero.

* Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js:
(WI.SingleSidebar.prototype.didInsertSidebarPanel):
(WI.SingleSidebar.prototype._recalculateWidth):

Canonical link: <a href="https://commits.webkit.org/265152@main">https://commits.webkit.org/265152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25e9ba688e78fbb28fd092fbbd711a93246537c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9695 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12635 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10955 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8484 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12061 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9084 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9362 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12495 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8888 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2400 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->