### PR TITLE
Allow specifying a base time when scheduling a Timer

### DIFF
--- a/Source/WebCore/platform/Timer.cpp
+++ b/Source/WebCore/platform/Timer.cpp
@@ -273,10 +273,15 @@ TimerBase::~TimerBase()
 
 void TimerBase::start(Seconds nextFireInterval, Seconds repeatInterval)
 {
+    startWithBaseTime(nextFireInterval, repeatInterval, MonotonicTime::now());
+}
+
+void TimerBase::startWithBaseTime(Seconds nextFireInterval, Seconds repeatInterval, MonotonicTime baseTime)
+{
     ASSERT(canCurrentThreadAccessThreadLocalData(m_thread));
 
     m_repeatInterval = repeatInterval;
-    setNextFireTime(MonotonicTime::now() + nextFireInterval);
+    setNextFireTime(baseTime + nextFireInterval);
 }
 
 void TimerBase::stop()

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -49,9 +49,11 @@ public:
     WEBCORE_EXPORT virtual ~TimerBase();
 
     WEBCORE_EXPORT void start(Seconds nextFireInterval, Seconds repeatInterval);
+    void startWithBaseTime(Seconds nextFireInterval, Seconds repeatInterval, MonotonicTime baseTime);
 
     void startRepeating(Seconds repeatInterval) { start(repeatInterval, repeatInterval); }
     void startOneShot(Seconds delay) { start(delay, 0_s); }
+    void startOneShotWithBaseTime(Seconds nextFireInterval, MonotonicTime baseTime) { startWithBaseTime(nextFireInterval, 0_s, baseTime); }
 
     WEBCORE_EXPORT void stop();
     bool isActive() const;


### PR DESCRIPTION
#### d3ea805f35aad69483bdebb89eccebc70ae9fc03
<pre>
Allow specifying a base time when scheduling a Timer
<a href="https://bugs.webkit.org/show_bug.cgi?id=258042">https://bugs.webkit.org/show_bug.cgi?id=258042</a>
&lt;radar://110507320&gt;

Reviewed by NOBODY (OOPS!).

Allow CaretAnimator to pass a specific timestamp
to scheduling timers instead of always using MonotonicTime::now()

* Source/WebCore/platform/Timer.cpp:
(WebCore::TimerBase::start):
(WebCore::TimerBase::startWithBaseTime):
* Source/WebCore/platform/Timer.h:
(WebCore::TimerBase::startOneShotWithBaseTime):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3ea805f35aad69483bdebb89eccebc70ae9fc03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11605 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12587 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11989 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16362 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12446 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9676 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->