### PR TITLE
[WebGPU] Add validation for RenderPassEncoder

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -77,6 +77,11 @@ public:
 
     bool isValid() const { return m_commandBuffer; }
 
+    EncoderState state() const { return m_state; }
+    void setState(EncoderState state) { m_state = state; }
+
+    void makeInvalid() { m_commandBuffer = nil; }
+
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&);
     CommandEncoder(Device&);
@@ -87,8 +92,6 @@ private:
     bool validatePopDebugGroup() const;
     bool validateComputePassDescriptor(const WGPUComputePassDescriptor&) const;
     bool validateRenderPassDescriptor(const WGPURenderPassDescriptor&) const;
-
-    void makeInvalid() { m_commandBuffer = nil; }
 
     void ensureBlitCommandEncoder();
     void finalizeBlitCommandEncoder();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -250,15 +250,15 @@ static bool isStencilOnlyFormat(MTLPixelFormat format)
 Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescriptor& descriptor)
 {
     if (descriptor.nextInChain)
-        return RenderPassEncoder::createInvalid(m_device);
+        return RenderPassEncoder::createInvalid(*this, m_device);
 
     if (!validateRenderPassDescriptor(descriptor))
-        return RenderPassEncoder::createInvalid(m_device);
+        return RenderPassEncoder::createInvalid(*this, m_device);
 
     MTLRenderPassDescriptor* mtlDescriptor = [MTLRenderPassDescriptor new];
 
     if (descriptor.colorAttachmentCount > 8)
-        return RenderPassEncoder::createInvalid(m_device);
+        return RenderPassEncoder::createInvalid(*this, m_device);
 
     finalizeBlitCommandEncoder();
 
@@ -363,7 +363,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
                 break;
             case WGPURenderPassTimestampLocation_Force32:
                 ASSERT_NOT_REACHED();
-                return RenderPassEncoder::createInvalid(m_device);
+                return RenderPassEncoder::createInvalid(*this, m_device);
             }
 
             fromAPI(timestampWrite.querySet).setOverrideLocation(timestampWrite.queryIndex, dummyQuerySet, otherIndex);
@@ -372,7 +372,8 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
     auto mtlRenderCommandEncoder = [m_commandBuffer renderCommandEncoderWithDescriptor:mtlDescriptor];
 
