### PR TITLE
[WGSL] Call graph builder needs to visit call arguments

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.cpp
+++ b/Source/WebGPU/WGSL/CallGraph.cpp
@@ -108,6 +108,9 @@ void CallGraphBuilder::visit(AST::Function& function)
 
 void CallGraphBuilder::visit(AST::CallExpression& call)
 {
+    for (auto& argument : call.arguments())
+        AST::Visitor::visit(argument);
+
     if (!is<AST::NamedTypeName>(call.target()))
         return;
 

--- a/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl
@@ -1,3 +1,4 @@
+// RUN: %metal-compile main
 // RUN: %metal main 2>&1 | %check
 
 var<private> x: i32;
@@ -30,6 +31,15 @@ fn i() -> i32
 {
     // CHECK: f\(parameter\d\)
     _ = f();
+    return 0;
+}
+
+// CHECK: float j\(float parameter\d, int parameter\d\)
+fn j(x: f32) -> f32
+{
+    // CHECK: f\(parameter\d\)
+    _ = f();
+    return x;
 }
 
 @compute @workgroup_size(1)
@@ -50,4 +60,7 @@ fn main()
 
     // CHECK: i\(local\d\)
     _ = i();
+
+    // CHECK: j\(j\(42, local\d\), local\d\)
+    _ = j(j(42));
 }

--- a/Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl
@@ -1,4 +1,4 @@
-// RUN: %metal main 2>&1 | %check
+// RUN: %metal main | %check
 
 @compute @workgroup_size(1)
 fn main() {


### PR DESCRIPTION
#### b6b1659c168301fe4033ca3b6008f26484d03320
<pre>
[WGSL] Call graph builder needs to visit call arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=258080">https://bugs.webkit.org/show_bug.cgi?id=258080</a>
rdar://110783356

Reviewed by Dan Glastonbury.

By not visiting call arguments the call graph was missing calls within calls,
e.g. `f(g())` would fail to add `g()` to the call graph.

* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::visit):
* Source/WebGPU/WGSL/tests/valid/global-used-by-callee.wgsl:
* Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl:

Canonical link: <a href="https://commits.webkit.org/265180@main">https://commits.webkit.org/265180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda97c4f831314f9547c9e674337256979a09953

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9729 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12666 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10215 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8514 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12096 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8294 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16440 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12527 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9761 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7925 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8920 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2428 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->