### PR TITLE
[Cocoa] Assume the orientation of an "external unknown" camera is 0

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -115,6 +115,8 @@ private:
 
     AVCaptureDevice* device() const { return m_device.get(); }
 
+    IntDegrees sensorOrientationFromVideoOutput();
+
 #if !RELEASE_LOG_DISABLED
     const char* logClassName() const override { return "AVVideoCaptureSource"; }
 #endif

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -507,9 +507,12 @@ static inline IntDegrees sensorOrientation(AVCaptureVideoOrientation videoOrient
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-static inline IntDegrees sensorOrientationFromVideoOutput(AVCaptureVideoDataOutput* videoOutput)
+IntDegrees AVVideoCaptureSource::sensorOrientationFromVideoOutput()
 {
-    AVCaptureConnection* connection = [videoOutput connectionWithMediaType:AVMediaTypeVideo];
+    if (PAL::canLoad_AVFoundation_AVCaptureDeviceTypeExternalUnknown() && [device() deviceType] == AVCaptureDeviceTypeExternalUnknown)
+        return 0;
+
+    AVCaptureConnection* connection = [m_videoOutput connectionWithMediaType:AVMediaTypeVideo];
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return connection ? sensorOrientation([connection videoOrientation]) : 0;
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -604,7 +607,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
 
     setSessionSizeFrameRateAndZoom();
 
-    m_sensorOrientation = sensorOrientationFromVideoOutput(m_videoOutput.get());
+    m_sensorOrientation = sensorOrientationFromVideoOutput();
     computeVideoFrameRotation();
 
     return true;


### PR DESCRIPTION
#### b76de3885bc00051d230226e8e5bfdb7b3a34b46
<pre>
[Cocoa] Assume the orientation of an &quot;external unknown&quot; camera is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=257967">https://bugs.webkit.org/show_bug.cgi?id=257967</a>
rdar://110650747

Reviewed by Andy Estes.

Assume the orientation of an AVCaptureDeviceTypeExternalUnknown camera is 0
instead of checking the AVCaptureConnection&apos;s videoOrientation.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::sensorOrientationFromVideoOutput):
(WebCore::AVVideoCaptureSource::setupCaptureSession):
(WebCore::sensorOrientationFromVideoOutput): Deleted.

Canonical link: <a href="https://commits.webkit.org/265079@main">https://commits.webkit.org/265079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/040cebcde48aa78046f42699991620b75b3257ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11397 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10727 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11557 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8846 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9130 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/8994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12330 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8670 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2340 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->