### PR TITLE
[GStreamer][EME] Break key waiting on PAUSED->READY state change

### DIFF
--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key-expected.txt
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key-expected.txt
@@ -1,0 +1,11 @@
+
+EME API is supported OK
+Media source is opened OK
+EVENT(encrypted)
+MediaKeys is created OK
+EVENT(message)
+Skipping keys update OK
+Changing URL OK
+URL changed in time OK
+END OF TEST
+

--- a/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html
+++ b/LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Playback ClearKey CENC audio with full-sample encryption</title>
+    <script src="../medias-enc.js"></script>
+    <script src="../../video-test.js"></script>
+    <script src="../../media-source/media-source-loader-simple.js"></script>
+    <script src="encrypted-media-clearKey-handler.js"></script>
+    <script>
+
+     const audioConf = streamMedias["simpleClearKeyMSE"].audio;
+
+     function runTest() {
+
+         findMediaElement();
+
+         const emeHandler = new EncryptedMediaHandler(video, audioConf);
+         if (!emeHandler)
+             failTest();
+
+         emeHandler.skipUpdateCallback = function() {
+             setTimeout(function() {
+                 logResult(true, "Changing URL");
+                 const startTime = Date.now();
+                 video.src = "../../content/counting.mp4"
+                 video.play(1);
+                 const difference = Date.now() - startTime;
+                 logResult(difference < 4000, "URL changed in time");
+                 endTest();
+             }, 2000);
+         }
+
+         const ms = new MediaSourceLoaderSimple(video);
+         ms.onready = function() {
+             logResult(true, "Media source is opened");
+             ms.createSourceBuffer(audioConf, 4);
+             video.play().catch(function(e) { });
+         };
+     }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/encrypted-media/clearKey/encrypted-media-clearKey-handler.js
+++ b/LayoutTests/media/encrypted-media/clearKey/encrypted-media-clearKey-handler.js
@@ -46,6 +46,7 @@ function EncryptedMediaHandler(video, videoConf, audioConf)
     }
     this.videoConf = videoConf;
     this.sessions = [];
+    this.skipUpdateCallback = undefined;
     this.setMediaKeyPromise;
     waitForEventOn(video, "encrypted", this.onEncrypted.bind(this));
     return this;
