### PR TITLE
Add a way to run incremental GC sweeps during runloop idle time in between rendering updates

### DIFF
--- a/Source/JavaScriptCore/heap/IncrementalSweeper.h
+++ b/Source/JavaScriptCore/heap/IncrementalSweeper.h
@@ -40,12 +40,14 @@ public:
     JS_EXPORT_PRIVATE void startSweeping(Heap&);
     void freeFastMallocMemoryAfterSweeping() { m_shouldFreeFastMallocMemoryAfterSweeping = true; }
 
+    void doWorkUntil(VM&, MonotonicTime deadline);
     void doWork(VM&) final;
     void stopSweeping();
 
 private:
-    bool sweepNextBlock(VM&);
-    void doSweep(VM&, MonotonicTime startTime);
+    enum class SweepTrigger : bool { Timer, OpportunisticTask };
+    bool sweepNextBlock(VM&, SweepTrigger);
+    void doSweep(VM&, MonotonicTime startTime, SweepTrigger);
     void scheduleTimer();
     
     BlockDirectory* m_currentDirectory;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -221,4 +221,10 @@ void DeferredWorkTimer::didResumeScriptExecutionOwner()
         setTimeUntilFire(0_s);
 }
 
+bool DeferredWorkTimer::hasAnyPendingWork() const
+{
+    ASSERT(m_apiLock->vm()->currentThreadIsHoldingAPILock() || (Thread::mayBeGCThread() && m_apiLock->vm()->heap.worldIsStopped()));
+    return !m_pendingTickets.isEmpty();
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -66,6 +66,7 @@ public:
     void doWork(VM&) final;
 
     Ticket addPendingWork(VM&, JSObject* target, Vector<Strong<JSCell>>&& dependencies);
+    bool hasAnyPendingWork() const;
     bool hasPendingWork(Ticket);
     bool hasDependancyInPendingWork(Ticket, JSCell* dependency);
     bool cancelPendingWork(Ticket);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -412,6 +412,8 @@ public:
         m_entryScopeServices.add(service);
     }
 
+    JS_EXPORT_PRIVATE void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
+
 private:
     VMIdentifier m_identifier;
     RefPtr<JSLock> m_apiLock;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -39,6 +39,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "CommonAtomStrings.h"
+#include "CommonVM.h"
 #include "ConstantPropertyMap.h"
 #include "ContextMenuClient.h"
 #include "ContextMenuController.h"
@@ -173,6 +174,7 @@
 #include "WheelEventTestMonitor.h"
 #include "Widget.h"
 #include "WorkerOrWorkletScriptController.h"
+#include <JavaScriptCore/VM.h>
 #include <wtf/FileSystem.h>
 #include <wtf/RefCountedLeakCounter.h>
 #include <wtf/StdLibExtras.h>
@@ -4460,9 +4462,7 @@ void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::opt
 
 void Page::performOpportunisticallyScheduledTasks(MonotonicTime deadline)
 {
-    // FIXME (257622): Call into JavaScriptCore to perform any imminently-scheduled
-    // work prior to the next rendering update.
-    UNUSED_PARAM(deadline);
+    commonVM().performOpportunisticallyScheduledTasks(deadline);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1a501dce9fa2e730808e6a4712a0ab4fb30e3302
<pre>
Add a way to run incremental GC sweeps during runloop idle time in between rendering updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=257622">https://bugs.webkit.org/show_bug.cgi?id=257622</a>
rdar://110076652

Reviewed by Mark Lam.

Add a new (privately-exposed) hook on `VM`, which enables JavaScriptCore to perform periodically-
scheduled work (for now, just limited to incremental sweeping) when the runloop enters idle state,
in between rendering updates. When combined with &lt;<a href="https://webkit.org/b/258032">https://webkit.org/b/258032</a>&gt;, this will allow us
to move a significant chunk of our incremental sweeping into time intervals when the runloop has
entered idle state, and we&apos;re still waiting for the next rendering update to arrive.

* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::doWorkUntil):
(JSC::IncrementalSweeper::doWork):
(JSC::IncrementalSweeper::doSweep):

Refactor this method, such that it may be called from either the periodic 100 ms timer, or the
opportunistic task hook from VM. In the case of the latter, we avoid eagerly shrinking or freeing
`MarkedBlock`s that have been swept, in order to mitigate the potential for unnecessarily shrinking
the heap capacity by freeing marked blocks more often, only to grow it again immediately thereafter.

(JSC::IncrementalSweeper::sweepNextBlock):
* Source/JavaScriptCore/heap/IncrementalSweeper.h:
* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::hasAnyPendingWork const):

Add a helper method to return whether the `DeferredWorkTimer` has any scheduled tasks. If so, we
avoid performing any opportunistically scheduled cleanup; this prevents us from scheduling
opportunistic tasks right as a WASM module is being compiled, and thus block it from running right
away.

* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::performOpportunisticallyScheduledTasks):

See above for more details.

* Source/JavaScriptCore/runtime/VM.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::performOpportunisticallyScheduledTasks):

Adopt the new `VM` hook.

Canonical link: <a href="https://commits.webkit.org/265197@main">https://commits.webkit.org/265197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11f5f3666f54598c3bd408573c84f71fa7ec2e44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11808 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12192 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16501 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12606 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9638 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9825 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7978 "3 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10295 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8984 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2445 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13222 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10575 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9639 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2621 "Passed tests") | 
<!--EWS-Status-Bubble-End-->