### PR TITLE
[WGSL] Initial support for arrays of packed structs

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -56,6 +56,7 @@ public:
     Attribute::List& attributes() { return m_attributes; }
     StructureMember::List& members() { return m_members; }
     Structure* original() const { return m_original; }
+    Structure* packed() const { return m_packed; }
 
     void setRole(StructureRole role) { m_role = role; }
 
@@ -67,13 +68,19 @@ private:
         , m_members(WTFMove(members))
         , m_role(role)
         , m_original(original)
-    { }
+    {
+        if (m_original) {
+            ASSERT(m_role == StructureRole::PackedResource);
+            m_original->m_packed = this;
+        }
+    }
 
     Identifier m_name;
     Attribute::List m_attributes;
     StructureMember::List m_members;
     StructureRole m_role;
     Structure* m_original;
+    Structure* m_packed { nullptr };
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -64,6 +64,14 @@ public:
     void setUsesExternalTextures() { m_usesExternalTextures = true; }
     void clearUsesExternalTextures() { m_usesExternalTextures = false; }
 
+    bool usesPackArray() const { return m_usesPackArray; }
+    void setUsesPackArray() { m_usesPackArray = true; }
+    void clearUsesPackArray() { m_usesPackArray = false; }
+
+    bool usesUnpackArray() const { return m_usesUnpackArray; }
+    void setUsesUnpackArray() { m_usesUnpackArray = true; }
+    void clearUsesUnpackArray() { m_usesUnpackArray = false; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -167,6 +175,8 @@ public:
 private:
     String m_source;
     bool m_usesExternalTextures { false };
+    bool m_usesPackArray { false };
+    bool m_usesUnpackArray { false };
     Configuration m_configuration;
     AST::Directive::List m_directives;
     AST::Function::List m_functions;

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -22,6 +22,9 @@ var<private> m3: mat3x3<f32>;
 @group(0) @binding(2) var<storage, read_write> v1: vec3<f32>;
 @group(0) @binding(3) var<storage, read_write> v2: vec3<f32>;
 
+@group(0) @binding(4) var<storage, read_write> at1: array<T, 1>;
+@group(0) @binding(5) var<storage, read_write> at2: array<T, 1>;
+
 fn testUnpacked() -> i32
 {
     _ = t.v3f * m3;
@@ -41,6 +44,14 @@ fn testAssignment() -> i32
     t1 = t2;
     // CHECK-NEXT: parameter\d+ = __pack\(local\d+\);
     t2 = t;
+
+    // array of packed structs
+    // CHECK-NEXT: local\d+ = __unpack_array\(parameter\d+\);
+    var at = at1;
+    // CHECK-NEXT: parameter\d+ = parameter\d+;
+    at1 = at2;
+    // CHECK-NEXT: parameter\d+ = __pack_array\(local\d+\);
+    at2 = at;
 
     return 0;
 }


### PR DESCRIPTION
#### 1a6362e1cd6b9e7d2cd503d5a6e75092541f1cd1
<pre>
[WGSL] Initial support for arrays of packed structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=258010">https://bugs.webkit.org/show_bug.cgi?id=258010</a>
rdar://110698511

Reviewed by Mike Wyrzykowski.

Continue expanding the types supported to be used in resources, with the correct
packing to match the spec.

* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::packingForType):
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::packResource):
(WGSL::RewriteGlobalVariables::packStructResource):
(WGSL::RewriteGlobalVariables::packArrayResource):
(WGSL::RewriteGlobalVariables::updateReference):
(WGSL::RewriteGlobalVariables::packStructType):
(WGSL::RewriteGlobalVariables::packResourceStruct): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesPackArray const):
(WGSL::ShaderModule::setUsesPackArray):
(WGSL::ShaderModule::clearUsesPackArray):
(WGSL::ShaderModule::usesUnpackArray const):
(WGSL::ShaderModule::setUsesUnpackArray):
(WGSL::ShaderModule::clearUsesUnpackArray):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/265145@main">https://commits.webkit.org/265145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ec3ccbbca193b7684bc602169e83de2f9d05df7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9589 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12535 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11921 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8146 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16308 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12482 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8778 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->