@@ -93,6 +94,12 @@ EncryptedMediaHandler.prototype = {
 
     onMessage : function(event)
     {
+        if (this.skipUpdateCallback) {
+            logResult(true, "Skipping keys update");
+            this.skipUpdateCallback();
+            return;
+        }
+
         let session = event.target;
         let msgStr = String.fromCharCode.apply(String, new Uint8Array(event.message));
         let msg = JSON.parse(msgStr);

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1166,6 +1166,7 @@ webkit.org/b/181594 media/encrypted-media/clearKey/clearKey-cenc-audio-playback-
 webkit.org/b/181594 media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse.html [ Skip ]
 webkit.org/b/189200 media/encrypted-media/clearKey/clearKey-webm-video-playback-mse.html [ Skip ]
 media/encrypted-media/clearKey/clearKey-cenc-video-playback-mse-multikey.html [ Skip ]
+webkit.org/b/258070 media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html [ Skip ]
 
 webkit.org/b/162507 http/tests/media/hls/hls-video-resize.html [ Pass Failure ]
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -44,7 +44,7 @@ public:
         : m_decryptor(decryptor) { }
     virtual bool isAborting()
     {
-        return webKitMediaCommonEncryptionDecryptIsFlushing(m_decryptor);
+        return webKitMediaCommonEncryptionDecryptIsAborting(m_decryptor);
     }
     virtual ~CDMProxyDecryptionClientImplementation() = default;
 private:
@@ -66,6 +66,7 @@ struct _WebKitMediaCommonEncryptionDecryptPrivate {
     Condition condition;
 
     bool isFlushing { false };
+    bool isStopped { true };
     std::unique_ptr<CDMProxyDecryptionClientImplementation> cdmProxyDecryptionClientImplementation;
     enum DecryptionState decryptionState { DecryptionState::Idle };
 };
@@ -238,12 +239,16 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
     if (!priv->cdmProxy) {
         GST_DEBUG_OBJECT(self, "CDM not available, going to wait for it");
         priv->condition.waitFor(priv->lock, MaxSecondsToWaitForCDMProxy, [priv] {
-            return priv->isFlushing || priv->cdmProxy;
+            return priv->isFlushing || priv->cdmProxy || priv->isStopped;
         });
         // Note that waitFor() releases the lock internally while it waits, so isFlushing may have been changed.
         if (priv->isFlushing) {
             GST_DEBUG_OBJECT(self, "Decryption aborted because of flush");
             return GST_FLOW_FLUSHING;
+        }
+        if (priv->isStopped) {
+            GST_DEBUG_OBJECT(self, "Element is closing");
+            return GST_FLOW_OK;
         }
         if (!priv->cdmProxy) {
             GST_ELEMENT_ERROR(self, STREAM, FAILED, ("CDMProxy was not retrieved in time"), (nullptr));
@@ -463,11 +468,11 @@ static gboolean sinkEventHandler(GstBaseTransform* trans, GstEvent* event)
     return GST_BASE_TRANSFORM_CLASS(parent_class)->sink_event(trans, event);
 }
 
-bool webKitMediaCommonEncryptionDecryptIsFlushing(WebKitMediaCommonEncryptionDecrypt* self)
+bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDecrypt* self)
 {
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
     Locker locker { priv->lock };
-    return priv->isFlushing;
+    return priv->isFlushing || priv->isStopped;
 }
 
 WeakPtr<WebCore::CDMProxyDecryptionClient> webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(WebKitMediaCommonEncryptionDecrypt* self)
@@ -482,10 +487,24 @@ static GstStateChangeReturn changeState(GstElement* element, GstStateChange tran
     WebKitMediaCommonEncryptionDecryptPrivate* priv = WEBKIT_MEDIA_CENC_DECRYPT_GET_PRIVATE(self);
 
     switch (transition) {
-    case GST_STATE_CHANGE_PAUSED_TO_READY:
-        GST_DEBUG_OBJECT(self, "PAUSED->READY");
-        priv->condition.notifyOne();
+    case GST_STATE_CHANGE_READY_TO_PAUSED: {
+        GST_DEBUG_OBJECT(self, "READY->PAUSED");
+
+        LockHolder locker(priv->lock);
+        priv->isStopped = false;
         break;
+    }
+    case GST_STATE_CHANGE_PAUSED_TO_READY: {
+        // We need to do this here instead of after the , otherwise we won't be able to break the wait.
+        GST_DEBUG_OBJECT(self, "PAUSED->READY");
+
+        LockHolder locker(priv->lock);
+        priv->isStopped = true;
+        priv->condition.notifyOne();
+        if (priv->cdmProxy)
+            priv->cdmProxy->abortWaitingForKey();
+        break;
+    }
     default:
         break;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -46,7 +46,7 @@ typedef struct _WebKitMediaCommonEncryptionDecryptPrivate WebKitMediaCommonEncry
 
 GType webkit_media_common_encryption_decrypt_get_type(void);
 
-bool webKitMediaCommonEncryptionDecryptIsFlushing(WebKitMediaCommonEncryptionDecrypt*);
+bool webKitMediaCommonEncryptionDecryptIsAborting(WebKitMediaCommonEncryptionDecrypt*);
 
 struct _WebKitMediaCommonEncryptionDecrypt {
     GstBaseTransform parent;


### PR DESCRIPTION
#### a65d75e0fad55dedd44857659f21bd7ee81b4e1e
<pre>
[GStreamer][EME] Break key waiting on PAUSED-&gt;READY state change
<a href="https://bugs.webkit.org/show_bug.cgi?id=258070">https://bugs.webkit.org/show_bug.cgi?id=258070</a>

Reviewed by Philippe Normand.

Changing a state can&apos;t be completed when decryptor is waiting for a key.
This can block main thread for max 7sec.

1) Signal key waiting condition to return when decryptor is closing.
2) Return waiting for CDMProxy for the same case.

Original patch by: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;.

* LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key-expected.txt: Added.
* LayoutTests/media/encrypted-media/clearKey/clearKey-cenc-stop-playback-before-key.html: Added.
* LayoutTests/media/encrypted-media/clearKey/encrypted-media-clearKey-handler.js:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(CDMProxyDecryptionClientImplementation::isAborting):
(transformInPlace):
(webKitMediaCommonEncryptionDecryptIsAborting):
(changeState):
(webKitMediaCommonEncryptionDecryptIsFlushing): Deleted.
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/265231@main">https://commits.webkit.org/265231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384ad08b2877796ca124ed7ba40b751874fa2e17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10358 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11101 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12229 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12630 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9847 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7993 "1 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->