### PR TITLE
InteractionRegions: improve region consolidation

### DIFF
--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -1,4 +1,5 @@
 Nested  Nested  Nested Secondary
+Tappable! Secondary
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -21,6 +22,12 @@ Nested  Nested  Nested Secondary
         (interaction (256,0) width=126 height=100)
         (borderRadius 12.00),
         (interaction (293,20) width=69 height=20)
+        (borderRadius 5.00),
+        (interaction (0,100) width=400 height=400)
+        (borderRadius 0.00),
+        (interaction (200,150) width=122 height=122)
+        (borderRadius 0.00),
+        (interaction (253,151) width=68 height=20)
         (borderRadius 5.00)])
       )
     )

--- a/LayoutTests/interaction-region/consolidated-nested-regions.html
+++ b/LayoutTests/interaction-region/consolidated-nested-regions.html
@@ -15,6 +15,32 @@
         border-radius: 5px;
         background: blue;
     }
+    .tappable-container {
+        position: relative;
+        cursor: pointer;
+        width: 400px;
+        height: 400px;
+        background: rgba(0, 0, 255, 0.5);
+    }
+    .positioning-x {
+        float: right;
+        width: 50%;
+        height: 100%;
+    }
+    .positioning-y {
+        width: 100%;
+        height: 50%;
+        margin-top: 25%;
+    }
+    .tappable {
+        position: relative;
+        display: flex;
+        align-items: center;
+
+        width: 120px;
+        height: 120px;
+        border: 1px blue dotted;
+    }
 </style>
 <body>
 <div class="nested" style="border-radius: 12px;">
@@ -42,6 +68,16 @@
                 Nested
             </div>
             <a href="#" class="secondary">Secondary</a>
+        </div>
+    </div>
+</div>
+<div class="tappable-container">
+    <div class="positioning-x">
+        <div class="positioning-y">
+            <div class="tappable">
+                Tappable!
+                <a href="#" class="secondary">Secondary</a>
+            </div>
         </div>
     </div>
 </div>

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -121,10 +121,11 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
         
         if (m_interactionRects.contains(bounds))
             return;
-        m_interactionRects.add(bounds);
 
         if (shouldConsolidateInteractionRegion(bounds, renderer))
             return;
