### PR TITLE
Resolution context for `::backdrop` must not use element's style as parent style

### DIFF
--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -510,11 +510,14 @@ ResolutionContext TreeResolver::makeResolutionContext()
 
 ResolutionContext TreeResolver::makeResolutionContextForPseudoElement(const ElementUpdate& elementUpdate, PseudoId pseudoId)
 {
-    auto parentStyle = [&] {
+    auto parentStyle = [&]() -> const RenderStyle* {
         if (pseudoId == PseudoId::FirstLetter) {
             if (auto* firstLineStyle = elementUpdate.style->getCachedPseudoStyle(PseudoId::FirstLine))
                 return firstLineStyle;
         }
+        // ::backdrop does not inherit style, hence using the view style as parent style
+        if (pseudoId == PseudoId::Backdrop)
+            return &m_document.renderView()->style();
         return elementUpdate.style.get();
     };
 


### PR DESCRIPTION
#### e8f5190a3e2d91d46bae1157dbfd14f95106ccf2
<pre>
Resolution context for `::backdrop` must not use element&apos;s style as parent style
<a href="https://bugs.webkit.org/show_bug.cgi?id=258015">https://bugs.webkit.org/show_bug.cgi?id=258015</a>

Reviewed by Antti Koivisto.

Until a very recent &quot;Fullscreen API&quot; spec update [1], `::backdrop`
pseudo-element was not supposed to inherit from any element, including
its owner element.

But because some style-related functions expect that the parent style is
never `nullptr` we use render view style as the parent style [2].

Since it&apos;s expected behavior for now across the codebase and the tests
were not updated yet, we should use the same approach when creating
`ResultionContext` for `::backdrop` pseudo-element.

[1] <a href="https://github.com/whatwg/fullscreen/commit/666438755d2f252be1d1f73d8214ac494489d32c">https://github.com/whatwg/fullscreen/commit/666438755d2f252be1d1f73d8214ac494489d32c</a>
[2] <a href="https://github.com/WebKit/WebKit/blob/b872c8723cdbb67aafa46776c2e05066fd4ebbe2/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp#L203C6-L204">https://github.com/WebKit/WebKit/blob/b872c8723cdbb67aafa46776c2e05066fd4ebbe2/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp#L203C6-L204</a>

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::makeResolutionContextForPseudoElement):

Canonical link: <a href="https://commits.webkit.org/265300@main">https://commits.webkit.org/265300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c7d5bda959445053635054ef0242f5e9d7a0db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11546 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9597 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12540 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11929 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12397 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9624 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7820 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8784 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2524 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->