-    return RenderPassEncoder::create(mtlRenderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, m_device);
+    m_state = EncoderState::Locked;
+    return RenderPassEncoder::create(mtlRenderCommandEncoder, descriptor, visibilityResultBufferSize, depthReadOnly, stencilReadOnly, *this, m_device);
 }
 
 bool CommandEncoder::validateCopyBufferToBuffer(const Buffer& source, uint64_t sourceOffset, const Buffer& destination, uint64_t destinationOffset, uint64_t size)

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -37,14 +37,15 @@ struct WGPURenderBundleImpl {
 namespace WebGPU {
 
 class Device;
+class PipelineLayout;
 
 // https://gpuweb.github.io/gpuweb/#gpurenderbundle
 class RenderBundle : public WGPURenderBundleImpl, public RefCounted<RenderBundle> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderBundle> create(id<MTLIndirectCommandBuffer> indirectCommandBuffer, Vector<BindableResource>&& resources, Device& device)
+    static Ref<RenderBundle> create(id<MTLIndirectCommandBuffer> indirectCommandBuffer, const WGPURenderBundleEncoderDescriptor& descriptor, Vector<BindableResource>&& resources, RefPtr<PipelineLayout>&& pipelineLayout, Device& device)
     {
-        return adoptRef(*new RenderBundle(indirectCommandBuffer, WTFMove(resources), device));
+        return adoptRef(*new RenderBundle(indirectCommandBuffer, descriptor, WTFMove(resources), WTFMove(pipelineLayout), device));
     }
     static Ref<RenderBundle> createInvalid(Device& device)
     {
@@ -62,14 +63,20 @@ public:
     Device& device() const { return m_device; }
     const Vector<BindableResource>& resources() const { return m_resources; }
 
+    bool depthReadOnly() const;
+    bool stencilReadOnly() const;
+    const PipelineLayout* pipelineLayout() const { return m_pipelineLayout.get(); }
+
 private:
-    RenderBundle(id<MTLIndirectCommandBuffer>, Vector<BindableResource>&&, Device&);
+    RenderBundle(id<MTLIndirectCommandBuffer>, const WGPURenderBundleEncoderDescriptor&, Vector<BindableResource>&&, RefPtr<PipelineLayout>&&, Device&);
     RenderBundle(Device&);
 
     const id<MTLIndirectCommandBuffer> m_indirectCommandBuffer { nil };
 
     const Ref<Device> m_device;
+    const WGPURenderBundleEncoderDescriptor m_descriptor;
     Vector<BindableResource> m_resources;
+    RefPtr<PipelineLayout> m_pipelineLayout;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -30,15 +30,18 @@
 
 namespace WebGPU {
 
-RenderBundle::RenderBundle(id<MTLIndirectCommandBuffer> indirectCommandBuffer, Vector<BindableResource>&& resources, Device& device)
+RenderBundle::RenderBundle(id<MTLIndirectCommandBuffer> indirectCommandBuffer, const WGPURenderBundleEncoderDescriptor& descriptor, Vector<BindableResource>&& resources, RefPtr<PipelineLayout>&& pipelineLayout, Device& device)
     : m_indirectCommandBuffer(indirectCommandBuffer)
     , m_device(device)
+    , m_descriptor(descriptor)
     , m_resources(WTFMove(resources))
+    , m_pipelineLayout(WTFMove(pipelineLayout))
 {
 }
 
 RenderBundle::RenderBundle(Device& device)
     : m_device(device)
+    , m_descriptor()
 {
 }
 
@@ -47,6 +50,16 @@ RenderBundle::~RenderBundle() = default;
 void RenderBundle::setLabel(String&& label)
 {
     m_indirectCommandBuffer.label = label;
+}
+
+bool RenderBundle::depthReadOnly() const
+{
+    return m_descriptor.depthReadOnly;
+}
+
+bool RenderBundle::stencilReadOnly() const
+{
+    return m_descriptor.stencilReadOnly;
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -41,6 +41,7 @@ namespace WebGPU {
 class BindGroup;
 class Buffer;
 class Device;
+class PipelineLayout;
 class RenderBundle;
 class RenderPipeline;
 
@@ -48,9 +49,9 @@ class RenderPipeline;
 class RenderBundleEncoder : public WGPURenderBundleEncoderImpl, public RefCounted<RenderBundleEncoder>, public CommandsMixin {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RenderBundleEncoder> create(MTLIndirectCommandBufferDescriptor *indirectCommandBufferDescriptor, Device& device)
+    static Ref<RenderBundleEncoder> create(MTLIndirectCommandBufferDescriptor *indirectCommandBufferDescriptor, const WGPURenderBundleEncoderDescriptor& descriptor, Device& device)
     {
-        return adoptRef(*new RenderBundleEncoder(indirectCommandBufferDescriptor, device));
+        return adoptRef(*new RenderBundleEncoder(indirectCommandBufferDescriptor, descriptor, device));
     }
     static Ref<RenderBundleEncoder> createInvalid(Device& device)
     {
@@ -78,7 +79,7 @@ public:
     bool isValid() const { return m_indirectCommandBuffer; }
 
 private:
-    RenderBundleEncoder(MTLIndirectCommandBufferDescriptor*, Device&);
+    RenderBundleEncoder(MTLIndirectCommandBufferDescriptor*, const WGPURenderBundleEncoderDescriptor&, Device&);
     RenderBundleEncoder(Device&);
 
     bool validatePopDebugGroup() const;
@@ -97,6 +98,8 @@ private:
     NSUInteger m_indexBufferOffset { 0 };
     Vector<WTF::Function<void(void)>> m_recordedCommands;
     Vector<BindableResource> m_resources;
+    const WGPURenderBundleEncoderDescriptor m_descriptor;
+    RefPtr<PipelineLayout> m_pipelineLayout;
     const Ref<Device> m_device;
 };
 

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -70,6 +70,7 @@ public:
     MTLDepthClipMode depthClipMode() const { return m_clipMode; }
 
     Device& device() const { return m_device; }
+    Ref<PipelineLayout> pipelineLayout() const { return m_pipelineLayout; }
 
 private:
     RenderPipeline(id<MTLRenderPipelineState>, MTLPrimitiveType, std::optional<MTLIndexType>, MTLWinding, MTLCullMode, MTLDepthClipMode, MTLDepthStencilDescriptor *, Ref<PipelineLayout>&&, Device&);


### PR DESCRIPTION
#### 8956275868e226d74eb8f8262f5f3ded5d62f05e
<pre>
[WebGPU] Add validation for RenderPassEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=258056">https://bugs.webkit.org/show_bug.cgi?id=258056</a>
&lt;radar://110746831&gt;

Reviewed by NOBODY (OOPS!).

Add validation per <a href="https://gpuweb.github.io/gpuweb/#gpurenderpassencoder">https://gpuweb.github.io/gpuweb/#gpurenderpassencoder</a> for
all GPURenderPassEncoder methods.

* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::occlusionQuerySetCount):
(WebGPU::RenderPassEncoder::beginOcclusionQuery):
(WebGPU::RenderPassEncoder::endOcclusionQuery):
(WebGPU::RenderPassEncoder::validateEncoderState const):
(WebGPU::RenderPassEncoder::setBlendConstant):
(WebGPU::RenderPassEncoder::attachmentWidth const):
(WebGPU::RenderPassEncoder::attachmentHeight const):
(WebGPU::RenderPassEncoder::setScissorRect):
(WebGPU::RenderPassEncoder::setStencilReference):
(WebGPU::RenderPassEncoder::setViewport):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8956275868e226d74eb8f8262f5f3ded5d62f05e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9727 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12094 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8291 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9759 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7926 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->