### PR TITLE
[Mac Catalyst] Disable spellchecking code in non-editable contexts

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
@@ -98,6 +98,9 @@ void TextCheckingControllerProxy::replaceRelativeToSelection(const WebCore::Attr
 {
     Ref frame = CheckedRef(m_page.corePage()->focusController())->focusedOrMainFrame();
     auto& frameSelection = frame->selection();
+    if (!frameSelection.selection().isContentEditable())
+        return;
+
     RefPtr root = frameSelection.rootEditableElementOrDocumentElement();
     if (!root)
         return;
@@ -165,6 +168,11 @@ void TextCheckingControllerProxy::removeAnnotationRelativeToSelection(const Stri
 
 WebCore::AttributedString TextCheckingControllerProxy::annotatedSubstringBetweenPositions(const WebCore::VisiblePosition& start, const WebCore::VisiblePosition& end)
 {
+    if (!isEditablePosition(start.deepEquivalent())) {
+        ASSERT(!isEditablePosition(end.deepEquivalent()));
+        return { };
+    }
+
     auto entireRange = makeSimpleRange(start, end);
     if (!entireRange)
         return { };

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -146,10 +146,14 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 
 @end
 
+#if !PLATFORM(MACCATALYST)
+
 @interface DragAndDropSimulator (DOMElementDrag)
 
 - (void)runFromElement:(NSString *)startSelector toElement:(NSString *)endSelector;
 
 @end
+
+#endif // !PLATFORM(MACCATALYST)
 
 #endif // ENABLE(DRAG_SUPPORT)

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.mm
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "DragAndDropSimulator.h"
 
-#if ENABLE(DRAG_SUPPORT) && PLATFORM(COCOA)
+#if ENABLE(DRAG_SUPPORT) && !PLATFORM(MACCATALYST)
 
 #import "TestWKWebView.h"
 #import <WebKit/WKWebViewPrivateForTesting.h>
@@ -52,4 +52,4 @@
 
 @end
 
-#endif // ENABLE(DRAG_SUPPORT) && PLATFORM(COCOA)
+#endif // ENABLE(DRAG_SUPPORT) && !PLATFORM(MACCATALYST)


### PR DESCRIPTION
#### 50d7d248178dab94af78bd8a20e2cba1959dcb8a
<pre>
[Mac Catalyst] Disable spellchecking code in non-editable contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=257962">https://bugs.webkit.org/show_bug.cgi?id=257962</a>
rdar://105576086

Reviewed by Aditya Keerthi.

On Mac Catalyst, the platform-driven text checking codepath is currently active even when selecting
non-editable web content (e.g. in the Books app). While this mostly has no observable effect (other
than unnecessarily calling into spellchecking APIs and attempting to fill spellchecking results back
into non-editable elements on the page), it sometimes causes the selection to change from underneath
the user, as we attempt to restore the previous text selection range underneath
`TextCheckingControllerProxy::replaceRelativeToSelection`.

To avoid this altogether, add a couple of editability checks in `TextCheckingControllerProxy`, such
that we return early in the case where the relevant selection or context range is not in editable
content. Since this annotation text is only used for platform spellchecking, there&apos;s no need to
extract this text via `TextIterator` upon every selection change.

Test: DocumentEditingContext.RequestAnnotationsForTextChecking

* Source/WebKit/WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm:
(WebKit::TextCheckingControllerProxy::replaceRelativeToSelection):
(WebKit::TextCheckingControllerProxy::annotatedSubstringBetweenPositions):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.mm:

Additionally fix the TestWebKitAPI build on Catalyst. The build was failing with a linker error
because the main `@implementation` of `DragAndDropSimulator` is guarded by `!PLATFORM(MACCATALYST)`,
but the `DOMElementDrag` category is not. For now, we address this by adding `!PLATFORM(MACCATALYST)`
checks for consistency with the main iOS-specific implementation, but in the future, we should
refactor `DragAndDropSimulator` to work properly on Catalyst.

Canonical link: <a href="https://commits.webkit.org/265082@main">https://commits.webkit.org/265082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05c4229a6588ce0bc7268f716eb189622af79183

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12422 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10722 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11553 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16248 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9125 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12326 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9490 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8666 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2341 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->