### PR TITLE
Implement relaxed SIMD madd and nmadd instructions

### DIFF
--- a/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f32-madd.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param $sz i32) (result f32)
+        (i32.const 9)
+        (drop)
+        (v128.const f32x4 5.0  4.0  -37.0 6.0)
+        (v128.const f32x4 22.0 25.0 -3.0  20.0)
+        (v128.const f32x4 -1.0 1.0  0.0   -1.0)
+        (f32x4.relaxed_madd)
+        (return (f32x4.extract_lane 1))
+    )
+    (func (export "test2") (param $sz i32) (result f32)
+        (i32.const 9)
+        (drop)
+        (v128.const f32x4 5.0   4.0   -37.0 -6.0)
+        (v128.const f32x4 -22.0 -25.0 3.0   20.0)
+        (v128.const f32x4 -1.0  1.0   0.0   -1.0)
+        (f32x4.relaxed_nmadd)
+        (return (f32x4.extract_lane 3))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 101.0);
+        assert.eq(test2(42), 119.0);
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
+++ b/JSTests/wasm/stress/simd-const-relaxed-f64-madd.js
@@ -1,0 +1,39 @@
+//@ requireOptions("--useWebAssemblyRelaxedSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param $sz i32) (result f64)
+        (i32.const 9)
+        (drop)
+        (v128.const f64x2 28.0 24.0)
+        (v128.const f64x2 10.0 20.0)
+        (v128.const f64x2 1.0  2.0)
+        (f64x2.relaxed_madd)
+        (return (f64x2.extract_lane 0))
+    )
+    (func (export "test2") (param $sz i32) (result f64)
+        (i32.const 9)
+        (drop)
+        (v128.const f64x2 28.0 24.0)
+        (v128.const f64x2 10.0 20.0)
+        (v128.const f64x2 -1.0  -2.0)
+        (f64x2.relaxed_nmadd)
+        (return (f64x2.extract_lane 1))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, relaxed_simd: true })
+    const { test, test2 } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(test(42), 281.0);
+        assert.eq(test2(42), -482.0);
+    }
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -1712,6 +1712,16 @@ public:
         insn(0b01101110001000001111110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
     }
 
