### PR TITLE
[WebGPU] GPUAutoLayout should have special designation

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -76,7 +76,7 @@ GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<PAL::We
     , m_lostPromise(makeUniqueRef<LostPromise>())
     , m_backing(WTFMove(backing))
     , m_queue(GPUQueue::create(Ref { m_backing->queue() }))
-    , m_autoPipelineLayout(createPipelineLayout({ { "autoLayout"_s, }, { } }))
+    , m_autoPipelineLayout(createAutoPipelineLayout())
 {
 }
 
@@ -171,6 +171,14 @@ Ref<GPUExternalTexture> GPUDevice::importExternalTexture(const GPUExternalTextur
 Ref<GPUBindGroupLayout> GPUDevice::createBindGroupLayout(const GPUBindGroupLayoutDescriptor& bindGroupLayoutDescriptor)
 {
     return GPUBindGroupLayout::create(m_backing->createBindGroupLayout(bindGroupLayoutDescriptor.convertToBacking()));
+}
+
+Ref<GPUPipelineLayout> GPUDevice::createAutoPipelineLayout()
+{
+    return GPUPipelineLayout::create(m_backing->createPipelineLayout(PAL::WebGPU::PipelineLayoutDescriptor {
+        { "autoLayout"_s, },
+        std::nullopt
+    }));
 }
 
 Ref<GPUPipelineLayout> GPUDevice::createPipelineLayout(const GPUPipelineLayoutDescriptor& pipelineLayoutDescriptor)

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -136,6 +136,7 @@ private:
     // ActiveDOMObject.
     // FIXME: We probably need to override more methods to make this work properly.
     const char* activeDOMObjectName() const final { return "GPUDevice"; }
+    Ref<GPUPipelineLayout> createAutoPipelineLayout();
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return GPUDeviceEventTargetInterfaceType; }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp
@@ -229,15 +229,18 @@ Ref<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDescrip
 {
     auto label = descriptor.label.utf8();
 
-    auto backingBindGroupLayouts = descriptor.bindGroupLayouts.map([&convertToBackingContext = m_convertToBackingContext.get()](auto bindGroupLayout) {
-        return convertToBackingContext.convertToBacking(bindGroupLayout.get());
-    });
+    Vector<WGPUBindGroupLayout> backingBindGroupLayouts;
+    if (descriptor.bindGroupLayouts) {
+        backingBindGroupLayouts = descriptor.bindGroupLayouts->map([&convertToBackingContext = m_convertToBackingContext.get()](auto bindGroupLayout) {
+            return convertToBackingContext.convertToBacking(bindGroupLayout.get());
+        });
+    }
 
     WGPUPipelineLayoutDescriptor backingDescriptor {
         nullptr,
         label.data(),
-        static_cast<uint32_t>(backingBindGroupLayouts.size()),
-        backingBindGroupLayouts.data(),
+        descriptor.bindGroupLayouts ? static_cast<uint32_t>(backingBindGroupLayouts.size()) : 0,
+        descriptor.bindGroupLayouts ? backingBindGroupLayouts.data() : nullptr,
     };
 
     return PipelineLayoutImpl::create(adoptWebGPU(wgpuDeviceCreatePipelineLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPipelineLayoutDescriptor.h
@@ -34,7 +34,7 @@ namespace PAL::WebGPU {
 class BindGroupLayout;
 
 struct PipelineLayoutDescriptor : public ObjectDescriptorBase {
-    Vector<std::reference_wrapper<BindGroupLayout>> bindGroupLayouts;
+    std::optional<Vector<std::reference_wrapper<BindGroupLayout>>> bindGroupLayouts;
 };
 
 } // namespace PAL::WebGPU

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -86,9 +86,7 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
     if (!function)
         return ComputePipeline::createInvalid(*this);
 
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=257947 - GPUAutoLayout should not rely on the only
-    // layout with zero bind group layouts
-    if (!pipelineLayout.numberOfBindGroupLayouts() && entryPointInformation.defaultLayout) {
+    if (pipelineLayout.isAutoLayout() && entryPointInformation.defaultLayout) {
         Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
         addPipelineLayouts(bindGroupEntries, entryPointInformation.defaultLayout);
 

--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -42,7 +42,7 @@ class Device;
 class PipelineLayout : public WGPUPipelineLayoutImpl, public RefCounted<PipelineLayout> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<PipelineLayout> create(Vector<Ref<BindGroupLayout>>&& bindGroupLayouts, Device& device)
+    static Ref<PipelineLayout> create(std::optional<Vector<Ref<BindGroupLayout>>>&& bindGroupLayouts, Device& device)
     {
         return adoptRef(*new PipelineLayout(WTFMove(bindGroupLayouts), device));
     }
@@ -55,23 +55,24 @@ public:
 
     void setLabel(String&&);
 
-    // FIXME: Is it impossible to legitimately have no bind group layouts in a valid object?
-    bool isValid() const { return !m_bindGroupLayouts.isEmpty(); }
+    bool isValid() const { return m_isValid; }
 
     bool operator==(const PipelineLayout&) const;
 
-    size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts.size(); }
-    const BindGroupLayout& bindGroupLayout(size_t i) const { return m_bindGroupLayouts[i]; }
+    bool isAutoLayout() const { return !m_bindGroupLayouts.has_value(); }
+    size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts->size(); }
+    const BindGroupLayout& bindGroupLayout(size_t) const;
 
     Device& device() const { return m_device; }
 
 private:
-    PipelineLayout(Vector<Ref<BindGroupLayout>>&&, Device&);
+    PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&&, Device&);
     PipelineLayout(Device&);
 
-    const Vector<Ref<BindGroupLayout>> m_bindGroupLayouts;
+    std::optional<Vector<Ref<BindGroupLayout>>> m_bindGroupLayouts;
 
     const Ref<Device> m_device;
+    const bool m_isValid { true };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -37,16 +37,22 @@ Ref<PipelineLayout> Device::createPipelineLayout(const WGPUPipelineLayoutDescrip
     if (descriptor.nextInChain)
         return PipelineLayout::createInvalid(*this);
 
-    Vector<Ref<BindGroupLayout>> bindGroupLayouts;
-    bindGroupLayouts.reserveInitialCapacity(descriptor.bindGroupLayoutCount);
-    for (uint32_t i = 0; i < descriptor.bindGroupLayoutCount; ++i) {
-        auto* bindGroupLayout = descriptor.bindGroupLayouts[i];
-        bindGroupLayouts.uncheckedAppend(WebGPU::fromAPI(bindGroupLayout));
+    std::optional<Vector<Ref<BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
+    if (descriptor.bindGroupLayouts) {
+        Vector<Ref<BindGroupLayout>> bindGroupLayouts;
+        bindGroupLayouts.reserveInitialCapacity(descriptor.bindGroupLayoutCount);
+        for (uint32_t i = 0; i < descriptor.bindGroupLayoutCount; ++i) {
+            auto* bindGroupLayout = descriptor.bindGroupLayouts[i];
+            bindGroupLayouts.uncheckedAppend(WebGPU::fromAPI(bindGroupLayout));
+        }
+
+        optionalBindGroupLayouts = bindGroupLayouts;
     }
-    return PipelineLayout::create(WTFMove(bindGroupLayouts), *this);
+
+    return PipelineLayout::create(WTFMove(optionalBindGroupLayouts), *this);
 }
 
-PipelineLayout::PipelineLayout(Vector<Ref<BindGroupLayout>>&& bindGroupLayouts, Device& device)
+PipelineLayout::PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&& bindGroupLayouts, Device& device)
     : m_bindGroupLayouts(WTFMove(bindGroupLayouts))
     , m_device(device)
 {
@@ -54,6 +60,7 @@ PipelineLayout::PipelineLayout(Vector<Ref<BindGroupLayout>>&& bindGroupLayouts, 
 
 PipelineLayout::PipelineLayout(Device& device)
     : m_device(device)
+    , m_isValid(false)
 {
 }
 
@@ -69,6 +76,12 @@ bool PipelineLayout::operator==(const PipelineLayout& other) const
     UNUSED_PARAM(other);
     // FIXME: Implement this
     return false;
+}
+
+const BindGroupLayout& PipelineLayout::bindGroupLayout(size_t i) const
+{
+    RELEASE_ASSERT(m_bindGroupLayouts.has_value());
+    return (*m_bindGroupLayouts)[i];
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -551,9 +551,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
     const PipelineLayout* pipelineLayout = nullptr;
     Vector<Vector<WGPUBindGroupLayoutEntry>> bindGroupEntries;
     if (descriptor.layout) {
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=257947 - GPUAutoLayout should not rely on the only
-        // layout with zero bind group layouts
-        if (auto& layout = WebGPU::fromAPI(descriptor.layout); layout.numberOfBindGroupLayouts())
+        if (auto& layout = WebGPU::fromAPI(descriptor.layout); layout.isValid() && !layout.isAutoLayout())
             pipelineLayout = &layout;
     }
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
@@ -40,16 +40,21 @@ std::optional<PipelineLayoutDescriptor> ConvertToBackingContext::convertToBackin
     if (!base)
         return std::nullopt;
 
+    std::optional<Vector<WebGPUIdentifier>> optionalBindGroupLayouts = std::nullopt;
     Vector<WebGPUIdentifier> bindGroupLayouts;
-    bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts.size());
-    for (auto backingBindGroupLayout : pipelineLayoutDescriptor.bindGroupLayouts) {
-        auto entry = convertToBacking(backingBindGroupLayout);
-        if (!entry)
-            return std::nullopt;
-        bindGroupLayouts.uncheckedAppend(entry);
+    if (pipelineLayoutDescriptor.bindGroupLayouts) {
+        bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts->size());
+        for (auto backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts) {
+            auto entry = convertToBacking(backingBindGroupLayout);
+            if (!entry)
+                return std::nullopt;
+            bindGroupLayouts.uncheckedAppend(entry);
+        }
+
+        optionalBindGroupLayouts = bindGroupLayouts;
     }
 
-    return { { WTFMove(*base), WTFMove(bindGroupLayouts) } };
+    return { { WTFMove(*base), bindGroupLayouts } };
 }
 
 std::optional<PAL::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingContext::convertFromBacking(const PipelineLayoutDescriptor& pipelineLayoutDescriptor)
@@ -58,16 +63,21 @@ std::optional<PAL::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingContext::
     if (!base)
         return std::nullopt;
 
+    std::optional<Vector<std::reference_wrapper<PAL::WebGPU::BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
     Vector<std::reference_wrapper<PAL::WebGPU::BindGroupLayout>> bindGroupLayouts;
-    bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts.size());
-    for (const auto& backingBindGroupLayout : pipelineLayoutDescriptor.bindGroupLayouts) {
-        auto* entry = convertBindGroupLayoutFromBacking(backingBindGroupLayout);
-        if (!entry)
-            return std::nullopt;
-        bindGroupLayouts.uncheckedAppend(*entry);
+    if (pipelineLayoutDescriptor.bindGroupLayouts) {
+        bindGroupLayouts.reserveInitialCapacity(pipelineLayoutDescriptor.bindGroupLayouts->size());
+        for (const auto& backingBindGroupLayout : *pipelineLayoutDescriptor.bindGroupLayouts) {
+            auto* entry = convertBindGroupLayoutFromBacking(backingBindGroupLayout);
+            if (!entry)
+                return std::nullopt;
+            bindGroupLayouts.uncheckedAppend(*entry);
+        }
+
+        optionalBindGroupLayouts = bindGroupLayouts;
     }
 
-    return { { WTFMove(*base), WTFMove(bindGroupLayouts) } };
+    return { { WTFMove(*base), optionalBindGroupLayouts } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.h
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.h
@@ -35,7 +35,7 @@
 namespace WebKit::WebGPU {
 
 struct PipelineLayoutDescriptor : public ObjectDescriptorBase {
-    Vector<WebGPUIdentifier> bindGroupLayouts;
+    std::optional<Vector<WebGPUIdentifier>> bindGroupLayouts;
 };
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.serialization.in
@@ -22,6 +22,6 @@
 
 #if ENABLE(GPU_PROCESS)
 [AdditionalEncoder=StreamConnectionEncoder] struct WebKit::WebGPU::PipelineLayoutDescriptor : WebKit::WebGPU::ObjectDescriptorBase {
-    Vector<WebKit::WebGPUIdentifier> bindGroupLayouts;
+    std::optional<Vector<WebKit::WebGPUIdentifier>> bindGroupLayouts;
 };
 #endif


### PR DESCRIPTION
#### fc7310ff1cabbb2f44a8259c1fca73f93958396d
<pre>
[WebGPU] GPUAutoLayout should have special designation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257947">https://bugs.webkit.org/show_bug.cgi?id=257947</a>
&lt;radar://110624583&gt;

Reviewed by Myles C. Maxfield.

Instead of assuming zero bind group layouts == auto layout, use
an optional to track auto layout.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::m_autoPipelineLayout):
(WebCore::GPUDevice::createAutoPipelineLayout):
* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createPipelineLayout):
* Source/WebCore/PAL/pal/graphics/WebGPU/WebGPUPipelineLayoutDescriptor.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/PipelineLayout.h:
(WebGPU::PipelineLayout::create):
(WebGPU::PipelineLayout::isValid const):
(WebGPU::PipelineLayout::isAutoLayout const):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::Device::createPipelineLayout):
(WebGPU::PipelineLayout::PipelineLayout):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
(WebKit::WebGPU::ConvertFromBackingContext::convertFromBacking):
* Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.h:

Canonical link: <a href="https://commits.webkit.org/265134@main">https://commits.webkit.org/265134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c2fe834ab5ff7541e6867187c6acb055c351675

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12580 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10892 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11982 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9017 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9670 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8829 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2381 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->