### PR TITLE
Stop autoreleasing WKWebView and WKContentView in WebKit::PageClientImplIOS

### DIFF
--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -324,6 +324,8 @@ private:
     void didExitFullscreen() final;
 #endif
 
+    RetainPtr<WKContentView> contentView() const { return m_contentView.get(); }
+
     WeakObjCPtr<WKContentView> m_contentView;
     RetainPtr<WKEditorUndoTarget> m_undoTarget;
 };

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -104,7 +104,7 @@ PageClientImpl::~PageClientImpl()
 
 std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy()
 {
-    return [m_contentView _createDrawingAreaProxy];
+    return [contentView() _createDrawingAreaProxy];
 }
 
 void PageClientImpl::setViewNeedsDisplay(const Region&)
@@ -114,12 +114,12 @@ void PageClientImpl::setViewNeedsDisplay(const Region&)
 
 void PageClientImpl::requestScroll(const FloatPoint& scrollPosition, const IntPoint& scrollOrigin, ScrollIsAnimated animated)
 {
-    [m_webView _scrollToContentScrollPosition:scrollPosition scrollOrigin:scrollOrigin animated:animated == ScrollIsAnimated::Yes];
+    [webView() _scrollToContentScrollPosition:scrollPosition scrollOrigin:scrollOrigin animated:animated == ScrollIsAnimated::Yes];
 }
 
 WebCore::FloatPoint PageClientImpl::viewScrollPosition()
 {
-    if (UIScrollView *scroller = [m_contentView _scroller])
+    if (UIScrollView *scroller = [contentView() _scroller])
         return scroller.contentOffset;
 
     return { };
@@ -127,18 +127,19 @@ WebCore::FloatPoint PageClientImpl::viewScrollPosition()
 
 IntSize PageClientImpl::viewSize()
 {
-    return IntSize([m_webView bounds].size);
+    return IntSize([webView() bounds].size);
 }
 
 bool PageClientImpl::isViewWindowActive()
 {
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=133098
-    return isViewVisible() || [m_webView _isRetainingActiveFocusedState];
+    return isViewVisible() || [webView() _isRetainingActiveFocusedState];
 }
 
 bool PageClientImpl::isViewFocused()
 {
-    return (isViewInWindow() && ![m_webView _isBackground] && [m_webView _contentViewIsFirstResponder]) || [m_webView _isRetainingActiveFocusedState];
+    auto webView = this->webView();
+    return (isViewInWindow() && ![webView _isBackground] && [webView _contentViewIsFirstResponder]) || [webView _isRetainingActiveFocusedState];
 }
 
 bool PageClientImpl::isViewVisible()
@@ -185,7 +186,7 @@ bool PageClientImpl::isViewInWindow()
     if (auto webView = this->webView())
         return [webView window];
 
-    return [m_contentView window];
+    return [contentView() window];
 }
 
 bool PageClientImpl::isViewVisibleOrOccluded()
@@ -200,32 +201,32 @@ bool PageClientImpl::isVisuallyIdle()
 
 void PageClientImpl::processDidExit()
 {
-    [m_contentView _processDidExit];
-    [m_webView _processDidExit];
+    [contentView() _processDidExit];
+    [webView() _processDidExit];
 }
 
 void PageClientImpl::processWillSwap()
 {
-    [m_contentView _processWillSwap];
-    [m_webView _processWillSwap];
+    [contentView() _processWillSwap];
+    [webView() _processWillSwap];
 }
 
 void PageClientImpl::didRelaunchProcess()
 {
-    [m_contentView _didRelaunchProcess];
-    [m_webView _didRelaunchProcess];
+    [contentView() _didRelaunchProcess];
+    [webView() _didRelaunchProcess];
 }
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 void PageClientImpl::didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID)
 {
-    [m_contentView _webProcessDidCreateContextForVisibilityPropagation];
+    [contentView() _webProcessDidCreateContextForVisibilityPropagation];
 }
 
 #if ENABLE(GPU_PROCESS)
 void PageClientImpl::didCreateContextInGPUProcessForVisibilityPropagation(LayerHostingContextID)
 {
-    [m_contentView _gpuProcessDidCreateContextForVisibilityPropagation];
+    [contentView() _gpuProcessDidCreateContextForVisibilityPropagation];
 }
 #endif // ENABLE(GPU_PROCESS)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
