### PR TITLE
HTMLOptionElement::defaultSelected should affect selection state of other option elements once added or removed

### DIFF
--- a/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
+++ b/LayoutTests/fast/forms/select/option-defaultselected-expected.txt
@@ -1,0 +1,21 @@
+Tests for HTMLOptionElement::defaultSelected
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS option1.defaultSelected is false
+PASS option1.defaultSelected = true; option1.hasAttribute("selected") is true
+PASS option1.selected is true
+PASS option1.selected = false; option1.defaultSelected is true
+PASS option1.defaultSelected = false; option1.hasAttribute("selected") is false
+PASS option1.setAttribute("selected", "no"); option1.defaultSelected is true
+PASS option1.removeAttribute("selected"); option1.defaultSelected is false
+PASS selectionMap(select1) is "100"
+PASS select1[2].defaultSelected = true; selectionMap(select1) is "001"
+PASS select1[1].defaultSelected = true; selectionMap(select1) is "010"
+PASS select1[1].defaultSelected = false; selectionMap(select1) is "100"
+PASS select1[2].selected = true; selectionMap(select1) is "001"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/select/option-defaultselected.html
+++ b/LayoutTests/fast/forms/select/option-defaultselected.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+function selectionMap(select) {
+    var result = '';
+    var options = select.options;
+    for (var i = 0; i < options.length; ++i)
+        result += options[i].selected ? '1' : '0';
+    return result;
+}
+
+description('Tests for HTMLOptionElement::defaultSelected');
+
+var option1 = document.createElement('option');
+shouldBeFalse('option1.defaultSelected');
+shouldBeTrue('option1.defaultSelected = true; option1.hasAttribute("selected")');
+shouldBeTrue('option1.selected');
+shouldBeTrue('option1.selected = false; option1.defaultSelected');
+shouldBeFalse('option1.defaultSelected = false; option1.hasAttribute("selected")');
+shouldBeTrue('option1.setAttribute("selected", "no"); option1.defaultSelected');
+shouldBeFalse('option1.removeAttribute("selected"); option1.defaultSelected');
+
+var select1 = document.createElement('select');
+select1.innerHTML = '<option>1<option>2<option>3';
+shouldBeEqualToString('selectionMap(select1)', '100');
+
+shouldBeEqualToString('select1[2].defaultSelected = true; selectionMap(select1)', '001');
+shouldBeEqualToString('select1[1].defaultSelected = true; selectionMap(select1)', '010');
+shouldBeEqualToString('select1[1].defaultSelected = false; selectionMap(select1)', '100');
+shouldBeEqualToString('select1[2].selected = true; selectionMap(select1)', '001');
+</script>
+</body>

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -3,7 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2010-2017 Google Inc. All rights reserved.
  * Copyright (C) 2011 Motorola Mobility, Inc.  All rights reserved.
  *
@@ -183,11 +183,10 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassDefault, !newValue.isNull());
         m_isDefault = !newValue.isNull();
 
-        // FIXME: This doesn't match what the HTML specification says.
-        // The specification implies that removing the selected attribute or
-        // changing the value of a selected attribute that is already present
-        // has no effect on whether the element is selected.
-        setSelectedState(!newValue.isNull());
+        // FIXME: WebKit still need to implement 'dirtiness'. See: https://bugs.webkit.org/show_bug.cgi?id=258073
+        // https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-selectedness
+        if (oldValue.isNull() != newValue.isNull())
+            setSelected(!newValue.isNull());
         break;
     }
 #if ENABLE(DATALIST_ELEMENT)


### PR DESCRIPTION
#### efb64fda19d2c873b1714e2d8a387c0e97ddc4c1
<pre>
HTMLOptionElement::defaultSelected should affect selection state of other option elements once added or removed

<a href="https://bugs.webkit.org/show_bug.cgi?id=119291">https://bugs.webkit.org/show_bug.cgi?id=119291</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Spec.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405">https://chromium.googlesource.com/chromium/blink/+/e8f0337fdc86554b48cf81d7ed8c286f251d2405</a> &amp;
<a href="https://chromium.googlesource.com/chromium/src.git/+/4288626a69e2e6426555bb174a99e555e174f755">https://chromium.googlesource.com/chromium/src.git/+/4288626a69e2e6426555bb174a99e555e174f755</a>

According to the standard, we should set selectedness to true if defaultSelected is set to
true, and we should not set selectedness to false if defaultSelected is set to false
because the standard says nothing about it.

[1]
&gt; Whenever an option element&apos;s selected attribute is added, its selectedness
&gt; must be set to true.

When the selectedness of an option is updated, other options&apos;s selectedness should become
false.

[2]
&gt; If the multiple attribute is absent, whenever an option element in the select
&gt; element&apos;s list of options has its selectedness set to true, and whenever an
&gt; option element with its selectedness set to true is added to the select
&gt; element&apos;s list of options, the user agent must set the selectedness of all the
&gt; other option elements in its list of options to false.

The old behavior doesn&apos;t match to the standard and any other browsers. The new behavior
matches to IE10, Chrome, Gecko and the standard.

Additionally, this patch also ensure that we update selectedness only if
selected attribute is added or removed and not value.

[1] <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#attr-option-selected">http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#attr-option-selected</a>
[2] <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#the-select-element">http://www.whatwg.org/specs/web-apps/current-work/multipage/the-button-element.html#the-select-element</a>

* Source/WebCore/html/HTMLOptionElement.cpp
(HTMLOptionElement::attributeChanged): As below:
(1) Update FIXME and bug link
(2) Link to spec
(3) As per commit log
* LayoutTests/fast/forms/select/option-defaultselected-expected.txt: Added Test Case Expectation
* LayoutTests/fast/forms/select/option-defaultselected.html: Added Test Case

Canonical link: <a href="https://commits.webkit.org/265167@main">https://commits.webkit.org/265167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7972f780020c3b6a466328a4d3d57d97e992709c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12083 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12513 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9749 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7914 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2414 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->