### PR TITLE
Setting unknown language to document.body.lang causes webkit to set invalid locale on a call ubrk_open (in ICU framework). This results in an assertion failure in TextBreakIteratorICU in JSC.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale-expected.txt
@@ -1,0 +1,1 @@
+Pass if no crash

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale.html
@@ -1,0 +1,8 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+       testRunner.dumpAsText();
+    document.body.append('Pass if no crash\x80');
+    document.body.lang = '-' + 'a'.repeat(155);
+  };
+</script>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -44,6 +44,7 @@
 #include "FontVariantBuilder.h"
 #include "HTMLElement.h"
 #include "LocalFrame.h"
+#include "LocaleToScriptMapping.h"
 #include "SVGElement.h"
 #include "StyleBuilderConverter.h"
 #include "StyleBuilderStateInlines.h"
@@ -810,7 +811,8 @@ inline void BuilderCustom::applyValueWebkitLocale(BuilderState& builderState, CS
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
     FontCascadeDescription fontDescription = builderState.fontDescription();
-    if (primitiveValue.valueID() == CSSValueAuto)
+    if (primitiveValue.valueID() == CSSValueAuto
+        || localeToScriptCodeForFontSelection(primitiveValue.stringValue()) == USCRIPT_COMMON)
         fontDescription.setSpecifiedLocale(nullAtom());
     else
         fontDescription.setSpecifiedLocale(AtomString { primitiveValue.stringValue() });


### PR DESCRIPTION
#### b0221933597b8539f7d7168601351ad3ad8753b6
<pre>
Setting unknown language to document.body.lang causes webkit to set invalid locale on a call ubrk_open (in ICU framework). This results in an assertion failure in TextBreakIteratorICU in JSC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257866.">https://bugs.webkit.org/show_bug.cgi?id=257866.</a>
rdar://110312470.

Reviewed by NOBODY (OOPS!).

This fix identifies the unknown language setting and modifies the locale ivar in FontDescription. This sends a null string as locale. This case is already handled by ICU framework.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/unkown-language-setting-causing-crash-due-to-incorrect-locale.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueWebkitLocale):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0221933597b8539f7d7168601351ad3ad8753b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12455 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9942 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10756 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11592 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8061 "5 flakes 4 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8879 "5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16278 "4 flakes 108 failures") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9159 "1 api test failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9027 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12357 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9531 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7767 "11 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8699 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8776 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->