@@ -233,7 +234,7 @@ void PageClientImpl::didCreateContextInGPUProcessForVisibilityPropagation(LayerH
 #if ENABLE(GPU_PROCESS)
 void PageClientImpl::gpuProcessDidExit()
 {
-    [m_contentView _gpuProcessDidExit];
+    [contentView() _gpuProcessDidExit];
     PageClientImplCocoa::gpuProcessDidExit();
 }
 #endif
@@ -250,17 +251,17 @@ void PageClientImpl::toolTipChanged(const String&, const String&)
 
 void PageClientImpl::didNotHandleTapAsClick(const WebCore::IntPoint& point)
 {
-    [m_contentView _didNotHandleTapAsClick:point];
+    [contentView() _didNotHandleTapAsClick:point];
 }
 
 void PageClientImpl::didHandleTapAsHover()
 {
-    [m_contentView _didHandleTapAsHover];
+    [contentView() _didHandleTapAsHover];
 }
 
 void PageClientImpl::didCompleteSyntheticClick()
 {
-    [m_contentView _didCompleteSyntheticClick];
+    [contentView() _didCompleteSyntheticClick];
 }
 
 void PageClientImpl::decidePolicyForGeolocationPermissionRequest(WebFrameProxy& frame, const FrameInfoData& frameInfo, Function<void(bool)>& completionHandler)
@@ -275,7 +276,7 @@ void PageClientImpl::didStartProvisionalLoadForMainFrame()
 {
     auto webView = this->webView();
     [webView _didStartProvisionalLoadForMainFrame];
-    [m_contentView _didStartProvisionalLoadForMainFrame];
+    [contentView() _didStartProvisionalLoadForMainFrame];
     [webView _hidePasswordView];
 }
 
@@ -289,7 +290,7 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
     auto webView = this->webView();
     [webView _hidePasswordView];
     [webView _setHasCustomContentView:useCustomContentProvider loadedMIMEType:mimeType];
-    [m_contentView _didCommitLoadForMainFrame];
+    [contentView() _didCommitLoadForMainFrame];
 }
 
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)
@@ -299,12 +300,12 @@ void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)
 
 void PageClientImpl::disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier requestID)
 {
-    [m_contentView _disableDoubleTapGesturesDuringTapIfNecessary:requestID];
+    [contentView() _disableDoubleTapGesturesDuringTapIfNecessary:requestID];
 }
 
 void PageClientImpl::handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier requestID, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel)
 {
-    [m_contentView _handleSmartMagnificationInformationForPotentialTap:requestID renderRect:renderRect fitEntireRect:fitEntireRect viewportMinimumScale:viewportMinimumScale viewportMaximumScale:viewportMaximumScale nodeIsRootLevel:nodeIsRootLevel];
+    [contentView() _handleSmartMagnificationInformationForPotentialTap:requestID renderRect:renderRect fitEntireRect:fitEntireRect viewportMinimumScale:viewportMinimumScale viewportMaximumScale:viewportMaximumScale nodeIsRootLevel:nodeIsRootLevel];
 }
 
 double PageClientImpl::minimumZoomScale() const
@@ -317,7 +318,7 @@ double PageClientImpl::minimumZoomScale() const
 
 WebCore::FloatRect PageClientImpl::documentRect() const
 {
-    return [m_contentView bounds];
+    return [contentView() bounds];
 }
 
 void PageClientImpl::setCursor(const Cursor& cursor)
@@ -345,7 +346,7 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
     auto actionName = command->label();
     auto commandObjC = adoptNS([[WKEditCommand alloc] initWithWebEditCommandProxy:WTFMove(command)]);
     
-    NSUndoManager *undoManager = [m_contentView undoManagerForWebView];
+    NSUndoManager *undoManager = [contentView() undoManagerForWebView];
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:((undoOrRedo == UndoOrRedo::Undo) ? @selector(undoEditing:) : @selector(redoEditing:)) object:commandObjC.get()];
     if (!actionName.isEmpty())
         [undoManager setActionName:(NSString *)actionName];
@@ -353,33 +354,33 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
 
 void PageClientImpl::clearAllEditCommands()
 {
-    [[m_contentView undoManager] removeAllActionsWithTarget:m_undoTarget.get()];
+    [[contentView() undoManager] removeAllActionsWithTarget:m_undoTarget.get()];
 }
 
 bool PageClientImpl::canUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_contentView undoManager] canUndo] : [[m_contentView undoManager] canRedo];
+    return (undoOrRedo == UndoOrRedo::Undo) ? [[contentView() undoManager] canUndo] : [[contentView() undoManager] canRedo];
 }
 
 void PageClientImpl::executeUndoRedo(UndoOrRedo undoOrRedo)
 {
-    return (undoOrRedo == UndoOrRedo::Undo) ? [[m_contentView undoManager] undo] : [[m_contentView undoManager] redo];
+    return (undoOrRedo == UndoOrRedo::Undo) ? [[contentView() undoManager] undo] : [[contentView() undoManager] redo];
 }
 
 void PageClientImpl::accessibilityWebProcessTokenReceived(const IPC::DataReference& data)
 {
     NSData *remoteToken = [NSData dataWithBytes:data.data() length:data.size()];
-    [m_contentView _setAccessibilityWebProcessToken:remoteToken];
+    [contentView() _setAccessibilityWebProcessToken:remoteToken];
 }
 
 bool PageClientImpl::interpretKeyEvent(const NativeWebKeyboardEvent& event, bool isCharEvent)
 {
-    return [m_contentView _interpretKeyEvent:event.nativeEvent() isCharEvent:isCharEvent];
+    return [contentView() _interpretKeyEvent:event.nativeEvent() isCharEvent:isCharEvent];
 }
 
 void PageClientImpl::positionInformationDidChange(const InteractionInformationAtPosition& info)
 {
-    [m_contentView _positionInformationDidChange:info];
+    [contentView() _positionInformationDidChange:info];
 }
 
 void PageClientImpl::saveImageToLibrary(Ref<SharedBuffer>&& imageBuffer)
@@ -396,7 +397,7 @@ bool PageClientImpl::executeSavedCommandBySelector(const String&)
 
 void PageClientImpl::selectionDidChange()
 {
-    [m_contentView _selectionChanged];
+    [contentView() _selectionChanged];
 }
 
 void PageClientImpl::updateSecureInputState()
@@ -416,7 +417,7 @@ void PageClientImpl::notifyInputContextAboutDiscardedComposition()
 
 void PageClientImpl::assistiveTechnologyMakeFirstResponder()
 {
-    [m_contentView becomeFirstResponder];
+    [contentView() becomeFirstResponder];
 }
 
 void PageClientImpl::makeFirstResponder()
