### PR TITLE
[CSSOM] Fix insertion of rule into orphaned style rule

### DIFF
--- a/LayoutTests/fast/css/cssom-mutation-stylerule-expected.html
+++ b/LayoutTests/fast/css/cssom-mutation-stylerule-expected.html
@@ -1,0 +1,2 @@
+
+Test passes if no crash.

--- a/LayoutTests/fast/css/cssom-mutation-stylerule.html
+++ b/LayoutTests/fast/css/cssom-mutation-stylerule.html
@@ -1,0 +1,14 @@
+<style>
+    aaa {
+        color: red;
+    }
+</style>
+<script>
+  onload = () => {
+    let cssStyleRule = document.styleSheets[0].cssRules[0];
+    document.styleSheets[0].deleteRule(0);
+    cssStyleRule.insertRule(`.bar { color: black; }`);
+  };
+</script>
+
+Test passes if no crash.


### PR DESCRIPTION
#### 36514195098dc050e1be84bf346f632b2c1234f7
<pre>
[CSSOM] Fix insertion of rule into orphaned style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=258017">https://bugs.webkit.org/show_bug.cgi?id=258017</a>
rdar://110629287

Reviewed by Antti Koivisto.

When a StyleRule is orphaned, we don&apos;t need any specific mechanism (such as RuleMutationScope)
and convert it directly to a StyleRuleWithNesting.

* LayoutTests/fast/css/cssom-mutation-stylerule-expected.html: Added.
* LayoutTests/fast/css/cssom-mutation-stylerule.html: Added.
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::insertRule):

Canonical link: <a href="https://commits.webkit.org/265154@main">https://commits.webkit.org/265154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec6d8a4f611faa3ae95549bf8d19c7d0bd2b37e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12054 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16402 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9229 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12488 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9722 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7893 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8975 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2403 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->