+    ALWAYS_INLINE void vectorFmla(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110001000001100110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void vectorFmls(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01001110101000001100110000000000 | (sizeForFloatingPointSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
     static uint32_t encodeLaneAndIndexToHLM(SIMDLane lane, uint32_t laneIndex)
     {
         switch (elementByteSize(lane)) {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -5343,6 +5343,22 @@ public:
         m_assembler.vectorFmulByElement(dest, left, right, SIMDLane::f64x2, lane.m_value);
     }
 
+    void vectorFusedMulAdd(SIMDInfo simdInfo, FPRegisterID mul1, FPRegisterID mul2, FPRegisterID addend, FPRegisterID dest, FPRegisterID scratch)
+    {
+        ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
+        moveVector(addend, scratch);
+        m_assembler.vectorFmla(scratch, mul1, mul2, simdInfo.lane);
+        moveVector(scratch, dest);
+    }
+
+    void vectorFusedNegMulAdd(SIMDInfo simdInfo, FPRegisterID mul1, FPRegisterID mul2, FPRegisterID addend, FPRegisterID dest, FPRegisterID scratch)
+    {
+        ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
+        moveVector(addend, scratch);
+        m_assembler.vectorFmls(scratch, mul1, mul2, simdInfo.lane);
+        moveVector(scratch, dest);
+    }
+
     void vectorDiv(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -2898,6 +2898,20 @@ public:
         }
     }
 
+    void vectorFusedMulAdd(SIMDInfo simdInfo, FPRegisterID mul1, FPRegisterID mul2, FPRegisterID addend, FPRegisterID dest, FPRegisterID scratch)
+    {
+        ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
+        vectorMul(simdInfo, mul1, mul2, scratch);
+        vectorAdd(simdInfo, addend, scratch, dest);
+    }
+
+    void vectorFusedNegMulAdd(SIMDInfo simdInfo, FPRegisterID mul1, FPRegisterID mul2, FPRegisterID addend, FPRegisterID dest, FPRegisterID scratch)
+    {
+        ASSERT(scalarTypeIsFloatingPoint(simdInfo.lane));
+        vectorMul(simdInfo, mul1, mul2, scratch);
+        vectorSub(simdInfo, addend, scratch, dest);
+    }
+
     void vectorDiv(SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
     {
         RELEASE_ASSERT(supportsAVX());

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4376,6 +4376,18 @@ private:
             emitSIMDMonomorphicBinaryOp(Air::VectorSwizzle);
             return;
 
+        case B3::VectorRelaxedMAdd: {
+            SIMDValue* value = m_value->as<SIMDValue>();
+            append(Air::VectorFusedMulAdd, Arg::simdInfo(value->simdInfo()), tmp(m_value->child(0)), tmp(m_value->child(1)), tmp(m_value->child(2)), tmp(m_value), m_code.newTmp(FP));
+            return;
+        }
+
+        case B3::VectorRelaxedNMAdd: {
+            SIMDValue* value = m_value->as<SIMDValue>();
+            append(Air::VectorFusedNegMulAdd, Arg::simdInfo(value->simdInfo()), tmp(m_value->child(0)), tmp(m_value->child(1)), tmp(m_value->child(2)), tmp(m_value), m_code.newTmp(FP));
+            return;
+        }
+
         case Fence: {
             FenceValue* fence = m_value->as<FenceValue>();
             if (!fence->write && !fence->read)

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -543,6 +543,12 @@ void printInternal(PrintStream& out, Opcode opcode)
     case VectorRelaxedTruncSat:
         out.print("VectorRelaxedTruncSat");
         return;
+    case VectorRelaxedMAdd:
+        out.print("VectorRelaxedMAdd");
+        return;
+    case VectorRelaxedNMAdd:
+        out.print("VectorRelaxedNMAdd");
+        return;
     case Upsilon:
         out.print("Upsilon");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -421,6 +421,8 @@ enum Opcode : uint8_t {
 
     VectorRelaxedSwizzle,
     VectorRelaxedTruncSat,
+    VectorRelaxedMAdd,
+    VectorRelaxedNMAdd,
 
     // Currently only some architectures support this.
     // FIXME: Expand this to identical instructions for the other architectures as a macro.

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -97,6 +97,8 @@ public:
         case VectorShiftByVector:
         case VectorDotProduct:
         case VectorRelaxedSwizzle:
+        case VectorRelaxedMAdd:
+        case VectorRelaxedNMAdd:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -682,6 +682,18 @@ public:
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
                 break;
 
+            case VectorRelaxedMAdd:
+            case VectorRelaxedNMAdd:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 3, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(2)->type() == V128, ("At ", *value));
+                VALIDATE((value->asSIMDValue()->simdLane() == SIMDLane::f32x4) || (value->asSIMDValue()->simdLane() == SIMDLane::f64x2), ("At ", *value));
+                VALIDATE(value->asSIMDValue()->signMode() == SIMDSignMode::None, ("At ", *value));
+                break;
+
             case CCall:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() >= 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -738,6 +738,8 @@ Effects Value::effects() const
     case VectorMulByElement:
     case VectorShiftByVector:
     case VectorRelaxedSwizzle:
+    case VectorRelaxedMAdd:
+    case VectorRelaxedNMAdd:
         break;
     case Div:
     case UDiv:
@@ -992,6 +994,8 @@ ValueKey Value::key() const
     case VectorMulByElement:
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), as<SIMDValue>()->immediate());
+    case VectorRelaxedMAdd:
+    case VectorRelaxedNMAdd:
     case VectorBitwiseSelect:
         numChildrenForKind(kind(), 3);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), child(2));

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -547,6 +547,8 @@ protected:
         case AtomicWeakCAS:
         case AtomicStrongCAS:
         case VectorBitwiseSelect:
+        case VectorRelaxedMAdd:
+        case VectorRelaxedNMAdd:
             return 3 * sizeof(Value*);
         case CCall:
         case Check:
@@ -767,6 +769,8 @@ private:
             return Two;
         case Select:
         case VectorBitwiseSelect:
+        case VectorRelaxedMAdd:
+        case VectorRelaxedNMAdd:
             if (UNLIKELY(numArgs != 3))
                 badKind(kind, numArgs);
             return Three;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -234,6 +234,8 @@ namespace JSC { namespace B3 {
     case VectorRelaxedSwizzle: \
     case VectorMulByElement: \
     case VectorShiftByVector: \
+    case VectorRelaxedMAdd: \
+    case VectorRelaxedNMAdd: \
         return MACRO(SIMDValue); \
     default: \
         RELEASE_ASSERT_NOT_REACHED(); \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -190,6 +190,8 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorReplaceLane:
     case VectorMulByElement:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[2]), child(proc, 0), child(proc, 1));
+    case VectorRelaxedMAdd:
+    case VectorRelaxedNMAdd:
     case VectorBitwiseSelect:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1), child(proc, 2));
     case VectorSwizzle:

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -2039,6 +2039,12 @@ x86_64: VectorDotProduct U:F:128, U:F:128, D:F:128
 arm64: VectorSwizzle2 U:F:128, U:F:128, U:F:128, D:F:128
     Tmp, Tmp*, Tmp, Tmp
 
