### PR TITLE
unset std::optional may be dereferenced in currentUserInterfaceIdiom()

### DIFF
--- a/Source/WebKit/Shared/UserInterfaceIdiom.mm
+++ b/Source/WebKit/Shared/UserInterfaceIdiom.mm
@@ -53,7 +53,7 @@ UserInterfaceIdiom currentUserInterfaceIdiom()
 {
     if (!s_currentUserInterfaceIdiom)
         updateCurrentUserInterfaceIdiom();
-    return *s_currentUserInterfaceIdiom;
+    return s_currentUserInterfaceIdiom.value_or(UserInterfaceIdiom::Default);
 }
 
 void setCurrentUserInterfaceIdiom(UserInterfaceIdiom idiom)


### PR DESCRIPTION
#### 9b3f38967bcdfcb722cb81f90660e478bbb4eeea
<pre>
unset std::optional may be dereferenced in currentUserInterfaceIdiom()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257966">https://bugs.webkit.org/show_bug.cgi?id=257966</a>
rdar://110626776

Reviewed by Wenson Hsieh.

updateCurrentUserInterfaceIdiom() doesn&apos;t set s_currentUserInterfaceIdiom
if s_currentUserInterfaceIdiom was previously unset and the new value is
UserInterfaceIdiom::Default. Therefore, use value_or(UserInterfaceIdiom::Default)
instead of dereferencing s_currentUserInterfaceIdiom unconditionally.

* Source/WebKit/Shared/UserInterfaceIdiom.mm:
(WebKit::currentUserInterfaceIdiom):

Canonical link: <a href="https://commits.webkit.org/265076@main">https://commits.webkit.org/265076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abbeb3b47a22b9aa5cfbf8d4bd415e7c14cabd64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11394 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9889 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10723 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11554 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8027 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16250 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12328 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9491 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2337 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->