### PR TITLE
Persistent black rectangles (or entirely black) page after app switching after GPU Process jetsam

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -267,6 +267,15 @@ bool ImageBuffer::flushDrawingContextAsync()
     return true;
 }
 
+void ImageBuffer::setBackend(std::unique_ptr<ImageBufferBackend>&& backend)
+{
+    if (m_backend.get() == backend.get())
+        return;
+
+    m_backend = WTFMove(backend);
+    ++m_backendGeneration;
+}
+
 std::unique_ptr<ImageBufferBackend> ImageBuffer::takeBackend()
 {
     return WTFMove(m_backend);
@@ -574,6 +583,11 @@ std::unique_ptr<ThreadSafeImageBufferFlusher> ImageBuffer::createFlusher()
     if (auto* backend = ensureBackendCreated())
         return backend->createFlusher();
     return nullptr;
+}
+
+unsigned ImageBuffer::backendGeneration() const
+{
+    return m_backendGeneration;
 }
 
 String ImageBuffer::debugDescription() const

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -219,6 +219,9 @@ public:
     WEBCORE_EXPORT void setVolatilityState(VolatilityState);
     WEBCORE_EXPORT virtual std::unique_ptr<ThreadSafeImageBufferFlusher> createFlusher();
 
+    // This value increments when the ImageBuffer gets a new backend, which can happen if, for example, the GPU Process exits.
+    WEBCORE_EXPORT unsigned backendGeneration() const;
+
     WEBCORE_EXPORT virtual String debugDescription() const;
 
 protected:
@@ -227,10 +230,13 @@ protected:
     WEBCORE_EXPORT virtual RefPtr<ImageBuffer> sinkIntoBufferForDifferentThread();
     WEBCORE_EXPORT virtual std::unique_ptr<SerializedImageBuffer> sinkIntoSerializedImageBuffer();
 
+    WEBCORE_EXPORT void setBackend(std::unique_ptr<ImageBufferBackend>&&);
+
     ImageBufferBackend::Parameters m_parameters;
     ImageBufferBackend::Info m_backendInfo;
     std::unique_ptr<ImageBufferBackend> m_backend;
     RenderingResourceIdentifier m_renderingResourceIdentifier;
