### PR TITLE
Add a mechanism to schedule opportunistic work in between rendering updates

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1867,6 +1867,7 @@ page/MouseEventWithHitTestResults.cpp
 page/Navigator.cpp
 page/NavigatorBase.cpp
 page/NavigatorIsLoggedIn.cpp
+page/OpportunisticTaskScheduler.cpp
 page/OriginAccessEntry.cpp
 page/OriginAccessPatterns.cpp
 page/Page.cpp

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -239,8 +239,8 @@ public:
     // Gets the next id in a circular sequence from 1 to 2^31-1.
     int circularSequentialID();
 
-    bool addTimeout(int timeoutId, DOMTimer& timer) { return m_timeouts.add(timeoutId, timer).isNewEntry; }
-    void removeTimeout(int timeoutId) { m_timeouts.remove(timeoutId); }
+    bool addTimeout(int timeoutId, DOMTimer& timer) { return m_timeouts.add(timeoutId, &timer).isNewEntry; }
+    RefPtr<DOMTimer> takeTimeout(int timeoutId) { return m_timeouts.take(timeoutId); }
     DOMTimer* findTimeout(int timeoutId) { return m_timeouts.get(timeoutId); }
 
     virtual JSC::VM& vm() = 0;
@@ -380,7 +380,7 @@ private:
     HashSet<ContextDestructionObserver*> m_destructionObservers;
     HashSet<ActiveDOMObject*> m_activeDOMObjects;
 
-    HashMap<int, Ref<DOMTimer>> m_timeouts;
+    HashMap<int, RefPtr<DOMTimer>> m_timeouts;
 
     struct PendingException;
     std::unique_ptr<Vector<std::unique_ptr<PendingException>>> m_pendingExceptions;

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -30,6 +30,7 @@
 #include "HTMLPlugInElement.h"
 #include "InspectorInstrumentation.h"
 #include "Logging.h"
+#include "OpportunisticTaskScheduler.h"
 #include "Page.h"
 #include "ScheduledAction.h"
 #include "ScriptExecutionContext.h"
@@ -188,6 +189,7 @@ int DOMTimer::install(ScriptExecutionContext& context, Function<void(ScriptExecu
 {
     Ref<DOMTimer> timer = adoptRef(*new DOMTimer(context, WTFMove(action), timeout, oneShot));
     timer->suspendIfNeeded();
+    timer->makeOpportunisticTaskDeferralScopeIfPossible(context);
 
     // Keep asking for the next id until we're given one that we don't already have.
     do {
@@ -233,7 +235,9 @@ void DOMTimer::removeById(ScriptExecutionContext& context, int timeoutId)
         nestedTimers->remove(timeoutId);
 
     InspectorInstrumentation::didRemoveTimer(context, timeoutId);
-    context.removeTimeout(timeoutId);
+
+    if (auto timer = context.takeTimeout(timeoutId))
+        timer->clearOpportunisticTaskDeferralScopeIfPossible();
 }
 
 inline bool DOMTimer::isDOMTimersThrottlingEnabled(const Document& document) const
@@ -328,10 +332,12 @@ void DOMTimer::fired()
         InspectorInstrumentation::didFireTimer(context, m_timeoutId, m_oneShot);
 
         updateThrottlingStateIfNecessary(fireState);
+
+        clearOpportunisticTaskDeferralScopeIfPossible();
         return;
     }
 
-    context.removeTimeout(m_timeoutId);
+    context.takeTimeout(m_timeoutId);
 
     // Keep track nested timer installs.
     NestedTimersMap* nestedTimers = NestedTimersMap::instanceForContext(context);
@@ -354,6 +360,8 @@ void DOMTimer::fired()
         }
         nestedTimers->stopTracking();
     }
+
+    clearOpportunisticTaskDeferralScopeIfPossible();
 }
 
 void DOMTimer::didStop()
@@ -362,6 +370,7 @@ void DOMTimer::didStop()
     // because they can form circular references back to the ScriptExecutionContext
     // which will cause a memory leak.
     m_action = nullptr;
+    clearOpportunisticTaskDeferralScopeIfPossible();
 }
 
 void DOMTimer::updateTimerIntervalIfNecessary()
