### PR TITLE
Make it possible to log information about ImageBufferBackends

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -579,7 +579,7 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
 String ImageBuffer::debugDescription() const
 {
     TextStream stream;
-    stream << "ImageBuffer " << this << " " << renderingResourceIdentifier() << " " << logicalSize() << " " << resolutionScale() << "x " << renderingMode();
+    stream << "ImageBuffer " << this << " " << renderingResourceIdentifier() << " " << logicalSize() << " " << resolutionScale() << "x " << renderingMode() << " backend " << ValueOrNull(m_backend.get());
     return stream.release();
 }
 

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -165,4 +165,19 @@ AffineTransform ImageBufferBackend::calculateBaseTransform(const Parameters& par
     return baseTransform;
 }
 
+TextStream& operator<<(TextStream& ts, VolatilityState state)
+{
+    switch (state) {
+    case VolatilityState::NonVolatile: ts << "non-volatile"; break;
+    case VolatilityState::Volatile: ts << "volatile"; break;
+    }
+    return ts;
+}
+
+TextStream& operator<<(TextStream& ts, const ImageBufferBackend& imageBufferBackend)
+{
+    ts << imageBufferBackend.debugDescription();
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -44,6 +44,10 @@
 #include <cairo.h>
 #endif
 
+namespace WTF {
+class TextStream;
+}
+
 namespace WebCore {
 
 struct ImageBufferCreationContext;
@@ -165,6 +169,8 @@ public:
         return t;
     }
 
+    WEBCORE_EXPORT virtual String debugDescription() const = 0;
+
 protected:
     WEBCORE_EXPORT ImageBufferBackend(const Parameters&);
 
@@ -185,5 +191,8 @@ protected:
 
     Parameters m_parameters;
 };
+
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, VolatilityState);
+WEBCORE_EXPORT TextStream& operator<<(TextStream&, const ImageBufferBackend&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp
@@ -118,6 +118,13 @@ void ImageBufferCairoSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuff
     cairo_surface_mark_dirty_rectangle(m_surface.get(), destPointScaled.x(), destPointScaled.y(), srcRectScaled.width(), srcRectScaled.height());
 }
 
+String ImageBufferCairoSurfaceBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferCairoSurfaceBackend " << this << " " << m_surface.get();
+    return stream.release();
+}
+
 } // namespace WebCore
 
 #endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h
@@ -54,6 +54,7 @@ protected:
 
     RefPtr<NativeImage> cairoSurfaceCoerceToImage();
     unsigned bytesPerRow() const override;
+    String debugDescription() const override;
 
     RefPtr<cairo_surface_t> m_surface;
     mutable GraphicsContextCairo m_context;

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp
@@ -36,6 +36,7 @@
 #include "RuntimeApplicationChecks.h"
 #include <CoreGraphics/CoreGraphics.h>
 #include <pal/spi/cg/CoreGraphicsSPI.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -78,6 +79,13 @@ void ImageBufferCGBackend::applyBaseTransform(GraphicsContextCG& context) const
 {
     context.applyDeviceScaleFactor(m_parameters.resolutionScale);
     context.setCTM(calculateBaseTransform(m_parameters, originAtBottomLeftCorner()));
+}
+
+String ImageBufferCGBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferCGBackend " << this;
+    return stream.release();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h
@@ -47,6 +47,8 @@ protected:
 
     std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher() override;
 
+    String debugDescription() const override;
+
     bool originAtBottomLeftCorner() const override;
     mutable std::unique_ptr<GraphicsContextCG> m_context;
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h
@@ -59,6 +59,7 @@ protected:
     CGDisplayListImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
 
     unsigned bytesPerRow() const final;
+    String debugDescription() const final;
 
     // ImageBufferBackendSharing
     ImageBufferBackendSharing* toBackendSharing() final { return this; }

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -191,6 +191,13 @@ void CGDisplayListImageBufferBackend::putPixelBuffer(const WebCore::PixelBuffer&
     ASSERT_NOT_REACHED();
 }
 
+String CGDisplayListImageBufferBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "CGDisplayListImageBufferBackend " << this;
+    return stream.release();
+}
+
 #pragma mark - CGDisplayListAcceleratedImageBufferBackend
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(CGDisplayListAcceleratedImageBufferBackend);

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -154,4 +154,11 @@ void ImageBufferShareableBitmapBackend::putPixelBuffer(const PixelBuffer& pixelB
     ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->data());
 }
 
+String ImageBufferShareableBitmapBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferShareableBitmapBackend " << this;
+    return stream.release();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.h
@@ -68,6 +68,7 @@ public:
 
 private:
     unsigned bytesPerRow() const final;
+    String debugDescription() const final;
 
     ImageBufferBackendSharing* toBackendSharing() final { return this; }
     void releaseGraphicsContext() final { /* Do nothing. This is only relevant for IOSurface backends */ }

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h
@@ -78,6 +78,8 @@ private:
     void clearBackendHandle() final;
     bool hasBackendHandle() const final;
 
+    String debugDescription() const final;
+
     ImageBufferBackendHandle m_handle;
 
     WebCore::VolatilityState m_volatilityState { WebCore::VolatilityState::NonVolatile };

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
@@ -34,6 +34,7 @@
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -95,6 +96,13 @@ RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBackend::copyNativeImage(
         invalidateCachedNativeImage();
 
     return ImageBufferIOSurfaceBackend::copyNativeImage(copyBehavior);
+}
+
+String ImageBufferShareableMappedIOSurfaceBackend::debugDescription() const
+{
+    TextStream stream;
+    stream << "ImageBufferShareableMappedIOSurfaceBackend " << this << " " << ValueOrNull(m_surface.get());
+    return stream.release();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h
@@ -54,6 +54,8 @@ private:
 
     RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
 
+    String debugDescription() const final;
+
     WebCore::IOSurfaceSeed m_lastSeedWhenCopyingImage { 0 };
 };
 


### PR DESCRIPTION
#### 719385cfcd83cd3867e37566a129756e912743b0
<pre>
Make it possible to log information about ImageBufferBackends
<a href="https://bugs.webkit.org/show_bug.cgi?id=257984">https://bugs.webkit.org/show_bug.cgi?id=257984</a>
rdar://110670224

Reviewed by Said Abou-Hallawa.

Add the virtual ImageBufferBackend::debugDescription() and implement in subclasses to output useful data.

Have ImageBuffer::debugDescription() call this to log data about its backend.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::debugDescription const):
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.cpp:
(WebCore::ImageBufferCGBackend::debugDescription const):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
(WebKit::CGDisplayListImageBufferBackend::debugDescription const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp:
(WebKit::operator&lt;&lt;):
(WebKit::ImageBufferRemoteIOSurfaceBackend::debugDescription const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.h:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp:
(WebKit::ImageBufferShareableMappedIOSurfaceBackend::debugDescription const):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.h:
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.cpp:
(WebCore::ImageBufferCairoSurfaceBackend::debugDescription const):
* Source/WebCore/platform/graphics/cairo/ImageBufferCairoSurfaceBackend.h:

Canonical link: <a href="https://commits.webkit.org/265124@main">https://commits.webkit.org/265124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8de3e31eb0c4ec0b15383a42ef9728dead2f0755

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10113 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12517 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11905 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16305 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9597 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7801 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8760 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2371 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->