@@ -436,39 +437,41 @@ FloatRect PageClientImpl::convertToUserSpace(const FloatRect& rect)
 
 IntPoint PageClientImpl::screenToRootView(const IntPoint& point)
 {
-    return IntPoint([m_contentView convertPoint:point fromView:nil]);
+    return IntPoint([contentView() convertPoint:point fromView:nil]);
 }
 
 IntRect PageClientImpl::rootViewToScreen(const IntRect& rect)
 {
-    return enclosingIntRect([m_contentView convertRect:rect toView:nil]);
+    return enclosingIntRect([contentView() convertRect:rect toView:nil]);
 }
     
 IntPoint PageClientImpl::accessibilityScreenToRootView(const IntPoint& point)
 {
     CGPoint rootViewPoint = point;
-    if ([m_contentView respondsToSelector:@selector(accessibilityConvertPointFromSceneReferenceCoordinates:)])
-        rootViewPoint = [m_contentView accessibilityConvertPointFromSceneReferenceCoordinates:rootViewPoint];
+    auto contentView = this->contentView();
+    if ([contentView respondsToSelector:@selector(accessibilityConvertPointFromSceneReferenceCoordinates:)])
+        rootViewPoint = [contentView accessibilityConvertPointFromSceneReferenceCoordinates:rootViewPoint];
     return IntPoint(rootViewPoint);
 }
     
 IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
 {
     CGRect rootViewRect = rect;
-    if ([m_contentView respondsToSelector:@selector(accessibilityConvertRectToSceneReferenceCoordinates:)])
-        rootViewRect = [m_contentView accessibilityConvertRectToSceneReferenceCoordinates:rootViewRect];
+    auto contentView = this->contentView();
+    if ([contentView respondsToSelector:@selector(accessibilityConvertRectToSceneReferenceCoordinates:)])
+        rootViewRect = [contentView accessibilityConvertRectToSceneReferenceCoordinates:rootViewRect];
     return enclosingIntRect(rootViewRect);
 }
     
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
 {
-    [m_contentView _didHandleKeyEvent:event.nativeEvent() eventWasHandled:eventWasHandled];
+    [contentView() _didHandleKeyEvent:event.nativeEvent() eventWasHandled:eventWasHandled];
 }
 
 #if ENABLE(TOUCH_EVENTS)
 void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& nativeWebTouchEvent, bool eventHandled)
 {
-    [m_contentView _webTouchEvent:nativeWebTouchEvent preventsNativeGestures:eventHandled];
+    [contentView() _webTouchEvent:nativeWebTouchEvent preventsNativeGestures:eventHandled];
 }
 #endif
 
@@ -476,17 +479,17 @@ void PageClientImpl::doneWithTouchEvent(const NativeWebTouchEvent& nativeWebTouc
 
 void PageClientImpl::doneDeferringTouchStart(bool preventNativeGestures)
 {
-    [m_contentView _doneDeferringTouchStart:preventNativeGestures];
+    [contentView() _doneDeferringTouchStart:preventNativeGestures];
 }
 
 void PageClientImpl::doneDeferringTouchMove(bool preventNativeGestures)
 {
-    [m_contentView _doneDeferringTouchMove:preventNativeGestures];
+    [contentView() _doneDeferringTouchMove:preventNativeGestures];
 }
 
 void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 {
-    [m_contentView _doneDeferringTouchEnd:preventNativeGestures];
+    [contentView() _doneDeferringTouchEnd:preventNativeGestures];
 }
 
 #endif // ENABLE(IOS_TOUCH_EVENTS)
@@ -495,14 +498,14 @@ void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)
 {
-    [m_contentView requestTextRecognition:imageURL imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier targetLanguageIdentifier:targetLanguageIdentifier completionHandler:WTFMove(completion)];
+    [contentView() requestTextRecognition:imageURL imageData:WTFMove(imageData) sourceLanguageIdentifier:sourceLanguageIdentifier targetLanguageIdentifier:targetLanguageIdentifier completionHandler:WTFMove(completion)];
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 WebCore::DataOwnerType PageClientImpl::dataOwnerForPasteboard(PasteboardAccessIntent intent) const
 {
-    return [m_contentView _dataOwnerForPasteboard:intent];
+    return [contentView() _dataOwnerForPasteboard:intent];
 }
 
 RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy&)
@@ -512,17 +515,17 @@ RefPtr<WebPopupMenuProxy> PageClientImpl::createPopupMenuProxy(WebPageProxy&)
 
 void PageClientImpl::setTextIndicator(Ref<TextIndicator> textIndicator, WebCore::TextIndicatorLifetime)
 {
-    [m_contentView setUpTextIndicator:textIndicator];
+    [contentView() setUpTextIndicator:textIndicator];
 }
 
 void PageClientImpl::clearTextIndicator(WebCore::TextIndicatorDismissalAnimation dismissalAnimation)
 {
-    [m_contentView clearTextIndicator:dismissalAnimation];
+    [contentView() clearTextIndicator:dismissalAnimation];
 }
 
 void PageClientImpl::setTextIndicatorAnimationProgress(float animationProgress)
 {
-    [m_contentView setTextIndicatorAnimationProgress:animationProgress];
+    [contentView() setTextIndicatorAnimationProgress:animationProgress];
 }
 
 void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