@@ -414,6 +423,30 @@ std::optional<MonotonicTime> DOMTimer::alignedFireTime(MonotonicTime fireTime) c
     Seconds randomizedOffset = alignmentInterval * randomizedProportion;
     MonotonicTime adjustedFireTime = fireTime - randomizedOffset;
     return adjustedFireTime - (adjustedFireTime % alignmentInterval) + alignmentInterval + randomizedOffset;
+}
+
+void DOMTimer::makeOpportunisticTaskDeferralScopeIfPossible(ScriptExecutionContext& context)
+{
+    if (!m_oneShot || m_currentTimerInterval <= 1_ms) {
+        // FIXME: This should eventually account for repeating timers and one-shot timers that were
+        // previously scheduled, and are about to fire.
+        return;
+    }
+
+    RefPtr document = dynamicDowncast<Document>(context);
+    if (!document)
+        return;
+
+    auto* page = document->page();
+    if (!page)
+        return;
+
+    m_opportunisticTaskDeferralScope = page->opportunisticTaskScheduler().makeDeferralScope();
+}
+
+void DOMTimer::clearOpportunisticTaskDeferralScopeIfPossible()
+{
+    m_opportunisticTaskDeferralScope = nullptr;
 }
 
 const char* DOMTimer::activeDOMObjectName() const

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -38,6 +38,7 @@ namespace WebCore {
 
 class DOMTimerFireState;
 class Document;
+class OpportunisticTaskDeferralScope;
 class ScheduledAction;
 
 class DOMTimer final : public RefCounted<DOMTimer>, public SuspendableTimerBase, public CanMakeWeakPtr<DOMTimer> {
@@ -70,6 +71,9 @@ private:
 
     WEBCORE_EXPORT Seconds intervalClampedToMinimum() const;
 
+    void makeOpportunisticTaskDeferralScopeIfPossible(ScriptExecutionContext&);
+    void clearOpportunisticTaskDeferralScopeIfPossible();
+
     bool isDOMTimersThrottlingEnabled(const Document&) const;
     void updateThrottlingStateIfNecessary(const DOMTimerFireState&);
 
@@ -95,6 +99,7 @@ private:
     bool m_oneShot;
     Seconds m_currentTimerInterval;
     RefPtr<UserGestureToken> m_userGestureTokenToForward;
+    std::unique_ptr<OpportunisticTaskDeferralScope> m_opportunisticTaskDeferralScope;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5891,6 +5891,11 @@ void LocalFrameView::fireLayoutRelatedMilestonesIfNeeded()
             addPaintPendingMilestones(DidFirstMeaningfulPaint);
             if (requestedMilestones & DidFirstVisuallyNonEmptyLayout)
                 milestonesAchieved.add(DidFirstVisuallyNonEmptyLayout);
+
+            if (m_frame->isMainFrame()) {
+                if (auto* page = m_frame->page())
+                    page->didFirstMeaningfulPaint();
+            }
         }
     }
 

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "OpportunisticTaskScheduler.h"
+
+#include "Page.h"
+
+namespace WebCore {
+
+OpportunisticTaskDeferralScope::OpportunisticTaskDeferralScope(OpportunisticTaskScheduler& scheduler)
+    : m_scheduler(&scheduler)
+{
+    scheduler.incrementDeferralCount();
+}
+
+OpportunisticTaskDeferralScope::OpportunisticTaskDeferralScope(OpportunisticTaskDeferralScope&& scope)
+    : m_scheduler(std::exchange(scope.m_scheduler, { }))
+{
+}
+
+OpportunisticTaskDeferralScope::~OpportunisticTaskDeferralScope()
+{
+    if (m_scheduler)
+        m_scheduler->decrementDeferralCount();
+}
+
+OpportunisticTaskScheduler::OpportunisticTaskScheduler(Page& page)
+    : m_page(&page)
+    , m_runLoopObserver(makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::PostRenderingUpdate, [weakThis = WeakPtr { this }] {
+        if (auto strongThis = weakThis.get())
+            strongThis->runLoopObserverFired();
+    }, RunLoopObserver::Type::OneShot))
+{
+}
+
+OpportunisticTaskScheduler::~OpportunisticTaskScheduler() = default;
+
+void OpportunisticTaskScheduler::reschedule(MonotonicTime deadline)
+{
+    m_currentDeadline = deadline;
+
+    if (m_runLoopObserver->isScheduled())
+        return;
+
+    if (m_taskDeferralCount)
+        m_runLoopObserver->invalidate();
+    else
+        m_runLoopObserver->schedule();
+}
+
+std::unique_ptr<OpportunisticTaskDeferralScope> OpportunisticTaskScheduler::makeDeferralScope()
+{
+    return makeUnique<OpportunisticTaskDeferralScope>(*this);
+}
+
+void OpportunisticTaskScheduler::runLoopObserverFired()
+{
+    m_runLoopObserver->invalidate();
+
+    if (m_taskDeferralCount)
+        return;
+
+    auto deadline = std::exchange(m_currentDeadline, MonotonicTime { });
+    if (!deadline)
+        return;
+
+    auto currentTime = MonotonicTime::now();
+    auto remainingTime = deadline - currentTime;
+    if (remainingTime <= 0_ms)
+        return;
+
+    if (auto page = m_page.get())
+        page->performOpportunisticallyScheduledTasks(currentTime + remainingTime);
+}
+
+void OpportunisticTaskScheduler::incrementDeferralCount()
+{
+    if (++m_taskDeferralCount == 1)
+        m_runLoopObserver->invalidate();
+}
+
+void OpportunisticTaskScheduler::decrementDeferralCount()
+{
+    if (!--m_taskDeferralCount && m_currentDeadline)
+        m_runLoopObserver->schedule();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "RunLoopObserver.h"
+#include <wtf/MonotonicTime.h>
+#include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Page;
+
+class OpportunisticTaskDeferralScope {
+    WTF_MAKE_NONCOPYABLE(OpportunisticTaskDeferralScope); WTF_MAKE_FAST_ALLOCATED;
+public:
+    OpportunisticTaskDeferralScope(OpportunisticTaskScheduler&);
+    OpportunisticTaskDeferralScope(OpportunisticTaskDeferralScope&&);
+    ~OpportunisticTaskDeferralScope();
+
+private:
+    WeakPtr<OpportunisticTaskScheduler> m_scheduler;
+};
+
+class OpportunisticTaskScheduler : public RefCounted<OpportunisticTaskScheduler>, public CanMakeWeakPtr<OpportunisticTaskScheduler> {
+public:
+    static Ref<OpportunisticTaskScheduler> create(Page& page)
+    {
+        return adoptRef(*new OpportunisticTaskScheduler(page));
+    }
+
+    ~OpportunisticTaskScheduler();
+
+    void reschedule(MonotonicTime deadline);
+
+    WARN_UNUSED_RETURN std::unique_ptr<OpportunisticTaskDeferralScope> makeDeferralScope();
+
+private:
+    friend class OpportunisticTaskDeferralScope;
+
+    OpportunisticTaskScheduler(Page&);
+    void runLoopObserverFired();
+
+    void incrementDeferralCount();
+    void decrementDeferralCount();
+
+    WeakPtr<Page> m_page;
+    uint64_t m_taskDeferralCount { 0 };
+    MonotonicTime m_currentDeadline;
+    std::unique_ptr<RunLoopObserver> m_runLoopObserver;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -128,6 +128,7 @@ class FormData;
 class HTMLElement;
 class HTMLMediaElement;
 class HistoryItem;
+class OpportunisticTaskScheduler;
 class ImageAnalysisQueue;
 class ImageOverlayController;
 class InspectorClient;
@@ -315,6 +316,8 @@ public:
     WEBCORE_EXPORT PluginData& pluginData();
     void clearPluginData();
 
+    OpportunisticTaskScheduler& opportunisticTaskScheduler() const { return m_opportunisticTaskScheduler.get(); }
+
     WEBCORE_EXPORT void setCanStartMedia(bool);
     bool canStartMedia() const { return m_canStartMedia; }
 
@@ -479,6 +482,7 @@ public:
     void didStartProvisionalLoad();
     void didCommitLoad();
     void didFinishLoad();
+    void didFirstMeaningfulPaint();
 
     bool delegatesScaling() const { return m_delegatesScaling; }
     WEBCORE_EXPORT void setDelegatesScaling(bool);
@@ -1054,6 +1058,8 @@ public:
     const WeakHashSet<LocalFrame>& rootFrames() const { return m_rootFrames; }
     WEBCORE_EXPORT void addRootFrame(LocalFrame&);
 
+    void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+
 private:
     struct Navigation {
         RegistrableDomain domain;
@@ -1412,6 +1418,9 @@ private:
 #if ENABLE(ATTACHMENT_ELEMENT)
     std::unique_ptr<AttachmentElementClient> m_attachmentElementClient;
 #endif
+
+    std::unique_ptr<OpportunisticTaskDeferralScope> m_opportunisticTaskDeferralScopeForFirstPaint;
+    Ref<OpportunisticTaskScheduler> m_opportunisticTaskScheduler;
 
 #if ENABLE(IMAGE_ANALYSIS)
     using CachedTextRecognitionResult = std::pair<TextRecognitionResult, IntRect>;

--- a/Source/WebCore/platform/RunLoopObserver.h
+++ b/Source/WebCore/platform/RunLoopObserver.h
@@ -62,9 +62,11 @@ public:
         AfterWaiting    = 1 << 3,
     };
 
-    RunLoopObserver(WellKnownOrder order, RunLoopObserverCallback&& callback)
+    enum class Type : bool { Repeating, OneShot };
+    RunLoopObserver(WellKnownOrder order, RunLoopObserverCallback&& callback, Type type = Type::Repeating)
         : m_order(order)
         , m_callback(WTFMove(callback))
+        , m_type(type)
     { }
 
     WEBCORE_EXPORT ~RunLoopObserver();
@@ -73,6 +75,8 @@ public:
     WEBCORE_EXPORT void schedule(PlatformRunLoop = nullptr, OptionSet<Activity> = defaultActivities);
     WEBCORE_EXPORT void invalidate();
     WEBCORE_EXPORT bool isScheduled() const;
+
+    bool isRepeating() const { return m_type == Type::Repeating; }
 
 #if USE(CF)
     static void runLoopObserverFired(PlatformRunLoopObserver, unsigned long, void*);
@@ -86,6 +90,7 @@ private:
 #if USE(CF)
     RetainPtr<PlatformRunLoopObserver> m_runLoopObserver;
 #endif
+    Type m_type { Type::Repeating };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
+++ b/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
@@ -84,8 +84,7 @@ void RunLoopObserver::schedule(PlatformRunLoop runLoop, OptionSet<Activity> acti
         return;
 
     CFRunLoopObserverContext context = { 0, this, 0, 0, 0 };
-    constexpr bool repeats = true;
-    m_runLoopObserver = adoptCF(CFRunLoopObserverCreate(kCFAllocatorDefault, cfRunLoopActivity(activity), repeats, cfRunLoopOrder(m_order), runLoopObserverFired, &context));
+    m_runLoopObserver = adoptCF(CFRunLoopObserverCreate(kCFAllocatorDefault, cfRunLoopActivity(activity), isRepeating(), cfRunLoopOrder(m_order), runLoopObserverFired, &context));
 
     CFRunLoopAddObserver(runLoop, m_runLoopObserver.get(), kCFRunLoopCommonModes);
 }


### PR DESCRIPTION
#### c7bdb5bcd411cab772466fdc79661c41c115095a
<pre>
Add a mechanism to schedule opportunistic work in between rendering updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=258032">https://bugs.webkit.org/show_bug.cgi?id=258032</a>
rdar://110076652

Reviewed by Ryosuke Niwa.

Add an `OpportunisticTaskScheduler` helper class to be used in a subsequent patch to dispatch
periodically-scheduled cleanup tasks, such as incremental sweeping, in between rendering updates
(i.e. after the runloop begins to wait for more work, but before the next rendering update is
scheduled to start).

This `OpportunisticTaskScheduler` is essentially a wrapper around a `RunLoopObserver`, which calls
into `Page` to perform scheduled work until a given deadline. The `Page` is the only entity that
owns the task scheduler, and will tell it to reschedule after every rendering update. Additionally,
we introduce another mechanism — `OpportunisticTaskDeferralScope` — that prevents the task scheduler
from firing during certain time intervals where we know that scheduled work is imminent. For now,
this just includes:

1. Scheduled one-shot timers with a very short duration.
2. Any time prior to first paint, after navigation.

No change in behavior (yet).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::addTimeout):
(WebCore::ScriptExecutionContext::takeTimeout):
(WebCore::ScriptExecutionContext::removeTimeout): Deleted.

Change `removeTimeout` to `takeTimeout`, and have it return the removed `DOMTimer`. This allows us
to (more easily) call `clearOpportunisticTaskDeferralScopeIfPossible()` on the removed timer below.

* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::install):
(WebCore::DOMTimer::removeById):
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::didStop):
(WebCore::DOMTimer::makeOpportunisticTaskDeferralScopeIfPossible):
(WebCore::DOMTimer::clearOpportunisticTaskDeferralScopeIfPossible):