+64: VectorFusedMulAdd U:G:Ptr, U:F:128, U:F:128, U:F:128, D:F:128, S:F:128
+    SIMDInfo, Tmp, Tmp, Tmp, Tmp, Tmp
+
+64: VectorFusedNegMulAdd U:G:Ptr, U:F:128, U:F:128, U:F:128, D:F:128, S:F:128
+    SIMDInfo, Tmp, Tmp, Tmp, Tmp, Tmp
+
 arm64: VectorDupElementInt8 U:G:8, U:F:128, D:F:128
     Imm, Tmp, Tmp
 arm64: VectorDupElementInt16 U:G:8, U:F:128, D:F:128

--- a/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp
@@ -559,6 +559,23 @@ public:
         return { };
     }
 
+    auto addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType m1, ExpressionType m2, ExpressionType add, ExpressionType& result) -> PartialResult
+    {
+        B3::Air::Opcode airOp = B3::Air::Oops;
+        if (op == SIMDLaneOperation::RelaxedMAdd)
+            airOp = B3::Air::VectorFusedMulAdd;
+        else if (op == SIMDLaneOperation::RelaxedNMAdd)
+            airOp = B3::Air::VectorFusedNegMulAdd;
+        else {
+            RELEASE_ASSERT_NOT_REACHED();
+            return { };
+        }
+        result = tmpForType(Types::V128);
+        auto scratch = tmpForType(Types::V128);
+        append(airOp, Arg::simdInfo(info), m1, m2, add, result, scratch);
+        return { };
+    }
+
     // Control flow
     PartialResult WARN_UNUSED_RETURN addReturn(const ControlData&, const Stack& returnValues);
     PartialResult WARN_UNUSED_RETURN addThrow(unsigned exceptionIndex, Vector<ExpressionType>& args, Stack&);

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -554,6 +554,17 @@ public:
         return { };
     }
 
+    auto addSIMDRelaxedFMA(SIMDLaneOperation op, SIMDInfo info, ExpressionType m1, ExpressionType m2, ExpressionType add, ExpressionType& result) -> PartialResult
+    {
+        B3_OP_CASES()
+        B3_OP_CASE(RelaxedMAdd)
+        B3_OP_CASE(RelaxedNMAdd)
+
+        result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), b3Op, B3::V128, info,
+            get(m1), get(m2), get(add)));
+        return { };
+    }
+
     PartialResult WARN_UNUSED_RETURN addDrop(ExpressionType);
     PartialResult WARN_UNUSED_RETURN addInlinedArguments(const TypeDefinition&);
     PartialResult WARN_UNUSED_RETURN addArguments(const TypeDefinition&);

--- a/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
+++ b/Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h
@@ -112,7 +112,9 @@ enum class SIMDLaneOperation : uint8_t {
 
     // relaxed SIMD
     RelaxedSwizzle,
-    RelaxedTruncSat
+    RelaxedTruncSat,
+    RelaxedMAdd,
+    RelaxedNMAdd,
 };
 
 #define FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -358,8 +360,12 @@ macro(I64x2ExtmulHighI32x4U,      0xdf,  ExtmulHigh,          SIMDLane::i64x2,  
 macro(I8x16RelaxedSwizzle,        0x100, RelaxedSwizzle,      SIMDLane::i8x16,  SIMDSignMode::None) \
 macro(I32x4RelaxedTruncF32x4S,    0x101, RelaxedTruncSat,     SIMDLane::f32x4,  SIMDSignMode::Signed) \
 macro(I32x4RelaxedTruncF32x4U,    0x102, RelaxedTruncSat,     SIMDLane::f32x4,  SIMDSignMode::Unsigned) \
-macro(I32x4RelaxedTruncF64x2SZero, 0x103, RelaxedTruncSat,     SIMDLane::f64x2,  SIMDSignMode::Signed) \
-macro(I32x4RelaxedTruncF64x2UZero, 0x104, RelaxedTruncSat,     SIMDLane::f64x2,  SIMDSignMode::Unsigned)
+macro(I32x4RelaxedTruncF64x2SZero, 0x103, RelaxedTruncSat,    SIMDLane::f64x2,  SIMDSignMode::Signed) \
+macro(I32x4RelaxedTruncF64x2UZero, 0x104, RelaxedTruncSat,    SIMDLane::f64x2,  SIMDSignMode::Unsigned) \
+macro(F32x4RelaxedMAdd,           0x105, RelaxedMAdd,         SIMDLane::f32x4,  SIMDSignMode::None) \
+macro(F32x4RelaxedNMAdd,          0x106, RelaxedNMAdd,        SIMDLane::f32x4,  SIMDSignMode::None) \
+macro(F64x2RelaxedMAdd,           0x107, RelaxedMAdd,         SIMDLane::f64x2,  SIMDSignMode::None) \
+macro(F64x2RelaxedNMAdd,          0x108, RelaxedNMAdd,        SIMDLane::f64x2,  SIMDSignMode::None)
 
 #define FOR_EACH_WASM_EXT_SIMD_OP(macro) \
 FOR_EACH_WASM_EXT_SIMD_REL_OP(macro) \
