### PR TITLE
Use more smart pointers instead of raw pointers

### DIFF
--- a/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp
@@ -257,7 +257,7 @@ void WebMediaSessionManager::showPlaybackTargetPicker(WebMediaSessionManagerClie
     ALWAYS_LOG_MEDIASESSIONMANAGER(__func__, m_clientState[index].get());
 
     bool hasActiveRoute = flagsAreSet(m_clientState[index]->flags, MediaProducerMediaState::IsPlayingToExternalDevice);
-    targetPicker().showPlaybackTargetPicker(client.platformView(), FloatRect(rect), hasActiveRoute, useDarkAppearance);
+    targetPicker().showPlaybackTargetPicker(client.platformView().get(), FloatRect(rect), hasActiveRoute, useDarkAppearance);
 }
 
 void WebMediaSessionManager::clientStateDidChange(WebMediaSessionManagerClient& client, PlaybackTargetClientContextIdentifier contextId, MediaProducerMediaStateFlags newFlags)

--- a/Source/WebCore/Modules/airplay/WebMediaSessionManagerClient.h
+++ b/Source/WebCore/Modules/airplay/WebMediaSessionManagerClient.h
@@ -32,6 +32,7 @@
 #include "PlatformView.h"
 #include "PlaybackTargetClientContextIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/RetainPtr.h>
 
 namespace WebCore {
 
@@ -44,7 +45,7 @@ public:
     virtual void setShouldPlayToPlaybackTarget(PlaybackTargetClientContextIdentifier, bool) = 0;
     virtual void playbackTargetPickerWasDismissed(PlaybackTargetClientContextIdentifier) = 0;
     virtual bool alwaysOnLoggingAllowed() const { return false; }
-    virtual PlatformView* platformView() const = 0;
+    virtual RetainPtr<PlatformView> platformView() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <wtf/RefCounted.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -48,7 +49,7 @@ public:
 <%- end -%>
 
 private:
-    Page* m_page;
+    WeakPtr<Page> m_page;
 
 <%- for @setting in @allSettingsSet.settings do -%>
 <%- if @setting.excludeFromInternalSettings == false and @setting.idlType -%>

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -171,12 +171,17 @@ void InspectorFrontendClientLocal::resetState()
     m_settings->deleteProperty(inspectorAttachedHeightSetting);
 }
 
+Page* InspectorFrontendClientLocal::frontendPage()
+{
+    return m_frontendPage.get();
+}
+
 void InspectorFrontendClientLocal::windowObjectCleared()
 {
     if (m_frontendHost)
         m_frontendHost->disconnectClient();
     
-    m_frontendHost = InspectorFrontendHost::create(this, m_frontendPage);
+    m_frontendHost = InspectorFrontendHost::create(this, frontendPage());
     m_frontendHost->addSelfToGlobalObjectInWorld(debuggerWorld());
 }
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -35,6 +35,7 @@
 #include "InspectorFrontendClient.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -103,7 +104,7 @@ public:
     String backendCommandsURL() const final { return String(); };
 
     InspectorFrontendAPIDispatcher& frontendAPIDispatcher() final { return m_frontendAPIDispatcher; }
-    Page* frontendPage() final { return m_frontendPage; }
+    WEBCORE_EXPORT Page* frontendPage() final;
     
     WEBCORE_EXPORT bool canAttachWindow();
     WEBCORE_EXPORT void setDockingUnavailable(bool);
@@ -131,7 +132,6 @@ public:
     WEBCORE_EXPORT void setAttachedWindow(DockSide);
 
     WEBCORE_EXPORT Page* inspectedPage() const;
-    Page* frontendPage() const { return m_frontendPage; }
 
 protected:
     virtual void setAttachedWindowHeight(unsigned) = 0;
@@ -145,7 +145,7 @@ private:
     std::optional<bool> evaluationResultToBoolean(InspectorFrontendAPIDispatcher::EvaluationResult);
 
     InspectorController* m_inspectedPageController { nullptr };
-    Page* m_frontendPage { nullptr };
+    WeakPtr<Page> m_frontendPage;
     // TODO(yurys): this ref shouldn't be needed.
     RefPtr<InspectorFrontendHost> m_frontendHost;
     std::unique_ptr<InspectorFrontendClientLocal::Settings> m_settings;

--- a/Source/WebCore/inspector/InspectorFrontendHost.h
+++ b/Source/WebCore/inspector/InspectorFrontendHost.h
@@ -179,7 +179,7 @@ private:
     WEBCORE_EXPORT InspectorFrontendHost(InspectorFrontendClient*, Page* frontendPage);
 
     InspectorFrontendClient* m_client;
