### PR TITLE
[WGSL] Add support for call expressions with packed types

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -125,6 +125,7 @@ private:
     Packing getPacking(AST::IndexAccessExpression&);
     Packing getPacking(AST::BinaryExpression&);
     Packing getPacking(AST::UnaryExpression&);
+    Packing getPacking(AST::CallExpression&);
     Packing packingForType(const Type*);
 
     CallGraph& m_callGraph;
@@ -328,6 +329,8 @@ auto RewriteGlobalVariables::pack(Packing expectedPacking, AST::Expression& expr
         return visitAndReplace(downcast<AST::BinaryExpression>(expression));
     case AST::NodeKind::UnaryExpression:
         return visitAndReplace(downcast<AST::UnaryExpression>(expression));
+    case AST::NodeKind::CallExpression:
+        return visitAndReplace(downcast<AST::CallExpression>(expression));
     default:
         AST::Visitor::visit(expression);
         return Packing::Unpacked;
@@ -397,6 +400,13 @@ auto RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression) -> Pa
 auto RewriteGlobalVariables::getPacking(AST::UnaryExpression& expression) -> Packing
 {
     pack(Packing::Unpacked, expression.expression());
+    return Packing::Unpacked;
+}
+
+auto RewriteGlobalVariables::getPacking(AST::CallExpression& call) -> Packing
+{
+    for (auto& argument : call.arguments())
+        pack(Packing::Unpacked, argument);
     return Packing::Unpacked;
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -304,6 +304,98 @@ fn testUnaryOperations() -> i32
     return 0;
 }
 
+fn testCall() -> i32
+{
+    // CHECK: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = abs\(float3\(parameter\d+\.v3f\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = abs\(uint3\(parameter\d+\.v3u\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    t.v2f.x = abs(t1.v2f.x);
+    t.v3f.x = abs(t1.v3f.x);
+    t.v4f.x = abs(t1.v4f.x);
+    t.v2u.x = abs(t1.v2u.x);
+    t.v3u.x = abs(t1.v3u.x);
+    t.v4u.x = abs(t1.v4u.x);
+    t.v2f   = abs(t1.v2f);
+    t.v3f   = abs(t1.v3f);
+    t.v4f   = abs(t1.v4f);
+    t.v2u   = abs(t1.v2u);
+    t.v3u   = abs(t1.v3u);
+    t.v4u   = abs(t1.v4u);
+    t.f     = abs(t1.f);
+    t.u     = abs(t1.u);
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(abs\(float3\(parameter\d+\.v3f\)\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(abs\(uint3\(parameter\d+\.v3u\)\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    t1.v2f.x = abs(t2.v2f.x);
+    t1.v3f.x = abs(t2.v3f.x);
+    t1.v4f.x = abs(t2.v4f.x);
+    t1.v2u.x = abs(t2.v2u.x);
+    t1.v3u.x = abs(t2.v3u.x);
+    t1.v4u.x = abs(t2.v4u.x);
+    t1.v2f   = abs(t2.v2f);
+    t1.v3f   = abs(t2.v3f);
+    t1.v4f   = abs(t2.v4f);
+    t1.v2u   = abs(t2.v2u);
+    t1.v3u   = abs(t2.v3u);
+    t1.v4u   = abs(t2.v4u);
+    t1.f     = abs(t2.f);
+    t1.u     = abs(t2.u);
+
+    // CHECK-NEXT: parameter\d+\.v2f\.x = abs\(parameter\d+\.v2f\.x\);
+    // CHECK-NEXT: parameter\d+\.v3f\.x = abs\(parameter\d+\.v3f\.x\);
+    // CHECK-NEXT: parameter\d+\.v4f\.x = abs\(parameter\d+\.v4f\.x\);
+    // CHECK-NEXT: parameter\d+\.v2u\.x = abs\(parameter\d+\.v2u\.x\);
+    // CHECK-NEXT: parameter\d+\.v3u\.x = abs\(parameter\d+\.v3u\.x\);
+    // CHECK-NEXT: parameter\d+\.v4u\.x = abs\(parameter\d+\.v4u\.x\);
+    // CHECK-NEXT: parameter\d+\.v2f = abs\(parameter\d+\.v2f\);
+    // CHECK-NEXT: parameter\d+\.v3f = packed_float3\(abs\(parameter\d+\.v3f\)\);
+    // CHECK-NEXT: parameter\d+\.v4f = abs\(parameter\d+\.v4f\);
+    // CHECK-NEXT: parameter\d+\.v2u = abs\(parameter\d+\.v2u\);
+    // CHECK-NEXT: parameter\d+\.v3u = packed_uint3\(abs\(parameter\d+\.v3u\)\);
+    // CHECK-NEXT: parameter\d+\.v4u = abs\(parameter\d+\.v4u\);
+    // CHECK-NEXT: parameter\d+\.f = abs\(parameter\d+\.f\);
+    // CHECK-NEXT: parameter\d+\.u = abs\(parameter\d+\.u\);
+    t2.v2f.x = abs(t.v2f.x);
+    t2.v3f.x = abs(t.v3f.x);
+    t2.v4f.x = abs(t.v4f.x);
+    t2.v2u.x = abs(t.v2u.x);
+    t2.v3u.x = abs(t.v3u.x);
+    t2.v4u.x = abs(t.v4u.x);
+    t2.v2f   = abs(t.v2f);
+    t2.v3f   = abs(t.v3f);
+    t2.v4f   = abs(t.v4f);
+    t2.v2u   = abs(t.v2u);
+    t2.v3u   = abs(t.v3u);
+    t2.v4u   = abs(t.v4u);
+    t2.f     = abs(t.f);
+    t2.u     = abs(t.u);
+
+    return 0;
+}
+
 @compute @workgroup_size(1)
 fn main()
 {
@@ -313,4 +405,5 @@ fn main()
     _ = testIndexAccess();
     _ = testBinaryOperations();
     _ = testUnaryOperations();
+    _ = testCall();
 }


### PR DESCRIPTION
#### e553d772f7834fb83fa734c0ec7aa21733e0055f
<pre>
[WGSL] Add support for call expressions with packed types
<a href="https://bugs.webkit.org/show_bug.cgi?id=258029">https://bugs.webkit.org/show_bug.cgi?id=258029</a>
rdar://110712618

Reviewed by Mike Wyrzykowski.

Expand the global variable rewriter to support call expressions with packed values.
Calls work by unpacking all arguments, and their result is always unpacked.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/265151@main">https://commits.webkit.org/265151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be5eef4a69e87c581f14e749e139497235639c3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12557 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11953 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8173 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16334 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12416 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9645 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8804 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->