### PR TITLE
Implemented SIMD trunc instructions.

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js
@@ -1,0 +1,47 @@
+//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "tests1") (param $sz i32) (result i32)
+        (i32.const 9)
+        (drop)
+        (v128.const f32x4 1.5 2.4 3.3 4.2)
+        (i32x4.relaxed_trunc_f32x4_s)
+        (return (i32x4.extract_lane 1))
+    )
+    (func (export "tests2") (param $sz i32) (result i32)
+        (v128.const f32x4 -1.4 -2.3 -3.2 -4.1)
+        (i32x4.relaxed_trunc_f32x4_s)
+        (return (i32x4.extract_lane 1))
+    )
+
+    (func (export "testu1") (param $sz i32) (result i32)
+        (v128.const f32x4 1.5 2.4 3.3 4.2)
+        (i32x4.relaxed_trunc_f32x4_u)
+        (return (i32x4.extract_lane 1))
+    )
+
+    (func (export "testu2") (param $sz i32) (result i32)
+        (v128.const f32x4 14.0 1.39 16.5 1.0)
+        (i32x4.relaxed_trunc_f32x4_u)
+        (return (i32x4.extract_lane 2))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { tests1, tests2, testu1, testu2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(tests1(42), 2)
+        assert.eq(tests2(48), -2);
+        assert.eq(testu1(48), 2);
+        assert.eq(testu2(48), 16);
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js
@@ -1,0 +1,47 @@
+//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "tests1") (param $sz i32) (result i32)
+        (i32.const 9)
+        (drop)
+        (v128.const f64x2 1.5 -1.5)
+        (i32x4.relaxed_trunc_f64x2_s_zero)
+        (return (i32x4.extract_lane 1))
+    )
+    (func (export "tests2") (param $sz i32) (result i32)
+        (v128.const f64x2 -1.4 -2.3)
+        (i32x4.relaxed_trunc_f64x2_s_zero)
+        (return (i32x4.extract_lane 2))
+    )
+
+    (func (export "testu1") (param $sz i32) (result i32)
+        (v128.const f64x2 1.5 2.4)
+        (i32x4.relaxed_trunc_f64x2_u_zero)
+        (return (i32x4.extract_lane 1))
+    )
+
+    (func (export "testu2") (param $sz i32) (result i32)
+        (v128.const f64x2 14.0 1.39)
+        (i32x4.relaxed_trunc_f64x2_u_zero)
+        (return (i32x4.extract_lane 2))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { tests1, tests2, testu1, testu2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(tests1(42), -1)
+        assert.eq(tests2(48), 0);
+        assert.eq(testu1(48), 2);
+        assert.eq(testu2(48), 0);
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4277,6 +4277,7 @@ private:
             emitSIMDUnaryOp(Air::VectorTrunc);
             return;
         case B3::VectorTruncSat:
+        case B3::VectorRelaxedTruncSat:
             if (isX86()) {
                 SIMDValue* value = m_value->as<SIMDValue>();
                 Tmp v = tmp(value->child(0));

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -540,6 +540,9 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorRelaxedSwizzle:
         out.print("VectorRelaxedSwizzle");
         return;
+    case VectorRelaxedTruncSat:
+        out.print("VectorRelaxedTruncSat");
+        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -420,6 +420,7 @@ enum Opcode : uint8_t {
     // Relaxed SIMD
 
     VectorRelaxedSwizzle,
+    VectorRelaxedTruncSat,
 
     // Currently only some architectures support this.
     // FIXME: Expand this to identical instructions for the other architectures as a macro.

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -75,6 +75,7 @@ public:
         case VectorFloor:
         case VectorTrunc:
         case VectorTruncSat:
+        case VectorRelaxedTruncSat:
         case VectorConvert:
         case VectorConvertLow:
         case VectorNearest:

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -550,6 +550,7 @@ public:
             case VectorFloor:
             case VectorTrunc:
             case VectorTruncSat:
+            case VectorRelaxedTruncSat:
             case VectorNearest:
             case VectorSqrt:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -717,6 +717,7 @@ Effects Value::effects() const
     case VectorFloor:
     case VectorTrunc:
     case VectorTruncSat:
+    case VectorRelaxedTruncSat:
     case VectorConvert:
     case VectorConvertLow:
     case VectorNearest:
@@ -934,6 +935,7 @@ ValueKey Value::key() const
     case VectorFloor:
     case VectorTrunc:
     case VectorTruncSat:
+    case VectorRelaxedTruncSat:
     case VectorConvert:
     case VectorConvertLow:
     case VectorNearest:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -456,6 +456,7 @@ protected:
         case VectorFloor:
         case VectorTrunc:
         case VectorTruncSat:
+        case VectorRelaxedTruncSat:
         case VectorConvert:
         case VectorConvertLow:
         case VectorNearest:
@@ -695,6 +696,7 @@ private:
         case VectorAllTrue:
         case VectorExtaddPairwise:
         case VectorDupElement:
+        case VectorRelaxedTruncSat:
             if (UNLIKELY(numArgs != 1))
                 badKind(kind, numArgs);
             return One;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -213,6 +213,7 @@ namespace JSC { namespace B3 {
     case VectorFloor: \
     case VectorTrunc: \
     case VectorTruncSat: \
+    case VectorRelaxedTruncSat: \
     case VectorConvert: \
     case VectorConvertLow: \
     case VectorNearest: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -137,6 +137,7 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorFloor:
     case VectorTrunc:
     case VectorTruncSat:
+    case VectorRelaxedTruncSat:
     case VectorConvert:
     case VectorConvertLow:
     case VectorNearest:

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -272,6 +272,8 @@ public:
         AIR_OP_CASE(Not)
         AIR_OP_CASE(Neg)
 
+        else if (op == SIMDLaneOperation::RelaxedTruncSat) airOp = B3::Air::VectorTruncSat;
+
         result = tmpForType(Types::V128);
 
         if (isX86()) {

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -419,6 +419,7 @@ public:
         B3_OP_CASE(ExtendHigh)
         B3_OP_CASE(ExtendLow)
         B3_OP_CASE(TruncSat)
+        B3_OP_CASE(RelaxedTruncSat)
         B3_OP_CASE(Not)
         B3_OP_CASE(Neg)
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -8903,6 +8903,7 @@ public:
             m_jit.vectorExtendLow(info, valueLocation.asFPR(), resultLocation.asFPR());
             return { };
         case JSC::SIMDLaneOperation::TruncSat:
+        case JSC::SIMDLaneOperation::RelaxedTruncSat:
 #if CPU(X86_64)
             switch (info.lane) {
             case SIMDLane::f64x2:

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1044,6 +1044,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
     case SIMDLaneOperation::ExtendHigh:
     case SIMDLaneOperation::ExtendLow:
     case SIMDLaneOperation::TruncSat:
+    case SIMDLaneOperation::RelaxedTruncSat:
     case SIMDLaneOperation::Not:
     case SIMDLaneOperation::Demote:
     case SIMDLaneOperation::Promote:

--- a/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
+++ b/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
@@ -112,6 +112,7 @@ enum class SIMDLaneOperation : uint8_t {
 
     // relaxed SIMD
     RelaxedSwizzle,
+    RelaxedTruncSat
 };
 
 #define FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -354,7 +355,11 @@ macro(I64x2ExtmulLowI32x4S,       0xdc,  ExtmulLow,           SIMDLane::i64x2,  
 macro(I64x2ExtmulHighI32x4S,      0xdd,  ExtmulHigh,          SIMDLane::i64x2,  SIMDSignMode::Signed) \
 macro(I64x2ExtmulLowI32x4U,       0xde,  ExtmulLow,           SIMDLane::i64x2,  SIMDSignMode::Unsigned) \
 macro(I64x2ExtmulHighI32x4U,      0xdf,  ExtmulHigh,          SIMDLane::i64x2,  SIMDSignMode::Unsigned) \
-macro(I8x16RelaxedSwizzle,        0x100, RelaxedSwizzle,      SIMDLane::i8x16,  SIMDSignMode::None)
+macro(I8x16RelaxedSwizzle,        0x100, RelaxedSwizzle,      SIMDLane::i8x16,  SIMDSignMode::None) \
+macro(I32x4RelaxedTruncF32x4S,    0x101, RelaxedTruncSat,     SIMDLane::f32x4,  SIMDSignMode::Signed) \
+macro(I32x4RelaxedTruncF32x4U,    0x102, RelaxedTruncSat,     SIMDLane::f32x4,  SIMDSignMode::Unsigned) \
+macro(I32x4RelaxedTruncF64x2SZero, 0x103, RelaxedTruncSat,     SIMDLane::f64x2,  SIMDSignMode::Signed) \
+macro(I32x4RelaxedTruncF64x2UZero, 0x104, RelaxedTruncSat,     SIMDLane::f64x2,  SIMDSignMode::Unsigned)
 
 #define FOR_EACH_WASM_EXT_SIMD_OP(macro) \
 FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -441,6 +446,7 @@ static void dumpSIMDLaneOperation(PrintStream& out, SIMDLaneOperation op)
     case SIMDLaneOperation::Neg: out.print("Neg"); break;
     case SIMDLaneOperation::MulSat: out.print("MulSat"); break;
     case SIMDLaneOperation::RelaxedSwizzle: out.print("RelaxedSwizzle"); break;
+    case SIMDLaneOperation::RelaxedTruncSat: out.print("RelaxedTruncSat"); break;
     }
 }
 MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperation);
@@ -449,7 +455,13 @@ MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperati
 
 inline bool isRelaxedSIMDOperation(SIMDLaneOperation op)
 {
-    return (op == SIMDLaneOperation::RelaxedSwizzle);
+    switch (op) {
+    case SIMDLaneOperation::RelaxedSwizzle:
+    case SIMDLaneOperation::RelaxedTruncSat:
+        return true;
+    default:
+        return false;
+    }
 }
 
 }


### PR DESCRIPTION
#### 46168caf6713a0f0287f2fa5b04861e586750c6d
<pre>
Implemented SIMD trunc instructions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257923">https://bugs.webkit.org/show_bug.cgi?id=257923</a>
rdar://problem/110554488

Reviewed by Justin Michaud.

Implemented and added tests for relaxed_trunc_f32x4_s, relaxed_trunc_f32x4_u, relaxed_trunc_f64x2_s_zero, and relaxed_trunc_64x2_u_zero.

* JSTests/wasm/stress/simd-const-relaxed-f32-trunc.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.i32.i32.const.9.drop.v128.const.f32x4.1.5.2.4.3.3.4.2.i32x4.relaxed_trunc_f32x4_s.return.i32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f32x4.1.4.2.3.3.2.4.1.i32x4.relaxed_trunc_f32x4_s.return.i32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f32x4.1.5.2.4.3.3.4.2.i32x4.relaxed_trunc_f32x4_u.return.i32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f32x4.14.0.1.39.16.5.1.0.i32x4.relaxed_trunc_f32x4_u.return.i32x4.extract_lane.2.async test):
* JSTests/wasm/stress/simd-const-relaxed-f64-trunc.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.i32.i32.const.9.drop.v128.const.f64x2.1.5.1.5.i32x4.relaxed_trunc_f64x2_s_zero.return.i32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f64x2.1.4.2.3.i32x4.relaxed_trunc_f64x2_s_zero.return.i32x4.extract_lane.2.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f64x2.1.5.2.4.i32x4.relaxed_trunc_f64x2_u_zero.return.i32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.i32.v128.const.f64x2.14.0.1.39.i32x4.relaxed_trunc_f64x2_u_zero.return.i32x4.extract_lane.2.async test):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addSIMDV_V):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSIMDV_V):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h:
(JSC::dumpSIMDLaneOperation):
(JSC::isRelaxedSIMDOperation):

Canonical link: <a href="https://commits.webkit.org/265136@main">https://commits.webkit.org/265136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f024ec7169ac07ed928d75b2654184c5a94f1f59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9928 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9625 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12565 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10877 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8412 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9003 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16341 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9282 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12423 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10071 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8813 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2576 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13039 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10341 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9428 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2561 "Passed tests") | 
<!--EWS-Status-Bubble-End-->