Add a opportunistic task deferral scope to prevent us from scheduling opportunistic tasks in the
case where one-shot zero-delay timers are about to fire.

* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fireLayoutRelatedMilestonesIfNeeded):

Add some plumbing to notify `Page` when we hit first meaningful paint.

* Source/WebCore/page/OpportunisticTaskScheduler.cpp: Added.
(WebCore::OpportunisticTaskDeferralScope::OpportunisticTaskDeferralScope):
(WebCore::OpportunisticTaskDeferralScope::~OpportunisticTaskDeferralScope):

Add a RAII helper class to increment and decrement the deferral count in
`OpportunisticTaskScheduler`, which prevents opportunistically scheduled tasks from firing; this
RAII pattern hopefully makes it a bit easier to ensure that nothing ends up with unbalanced calls to
increment or decrement.

(WebCore::OpportunisticTaskScheduler::OpportunisticTaskScheduler):
(WebCore::OpportunisticTaskScheduler::reschedule):

Helper method to reschedule the task scheduler, with a target deadline; called after completing
rendering updates in `Page`.

(WebCore::OpportunisticTaskScheduler::makeDeferralScope):

Helper method to make a `OpportunisticTaskDeferralScope`, which increments the deferral count (and
only decrements the count upon detroying the scope).

(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

Call into page to `performOpportunisticallyScheduledTasks`, once the runloop observer fires (i.e.,
the runloop has become idle) and only if we still have remaining time until the next deadline (which
is established when we were most recently rescheduled). This ensures that if post-rendering-update
tasks take a long time to finish and another rendering update is imminent, we&apos;ll skip this
opportunistic task call entirely, and instead do the work when we&apos;re less busy.

(WebCore::OpportunisticTaskScheduler::incrementDeferralCount):
(WebCore::OpportunisticTaskScheduler::decrementDeferralCount):

Private methods to manage the task deferral count; while the count is non-zero, we avoid calling
into the page to perform opportunistic tasks. When the deferral count is restored to 0, we then
wait for the runloop to become idle (via `RunLoopObserver`), and then run tasks if appropriate.

* Source/WebCore/page/OpportunisticTaskScheduler.h: Added.
(WebCore::OpportunisticTaskScheduler::create):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
(WebCore::Page::didFirstMeaningfulPaint):

Hold on to a `OpportunisticTaskDeferralScope` before the page has finished first paint.

(WebCore::Page::renderingUpdateCompleted):

Reschedule opportunistic tasks (see above for more information).

(WebCore::Page::performOpportunisticallyScheduledTasks):

Leave an empty method stub for now; in the next patch, this will call into a new `JSC::VM`
entrypoint to perform some pre-scheduled, periodic cleanup tasks, such as running the incremental
sweeper until the deadline.

* Source/WebCore/page/Page.h:
(WebCore::Page::opportunisticTaskScheduler const):
* Source/WebCore/platform/RunLoopObserver.h:
(WebCore::RunLoopObserver::RunLoopObserver):
(WebCore::RunLoopObserver::isRepeating const):
* Source/WebCore/platform/cf/RunLoopObserverCF.cpp:
(WebCore::RunLoopObserver::schedule):

Add an option to make the `RunLoopObserver` one-shot (as opposed to repeating). We use this flag
when creating runloop observers in the new `OpportunisticTaskScheduler`, since we don&apos;t want the
runloop observer to continue listening forever.

Canonical link: <a href="https://commits.webkit.org/265178@main">https://commits.webkit.org/265178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd2a90f22bc2b761e2ab2478bb74fc9dc76ddc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11768 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12717 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12151 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9166 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16476 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9443 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9799 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8958 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2426 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->