### PR TITLE
SWServerWorker::didFinishActivation is sometimes called on workers that are not in activating state

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1045,14 +1045,17 @@ void SWServer::fireInstallEvent(SWServerWorker& worker)
 
 void SWServer::runServiceWorkerAndFireActivateEvent(SWServerWorker& worker)
 {
-    runServiceWorkerIfNecessary(worker, [identifier = worker.identifier()](auto* contextConnection) {
+    runServiceWorkerIfNecessary(worker, [worker = Ref { worker }](auto* contextConnection) {
         if (!contextConnection) {
             RELEASE_LOG_ERROR(ServiceWorker, "Request to fire activate event on a worker whose context connection does not exist");
             return;
         }
 
-        RELEASE_LOG(ServiceWorker, "SWServer::runServiceWorkerAndFireActivateEvent on worker %llu", identifier.toUInt64());
-        contextConnection->fireActivateEvent(identifier);
+        if (worker->state() != ServiceWorkerState::Activating)
+            return;
+
+        RELEASE_LOG(ServiceWorker, "SWServer::runServiceWorkerAndFireActivateEvent on worker %llu", worker->identifier().toUInt64());
+        contextConnection->fireActivateEvent(worker->identifier());
     });
 }
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -201,7 +201,7 @@ void SWServerWorker::didFinishInstall(const std::optional<ServiceWorkerJobDataId
         return;
 
     ASSERT(m_server);
-    RELEASE_ASSERT(state == ServiceWorkerState::Installing);
+    RELEASE_ASSERT_WITH_MESSAGE(state == ServiceWorkerState::Installing, "State is %hhu", state);
     if (m_server)
         m_server->didFinishInstall(jobDataIdentifier, *this, wasSuccessful);
 }
@@ -213,7 +213,7 @@ void SWServerWorker::didFinishActivation()
         return;
 
     ASSERT(m_server);
-    RELEASE_ASSERT(state == ServiceWorkerState::Activating);
+    RELEASE_ASSERT_WITH_MESSAGE(state == ServiceWorkerState::Activating, "State is %hhu", state);
     if (m_server)
         m_server->didFinishActivation(*this);
 }


### PR DESCRIPTION
#### fb46eb89ed570c6cab4f55ba8d7b7cd432a99e6b
<pre>
SWServerWorker::didFinishActivation is sometimes called on workers that are not in activating state
<a href="https://bugs.webkit.org/show_bug.cgi?id=258021">https://bugs.webkit.org/show_bug.cgi?id=258021</a>
rdar://110529723

Reviewed by Chris Dumez.

After <a href="https://commits.webkit.org/264242@main">https://commits.webkit.org/264242@main</a>, activating service workers that are terminating will not send the order to activate immediately.
They will first be stopped, then the service worker will run, and then the order to activate will be sent.
The issue is that, when being stopped, the service worker is automatically moved from Activating to Activated.
When we send the order to activate and receive the didFinishActivation message, we then hit  the SWServerWorker::didFinishActivation assertion,
as the service worker is already in activated state.

To prevent this, we check whether the service worker is activating just before sending the order to activate.
This assertion is sometimes hit in bots so this code path is covered by existing tests (though this is very racy).

We update the assert to display the worker state in case this patch does not fully fix hitting this assert.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::runServiceWorkerAndFireActivateEvent):
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::didFinishInstall):
(WebCore::SWServerWorker::didFinishActivation):

Canonical link: <a href="https://commits.webkit.org/265121@main">https://commits.webkit.org/265121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eca7f9a6be1de3a5b4f0db638e2058bfd0a1b129

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9605 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12548 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11938 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16323 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9633 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8793 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->