@@ -531,7 +534,7 @@ void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& lay
 
 void PageClientImpl::makeViewBlank(bool makeBlank)
 {
-    [m_contentView layer].opacity = makeBlank ? 0 : 1;
+    [contentView() layer].opacity = makeBlank ? 0 : 1;
 }
 
 void PageClientImpl::showSafeBrowsingWarning(const SafeBrowsingWarning& warning, CompletionHandler<void(std::variant<WebKit::ContinueUnsafeLoad, URL>&&)>&& completionHandler)
@@ -582,7 +585,7 @@ bool PageClientImpl::effectiveUserInterfaceLevelIsElevated() const
 
 void PageClientImpl::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    [m_contentView _setAcceleratedCompositingRootView:rootNode ? rootNode->uiView() : nil];
+    [contentView() _setAcceleratedCompositingRootView:rootNode ? rootNode->uiView() : nil];
 }
 
 CALayer *PageClientImpl::acceleratedCompositingRootLayer() const
@@ -603,22 +606,22 @@ void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&
 
 void PageClientImpl::commitPotentialTapFailed()
 {
-    [m_contentView _commitPotentialTapFailed];
+    [contentView() _commitPotentialTapFailed];
 }
 
 void PageClientImpl::didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color& color, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling)
 {
-    [m_contentView _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
+    [contentView() _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
 }
 
 void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction)
 {
-    [m_contentView _didCommitLayerTree:layerTreeTransaction];
+    [contentView() _didCommitLayerTree:layerTreeTransaction];
 }
 
 void PageClientImpl::layerTreeCommitComplete()
 {
-    [m_contentView _layerTreeCommitComplete];
+    [contentView() _layerTreeCommitComplete];
 }
 
 void PageClientImpl::couldNotRestorePageState()
@@ -639,84 +642,84 @@ void PageClientImpl::restorePageCenterAndScale(std::optional<WebCore::FloatPoint
 void PageClientImpl::elementDidFocus(const FocusedElementInformation& nodeInformation, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, API::Object* userData)
 {
     auto userObject = userData ? userData->toNSObject() : RetainPtr<NSObject<NSSecureCoding>>();
-    [m_contentView _elementDidFocus:nodeInformation userIsInteracting:userIsInteracting blurPreviousNode:blurPreviousNode activityStateChanges:activityStateChanges userObject:userObject.get()];
+    [contentView() _elementDidFocus:nodeInformation userIsInteracting:userIsInteracting blurPreviousNode:blurPreviousNode activityStateChanges:activityStateChanges userObject:userObject.get()];
 }
 
 void PageClientImpl::updateInputContextAfterBlurringAndRefocusingElement()
 {
-    [m_contentView _updateInputContextAfterBlurringAndRefocusingElement];
+    [contentView() _updateInputContextAfterBlurringAndRefocusingElement];
 }
 
 bool PageClientImpl::isFocusingElement()
 {
-    return [m_contentView isFocusingElement];
+    return [contentView() isFocusingElement];
 }
 
 void PageClientImpl::elementDidBlur()
 {
-    [m_contentView _elementDidBlur];
+    [contentView() _elementDidBlur];
 }
 
 void PageClientImpl::focusedElementDidChangeInputMode(WebCore::InputMode mode)
 {
-    [m_contentView _didUpdateInputMode:mode];
+    [contentView() _didUpdateInputMode:mode];
 }
 
 void PageClientImpl::didUpdateEditorState()
 {
-    [m_contentView _didUpdateEditorState];
+    [contentView() _didUpdateEditorState];
 }
 
 void PageClientImpl::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
-    [m_contentView _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];
+    [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];
 }
 
 bool PageClientImpl::handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData& frameInfo, API::OpenPanelParameters* parameters, WebOpenPanelResultListenerProxy* listener)
 {
-    [m_contentView _showRunOpenPanel:parameters frameInfo:frameInfo resultListener:listener];
+    [contentView() _showRunOpenPanel:parameters frameInfo:frameInfo resultListener:listener];
     return true;
 }
 
 bool PageClientImpl::showShareSheet(const ShareDataWithParsedURL& shareData, WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    [m_contentView _showShareSheet:shareData inRect:std::nullopt completionHandler:WTFMove(completionHandler)];
+    [contentView() _showShareSheet:shareData inRect:std::nullopt completionHandler:WTFMove(completionHandler)];
     return true;
 }
 
 void PageClientImpl::showContactPicker(const WebCore::ContactsRequestData& requestData, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&& completionHandler)
 {
-    [m_contentView _showContactPicker:requestData completionHandler:WTFMove(completionHandler)];
+    [contentView() _showContactPicker:requestData completionHandler:WTFMove(completionHandler)];
 }
 
 void PageClientImpl::showInspectorHighlight(const WebCore::InspectorOverlay::Highlight& highlight)
 {
-    [m_contentView _showInspectorHighlight:highlight];
+    [contentView() _showInspectorHighlight:highlight];
 }
 
 void PageClientImpl::hideInspectorHighlight()
 {
-    [m_contentView _hideInspectorHighlight];
+    [contentView() _hideInspectorHighlight];
 }
 
 void PageClientImpl::showInspectorIndication()
 {
-    [m_contentView setShowingInspectorIndication:YES];
+    [contentView() setShowingInspectorIndication:YES];
 }
 
 void PageClientImpl::hideInspectorIndication()
 {
-    [m_contentView setShowingInspectorIndication:NO];
+    [contentView() setShowingInspectorIndication:NO];
 }
 
 void PageClientImpl::enableInspectorNodeSearch()
 {
-    [m_contentView _enableInspectorNodeSearch];
+    [contentView() _enableInspectorNodeSearch];
 }
 
 void PageClientImpl::disableInspectorNodeSearch()
 {
-    [m_contentView _disableInspectorNodeSearch];
+    [contentView() _disableInspectorNodeSearch];
 }
 
 #if ENABLE(FULLSCREEN_API)