+
+        m_interactionRects.add(bounds);
 
         auto regionIterator = m_discoveredRegionsByElement.find(interactionRegion->elementIdentifier);
         if (regionIterator != m_discoveredRegionsByElement.end()) {
@@ -175,39 +176,60 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
 
 bool EventRegionContext::shouldConsolidateInteractionRegion(IntRect bounds, RenderObject& renderer)
 {
-    if (renderer.hasVisibleBoxDecorations())
-        return false;
-
     for (auto& ancestor : ancestorsOfType<RenderElement>(renderer)) {
         if (!ancestor.element())
             continue;
 
-        auto elementIdentifier = ancestor.element()->identifier();
-        auto regionIterator = m_discoveredRegionsByElement.find(elementIdentifier);
-        if (regionIterator != m_discoveredRegionsByElement.end()) {
-            auto parentBounds = regionIterator->value.bounds();
-            if (!parentBounds.contains(bounds))
+        auto ancestorElementIdentifier = ancestor.element()->identifier();
+        auto regionIterator = m_discoveredRegionsByElement.find(ancestorElementIdentifier);
+
+        // The ancestor has no known InteractionRegion, we can skip it.
+        if (regionIterator == m_discoveredRegionsByElement.end()) {
+            // If it has a border / background, stop the search.
+            if (ancestor.hasVisibleBoxDecorations())
                 return false;
+            continue;
+        }
 
-            float marginLeft = bounds.x() - parentBounds.x();
-            float marginRight = parentBounds.maxX() - bounds.maxX();
-            float marginTop = bounds.y() - parentBounds.y();
-            float marginBottom = parentBounds.maxY() - bounds.maxY();
+        auto ancestorBounds = regionIterator->value.bounds();
 
-            constexpr auto maxMargin = 50;
+        // The ancestor's InteractionRegion does not contain ours, we don't consolidate and stop the search.
+        if (!ancestorBounds.contains(bounds))
+            return false;
 
-            if (marginLeft > maxMargin
-                || marginRight > maxMargin
-                || marginTop > maxMargin
-                || marginBottom > maxMargin)
-                return false;
+        float marginLeft = bounds.x() - ancestorBounds.x();
+        float marginRight = ancestorBounds.maxX() - bounds.maxX();
+        float marginTop = bounds.y() - ancestorBounds.y();
+        float marginBottom = ancestorBounds.maxY() - bounds.maxY();
 
+        constexpr auto maxMargin = 50;
+
+        bool canConsolidate = marginLeft <= maxMargin
+            && marginRight <= maxMargin
+            && marginTop <= maxMargin
+            && marginBottom <= maxMargin
+            && !renderer.hasVisibleBoxDecorations();
+
+        // We're consolidating the region based on this ancestor, it shouldn't be removed or candidate for removal.
+        if (canConsolidate) {
+            m_containerRemovalCandidates.remove(ancestorElementIdentifier);
+            m_containersToRemove.remove(ancestorElementIdentifier);
             return true;
         }
 
-        // If we find a border / background, stop the search.
-        if (ancestor.hasVisibleBoxDecorations())
-            return false;
+        // We can't consolidate this region but it might be a container we can remove later.
+        if (!renderer.hasVisibleBoxDecorations() && is<RenderElement>(renderer)) {
+            auto& renderElement = downcast<RenderElement>(renderer);
+            m_containerRemovalCandidates.add(renderElement.element()->identifier());
+        }
+
+        // We found a region nested inside a container candidate for removal, flag it for removal.
+        if (m_containerRemovalCandidates.contains(ancestorElementIdentifier)) {
+            m_containerRemovalCandidates.remove(ancestorElementIdentifier);
+            m_containersToRemove.add(ancestorElementIdentifier);
+        }
+
+        return false;
     }
 
     return false;
@@ -272,6 +294,10 @@ void EventRegionContext::shrinkWrapInteractionRegions()
 
 void EventRegionContext::copyInteractionRegionsToEventRegion()
 {
+    m_interactionRegions.removeAllMatching([&] (auto& region) {
+        return m_containersToRemove.contains(region.elementIdentifier);
+    });
+
     shrinkWrapInteractionRegions();
     m_eventRegion.appendInteractionRegions(m_interactionRegions);
 }

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -69,6 +69,8 @@ private:
     Vector<InteractionRegion> m_interactionRegions;
     HashSet<IntRect> m_interactionRects;
     HashSet<IntRect> m_occlusionRects;
+    HashSet<ElementIdentifier> m_containerRemovalCandidates;
+    HashSet<ElementIdentifier> m_containersToRemove;
     HashMap<ElementIdentifier, Region> m_discoveredRegionsByElement;
 #endif
 };


### PR DESCRIPTION
#### 9ac8cd985eb6d6e2f366ccd610fbd4d9fc0267b4
<pre>
InteractionRegions: improve region consolidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=258026">https://bugs.webkit.org/show_bug.cgi?id=258026</a>
&lt;rdar://110283650&gt;

Reviewed by Megan Gardner.

Introduce a new InteractionRegion consolidation method aimed at removing
superfluous regions generated for structural elements nested in an
interactive container. Typically, when the container and everything
inside has `cursor: pointer`.
This requires looking at the ancestors (are we contained by an existing
region?) and children (do we discover a nested region in the subtree
later on?).

* Source/WebCore/rendering/EventRegion.h:
Add new HashSets for containers removal tracking.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Clean-up, don&apos;t keep track of rects for interactions we consolidate.
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Add potential containers to the candidates set.
Flag containers for removal if we discover a nested interaction in
their subtree.
Add comments explaining the logic.
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
Filter out the regions flagged for removal before doing the shrink wrap.

* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions.html:
Add a new test case for this scenario.

Canonical link: <a href="https://commits.webkit.org/265186@main">https://commits.webkit.org/265186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bbf72ce77faf4a773e37353d4835a74fd5220e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12139 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9432 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12569 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9789 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7950 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2439 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->