### PR TITLE
Regression(264098@main) HTMLFieldsetElement behavior for :enabled / :disabled CSS selectors is incorrect

### DIFF
--- a/LayoutTests/fast/css/pseudo-indeterminate-radio-buttons-basics-expected.html
+++ b/LayoutTests/fast/css/pseudo-indeterminate-radio-buttons-basics-expected.html
@@ -110,7 +110,7 @@
         <input type="radio" name="group12" readonly>
         <span><input type="radio" name="group12" checked readonly class="checked"></span>
     </form>
-    <fieldset disabled>
+    <fieldset disabled class="disabled">
         <input type="radio" class="indeterminate disabled">
         <input type="radio" class="indeterminate disabled">
         <input type="radio" name="group1" class="indeterminate disabled">
@@ -141,7 +141,7 @@
         <span><input type="radio" name="group12" checked readonly class="checked disabled"></span>
     </fieldset>
     <form>
-        <fieldset disabled>
+        <fieldset disabled class="disabled">
             <input type="radio" class="indeterminate disabled">
             <input type="radio" class="indeterminate disabled">
             <input type="radio" name="group1" class="indeterminate disabled">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html
@@ -26,6 +26,7 @@
 </select>
 <textarea id=textarea1>textarea1</textarea>
 <textarea disabled id=textarea2>textarea2</textarea>
+<fieldset id=fieldset1></fieldset>
 <fieldset disabled id=fieldset2>
   <legend><input type=checkbox id=club></legend>
   <p><label>Name on card: <input id=clubname required></label></p>
@@ -39,21 +40,21 @@
 <progress disabled></progress>
 
 <script>
-  testSelectorIdsMatch(":disabled", ["button2", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should match only disabled elements");
+  testSelectorIdsMatch(":disabled", ["button2", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should match only disabled elements");
 
   document.getElementById("button2").removeAttribute("disabled");
-  testSelectorIdsMatch(":disabled", ["input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should not match elements whose disabled attribute has been removed");
+  testSelectorIdsMatch(":disabled", ["input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements whose disabled attribute has been removed");
 
   document.getElementById("button1").setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set");
 
   document.getElementById("button1").setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set twice");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match elements whose disabled attribute has been set twice");
 
   document.getElementById("input2").setAttribute("type", "submit"); // change input type to submit
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should also match disabled elements whose type has changed");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should also match disabled elements whose type has changed");
 
   var input = document.createElement("input");
   input.setAttribute("disabled", "disabled");
-  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
+  testSelectorIdsMatch(":disabled", ["button1", "input2", "select2", "optgroup2", "option2", "textarea2", "fieldset2", "clubname", "clubnum"], "':disabled' should not match elements not in the document");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/enabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/enabled.html
@@ -36,6 +36,7 @@
  </menu>
 </form>
 <fieldset id=fieldset1></fieldset>
+<fieldset disabled id=fieldset2></fieldset>
 
 <script>
   testSelectorIdsMatch(":enabled", ["button1", "input1", "select1", "optgroup1", "option1", "textarea1", "submitbutton", "fieldset1"], "':enabled' elements that are not disabled");

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -96,7 +96,7 @@ ALWAYS_INLINE bool matchesDisabledPseudoClass(const Element& element)
 // https://html.spec.whatwg.org/multipage/scripting.html#selector-enabled
 ALWAYS_INLINE bool matchesEnabledPseudoClass(const Element& element)
 {
-    return is<HTMLElement>(element) && downcast<HTMLElement>(element).canBeActuallyDisabled() && !element.isDisabledFormControl();
+    return is<HTMLElement>(element) && downcast<HTMLElement>(element).canBeActuallyDisabled() && !downcast<HTMLElement>(element).isActuallyDisabled();
 }
 
 // https://dom.spec.whatwg.org/#concept-element-defined

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -122,7 +122,7 @@ public:
 
     // Only some element types can be disabled: https://html.spec.whatwg.org/multipage/scripting.html#concept-element-disabled
     bool canBeActuallyDisabled() const;
-    bool isActuallyDisabled() const;
+    virtual bool isActuallyDisabled() const;
 
 #if ENABLE(AUTOCAPITALIZE)
     WEBCORE_EXPORT virtual AutocapitalizeType autocapitalizeType() const;

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -73,6 +73,13 @@ bool HTMLFieldSetElement::isDisabledFormControl() const
     return HTMLFormControlElement::isDisabledFormControl();
 }
 
+// https://html.spec.whatwg.org/#concept-element-disabled
+// https://html.spec.whatwg.org/#concept-fieldset-disabled
+bool HTMLFieldSetElement::isActuallyDisabled() const
+{
+    return HTMLFormControlElement::isDisabledFormControl();
+}
+
 static void updateFromControlElementsAncestorDisabledStateUnder(HTMLElement& startNode, bool isDisabled)
 {
     auto range = inclusiveDescendantsOfType<Element>(startNode);

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -45,6 +45,7 @@ private:
     ~HTMLFieldSetElement();
 
     bool isDisabledFormControl() const final;
+    bool isActuallyDisabled() const final;
     bool isEnumeratable() const final { return true; }
     bool supportsFocus() const final;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;


### PR DESCRIPTION
#### a6d354d7281cc2adcfbffc89b5c0f741bed92ff2
<pre>
Regression(264098@main) HTMLFieldsetElement behavior for :enabled / :disabled CSS selectors is incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=258078">https://bugs.webkit.org/show_bug.cgi?id=258078</a>

Reviewed by Tim Nguyen.

264098@main updated HTMLFieldSetElement::isDisabledFormControl() to return false
since a fieldset element can never be disabled per the specification.

This had the side effect of affecting our behavior for :enabled / :disabled CSS
selectors, which relied on this function. However, the behavior of these CSS
selectors shouldn&apos;t have changed since they rely on the &quot;actually disabled&quot; state,
not the &quot;disabled&quot; state [1].

There were two issues here, some of our CSS selector logic was relying on
isDisabledFormControl() instead of isActuallyDisabled(). Also, 264098@main
shouldn&apos;t have changed the value returned by isActuallyDisabled() for
HTMLFieldsetElements.

This was pointed out at:
- <a href="https://github.com/whatwg/html/issues/5886#issuecomment-1582410112">https://github.com/whatwg/html/issues/5886#issuecomment-1582410112</a>

[1] <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled">https://html.spec.whatwg.org/multipage/semantics-other.html#selector-enabled</a>
[2] <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled">https://html.spec.whatwg.org/multipage/semantics-other.html#selector-disabled</a>
[3] <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled">https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled</a>
[4] <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-fieldset-disabled">https://html.spec.whatwg.org/multipage/form-elements.html#concept-fieldset-disabled</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/disabled.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/selectors/pseudo-classes/enabled.html:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesEnabledPseudoClass):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::isActuallyDisabled const):
* Source/WebCore/html/HTMLFieldSetElement.h:

Canonical link: <a href="https://commits.webkit.org/265166@main">https://commits.webkit.org/265166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a32e60b199b8ed3879dd7da3f6b1372b1e988081

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11719 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12678 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12104 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16452 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12540 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9767 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9020 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2412 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->