### PR TITLE
REGRESSION (262850@main): [ iOS, macOS Debug ] TestWebKitAPI.IPCTestingAPI.CanInterceptHasStorageAccess is a constant failure.

### DIFF
--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -95,7 +95,14 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, uin
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, uint64_t);
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, size_t);
 
-inline JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, const ObjectIdentifierGenericBase& value)
+template<typename U>
+JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, ObjectIdentifier<U>&& value)
+{
+    return jsValueForDecodedArgumentValue(globalObject, value.toUInt64());
+}
+
+template<typename U>
+JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, AtomicObjectIdentifier<U>&& value)
 {
     return jsValueForDecodedArgumentValue(globalObject, value.toUInt64());
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -416,8 +416,7 @@ TEST(IPCTestingAPI, CanInterceptAlert)
         [webView stringByEvaluatingJavaScript:@"IPC.webPageProxyID.toString()"].intValue);
 }
 
-// FIXME when rdar://108168809 is resolved
-TEST(IPCTestingAPI, DISABLED_CanInterceptHasStorageAccess)
+TEST(IPCTestingAPI, CanInterceptHasStorageAccess)
 {
     auto webView = createWebViewWithIPCTestingAPI();
 


### PR DESCRIPTION
#### cbd5d8089b51367c195902b841af603705a01544
<pre>
REGRESSION (262850@main): [ iOS, macOS Debug ] TestWebKitAPI.IPCTestingAPI.CanInterceptHasStorageAccess is a constant failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255563">https://bugs.webkit.org/show_bug.cgi?id=255563</a>
rdar://108168809

Reviewed by Alex Christensen.

In 262850@main, I modified the jsValueForDecodedArgumentValue() taking an
ObjectIdentifier&lt;U&gt; to take an ObjectIdentifierGenericBase instead, in order
to support AtomicObjectIdentifiers as well. However, this broke the API test,
indicating that the wrong jsValueForDecodedArgumentValue() is likely getting
picked now. To address the issue, I am restoring the ObjectIdentifier&lt;U&gt;
overload and introducing a new AtomicObjectIdentifier&lt;U&gt; instead.

* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArgumentValue):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/265087@main">https://commits.webkit.org/265087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62fcee305a5153c45cc9f60abc338bd44ffae908

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11423 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9778 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12443 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10743 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11576 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8864 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16268 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9013 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8687 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2345 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->