### PR TITLE
REGRESSION: YouTube resumes Playing during Paused Video when attempting to Select Text

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/VisionKitCoreSPI.h
@@ -302,6 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, strong) VKCImageAnalysis *analysis;
 @property (nonatomic, weak) id<VKCImageAnalysisOverlayViewDelegate> delegate;
 @property (nonatomic) BOOL wantsAutomaticContentsRectCalculation;
+@property (nonatomic, readonly) BOOL hasActiveTextSelection;
 
 - (BOOL)interactableItemExistsAtPoint:(CGPoint)point;
 - (void)setActionInfoViewHidden:(BOOL)hidden animated:(BOOL)animated;
@@ -335,6 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readwrite) BOOL highlightSelectableItems;
 @property (nonatomic, readwrite, copy, nullable) UIButtonConfigurationUpdateHandler quickActionConfigurationUpdateHandler;
 @property (nonatomic) BOOL wantsAutomaticContentsRectCalculation;
+
 - (BOOL)interactableItemExistsAtPoint:(CGPoint)point;
 - (void)resetSelection;
 - (void)setActionInfoViewHidden:(BOOL)hidden animated:(BOOL)animated;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -326,7 +326,7 @@ void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
     if ([NSCursor currentCursor] == platformCursor)
         return;
 
-    if (m_impl->imageAnalysisOverlayViewHasCursorAtPoint([m_view convertPoint:mouseLocationInScreen fromView:nil]))
+    if (m_impl->imageAnalysisOverlayViewHasInteractableItemAtPoint([m_view convertPoint:mouseLocationInScreen fromView:nil]))
         return;
 
     [platformCursor set];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -609,7 +609,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     VKCImageAnalysisOverlayView *imageAnalysisOverlayView() const { return m_imageAnalysisOverlayView.get(); }
 #endif
 
-    bool imageAnalysisOverlayViewHasCursorAtPoint(NSPoint locationInView) const;
+    bool imageAnalysisOverlayViewShouldHandleMouseEvents(NSPoint locationInWindow) const;
+    bool imageAnalysisOverlayViewHasInteractableItemAtPoint(NSPoint locationInView) const;
 
     bool acceptsPreviewPanelControl(QLPreviewPanel *);
     void beginPreviewPanelControl(QLPreviewPanel *);


### PR DESCRIPTION
#### 31474299f9ac565f0d0d0128e1c4ab7782e134b9
<pre>
REGRESSION: YouTube resumes Playing during Paused Video when attempting to Select Text
<a href="https://bugs.webkit.org/show_bug.cgi?id=257971">https://bugs.webkit.org/show_bug.cgi?id=257971</a>
rdar://104320780

Reviewed by NOBODY (OOPS!).

In full-screen video, a `VCKImageAnalysisOverlayView` is added on top of the `WKWebView` in the
view hierarchy to facilitate Live Text interaction. Previously, the `VCKImageAnalysisOverlayView`
would handle any `mouseDown` events and not pass them on to the `WKWebView`. However, a change was
made such that the view now always calls `[super mouseDown:event]`, resulting in the `WKWebView`
errenously being given mouse down events.

As a result, a `click` JS event is now being dispatched when the Live Text selection is interacted with
because the mouse down event is given to WebKit.

This PR fixes this by early returning from the `mouseDown` and `mouseUp` methods if the interaction point
is within the `VCKImageAnalysisOverlayView` bounds, and if there is an interactable item underneath the
interaction point, or if there is an active text selection.

Also renamed the `imageAnalysisOverlayViewHasInteractableItemAtPoint` function to better reflect its
meaning.

Also added an API test to verify this correct behavior.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::setCursor):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::mouseDown):
(WebKit::WebViewImpl::mouseUp):
(WebKit::WebViewImpl::imageAnalysisOverlayViewShouldHandleMouseEvents const):
(WebKit::WebViewImpl::imageAnalysisOverlayViewHasInteractableItemAtPoint const):
(WebKit::WebViewImpl::imageAnalysisOverlayViewHasCursorAtPoint const): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:
(swizzleInteractableItemExistsAtPoint):
(-[FullscreenVideoTextRecognitionWebView initWithFrame:configuration:]):
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31474299f9ac565f0d0d0128e1c4ab7782e134b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11433 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12452 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10752 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11586 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8057 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/12920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->