### PR TITLE
readAsDataURL.readAsDataURL() is incorrect for empty blobs

### DIFF
--- a/LayoutTests/fast/files/read-file-async-expected.txt
+++ b/LayoutTests/fast/files/read-file-async-expected.txt
@@ -60,8 +60,8 @@ Received loadstart event
 readyState: 1
 Received load event
 readyState: 2
-result size: 5
-result: data:
+result size: 37
+result: data:application/octet-stream;base64,
 Received loadend event
 Test reading a UTF-8 file as array buffer
 readyState: 0

--- a/LayoutTests/fast/files/workers/worker-read-file-async-expected.txt
+++ b/LayoutTests/fast/files/workers/worker-read-file-async-expected.txt
@@ -61,8 +61,8 @@ Received loadstart event
 readyState: 1
 Received load event
 readyState: 2
-result size: 5
-result: data:
+result size: 37
+result: data:application/octet-stream;base64,
 Received loadend event
 Test reading a UTF-8 file as array buffer
 readyState: 0

--- a/LayoutTests/fast/files/workers/worker-read-file-sync-expected.txt
+++ b/LayoutTests/fast/files/workers/worker-read-file-sync-expected.txt
@@ -25,8 +25,8 @@ result size: 0
 result:
 Received exception undefined: TypeError
 Test reading an empty file as data URL
-result size: 5
-result: data:
+result size: 37
+result: data:application/octet-stream;base64,
 Received exception undefined: TypeError
 Test reading a UTF-8 file as array buffer
 result size: 5
@@ -81,7 +81,7 @@ result size: 5
 result: Hello
 result size: 9
 result: 0x0 0x1 0x2 0x80 0x81 0x82 0xfd 0xfe 0xff
-result size: 5
-result: data:
+result size: 37
+result: data:application/octet-stream;base64,
 DONE
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any-expected.txt
@@ -2,4 +2,5 @@
 PASS FileReader readyState during readAsDataURL
 PASS readAsDataURL result for Blob with specified MIME type
 PASS readAsDataURL result for Blob with unspecified MIME type
+PASS readAsDataURL result for empty Blob
 

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any.js
@@ -40,3 +40,15 @@ async_test(function(testCase) {
   });
   reader.readAsDataURL(blob);
 }, 'readAsDataURL result for Blob with unspecified MIME type');
+
+async_test(function(testCase) {
+  var blob = new Blob([]);
+  var reader = new FileReader();
+
+  reader.onload = this.step_func(function() {
+    assert_equals(reader.result,
+                  "data:application/octet-stream;base64,");
+    testCase.done();
+  });
+  reader.readAsDataURL(blob);
+}, 'readAsDataURL result for empty Blob');

--- a/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any.worker-expected.txt
@@ -2,4 +2,5 @@
 PASS FileReader readyState during readAsDataURL
 PASS readAsDataURL result for Blob with specified MIME type
 PASS readAsDataURL result for Blob with unspecified MIME type
+PASS readAsDataURL result for empty Blob
 

--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -347,12 +347,7 @@ void FileReaderLoader::convertToText()
 
 void FileReaderLoader::convertToDataURL()
 {
-    if (!m_bytesLoaded) {
-        m_stringResult = "data:"_s;
-        return;
-    }
-
-    m_stringResult = makeString("data:", m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,", base64Encoded(m_rawData->data(), m_bytesLoaded));
+    m_stringResult = makeString("data:", m_dataType.isEmpty() ? "application/octet-stream"_s : m_dataType, ";base64,", base64Encoded(m_rawData ? m_rawData->data() : nullptr, m_bytesLoaded));
 }
 
 bool FileReaderLoader::isCompleted() const


### PR DESCRIPTION
#### 7e2fcfdc82fa6d96309501c74e857fe7bc273151
<pre>
readAsDataURL.readAsDataURL() is incorrect for empty blobs
<a href="https://bugs.webkit.org/show_bug.cgi?id=258043">https://bugs.webkit.org/show_bug.cgi?id=258043</a>

Reviewed by Darin Adler.

readAsDataURL.readAsDataURL() was incorrect for empty blobs. Our behavior didn&apos;t
match Chrome or Firefox and causes us to fail the
FileAPI/reading-data-section/filereader_readAsDataURL.any.html WPT test.

We used to return &quot;data:&quot; instead of &quot;data:application/octet-stream;base64,&quot;.

* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/FileAPI/reading-data-section/filereader_readAsDataURL.any.js:
Resync from upstream to gain test coverage and rebaseline.

* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::convertToDataURL):

Canonical link: <a href="https://commits.webkit.org/265153@main">https://commits.webkit.org/265153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88e6cb9b96469778d8a1b7a5526cc0d592f039d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12047 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16395 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8464 "Found 1 jsc stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9340 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12480 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9710 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7877 "4 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10142 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8869 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8963 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2401 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13100 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10417 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9494 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2584 "Passed tests") | 
<!--EWS-Status-Bubble-End-->