@@ -447,6 +453,8 @@ static void dumpSIMDLaneOperation(PrintStream& out, SIMDLaneOperation op)
     case SIMDLaneOperation::MulSat: out.print("MulSat"); break;
     case SIMDLaneOperation::RelaxedSwizzle: out.print("RelaxedSwizzle"); break;
     case SIMDLaneOperation::RelaxedTruncSat: out.print("RelaxedTruncSat"); break;
+    case SIMDLaneOperation::RelaxedMAdd: out.print("RelaxedMAdd"); break;
+    case SIMDLaneOperation::RelaxedNMAdd: out.print("RelaxedNMAdd"); break;
     }
 }
 MAKE_PRINT_ADAPTOR(SIMDLaneOperationDump, SIMDLaneOperation, dumpSIMDLaneOperation);
@@ -458,6 +466,8 @@ inline bool isRelaxedSIMDOperation(SIMDLaneOperation op)
     switch (op) {
     case SIMDLaneOperation::RelaxedSwizzle:
     case SIMDLaneOperation::RelaxedTruncSat:
+    case SIMDLaneOperation::RelaxedMAdd:
+    case SIMDLaneOperation::RelaxedNMAdd:
         return true;
     default:
         return false;


### PR DESCRIPTION
#### 5236c954e0b8cc779c14498d7530ff8d59b7d0a0
<pre>
Implement relaxed SIMD madd and nmadd instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=258047">https://bugs.webkit.org/show_bug.cgi?id=258047</a>
rdar://110736062

Reviewed by Justin Michaud.

Added implementation and tests for f32x4.relaxed_madd, f32x4.relaxed_nmadd, f64x2.relaxed_madd, f64x2.relaxed_nmadd.

* JSTests/wasm/stress/simd-const-relaxed-f32-madd.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.f32.i32.const.9.drop.v128.const.f32x4.5.0.4.0.37.0.6.0.v128.const.f32x4.22.0.25.0.3.0.20.0.v128.const.f32x4.1.0.1.0.0.0.1.0.f32x4.relaxed_madd.return.f32x4.extract_lane.1.func.export.string_appeared_here.param.sz.i32.result.f32.i32.const.9.drop.v128.const.f32x4.5.0.4.0.37.0.6.0.v128.const.f32x4.22.0.25.0.3.0.20.0.v128.const.f32x4.1.0.1.0.0.0.1.0.f32x4.relaxed_nmadd.return.f32x4.extract_lane.3.async test):
* JSTests/wasm/stress/simd-const-relaxed-f64-madd.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.sz.i32.result.f64.i32.const.9.drop.v128.const.f64x2.28.0.24.0.v128.const.f64x2.10.0.20.0.v128.const.f64x2.1.0.2.0.f64x2.relaxed_madd.return.f64x2.extract_lane.0.func.export.string_appeared_here.param.sz.i32.result.f64.i32.const.9.drop.v128.const.f64x2.28.0.24.0.v128.const.f64x2.10.0.20.0.v128.const.f64x2.1.0.2.0.f64x2.relaxed_nmadd.return.f64x2.extract_lane.1.async test):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorFusedMulAdd):
(JSC::MacroAssemblerARM64::vectorFusedNegMulAdd):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::vectorMulAdd):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/wasm/WasmAirIRGenerator64.cpp:
(JSC::Wasm::AirIRGenerator64::addSIMDRelaxedFMA):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addSIMDRelaxedFMA):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSIMDRelaxedFMA):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmSIMDOpcodes.h:
(JSC::dumpSIMDLaneOperation):
(JSC::isRelaxedSIMDOperation):

Canonical link: <a href="https://commits.webkit.org/265324@main">https://commits.webkit.org/265324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efac7fc2262c408f1a869ab854e9bb9c3b47bade

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9977 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12940 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12430 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16677 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9734 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12812 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9854 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10001 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8110 "2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10521 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9159 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2539 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13411 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10809 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9854 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2670 "Passed tests") | 
<!--EWS-Status-Bubble-End-->