### PR TITLE
Improve Canvas ImageData noise injection algorithm

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
@@ -98,15 +98,15 @@ function fullTextCanvasImageData() {
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
 }
 
-function initialCanvasImageDataAsString(imageData, length) {
-    let stringify = "";
+function initialCanvasImageDataAsObject(imageData, length) {
     if (length < 0)
-        return "";
+        return {};
     if (length > imageData.data.length)
         length = imageData.data.length;
-    for (i = 0; i < length; i++)
-        stringify += imageData.data[i] + ",";
-    return stringify;
+    let obj = {};
+    for (let i = 0; i < length; ++i)
+      obj[i] = imageData.data[i];
+    return obj;
 }
 
 function isHorizontalLinearGradientCanvasGradient() {
@@ -134,20 +134,20 @@ function isVerticalLinearGradientCanvasGradient() {
     return true;
 }
 
-function initialTextCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullTextCanvasImageData(), length);
+function initialTextCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullTextCanvasImageData(), length);
 }
 
-function initialHorizontalLinearGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullHorizontalLinearGradientCanvasImageData(), length);
+function initialHorizontalLinearGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullHorizontalLinearGradientCanvasImageData(), length);
 }
 
-function initialVerticalLinearGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullVerticalLinearGradientCanvasImageData(), length);
+function initialVerticalLinearGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullVerticalLinearGradientCanvasImageData(), length);
 }
 
-function initialRadialGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullRadialGradientCanvasImageData(), length);
+function initialRadialGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullRadialGradientCanvasImageData(), length);
 }
 
 async function fullCanvasHash(data) {


### PR DESCRIPTION
#### e4317abe6ad69ce6d7c4be9087003cc4180790e4
<pre>
Improve Canvas ImageData noise injection algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=257574">https://bugs.webkit.org/show_bug.cgi?id=257574</a>
rdar://109271231

Reviewed by Kimmo Kinnunen.

The current algorithm attempts to recognize gradients within a PixelBuffer, but
the logic for detecting a gradient is incorrect where it assumes a gradient
region always contain strictly increase (or decreasing) colors. This assumption
resulted in poor gradient detection and very visible anomalies in some cases.
In addition, in the case where the gradient was correctly detected, in some
cases the amount of added noise was too large and it cause a clustering effect
around some colors within the resulting image.

In this patch, I modified the noise-addition algorithm such that it provides
the best result for every pixel depending on its surrounding colors, instead of
restricting special behavior to gradients. We introduce a concept of &quot;related
colors&quot; which identifies two colors as related if the difference between each
of their RGBA components is not more than 8 - this threshold was mostly chosen
by experimentation.

The algorithm proceeds as follows:
1) For each color, identify if any of the immediately surrounding colors are related.
2) If any of the colors are related, then find the colors with the smallest distance.
3) If any related colors were identified, then those colors define the upper/lower
   bounds within which noise can be added.
4) Furthermore, if any related colors were identified, then noise is restricted
   to +/-1 (~0.5%), otherwise it is restricted to +/-3 (~1%);
5) After identifying the closest surrounding colors, we define the upper and lower
   bounds for each color component.
6) Finally, each color component is mutated by adding the noise value

* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::setTightnessBounds):
(WebCore::boundingNeighbors):
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::lowerAndUpperBound):
(WebCore::adjustNeighborColorBounds):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
(WebCore::getGradientNeighbors): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html:

Canonical link: <a href="https://commits.webkit.org/265216@main">https://commits.webkit.org/265216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a78ec761fa4aba42ba868baa30e7abc690a3091

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9543 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12468 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11877 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16284 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9175 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9545 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7774 "12 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8713 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2464 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->