+    unsigned m_backendGeneration { 0 };
 };
 
 class SerializedImageBuffer {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RemoteLayerBackingStore.h"
 #include <WebCore/EventRegion.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PlatformLayerIdentifier.h>
@@ -93,11 +94,11 @@ public:
 
     // A cached CAIOSurface object to retain CA render resources.
     struct CachedContentsBuffer {
-        WebCore::RenderingResourceIdentifier m_renderingResourceIdentifier;
-        RetainPtr<id> m_buffer;
+        BufferAndBackendInfo imageBufferInfo;
+        RetainPtr<id> buffer;
     };
 
-    Vector<CachedContentsBuffer> takeCachedContentsBuffers() { return WTFMove(m_cachedContentsBuffers); }
+    Vector<CachedContentsBuffer> takeCachedContentsBuffers() { return std::exchange(m_cachedContentsBuffers, { }); }
     void setCachedContentsBuffers(Vector<CachedContentsBuffer>&& buffers)
     {
         m_cachedContentsBuffers = WTFMove(buffers);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -151,12 +151,15 @@ void RemoteImageBufferProxy::didCreateImageBufferBackend(ImageBufferBackendHandl
     if (renderingMode() == RenderingMode::Accelerated && std::holds_alternative<ShareableBitmap::Handle>(handle))
         m_backendInfo = ImageBuffer::populateBackendInfo<UnacceleratedImageBufferShareableBackend>(parameters());
     
+    std::unique_ptr<ImageBufferBackend> backend;
     if (renderingMode() == RenderingMode::Unaccelerated)
-        m_backend = UnacceleratedImageBufferShareableBackend::create(parameters(), WTFMove(handle));
+        backend = UnacceleratedImageBufferShareableBackend::create(parameters(), WTFMove(handle));
     else if (canMapBackingStore())
-        m_backend = AcceleratedImageBufferShareableMappedBackend::create(parameters(), WTFMove(handle));
+        backend = AcceleratedImageBufferShareableMappedBackend::create(parameters(), WTFMove(handle));
     else
-        m_backend = AcceleratedImageBufferRemoteBackend::create(parameters(), WTFMove(handle));
+        backend = AcceleratedImageBufferRemoteBackend::create(parameters(), WTFMove(handle));
+
+    setBackend(WTFMove(backend));
 }
 
 ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const


### PR DESCRIPTION
#### 800a12569f6908d448eb0f6834113ad3afe83fa4
<pre>
Persistent black rectangles (or entirely black) page after app switching after GPU Process jetsam
<a href="https://bugs.webkit.org/show_bug.cgi?id=258083">https://bugs.webkit.org/show_bug.cgi?id=258083</a>
rdar://110507750

Reviewed by Kimmo Kinnunen.

After 261553@main there was an assumption that there was a 1:1 relationship between an ImageBuffer
(identified by a RenderingResourceIdentifier) and an IOSurface, since the UI process cached
IOSurfaces via RemoteLayerTreeNode::m_cachedContentsBuffers and left these IOSurfaces on layers
contents if the RenderingResourceIdentifier didn&apos;t change.

This assumption is broken in the case of a GPU Process exit (crash, jetsam or idle exit). When that
happens, RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed() is called, and triggers backend
recreation on all the ImageBuffers, which allocates new IOSurfaces in the GPU Process.

This could lead to the following scenario:
* We have a layer, and make two or more ImageBuffers for it, referencing IOSurfaces which make their way
  to the UI Process and are set as layer contents.
* Tab goes into the background, we make the IOSurfaces volatile
* Device suffers memory pressure and the IOSurfaces are purged
* GPU Process exits for some reason
* RemoteRenderingBackendProxy::didClose() calls m_remoteResourceCacheProxy.remoteResourceCacheWasDestroyed() which
  clears ImageBuffer backends, then creates new ones but reusing the same rendering resource identifiers
* We buffer swap using the new ImageBuffers
* In the UI process, we get to RemoteLayerBackingStoreProperties::updateCachedBuffers(), compare with RemoteLayerTreeNode’s
  m_cachedContentsBuffers, and decide that we can re-use the RetainPtr&lt;id&gt; m_buffer; because the RenderingResourceIdentifier match.
* We leave a purged IOSurface on a CALayer, which renders black or otherwise wrong.

Fix by adding ImageBuffer::backendGeneration() which is incremented when the ImageBuffer gets a new
backend. Track both the RenderingResourceIdentifier and the backend generation in
CachedContentsBuffer via BufferAndBackendInfo, and clear the cached buffers when the
backendGeneration changes.

* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::setBackend):
(WebCore::ImageBuffer::backendGeneration const):
* Source/WebCore/platform/graphics/ImageBuffer.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
(WebKit::BufferAndBackendInfo::BufferAndBackendInfo):
(WebKit::RemoteLayerBackingStoreProperties::frontBufferIdentifier const): Deleted.
(WebKit::RemoteLayerBackingStoreProperties::backBufferIdentifier const): Deleted.
(WebKit::RemoteLayerBackingStoreProperties::secondaryBackBufferIdentifier const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::BufferAndBackendInfo::encode const):
(WebKit::BufferAndBackendInfo::decode):
(WebKit::RemoteLayerBackingStore::encode const):
(WebKit::RemoteLayerBackingStoreProperties::decode):
(WebKit::RemoteLayerBackingStoreProperties::dump const):
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):
(WebKit::RemoteLayerBackingStoreProperties::updateCachedBuffers):
(WebKit::operator&lt;&lt;):
(WebKit::RemoteLayerBackingStore::Buffer::encode const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::takeCachedContentsBuffers):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::didCreateImageBufferBackend):

Canonical link: <a href="https://commits.webkit.org/265163@main">https://commits.webkit.org/265163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26df596898eda6b4d5361fd3e3cbb25e8dee050f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11720 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12682 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12105 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9127 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12537 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9768 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8927 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->