### PR TITLE
New fast/dom/Window/setInterval-setTimeout-zero-ordering.html test is flaky

### DIFF
--- a/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html
+++ b/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html
@@ -10,19 +10,22 @@ let setInterval0Called = false;
 let setInterval1Called = false;
 let setTimeout0Called = false;
 
-setInterval1Handle = setInterval(() => {
-    debug("* setInterval(1)");
-    shouldBeTrue("setInterval0Called");
-    shouldBeTrue("setTimeout0Called");
-    setInterval1Called = true;
-}, 1);
+function runNonZeroDelayTests()
+{
+    setInterval1Handle = setInterval(() => {
+        debug("* setInterval(1)");
+        shouldBeTrue("setInterval0Called");
+        shouldBeTrue("setTimeout0Called");
+        setInterval1Called = true;
+    }, 1);
 
-setTimeout(() => {
-    debug("* setTimeout(1)");
-    shouldBeTrue("setInterval1Called");
-    clearInterval(setInterval1Handle);
-    finishJSTest();
-}, 1);
+    setTimeout(() => {
+        debug("* setTimeout(1)");
+        shouldBeTrue("setInterval1Called");
+        clearInterval(setInterval1Handle);
+        finishJSTest();
+    }, 1);
+}
 
 setInterval0Handle = setInterval(() => {
     debug("* setInterval(0)");
@@ -34,6 +37,7 @@ setTimeout(() => {
     shouldBeTrue("setInterval0Called");
     clearInterval(setInterval0Handle);
     setTimeout0Called = true;
+    runNonZeroDelayTests();
 }, 0);
 </script>
 </body>


### PR DESCRIPTION
#### cae01009ef150d4952abb2da9140b74a7a77388b
<pre>
New fast/dom/Window/setInterval-setTimeout-zero-ordering.html test is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=258039">https://bugs.webkit.org/show_bug.cgi?id=258039</a>

Reviewed by Brent Fulgham.

Separate the testing of the zero delay timers with the 1ms delay timers
to avoid flakiness.

* LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html:

Canonical link: <a href="https://commits.webkit.org/265165@main">https://commits.webkit.org/265165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37b8154e0039f03d8d2ab00e5b62dfc33ad93af3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11978 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12435 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9667 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7849 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2411 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->