### PR TITLE
Update VideoColorSpaceInit WebIDL according latest spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_av1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_av1-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_av1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_av1-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
-FAIL Test that isConfigSupported() returns a parsed configuration assert_equals: color transfer expected (object) null but got (undefined) undefined
+PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
 PASS Decode a key frame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -23,7 +23,7 @@ PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
 PASS Test planar constructed I420 VideoFrame with colorSpace
-FAIL Test planar constructed I420 VideoFrame with null colorSpace values Type error
+PASS Test planar constructed I420 VideoFrame with null colorSpace values
 PASS Test buffer constructed I420+Alpha VideoFrame
 PASS Test buffer constructed NV12 VideoFrame
 PASS Test buffer constructed RGB VideoFrames

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt
@@ -21,7 +21,7 @@ PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
 PASS Test planar constructed I420 VideoFrame with colorSpace
-FAIL Test planar constructed I420 VideoFrame with null colorSpace values Type error
+PASS Test planar constructed I420 VideoFrame with null colorSpace values
 PASS Test buffer constructed I420+Alpha VideoFrame
 PASS Test buffer constructed NV12 VideoFrame
 PASS Test buffer constructed RGB VideoFrames

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpaceInit.idl
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpaceInit.idl
@@ -26,8 +26,8 @@
     Conditional=VIDEO,
     JSGenerateToJSObject,
 ] dictionary VideoColorSpaceInit {
-  VideoColorPrimaries primaries;
-  VideoTransferCharacteristics transfer;
-  VideoMatrixCoefficients matrix;
-  boolean fullRange;
+  VideoColorPrimaries? primaries = null;
+  VideoTransferCharacteristics? transfer = null;
+  VideoMatrixCoefficients? matrix = null;
+  boolean? fullRange = null;
 };


### PR DESCRIPTION
#### 7e911ba2b9101e0375d6d673df3973a6fedce9c9
<pre>
Update VideoColorSpaceInit WebIDL according latest spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=258023">https://bugs.webkit.org/show_bug.cgi?id=258023</a>
rdar://110708317

Reviewed by Eric Carlson.

Marking the fields as nullable with null as the default value, as per latest spec in <a href="https://w3c.github.io/webcodecs/#dictdef-videocolorspaceinit.">https://w3c.github.io/webcodecs/#dictdef-videocolorspaceinit.</a>

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_av1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_vp9-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_av1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h264_avc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp8-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_vp9-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/VideoColorSpaceInit.idl:

Canonical link: <a href="https://commits.webkit.org/265130@main">https://commits.webkit.org/265130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb542d8b67741f87ea09d9cd274638f9ffb06d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10888 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11970 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9010 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9294 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9160 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9661 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8820 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2378 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->