-    Page* m_frontendPage;
+    WeakPtr<Page> m_frontendPage;
 #if ENABLE(CONTEXT_MENUS)
     FrontendMenuProvider* m_menuProvider;
 #endif

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -429,8 +429,6 @@ Page::~Page()
         --gNonUtilityPageCount;
         MemoryPressureHandler::setPageCount(gNonUtilityPageCount);
     }
-    
-    m_settings->pageDestroyed();
 
     m_inspectorController->inspectedPageDestroyed();
 

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -64,6 +64,11 @@ PageOverlay::PageOverlay(Client& client, OverlayType overlayType, AlwaysTileOver
 
 PageOverlay::~PageOverlay() = default;
 
+Page* PageOverlay::page() const
+{
+    return m_page.get();
+}
+
 PageOverlayController* PageOverlay::controller() const
 {
     if (!m_page)

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -81,7 +81,7 @@ public:
     virtual PageOverlayID pageOverlayID() const { return m_pageOverlayID; }
 
     void setPage(Page*);
-    Page* page() const { return m_page; }
+    WEBCORE_EXPORT Page* page() const;
     WEBCORE_EXPORT void setNeedsDisplay(const IntRect& dirtyRect);
     WEBCORE_EXPORT void setNeedsDisplay();
 
@@ -130,7 +130,7 @@ private:
     void fadeAnimationTimerFired();
 
     Client& m_client;
-    Page* m_page { nullptr };
+    WeakPtr<Page> m_page;
 
     Timer m_fadeAnimationTimer;
     WallTime m_fadeAnimationStartTime;

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -109,7 +109,7 @@ void SettingsBase::setStandardFontFamily(const String& family, UScriptCode scrip
 {
     bool changes = fontGenericFamilies().setStandardFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::fixedFontFamily(UScriptCode script) const
@@ -121,7 +121,7 @@ void SettingsBase::setFixedFontFamily(const String& family, UScriptCode script)
 {
     bool changes = fontGenericFamilies().setFixedFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::serifFontFamily(UScriptCode script) const
@@ -133,7 +133,7 @@ void SettingsBase::setSerifFontFamily(const String& family, UScriptCode script)
 {
     bool changes = fontGenericFamilies().setSerifFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::sansSerifFontFamily(UScriptCode script) const
@@ -145,7 +145,7 @@ void SettingsBase::setSansSerifFontFamily(const String& family, UScriptCode scri
 {
     bool changes = fontGenericFamilies().setSansSerifFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::cursiveFontFamily(UScriptCode script) const
@@ -157,7 +157,7 @@ void SettingsBase::setCursiveFontFamily(const String& family, UScriptCode script
 {
     bool changes = fontGenericFamilies().setCursiveFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::fantasyFontFamily(UScriptCode script) const
@@ -169,7 +169,7 @@ void SettingsBase::setFantasyFontFamily(const String& family, UScriptCode script
 {
     bool changes = fontGenericFamilies().setFantasyFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 const String& SettingsBase::pictographFontFamily(UScriptCode script) const
@@ -181,7 +181,7 @@ void SettingsBase::setPictographFontFamily(const String& family, UScriptCode scr
 {
     bool changes = fontGenericFamilies().setPictographFontFamily(family, script);
     if (changes)
-        invalidateAfterGenericFamilyChange(m_page);
+        invalidateAfterGenericFamilyChange(m_page.get());
 }
 
 void SettingsBase::setMinimumDOMTimerInterval(Seconds interval)

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -62,7 +62,6 @@ class Page;
 class SettingsBase {
     WTF_MAKE_NONCOPYABLE(SettingsBase); WTF_MAKE_FAST_ALLOCATED;
 public:
-    void pageDestroyed() { m_page = nullptr; }
 
 #if ENABLE(MEDIA_SOURCE)
     WEBCORE_EXPORT static bool platformDefaultMediaSourceEnabled();
@@ -169,7 +168,7 @@ protected:
     void sampleBufferContentKeySessionSupportEnabledChanged();
 #endif
 
-    Page* m_page;
+    WeakPtr<Page> m_page;
 
     Seconds m_minimumDOMTimerInterval;
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -223,7 +223,7 @@ protected:
 
     virtual void willCommitTree() { }
 
-    Page* m_page; // FIXME: ideally this would be a reference but it gets nulled on async teardown.
+    WeakPtr<Page> m_page; // FIXME: ideally this would be a reference but it gets nulled on async teardown.
 
 private:
     virtual bool hasVisibleSlowRepaintViewportConstrainedObjects(const LocalFrameView&) const;

--- a/Source/WebCore/testing/InternalSettings.h
+++ b/Source/WebCore/testing/InternalSettings.h
@@ -167,7 +167,7 @@ private:
         bool m_shouldDeactivateAudioSession;
     };
 
-    Page* m_page;
+    WeakPtr<Page> m_page;
     Backup m_backup;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -367,7 +367,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     void setShouldPlayToPlaybackTarget(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
     bool alwaysOnLoggingAllowed() const final { return page.sessionID().isAlwaysOnLoggingAllowed(); }
-    PlatformView* platformView() const final;
+    RetainPtr<PlatformView> platformView() const final;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -653,7 +653,7 @@ void WebPageProxy::willPerformPasteCommand(DOMPasteAccessCategory pasteAccessCat
     }
 }
 
-NSView *WebPageProxy::Internals::platformView() const
+RetainPtr<NSView> WebPageProxy::Internals::platformView() const
 {
     return [page.pageClient().platformWindow() contentView];
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm
@@ -56,11 +56,6 @@ public:
 
 private:
     // PageBanner::Client.
-    void pageBannerDestroyed(PageBanner*) override
-    {
-        delete this;
-    }
-    
     bool mouseEvent(PageBanner* pageBanner, WebEventType type, WebMouseEventButton button, const IntPoint& position) override
     {
         switch (type) {
@@ -105,7 +100,7 @@ WKBundlePageBannerRef WKBundlePageBannerCreateBannerWithCALayer(CALayer *layer, 
         return 0;
 
     auto clientImpl = makeUnique<WebKit::PageBannerClientImpl>(wkClient);
-    return toAPI(&WebKit::PageBanner::create(layer, height, clientImpl.release()).leakRef());
+    return toAPI(&WebKit::PageBanner::create(layer, height, WTFMove(clientImpl)).leakRef());
 }
 
 CALayer *WKBundlePageBannerGetLayer(WKBundlePageBannerRef pageBanner)

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
@@ -70,6 +70,11 @@ WebInspector::~WebInspector()
         m_frontendConnection->invalidate();
 }
 
+WebPage* WebInspector::page() const
+{
+    return m_page.get();
+}
+
 void WebInspector::openLocalInspectorFrontend(bool underTest)
 {
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebInspectorUIProxy::OpenLocalInspectorFrontend(canAttachWindow(), underTest), m_page->identifier());

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.h
@@ -41,7 +41,7 @@ class WebInspector : public API::ObjectImpl<API::Object::Type::BundleInspector>,
 public:
     static Ref<WebInspector> create(WebPage*);
 
-    WebPage* page() const { return m_page; }
+    WebPage* page() const;
 
     void updateDockingAvailability();
 
@@ -99,7 +99,7 @@ private:
 
     void whenFrontendConnectionEstablished(Function<void()>&&);
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 
     RefPtr<IPC::Connection> m_frontendConnection;
     Vector<Function<void()>> m_frontendConnectionActions;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorClient.h
@@ -87,7 +87,7 @@ private:
 
     void animationEndedForLayer(const WebCore::GraphicsLayer*);
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     WebCore::PageOverlay* m_highlightOverlay;
     
     RefPtr<WebCore::PageOverlay> m_paintRectOverlay;

--- a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.h
@@ -69,7 +69,7 @@ private:
     static void callPermissionHandlersWith(PermissionHandlers&, Permission);
 
     HashMap<WebCore::SecurityOriginData, PermissionHandlers> m_requestsPerOrigin;
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
@@ -54,7 +54,7 @@ private:
 #if !(USE(AUTOCORRECTION_PANEL) || USE(DICTATION_ALTERNATIVES))
     IGNORE_CLANG_WARNINGS_BEGIN("unused-private-field")
 #endif
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 #if !(USE(AUTOCORRECTION_PANEL) || USE(DICTATION_ALTERNATIVES))
     IGNORE_CLANG_WARNINGS_END
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
@@ -54,7 +54,7 @@ public:
 
 private:
     WebCore::ColorChooserClient* m_colorChooserClient;
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -74,7 +74,7 @@ private:
     void showContextMenu() override;
 #endif
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -54,7 +54,7 @@ private:
     void declareAndWriteDragImage(const String& pasteboardName, WebCore::Element&, const URL&, const String&, WebCore::LocalFrame*) override;
 #endif
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -362,7 +362,7 @@ void WebEditorClient::textFieldDidBeginEditing(Element& element)
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page, *inputElement, webFrame);
+    m_page->injectedBundleFormClient().textFieldDidBeginEditing(m_page.get(), *inputElement, webFrame);
 }
 
 void WebEditorClient::textFieldDidEndEditing(Element& element)
@@ -374,7 +374,7 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page, *inputElement, webFrame);
+    m_page->injectedBundleFormClient().textFieldDidEndEditing(m_page.get(), *inputElement, webFrame);
 }
 
 void WebEditorClient::textDidChangeInTextField(Element& element)
@@ -388,7 +388,7 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page, *inputElement, webFrame, initiatedByUserTyping);
+    m_page->injectedBundleFormClient().textDidChangeInTextField(m_page.get(), *inputElement, webFrame, initiatedByUserTyping);
 }
 
 void WebEditorClient::textDidChangeInTextArea(Element& element)
@@ -400,7 +400,7 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page, *textAreaElement, webFrame);
+    m_page->injectedBundleFormClient().textDidChangeInTextArea(m_page.get(), *textAreaElement, webFrame);
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -473,7 +473,7 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, *inputElement, toInputFieldAction(actionType), webFrame);
+    return m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(actionType), webFrame);
 }
 
 void WebEditorClient::textWillBeDeletedInTextField(Element& element)
@@ -485,7 +485,7 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     auto* webFrame = WebFrame::fromCoreFrame(*element.document().frame());
     ASSERT(webFrame);
 
-    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page, *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame);
+    m_page->injectedBundleFormClient().shouldPerformActionInTextField(m_page.get(), *inputElement, toInputFieldAction(WKInputFieldActionTypeInsertDelete), webFrame);
 }
 
 bool WebEditorClient::shouldEraseMarkersAfterChangeSelection(WebCore::TextCheckingType type) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -197,7 +197,7 @@ private:
     bool performTwoStepDrop(WebCore::DocumentFragment&, const WebCore::SimpleRange&, bool isMove) final;
     bool supportsGlobalSelection() final;
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
@@ -53,7 +53,7 @@ bool WebNotificationClient::show(ScriptExecutionContext& context, NotificationDa
 {
     bool result;
     callOnMainRunLoopAndWait([&result, notification = WTFMove(notification).isolatedCopy(), resources = WTFMove(resources), page = m_page, contextIdentifier = context.identifier(), callbackIdentifier = context.addNotificationCallback(WTFMove(callback))]() mutable {
-        result = WebProcess::singleton().supplement<WebNotificationManager>()->show(WTFMove(notification), WTFMove(resources), page, [contextIdentifier, callbackIdentifier] {
+        result = WebProcess::singleton().supplement<WebNotificationManager>()->show(WTFMove(notification), WTFMove(resources), page.get(), [contextIdentifier, callbackIdentifier] {
             ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [callbackIdentifier](auto& context) {
                 if (auto callback = context.takeNotificationCallback(callbackIdentifier))
                     callback();
@@ -66,14 +66,14 @@ bool WebNotificationClient::show(ScriptExecutionContext& context, NotificationDa
 void WebNotificationClient::cancel(NotificationData&& notification)
 {
     callOnMainRunLoopAndWait([notification = WTFMove(notification).isolatedCopy(), page = m_page]() mutable {
-        WebProcess::singleton().supplement<WebNotificationManager>()->cancel(WTFMove(notification), page);
+        WebProcess::singleton().supplement<WebNotificationManager>()->cancel(WTFMove(notification), page.get());
     });
 }
 
 void WebNotificationClient::notificationObjectDestroyed(NotificationData&& notification)
 {
     callOnMainRunLoopAndWait([notification = WTFMove(notification).isolatedCopy(), page = m_page]() mutable {
-        WebProcess::singleton().supplement<WebNotificationManager>()->didDestroyNotification(WTFMove(notification), page);
+        WebProcess::singleton().supplement<WebNotificationManager>()->didDestroyNotification(WTFMove(notification), page.get());
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h
@@ -51,7 +51,7 @@ private:
     WebCore::NotificationClient::Permission checkPermission(WebCore::ScriptExecutionContext*) final;
 
     HashSet<WebCore::SecurityOriginData> m_notificationPermissionRequesters;
-    WebPage* m_page { nullptr };
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -42,7 +42,7 @@ public:
     static Ref<WebPopupMenu> create(WebPage*, WebCore::PopupMenuClient*);
     ~WebPopupMenu();
 
-    WebPage* page() { return m_page; }
+    WebPage* page() { return m_page.get(); }
 
     void disconnectFromPage() { m_page = 0; }
     void didChangeSelectedIndex(int newIndex);
@@ -63,7 +63,7 @@ private:
     void setUpPlatformData(const WebCore::IntRect& pageCoordinates, PlatformPopupMenuData&);
 
     WebCore::PopupMenuClient* m_popupClient;
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
@@ -79,21 +79,21 @@ static void changeWordCase(WebPage* page, NSString *(*changeCase)(NSString *))
 
 void WebEditorClient::uppercaseWord()
 {
-    changeWordCase(m_page, [] (NSString *string) {
+    changeWordCase(m_page.get(), [] (NSString *string) {
         return [string uppercaseString];
     });
 }
 
 void WebEditorClient::lowercaseWord()
 {
-    changeWordCase(m_page, [] (NSString *string) {
+    changeWordCase(m_page.get(), [] (NSString *string) {
         return [string lowercaseString];
     });
 }
 
 void WebEditorClient::capitalizeWord()
 {
-    changeWordCase(m_page, [] (NSString *string) {
+    changeWordCase(m_page.get(), [] (NSString *string) {
         return [string capitalizedString];
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -300,7 +300,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     }
 #endif
 
-    RefPtr<WebPage> protectedWebPage = m_webPage;
+    RefPtr<WebPage> protectedWebPage { m_webPage.get() };
     m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage, found, string, options, maxMatchCount, didWrap] () {
         protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, didWrap, FindUIOriginator::FindString);
     });
@@ -323,7 +323,7 @@ void FindController::findStringMatches(const String& string, OptionSet<FindOptio
         return;
 
     bool found = !m_findMatches.isEmpty();
-    m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage }, found, string, options, maxMatchCount] () {
+    m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage.get() }, found, string, options, maxMatchCount] () {
         protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, DidWrap::No, FindUIOriginator::FindStringMatches);
     });
 }
@@ -344,7 +344,7 @@ void FindController::findRectsForStringMatches(const String& string, OptionSet<F
         return;
 
     bool found = !m_findMatches.isEmpty();
-    m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage }, found, string, options, maxMatchCount] () {
+    m_webPage->drawingArea()->dispatchAfterEnsuringUpdatedScrollPosition([protectedWebPage = RefPtr { m_webPage.get() }, found, string, options, maxMatchCount] () {
         protectedWebPage->findController().updateFindUIAfterPageScroll(found, string, options, maxMatchCount, DidWrap::No, FindUIOriginator::FindStringMatches);
     });
 }

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -109,7 +109,7 @@ private:
     PluginView* mainFramePlugIn();
 #endif
 
-    WebPage* m_webPage;
+    WeakPtr<WebPage> m_webPage;
     WebCore::PageOverlay* m_findPageOverlay { nullptr };
 
     // Whether the UI process is showing the find indicator. Note that this can be true even if

--- a/Source/WebKit/WebProcess/WebPage/PageBanner.cpp
+++ b/Source/WebKit/WebProcess/WebPage/PageBanner.cpp
@@ -36,7 +36,6 @@ PageBanner::~PageBanner()
 #if PLATFORM(MAC)
     ASSERT(!m_webPage);
 #endif
-    m_client->pageBannerDestroyed(this);
 }
 
 #if !PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/PageBanner.h
+++ b/Source/WebKit/WebProcess/WebPage/PageBanner.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "WebMouseEvent.h"
+#include <wtf/WeakPtr.h>
 
 #if PLATFORM(MAC)
 OBJC_CLASS CALayer;
@@ -50,16 +51,13 @@ public:
     };
 
     class Client {
-    protected:
-        virtual ~Client() { }
-    
     public:
-        virtual void pageBannerDestroyed(PageBanner*) = 0;
+        virtual ~Client() { }
         virtual bool mouseEvent(PageBanner*, WebEventType, WebMouseEventButton, const WebCore::IntPoint&) = 0;
     };
 
 #if PLATFORM(MAC)
-    static Ref<PageBanner> create(CALayer *, int height, Client*);
+    static Ref<PageBanner> create(CALayer *, int height, std::unique_ptr<Client>&&);
     CALayer *layer();
 #endif
 
@@ -78,14 +76,14 @@ public:
 
 private:
 #if PLATFORM(MAC)
-    explicit PageBanner(CALayer *, int height, Client*);
+    explicit PageBanner(CALayer *, int height, std::unique_ptr<Client>&&);
 #endif
 
-    Client* m_client;
+    std::unique_ptr<Client> m_client;
 
 #if PLATFORM(MAC)
     Type m_type = NotSet;
-    WebPage* m_webPage = 0;
+    WeakPtr<WebPage> m_webPage;
     bool m_mouseDownInBanner = false;
     bool m_isHidden = false;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -100,7 +100,7 @@ private:
 
     WebCore::WheelEventHandlingResult handleWheelEventForScrolling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 
-    WebPage* m_webPage;
+    WeakPtr<WebPage> m_webPage;
 
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveRubberBanding;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveScrollSnap;

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -62,7 +62,7 @@ private:
 
     void close() override;
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     mutable std::optional<WebBackForwardListCounts> m_cachedBackForwardListCounts;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
+++ b/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
@@ -53,7 +53,7 @@ public:
 private:
     WebOpenPanelResultListener(WebPage&, Ref<WebCore::FileChooser>&&);
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     Ref<WebCore::FileChooser> m_fileChooser;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -36,13 +36,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-Ref<PageBanner> PageBanner::create(CALayer *layer, int height, Client* client)
+Ref<PageBanner> PageBanner::create(CALayer *layer, int height, std::unique_ptr<Client>&& client)
 {
-    return adoptRef(*new PageBanner(layer, height, client));
+    return adoptRef(*new PageBanner(layer, height, WTFMove(client)));
 }
 
-PageBanner::PageBanner(CALayer *layer, int height, Client* client)
-    : m_client(client)
+PageBanner::PageBanner(CALayer *layer, int height, std::unique_ptr<Client>&& client)
+    : m_client(WTFMove(client))
     , m_layer(layer)
     , m_height(height)
 {
@@ -115,7 +115,7 @@ void PageBanner::showIfHidden()
 
     // This will re-create a parent layer in the WebCore layer tree, and we will re-add
     // m_layer as a child of it. 
-    addToPage(m_type, m_webPage);
+    addToPage(m_type, m_webPage.get());
 }
 
 void PageBanner::didChangeDeviceScaleFactor(float scaleFactor)

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.h
@@ -47,7 +47,7 @@ private:
     void pageDestroyed() final;
     void hasNodeWithAnimatedScrollChanged(bool) final;
     
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -177,7 +177,7 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     WeakHashSet<WebCore::HTMLMediaElement, WebCore::WeakPtrImplWithEventTargetData> m_mediaElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -193,7 +193,7 @@ protected:
     WTFLogChannel& logChannel() const;
 #endif
 
-    WebPage* m_page;
+    WeakPtr<WebPage> m_page;
     Ref<PlaybackSessionManager> m_playbackSessionManager;
     HashMap<WebCore::HTMLVideoElement*, PlaybackSessionContextIdentifier> m_videoElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
@@ -83,12 +83,12 @@ void WebInspectorClient::hideHighlight()
 
 void WebInspectorClient::showInspectorIndication()
 {
-    [m_inspectedWebView setShowingInspectorIndication:YES];
+    [m_inspectedWebView.get() setShowingInspectorIndication:YES];
 }
 
 void WebInspectorClient::hideInspectorIndication()
 {
-    [m_inspectedWebView setShowingInspectorIndication:NO];
+    [m_inspectedWebView.get() setShowingInspectorIndication:NO];
 }
 
 void WebInspectorClient::setShowPaintRects(bool)
@@ -104,7 +104,7 @@ void WebInspectorClient::showPaintRect(const FloatRect&)
 void WebInspectorClient::didSetSearchingForNode(bool enabled)
 {
     NSString *notificationName = enabled ? WebInspectorDidStartSearchingForNode : WebInspectorDidStopSearchingForNode;
-    RunLoop::main().dispatch([notificationName = retainPtr(notificationName), inspector = retainPtr([m_inspectedWebView inspector])] {
+    RunLoop::main().dispatch([notificationName = retainPtr(notificationName), inspector = retainPtr([m_inspectedWebView.get() inspector])] {
         [[NSNotificationCenter defaultCenter] postNotificationName:notificationName.get() object:inspector.get()];
     });
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -34,6 +34,8 @@
 #import <wtf/Forward.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WeakObjCPtr.h>
+#import <wtf/WeakPtr.h>
 #import <wtf/text/StringHash.h>
 #import <wtf/text/WTFString.h>
 
@@ -100,9 +102,9 @@ public:
 private:
     std::unique_ptr<WebCore::InspectorFrontendClientLocal::Settings> createFrontendSettings();
 
-    WebView *m_inspectedWebView { nullptr };
+    WeakObjCPtr<WebView> m_inspectedWebView;
     RetainPtr<WebNodeHighlighter> m_highlighter;
-    WebCore::Page* m_frontendPage { nullptr };
+    WeakPtr<WebCore::Page> m_frontendPage;
     std::unique_ptr<WebInspectorFrontendClient> m_frontendClient;
 };
 
@@ -160,7 +162,7 @@ private:
     void save(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool base64Encoded) override;
 
 #if !PLATFORM(IOS_FAMILY)
-    WebView *m_inspectedWebView;
+    WeakObjCPtr<WebView> m_inspectedWebView;
     RetainPtr<WebInspectorWindowController> m_frontendWindowController;
     String m_inspectedURL;
     HashMap<String, RetainPtr<NSURL>> m_suggestedToActualURLMap;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -106,14 +106,14 @@ void WebInspectorClient::inspectedPageDestroyed()
 
 FrontendChannel* WebInspectorClient::openLocalFrontend(InspectorController* inspectedPageController)
 {
-    RetainPtr<WebInspectorWindowController> windowController = adoptNS([[WebInspectorWindowController alloc] initWithInspectedWebView:m_inspectedWebView isUnderTest:inspectedPageController->isUnderTest()]);
+    RetainPtr<WebInspectorWindowController> windowController = adoptNS([[WebInspectorWindowController alloc] initWithInspectedWebView:m_inspectedWebView.get().get() isUnderTest:inspectedPageController->isUnderTest()]);
     [windowController.get() setInspectorClient:this];
 
     m_frontendPage = core([windowController.get() frontendWebView]);
-    m_frontendClient = makeUnique<WebInspectorFrontendClient>(m_inspectedWebView, windowController.get(), inspectedPageController, m_frontendPage, createFrontendSettings());
+    m_frontendClient = makeUnique<WebInspectorFrontendClient>(m_inspectedWebView.get().get(), windowController.get(), inspectedPageController, m_frontendPage.get(), createFrontendSettings());
 
     RetainPtr<WebInspectorFrontend> webInspectorFrontend = adoptNS([[WebInspectorFrontend alloc] initWithFrontendClient:m_frontendClient.get()]);
-    [[m_inspectedWebView inspector] setFrontend:webInspectorFrontend.get()];
+    [[m_inspectedWebView.get() inspector] setFrontend:webInspectorFrontend.get()];
 
     m_frontendPage->inspectorController().setInspectorFrontendClient(m_frontendClient.get());
 
@@ -155,13 +155,13 @@ void WebInspectorClient::hideHighlight()
 
 void WebInspectorClient::didSetSearchingForNode(bool enabled)
 {
-    WebInspector *inspector = [m_inspectedWebView inspector];
+    WebInspector *inspector = [m_inspectedWebView.get() inspector];
 
     ASSERT(isMainThread());
 
     if (enabled) {
-        [[m_inspectedWebView window] makeKeyAndOrderFront:nil];
-        [[m_inspectedWebView window] makeFirstResponder:m_inspectedWebView];
+        [[m_inspectedWebView.get() window] makeKeyAndOrderFront:nil];
+        [[m_inspectedWebView.get() window] makeFirstResponder:m_inspectedWebView.get().get()];
         [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStartSearchingForNode object:inspector];
     } else
         [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStopSearchingForNode object:inspector];
@@ -204,11 +204,11 @@ void WebInspectorFrontendClient::frontendLoaded()
 
     InspectorFrontendClientLocal::frontendLoaded();
 
-    WebFrame *frame = [m_inspectedWebView mainFrame];
+    WebFrame *frame = [m_inspectedWebView.get() mainFrame];
 
-    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(m_inspectedWebView);
+    WebFrameLoadDelegateImplementationCache* implementations = WebViewGetFrameLoadDelegateImplementations(m_inspectedWebView.get().get());
     if (implementations->didClearInspectorWindowObjectForFrameFunc)
-        CallFrameLoadDelegate(implementations->didClearInspectorWindowObjectForFrameFunc, m_inspectedWebView,
+        CallFrameLoadDelegate(implementations->didClearInspectorWindowObjectForFrameFunc, m_inspectedWebView.get().get(),
                               @selector(webView:didClearInspectorWindowObject:forFrame:), [frame windowObject], frame);
 
     bool attached = [m_frontendWindowController.get() attached];
@@ -252,7 +252,7 @@ void WebInspectorFrontendClient::closeWindow()
 
 void WebInspectorFrontendClient::reopen()
 {
-    WebInspector* inspector = [m_inspectedWebView inspector];
+    WebInspector* inspector = [m_inspectedWebView.get() inspector];
     [inspector close:nil];
     [inspector show:nil];
 }

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h
@@ -31,6 +31,8 @@
 #include <WebCore/MediaPlaybackTargetContext.h>
 #include <WebCore/WebMediaSessionManagerClient.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakObjCPtr.h>
+#include <wtf/WeakPtr.h>
 
 OBJC_CLASS WebView;
 
@@ -64,10 +66,10 @@ private:
     void externalOutputDeviceAvailableDidChange(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void setShouldPlayToPlaybackTarget(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
-    PlatformView* platformView() const final;
+    RetainPtr<PlatformView> platformView() const final;
 
-    WebCore::Page* m_page;
-    WebView *m_webView;
+    WeakPtr<WebCore::Page> m_page;
+    WeakObjCPtr<WebView> m_webView;
 };
 
 #endif

--- a/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm
@@ -115,10 +115,10 @@ void WebMediaPlaybackTargetPicker::invalidate()
     WebCore::WebMediaSessionManager::shared().removeAllPlaybackTargetPickerClients(*this);
 }
 
-PlatformView* WebMediaPlaybackTargetPicker::platformView() const
+RetainPtr<PlatformView> WebMediaPlaybackTargetPicker::platformView() const
 {
     ASSERT(m_webView);
-    return m_webView;
+    return m_webView.get();
 }
 
 #endif


### PR DESCRIPTION
#### cd352c23e71a20eb51389b4b3845293c78432a1c
<pre>
Use more smart pointers instead of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=258046">https://bugs.webkit.org/show_bug.cgi?id=258046</a>
rdar://110734344

Reviewed by David Kilzer.

* Source/WebCore/Modules/airplay/WebMediaSessionManager.cpp:
(WebCore::WebMediaSessionManager::showPlaybackTargetPicker):
* Source/WebCore/Modules/airplay/WebMediaSessionManagerClient.h:
* Source/WebCore/Scripts/SettingsTemplates/InternalSettingsGenerated.h.erb:
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::frontendPage):
(WebCore::InspectorFrontendClientLocal::windowObjectCleared):
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
(WebCore::InspectorFrontendClientLocal::frontendPage const): Deleted.
* Source/WebCore/inspector/InspectorFrontendHost.h:
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::page const):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::setStandardFontFamily):
(WebCore::SettingsBase::setFixedFontFamily):
(WebCore::SettingsBase::setSerifFontFamily):
(WebCore::SettingsBase::setSansSerifFontFamily):
(WebCore::SettingsBase::setCursiveFontFamily):
(WebCore::SettingsBase::setFantasyFontFamily):
(WebCore::SettingsBase::setPictographFontFamily):
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/testing/InternalSettings.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::Internals::platformView const):
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageBannerMac.mm:
(WKBundlePageBannerCreateBannerWithCALayer):
* Source/WebKit/WebProcess/Inspector/WebInspector.cpp:
(WebKit::WebInspector::page const):
* Source/WebKit/WebProcess/Inspector/WebInspector.h:
(WebKit::WebInspector::page const): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorClient.h:
* Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::textFieldDidBeginEditing):
(WebKit::WebEditorClient::textFieldDidEndEditing):
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
(WebKit::WebEditorClient::textWillBeDeletedInTextField):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::show):
(WebKit::WebNotificationClient::cancel):
(WebKit::WebNotificationClient::notificationObjectDestroyed):
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h:
(WebKit::WebPopupMenu::page):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::WebEditorClient::uppercaseWord):
(WebKit::WebEditorClient::lowercaseWord):
(WebKit::WebEditorClient::capitalizeWord):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):
(WebKit::FindController::findStringMatches):
(WebKit::FindController::findRectsForStringMatches):
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/PageBanner.cpp:
(WebKit::PageBanner::~PageBanner):
* Source/WebKit/WebProcess/WebPage/PageBanner.h:
(WebKit::PageBanner::Client::~Client):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h:
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::create):
(WebKit::PageBanner::PageBanner):
(WebKit::PageBanner::showIfHidden):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorClient::openLocalFrontend):
(WebInspectorClient::didSetSearchingForNode):
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.h:
* Source/WebKitLegacy/mac/WebView/WebMediaPlaybackTargetPicker.mm:
(WebMediaPlaybackTargetPicker::platformView const):

Canonical link: <a href="https://commits.webkit.org/265162@main">https://commits.webkit.org/265162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ade41d655b1970436bc98ec3bd125770c5258a24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11714 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12099 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16445 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9763 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13155 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->