### PR TITLE
[WebGPU] Implement validation for getBindGroupLayout

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -126,7 +126,19 @@ ComputePipeline::~ComputePipeline() = default;
 
 RefPtr<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
 {
-    return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
+    if (!isValid()) {
+        m_device->generateAValidationError("getBindGroupLayout: ComputePipeline is invalid"_s);
+        m_pipelineLayout->makeInvalid();
+        return nullptr;
+    }
+
+    if (groupIndex >= m_pipelineLayout->numberOfBindGroupLayouts()) {
+        m_device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
+        m_pipelineLayout->makeInvalid();
+        return nullptr;
+    }
+
+    return &m_pipelineLayout->bindGroupLayout(groupIndex);
 }
 
 void ComputePipeline::setLabel(String&&)

--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -61,9 +61,10 @@ public:
 
     bool isAutoLayout() const { return !m_bindGroupLayouts.has_value(); }
     size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts->size(); }
-    const BindGroupLayout& bindGroupLayout(size_t) const;
+    BindGroupLayout& bindGroupLayout(size_t) const;
 
     Device& device() const { return m_device; }
+    void makeInvalid();
 
 private:
     PipelineLayout(std::optional<Vector<Ref<BindGroupLayout>>>&&, Device&);
@@ -72,7 +73,7 @@ private:
     std::optional<Vector<Ref<BindGroupLayout>>> m_bindGroupLayouts;
 
     const Ref<Device> m_device;
-    const bool m_isValid { true };
+    bool m_isValid { true };
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -78,10 +78,16 @@ bool PipelineLayout::operator==(const PipelineLayout& other) const
     return false;
 }
 
-const BindGroupLayout& PipelineLayout::bindGroupLayout(size_t i) const
+BindGroupLayout& PipelineLayout::bindGroupLayout(size_t i) const
 {
     RELEASE_ASSERT(m_bindGroupLayouts.has_value());
     return (*m_bindGroupLayouts)[i];
+}
+
+void PipelineLayout::makeInvalid()
+{
+    m_isValid = false;
+    m_bindGroupLayouts->clear();
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -710,7 +710,19 @@ RenderPipeline::~RenderPipeline() = default;
 
 RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
 {
-    return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
+    if (!isValid()) {
+        m_device->generateAValidationError("getBindGroupLayout: RenderPipeline is invalid"_s);
+        m_pipelineLayout->makeInvalid();
+        return nullptr;
+    }
+
+    if (groupIndex >= m_pipelineLayout->numberOfBindGroupLayouts()) {
+        m_device->generateAValidationError("getBindGroupLayout: groupIndex is out of range"_s);
+        m_pipelineLayout->makeInvalid();
+        return nullptr;
+    }
+
+    return &m_pipelineLayout->bindGroupLayout(groupIndex);
 }
 
 void RenderPipeline::setLabel(String&&)

--- a/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUPipelineLayoutDescriptor.cpp
@@ -54,7 +54,7 @@ std::optional<PipelineLayoutDescriptor> ConvertToBackingContext::convertToBackin
         optionalBindGroupLayouts = bindGroupLayouts;
     }
 
-    return { { WTFMove(*base), bindGroupLayouts } };
+    return { { WTFMove(*base), WTFMove(optionalBindGroupLayouts) } };
 }
 
 std::optional<PAL::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingContext::convertFromBacking(const PipelineLayoutDescriptor& pipelineLayoutDescriptor)
@@ -77,7 +77,7 @@ std::optional<PAL::WebGPU::PipelineLayoutDescriptor> ConvertFromBackingContext::
         optionalBindGroupLayouts = bindGroupLayouts;
     }
 
-    return { { WTFMove(*base), optionalBindGroupLayouts } };
+    return { { WTFMove(*base), WTFMove(optionalBindGroupLayouts) } };
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 79d919888cc9af292a5ebfd0a98dd2dd35d99253
<pre>
[WebGPU] Implement validation for getBindGroupLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=258004">https://bugs.webkit.org/show_bug.cgi?id=258004</a>
&lt;radar://110688660&gt;

Reviewed by Myles C. Maxfield.

Implement validation as described in <a href="https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout">https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout</a>

* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/PipelineLayout.h:
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::PipelineLayout::makeInvalid):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):

Canonical link: <a href="https://commits.webkit.org/265139@main">https://commits.webkit.org/265139@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94bfd4f8ad92f00ffb43d1c45ca34a356a0dd6ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11646 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12610 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12030 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8234 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12467 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9701 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7870 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8860 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2387 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->