@@ -799,22 +802,22 @@ void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& 
 
 void PageClientImpl::scrollingNodeScrollViewWillStartPanGesture(ScrollingNodeID)
 {
-    [m_contentView scrollViewWillStartPanOrPinchGesture];
+    [contentView() scrollViewWillStartPanOrPinchGesture];
 }
 
 void PageClientImpl::scrollingNodeScrollViewDidScroll(ScrollingNodeID)
 {
-    [m_contentView _didScroll];
+    [contentView() _didScroll];
 }
 
 void PageClientImpl::scrollingNodeScrollWillStartScroll(ScrollingNodeID nodeID)
 {
-    [m_contentView _scrollingNodeScrollingWillBegin:nodeID];
+    [contentView() _scrollingNodeScrollingWillBegin:nodeID];
 }
 
 void PageClientImpl::scrollingNodeScrollDidEndScroll(ScrollingNodeID nodeID)
 {
-    [m_contentView _scrollingNodeScrollingDidEnd:nodeID];
+    [contentView() _scrollingNodeScrollingDidEnd:nodeID];
 }
 
 Vector<String> PageClientImpl::mimeTypesWithCustomContentProviders()
@@ -850,7 +853,7 @@ void PageClientImpl::navigationGestureDidEnd(bool willNavigate, WebBackForwardLi
 
 void PageClientImpl::navigationGestureDidEnd()
 {
-    [m_webView _navigationGestureDidEnd];
+    [webView() _navigationGestureDidEnd];
 }
 
 void PageClientImpl::willRecordNavigationSnapshot(WebBackForwardListItem& item)
@@ -916,9 +919,9 @@ void PageClientImpl::didRestoreScrollPosition()
 
 WebCore::UserInterfaceLayoutDirection PageClientImpl::userInterfaceLayoutDirection()
 {
-    if (!m_webView)
-        return WebCore::UserInterfaceLayoutDirection::LTR;
-    return ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:[m_webView semanticContentAttribute]] == UIUserInterfaceLayoutDirectionLeftToRight) ? WebCore::UserInterfaceLayoutDirection::LTR : WebCore::UserInterfaceLayoutDirection::RTL;
+    if (auto webView = this->webView())
+        return ([UIView userInterfaceLayoutDirectionForSemanticContentAttribute:[webView semanticContentAttribute]] == UIUserInterfaceLayoutDirectionLeftToRight) ? WebCore::UserInterfaceLayoutDirection::LTR : WebCore::UserInterfaceLayoutDirection::RTL;
+    return WebCore::UserInterfaceLayoutDirection::LTR;
 }
 
 Ref<ValidationBubble> PageClientImpl::createValidationBubble(const String& message, const ValidationBubble::Settings& settings)
@@ -950,17 +953,17 @@ RefPtr<WebDateTimePicker> PageClientImpl::createDateTimePicker(WebPageProxy&)
 #if ENABLE(DRAG_SUPPORT)
 void PageClientImpl::didPerformDragOperation(bool handled)
 {
-    [m_contentView _didPerformDragOperation:handled];
+    [contentView() _didPerformDragOperation:handled];
 }
 
 void PageClientImpl::didHandleDragStartRequest(bool started)
 {
-    [m_contentView _didHandleDragStartRequest:started];
+    [contentView() _didHandleDragStartRequest:started];
 }
 
 void PageClientImpl::didHandleAdditionalDragItemsRequest(bool added)
 {
-    [m_contentView _didHandleAdditionalDragItemsRequest:added];
+    [contentView() _didHandleAdditionalDragItemsRequest:added];
 }
 
 void PageClientImpl::startDrag(const DragItem& item, ShareableBitmap::Handle&& image)
@@ -968,22 +971,22 @@ void PageClientImpl::startDrag(const DragItem& item, ShareableBitmap::Handle&& i
     auto bitmap = ShareableBitmap::create(WTFMove(image));
     if (!bitmap)
         return;
-    [m_contentView _startDrag:bitmap->makeCGImageCopy() item:item];
+    [contentView() _startDrag:bitmap->makeCGImageCopy() item:item];
 }
 
 void PageClientImpl::willReceiveEditDragSnapshot()
 {
-    [m_contentView _willReceiveEditDragSnapshot];
+    [contentView() _willReceiveEditDragSnapshot];
 }
 
 void PageClientImpl::didReceiveEditDragSnapshot(std::optional<TextIndicatorData> data)
 {
-    [m_contentView _didReceiveEditDragSnapshot:data];
+    [contentView() _didReceiveEditDragSnapshot:data];
 }
 
 void PageClientImpl::didChangeDragCaretRect(const IntRect& previousCaretRect, const IntRect& caretRect)
 {
-    [m_contentView _didChangeDragCaretRect:previousCaretRect currentRect:caretRect];
+    [contentView() _didChangeDragCaretRect:previousCaretRect currentRect:caretRect];
 }
 #endif
 
@@ -994,35 +997,36 @@ void PageClientImpl::requestPasswordForQuickLookDocument(const String& fileName,
         completionHandler(password);
     });
 
