### PR TITLE
MediaStream from canvas (captureStream) cannot be rendered into a different canvas

### DIFF
--- a/LayoutTests/fast/mediastream/canvas-video-to-canvas-expected.html
+++ b/LayoutTests/fast/mediastream/canvas-video-to-canvas-expected.html
@@ -1,0 +1,12 @@
+<div>
+<canvas id="canvas1" width=100 height=100></canvas>
+<canvas id="canvas2" width=100 height=100></canvas>
+</div>
+<script>
+const context1 = canvas1.getContext('2d');
+const context2 = canvas2.getContext('2d');
+context1.fillStyle = "green";
+context1.fillRect(0, 0, 100, 100);
+context2.fillStyle = "green";
+context2.fillRect(0, 0, 100, 100);
+</script>

--- a/LayoutTests/fast/mediastream/canvas-video-to-canvas.html
+++ b/LayoutTests/fast/mediastream/canvas-video-to-canvas.html
@@ -1,0 +1,26 @@
+<div>
+<canvas id="canvas1" width=100 height=100></canvas>
+<canvas id="canvas2" width=100 height=100></canvas>
+<video id="video" width=100 height=100></video>
+</div>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function test()
+{
+     const context1 = canvas1.getContext('2d');
+     setInterval(() => {
+        context1.fillStyle = "green";
+        context1.fillRect(0, 0, 100, 100);
+    }, 100);
+    video.srcObject = canvas1.captureStream();
+    await video.play();
+    video.style.visibility = 'hidden';
+    await new Promise(resolve => setTimeout(resolve, 500));
+    canvas2.getContext('2d').drawImage(video, 0, 0);
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+test();
+</script>


### PR DESCRIPTION
#### e7326a948d62036667f2f3c35813528c145befd0
<pre>
MediaStream from canvas (captureStream) cannot be rendered into a different canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=257956">https://bugs.webkit.org/show_bug.cgi?id=257956</a>
rdar://110696945

Reviewed by Eric Carlson.

When painting a BGRA video into a canvas, we do not need to convert the video frame.
Our code path would return null and we would bail out.
Instead, we are now skipping the convert step.

* LayoutTests/fast/mediastream/canvas-video-to-canvas-expected.html: Added.
* LayoutTests/fast/mediastream/canvas-video-to-canvas.html: Added.
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::convertFrameBuffer):

Canonical link: <a href="https://commits.webkit.org/265128@main">https://commits.webkit.org/265128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba1c180f78ca0989bbb60a594b1a9f62b18c103b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9624 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10081 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/10875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9002 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12420 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9653 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->