### PR TITLE
REGRESSION(264920@main): TestWebKitAPI.ApplicationStateTracking.WindowDeallocDoesNotPermanentlyFreezeLayerTree is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
@@ -37,7 +37,12 @@
 
 namespace TestWebKitAPI {
 
+// FIXME when rdar://110536156 is resolved.
+#if PLATFORM(IOS)
+TEST(ApplicationStateTracking, DISABLED_WindowDeallocDoesNotPermanentlyFreezeLayerTree)
+#else
 TEST(ApplicationStateTracking, WindowDeallocDoesNotPermanentlyFreezeLayerTree)
+#endif
 {
     auto configuration = adoptNS([WKWebViewConfiguration new]);
 


### PR DESCRIPTION
#### 0cd636e251b5465011d01497be5c1d8b0a827946
<pre>
REGRESSION(264920@main): TestWebKitAPI.ApplicationStateTracking.WindowDeallocDoesNotPermanentlyFreezeLayerTree is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=257897">https://bugs.webkit.org/show_bug.cgi?id=257897</a>
rdar://110536156

Unreviewed test gardening.

Disabling API while investigated.

* Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265138@main">https://commits.webkit.org/265138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fcca5b20edc4f2e1c5bf854e282f7a7668a2c00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11626 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10173 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10912 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9039 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9188 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9690 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13078 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1126 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->