-    if (WKPasswordView *passwordView = [m_webView _passwordView]) {
+    auto webView = this->webView();
+    if (WKPasswordView *passwordView = [webView _passwordView]) {
         ASSERT(fileName == String { passwordView.documentName });
         [passwordView showPasswordFailureAlert];
         passwordView.userDidEnterPassword = passwordHandler.get();
         return;
     }
 
-    [m_webView _showPasswordViewWithDocumentName:fileName passwordHandler:passwordHandler.get()];
+    [webView _showPasswordViewWithDocumentName:fileName passwordHandler:passwordHandler.get()];
 }
 #endif
 
 void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, const WebCore::IntRect& elementRect, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completionHandler)
 {
-    [m_contentView _requestDOMPasteAccessForCategory:pasteAccessCategory elementRect:elementRect originIdentifier:originIdentifier completionHandler:WTFMove(completionHandler)];
+    [contentView() _requestDOMPasteAccessForCategory:pasteAccessCategory elementRect:elementRect originIdentifier:originIdentifier completionHandler:WTFMove(completionHandler)];
 }
 
 void PageClientImpl::cancelPointersForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    [m_contentView cancelPointersForGestureRecognizer:gestureRecognizer];
+    [contentView() cancelPointersForGestureRecognizer:gestureRecognizer];
 }
 
 std::optional<unsigned> PageClientImpl::activeTouchIdentifierForGestureRecognizer(UIGestureRecognizer* gestureRecognizer)
 {
-    return [m_contentView activeTouchIdentifierForGestureRecognizer:gestureRecognizer];
+    return [contentView() activeTouchIdentifierForGestureRecognizer:gestureRecognizer];
 }
 
 void PageClientImpl::handleAutocorrectionContext(const WebAutocorrectionContext& context)
 {
-    [m_contentView _handleAutocorrectionContext:context];
+    [contentView() _handleAutocorrectionContext:context];
 }
 
 void PageClientImpl::showDictationAlternativeUI(const WebCore::FloatRect&, WebCore::DictationContext)
