### PR TITLE
[WGSL] Add support for index access on packed types

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -148,6 +148,20 @@ fn testFieldAccess() -> i32
     return 0;
 }
 
+fn testIndexAccess() -> i32
+{
+    // CHECK: local\d+ = __unpack_array\(parameter\d+\);
+    // CHECK-NEXT: local\d+\[0\] = __unpack\(parameter\d+\[0\]\);
+    // CHECK-NEXT: parameter\d+\[0\] = parameter\d+\[0\];
+    // CHECK-NEXT: parameter\d+\[0\] = __pack\(local\d+\[0\]\);
+    var at = at1;
+    at[0] = at1[0];
+    at1[0] = at2[0];
+    at2[0] = at[0];
+    return 0;
+}
+
+
 fn testBinaryOperations() -> i32
 {
     // CHECK: parameter\d+\.v2f\.x = \(2 \* parameter\d+\.v2f\.x\);
@@ -296,6 +310,7 @@ fn main()
     _ = testUnpacked();
     _ = testAssignment();
     _ = testFieldAccess();
+    _ = testIndexAccess();
     _ = testBinaryOperations();
     _ = testUnaryOperations();
 }


### PR DESCRIPTION
#### dc8ed15466fe404be6683cf630b404353a82ae81
<pre>
[WGSL] Add support for index access on packed types
<a href="https://bugs.webkit.org/show_bug.cgi?id=258011">https://bugs.webkit.org/show_bug.cgi?id=258011</a>
rdar://110698705

Reviewed by Mike Wyrzykowski.

During global variable rewriting, determine the resulting packing of an index access.
This is most often unpacked, but important when accessing an array of packed structs.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/265150@main">https://commits.webkit.org/265150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a0bf31339f63d22f820b25d55f25bfadf4cee6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9691 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12057 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8257 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12491 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9725 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8884 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2397 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->