### PR TITLE
[Curl] Remove CFNetwork-related code in curl port

### DIFF
--- a/Source/WebCore/platform/network/curl/ResourceRequest.h
+++ b/Source/WebCore/platform/network/curl/ResourceRequest.h
@@ -29,8 +29,6 @@
 
 #include "ResourceRequestBase.h"
 
-typedef const struct _CFURLRequest* CFURLRequestRef;
-
 namespace WebCore {
 
 class ResourceRequest : public ResourceRequestBase {
@@ -56,11 +54,6 @@ public:
     {
     }
 
-    ResourceRequest(CFURLRequestRef)
-        : ResourceRequestBase()
-    {
-    }
-
     ResourceRequest(ResourceRequestBase&& base)
         : ResourceRequestBase(WTFMove(base))
     {
@@ -71,13 +64,6 @@ public:
 
     WEBCORE_EXPORT void updateFromDelegatePreservingOldProperties(const ResourceRequest&);
 
-    // Needed for compatibility.
-    CFURLRequestRef cfURLRequest(HTTPBodyUpdatePolicy) const { return 0; }
-
-    // The following two stubs are for compatibility with CFNetwork, and are not used.
-    static bool httpPipeliningEnabled() { return false; }
-    static void setHTTPPipeliningEnabled(bool) { }
-
 private:
     friend class ResourceRequestBase;
 
@@ -87,8 +73,6 @@ private:
     void doUpdateResourceHTTPBody() { }
 
     void doPlatformSetAsIsolatedCopy(const ResourceRequest&) { }
-
-    static bool s_httpPipeliningEnabled;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -28,8 +28,6 @@
 
 #include "ResourceResponseBase.h"
 
-typedef struct _CFURLResponse* CFURLResponseRef;
-
 namespace WebCore {
 
 class CurlResponse;
@@ -62,9 +60,6 @@ public:
     bool isNotModified() const;
     bool isUnauthorized() const;
     bool isProxyAuthenticationRequired() const;
-
-    // Needed for compatibility.
-    CFURLResponseRef cfURLResponse() const { return 0; }
 
 private:
     friend class ResourceResponseBase;


### PR DESCRIPTION
#### cd7cdb4d4f2755eee1a3a15a7176b3971ad2dc21
<pre>
[Curl] Remove CFNetwork-related code in curl port
<a href="https://bugs.webkit.org/show_bug.cgi?id=258008">https://bugs.webkit.org/show_bug.cgi?id=258008</a>

Reviewed by Fujii Hironori.

WinCairo WK1 was removed. So remove the CFNetwork related code
in curl port that was kept for compatibility.

* Source/WebCore/platform/network/curl/ResourceRequest.h:
(WebCore::ResourceRequest::doPlatformSetAsIsolatedCopy):
(WebCore::ResourceRequest::cfURLRequest const): Deleted.
(WebCore::ResourceRequest::httpPipeliningEnabled): Deleted.
(WebCore::ResourceRequest::setHTTPPipeliningEnabled): Deleted.
* Source/WebCore/platform/network/curl/ResourceResponse.h:

Canonical link: <a href="https://commits.webkit.org/265132@main">https://commits.webkit.org/265132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54b888c0d3b7421fbb6547e267119eeda460c205

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10023 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10828 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11909 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16299 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9233 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12379 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9601 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7805 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12988 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1124 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->