@@ -1032,19 +1036,19 @@ void PageClientImpl::showDictationAlternativeUI(const WebCore::FloatRect&, WebCo
 
 void PageClientImpl::showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition& positionInformation)
 {
-    [m_contentView _showDataDetectorsUIForPositionInformation:positionInformation];
+    [contentView() _showDataDetectorsUIForPositionInformation:positionInformation];
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
 void PageClientImpl::didEnterFullscreen()
 {
-    [m_contentView _didEnterFullscreen];
+    [contentView() _didEnterFullscreen];
 }
 
 void PageClientImpl::didExitFullscreen()
 {
-    [m_contentView _didExitFullscreen];
+    [contentView() _didExitFullscreen];
 }
 
 #endif // ENABLE(VIDEO_PRESENTATION_MODE)
@@ -1053,7 +1057,7 @@ void PageClientImpl::didExitFullscreen()
 
 void PageClientImpl::writePromisedAttachmentToPasteboard(WebCore::PromisedAttachmentInfo&& info)
 {
-    [m_contentView _writePromisedAttachmentToPasteboard:WTFMove(info)];
+    [contentView() _writePromisedAttachmentToPasteboard:WTFMove(info)];
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)
@@ -1061,34 +1065,34 @@ void PageClientImpl::writePromisedAttachmentToPasteboard(WebCore::PromisedAttach
 void PageClientImpl::setMouseEventPolicy(WebCore::MouseEventPolicy policy)
 {
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-    [m_contentView _setMouseEventPolicy:policy];
+    [contentView() _setMouseEventPolicy:policy];
 #endif
 }
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 void PageClientImpl::showMediaControlsContextMenu(FloatRect&& targetFrame, Vector<MediaControlsContextMenuItem>&& items, CompletionHandler<void(MediaControlsContextMenuItem::ID)>&& completionHandler)
 {
-    [m_contentView _showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) completionHandler:WTFMove(completionHandler)];
+    [contentView() _showMediaControlsContextMenu:WTFMove(targetFrame) items:WTFMove(items) completionHandler:WTFMove(completionHandler)];
 }
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
 
 #if HAVE(UISCROLLVIEW_ASYNCHRONOUS_SCROLL_EVENT_HANDLING)
 void PageClientImpl::handleAsynchronousCancelableScrollEvent(UIScrollView *scrollView, UIScrollEvent *scrollEvent, void (^completion)(BOOL handled))
 {
-    [m_webView _scrollView:scrollView asynchronouslyHandleScrollEvent:scrollEvent completion:completion];
+    [webView() _scrollView:scrollView asynchronouslyHandleScrollEvent:scrollEvent completion:completion];
 }
 #endif
 
 void PageClientImpl::runModalJavaScriptDialog(CompletionHandler<void()>&& callback)
 {
-    [m_contentView runModalJavaScriptDialog:WTFMove(callback)];
+    [contentView() runModalJavaScriptDialog:WTFMove(callback)];
 }
 
 WebCore::Color PageClientImpl::contentViewBackgroundColor()
 {
     WebCore::Color color;
     auto computeContentViewBackgroundColor = [&]() {
-        color = WebCore::roundAndClampToSRGBALossy([m_contentView backgroundColor].CGColor);
+        color = WebCore::roundAndClampToSRGBALossy([contentView() backgroundColor].CGColor);
         if (color.isValid())
             return;
 
@@ -1100,7 +1104,7 @@ WebCore::Color PageClientImpl::contentViewBackgroundColor()
     };
 
 #if HAVE(OS_DARK_MODE_SUPPORT)
-    [[m_webView traitCollection] performAsCurrentTraitCollection:computeContentViewBackgroundColor];
+    [[webView() traitCollection] performAsCurrentTraitCollection:computeContentViewBackgroundColor];
 #else
     computeContentViewBackgroundColor();
 #endif
@@ -1110,50 +1114,50 @@ WebCore::Color PageClientImpl::contentViewBackgroundColor()
 
 Color PageClientImpl::insertionPointColor()
 {
-    return roundAndClampToSRGBALossy([m_webView _insertionPointColor].CGColor);
+    return roundAndClampToSRGBALossy([webView() _insertionPointColor].CGColor);
 }
 
 void PageClientImpl::requestScrollToRect(const FloatRect& targetRect, const FloatPoint& origin)
 {
-    [m_contentView _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];
+    [contentView() _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];
 }
 
 String PageClientImpl::sceneID()
 {
-    return [m_contentView window].windowScene._sceneIdentifier;
+    return [contentView() window].windowScene._sceneIdentifier;
 }
 
 void PageClientImpl::beginTextRecognitionForFullscreenVideo(ShareableBitmap::Handle&& imageHandle, AVPlayerViewController *playerViewController)
 {
-    [m_contentView beginTextRecognitionForFullscreenVideo:WTFMove(imageHandle) playerViewController:playerViewController];
+    [contentView() beginTextRecognitionForFullscreenVideo:WTFMove(imageHandle) playerViewController:playerViewController];
 }
 
 void PageClientImpl::cancelTextRecognitionForFullscreenVideo(AVPlayerViewController *controller)
 {
-    [m_contentView cancelTextRecognitionForFullscreenVideo:controller];
+    [contentView() cancelTextRecognitionForFullscreenVideo:controller];
 }
 
 bool PageClientImpl::isTextRecognitionInFullscreenVideoEnabled() const
 {
-    return [m_contentView isTextRecognitionInFullscreenVideoEnabled];
+    return [contentView() isTextRecognitionInFullscreenVideoEnabled];
 }
 
 #if ENABLE(VIDEO)
 void PageClientImpl::beginTextRecognitionForVideoInElementFullscreen(ShareableBitmap::Handle&& bitmapHandle, FloatRect bounds)
 {
-    [m_contentView beginTextRecognitionForVideoInElementFullscreen:WTFMove(bitmapHandle) bounds:bounds];
+    [contentView() beginTextRecognitionForVideoInElementFullscreen:WTFMove(bitmapHandle) bounds:bounds];
 }
 
 void PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen()
 {
-    [m_contentView cancelTextRecognitionForVideoInElementFullscreen];
+    [contentView() cancelTextRecognitionForVideoInElementFullscreen];
 }
 #endif
 
 bool PageClientImpl::hasResizableWindows() const
 {
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
-    return [m_webView _isWindowResizingEnabled];
+    return [webView() _isWindowResizingEnabled];
 #else
     return false;
 #endif


### PR DESCRIPTION
#### 3fe8f3b95be547534fd945e5b0a9786f09ef237a
<pre>
Stop autoreleasing WKWebView and WKContentView in WebKit::PageClientImplIOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=258051">https://bugs.webkit.org/show_bug.cgi?id=258051</a>
&lt;rdar://110740310&gt;

Reviewed by Alex Christensen.

Replace m_contentView with contentView() (and m_webView with webView())
in PageClientImplIOS.mm to prevent those objects from being
autoreleased.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
(WebKit::PageClientImpl::contentView): Add.
- Add convenience method to call WeakObjCPtr&lt;WKContentView&gt;::get() to
  return a RetainPtr&lt;WKContentView&gt;, which avoids autoreleasing the
  object.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::createDrawingAreaProxy):
(WebKit::PageClientImpl::requestScroll):
(WebKit::PageClientImpl::viewScrollPosition):
(WebKit::PageClientImpl::viewSize):
(WebKit::PageClientImpl::isViewWindowActive):
(WebKit::PageClientImpl::isViewFocused):
(WebKit::PageClientImpl::isViewInWindow):
(WebKit::PageClientImpl::processDidExit):
(WebKit::PageClientImpl::processWillSwap):
(WebKit::PageClientImpl::didRelaunchProcess):
(WebKit::PageClientImpl::didCreateContextInWebProcessForVisibilityPropagation):
(WebKit::PageClientImpl::didCreateContextInGPUProcessForVisibilityPropagation):
(WebKit::PageClientImpl::gpuProcessDidExit):
(WebKit::PageClientImpl::didNotHandleTapAsClick):
(WebKit::PageClientImpl::didHandleTapAsHover):
(WebKit::PageClientImpl::didCompleteSyntheticClick):
(WebKit::PageClientImpl::didStartProvisionalLoadForMainFrame):
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
(WebKit::PageClientImpl::disableDoubleTapGesturesDuringTapIfNecessary):
(WebKit::PageClientImpl::handleSmartMagnificationInformationForPotentialTap):
(WebKit::PageClientImpl::documentRect const):
(WebKit::PageClientImpl::registerEditCommand):
(WebKit::PageClientImpl::clearAllEditCommands):
(WebKit::PageClientImpl::canUndoRedo):
(WebKit::PageClientImpl::executeUndoRedo):
(WebKit::PageClientImpl::accessibilityWebProcessTokenReceived):
(WebKit::PageClientImpl::interpretKeyEvent):
(WebKit::PageClientImpl::positionInformationDidChange):
(WebKit::PageClientImpl::selectionDidChange):
(WebKit::PageClientImpl::assistiveTechnologyMakeFirstResponder):
(WebKit::PageClientImpl::screenToRootView):
(WebKit::PageClientImpl::rootViewToScreen):
(WebKit::PageClientImpl::accessibilityScreenToRootView):
(WebKit::PageClientImpl::rootViewToAccessibilityScreen):
(WebKit::PageClientImpl::doneWithKeyEvent):
(WebKit::PageClientImpl::doneWithTouchEvent):
(WebKit::PageClientImpl::doneDeferringTouchStart):
(WebKit::PageClientImpl::doneDeferringTouchMove):
(WebKit::PageClientImpl::doneDeferringTouchEnd):
(WebKit::PageClientImpl::requestTextRecognition):
(WebKit::PageClientImpl::dataOwnerForPasteboard const):
(WebKit::PageClientImpl::setTextIndicator):
(WebKit::PageClientImpl::clearTextIndicator):
(WebKit::PageClientImpl::setTextIndicatorAnimationProgress):
(WebKit::PageClientImpl::makeViewBlank):
(WebKit::PageClientImpl::setRemoteLayerTreeRootNode):
(WebKit::PageClientImpl::commitPotentialTapFailed):
(WebKit::PageClientImpl::didGetTapHighlightGeometries):
(WebKit::PageClientImpl::didCommitLayerTree):
(WebKit::PageClientImpl::layerTreeCommitComplete):
(WebKit::PageClientImpl::elementDidFocus):
(WebKit::PageClientImpl::updateInputContextAfterBlurringAndRefocusingElement):
(WebKit::PageClientImpl::isFocusingElement):
(WebKit::PageClientImpl::elementDidBlur):
(WebKit::PageClientImpl::focusedElementDidChangeInputMode):
(WebKit::PageClientImpl::didUpdateEditorState):
(WebKit::PageClientImpl::showPlaybackTargetPicker):
(WebKit::PageClientImpl::handleRunOpenPanel):
(WebKit::PageClientImpl::showShareSheet):
(WebKit::PageClientImpl::showContactPicker):
(WebKit::PageClientImpl::showInspectorHighlight):
(WebKit::PageClientImpl::hideInspectorHighlight):
(WebKit::PageClientImpl::showInspectorIndication):
(WebKit::PageClientImpl::hideInspectorIndication):
(WebKit::PageClientImpl::enableInspectorNodeSearch):
(WebKit::PageClientImpl::disableInspectorNodeSearch):
(WebKit::PageClientImpl::scrollingNodeScrollViewWillStartPanGesture):
(WebKit::PageClientImpl::scrollingNodeScrollViewDidScroll):
(WebKit::PageClientImpl::scrollingNodeScrollWillStartScroll):
(WebKit::PageClientImpl::scrollingNodeScrollDidEndScroll):
(WebKit::PageClientImpl::navigationGestureDidEnd):
(WebKit::PageClientImpl::userInterfaceLayoutDirection):
(WebKit::PageClientImpl::didPerformDragOperation):
(WebKit::PageClientImpl::didHandleDragStartRequest):
(WebKit::PageClientImpl::didHandleAdditionalDragItemsRequest):
(WebKit::PageClientImpl::startDrag):
(WebKit::PageClientImpl::willReceiveEditDragSnapshot):
(WebKit::PageClientImpl::didReceiveEditDragSnapshot):
(WebKit::PageClientImpl::didChangeDragCaretRect):
(WebKit::PageClientImpl::requestPasswordForQuickLookDocument):
(WebKit::PageClientImpl::requestDOMPasteAccess):
(WebKit::PageClientImpl::cancelPointersForGestureRecognizer):
(WebKit::PageClientImpl::activeTouchIdentifierForGestureRecognizer):
(WebKit::PageClientImpl::handleAutocorrectionContext):
(WebKit::PageClientImpl::showDataDetectorsUIForPositionInformation):
(WebKit::PageClientImpl::didEnterFullscreen):
(WebKit::PageClientImpl::didExitFullscreen):
(WebKit::PageClientImpl::writePromisedAttachmentToPasteboard):
(WebKit::PageClientImpl::setMouseEventPolicy):
(WebKit::PageClientImpl::showMediaControlsContextMenu):
(WebKit::PageClientImpl::handleAsynchronousCancelableScrollEvent):
(WebKit::PageClientImpl::runModalJavaScriptDialog):
(WebKit::PageClientImpl::contentViewBackgroundColor):
(WebKit::PageClientImpl::insertionPointColor):
(WebKit::PageClientImpl::requestScrollToRect):
(WebKit::PageClientImpl::sceneID):
(WebKit::PageClientImpl::beginTextRecognitionForFullscreenVideo):
(WebKit::PageClientImpl::cancelTextRecognitionForFullscreenVideo):
(WebKit::PageClientImpl::isTextRecognitionInFullscreenVideoEnabled const):
(WebKit::PageClientImpl::beginTextRecognitionForVideoInElementFullscreen):
(WebKit::PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen):
(WebKit::PageClientImpl::hasResizableWindows const):

Canonical link: <a href="https://commits.webkit.org/265157@main">https://commits.webkit.org/265157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bab8f10a99f38d96f4cc2c01c2f074fd05910d95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9662 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12602 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10918 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8448 "53 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12018 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8225 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16375 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9396 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12460 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9695 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7868 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8854 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13083 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1129 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->