### PR TITLE
[WGSL] Use array<T, 1> syntax to serialize runtime-sized array

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -119,7 +119,6 @@ private:
     Indentation<4> m_indent { 0 };
     std::optional<AST::StructureRole> m_structRole;
     std::optional<AST::StageAttribute::Stage> m_entryPointStage;
-    std::optional<String> m_suffix;
     unsigned m_functionConstantIndex { 0 };
     HashSet<AST::Function*> m_visitedFunctions;
 };
@@ -291,10 +290,6 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
             m_stringBuilder.append(m_indent);
             visit(member.type());
             m_stringBuilder.append(" ", name);
-            if (m_suffix.has_value()) {
-                m_stringBuilder.append(*m_suffix);
-                m_suffix.reset();
-            }
             for (auto &attribute : member.attributes()) {
                 m_stringBuilder.append(" ");
                 visit(attribute);
@@ -603,16 +598,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append(", ", matrix.columns, ", ", matrix.rows, ">");
         },
         [&](const Array& array) {
-            ASSERT(array.element);
-            if (!array.size.has_value()) {
-                visit(array.element);
-                m_suffix = { "[1]"_s };
-                return;
-            }
-
             m_stringBuilder.append("array<");
             visit(array.element);
-            m_stringBuilder.append(", ", *array.size, ">");
+            m_stringBuilder.append(", ", array.size.value_or(1), ">");
         },
         [&](const Struct& structure) {
             m_stringBuilder.append(structure.structure.name());

--- a/Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl
@@ -1,0 +1,9 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(0) var<storage, read_write> x: array<i32>;
+
+@compute @workgroup_size(1)
+fn main()
+{
+    x[0] = x[42];
+}


### PR DESCRIPTION
#### bce46d260f1dd126c442ff06bcaf493d067a4116
<pre>
[WGSL] Use array&lt;T, 1&gt; syntax to serialize runtime-sized array
<a href="https://bugs.webkit.org/show_bug.cgi?id=258085">https://bugs.webkit.org/show_bug.cgi?id=258085</a>
rdar://110789289

Reviewed by Dan Glastonbury.

In 259611@main we started serializing runtime-sized arrays. The original implementation
used C-style syntax, and doesn&apos;t work with references to arrays, as the generated code
becomes `T&amp; t[1]`, which is parsed as an array of references, and therefore invalid.
This is easily fixed by using the same syntax we use for constant-sized arrays, and
becomes `array&lt;T, 1&gt;&amp; t`.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::visitGlobal):
* Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/265190@main">https://commits.webkit.org/265190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09e72eb038446762ade3f633a1e6426d04af8b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9773 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12680 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12109 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8305 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16450 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12538 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9771 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7935 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8930 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->