### PR TITLE
StyleRuleCSSStyleDeclaration should use RefCounted instead of re-implementing the same thing

### DIFF
--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -64,18 +64,6 @@ Ref<CSSComputedStyleDeclaration> CSSComputedStyleDeclaration::create(Element& el
     return adoptRef(*new CSSComputedStyleDeclaration(element, allowVisitedStyle, pseudoElementName));
 }
 
-void CSSComputedStyleDeclaration::ref()
-{
-    ++m_refCount;
-}
-
-void CSSComputedStyleDeclaration::deref()
-{
-    ASSERT(m_refCount);
-    if (!--m_refCount)
-        delete this;
-}
-
 String CSSComputedStyleDeclaration::cssText() const
 {
     return emptyString();

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -33,14 +33,14 @@ namespace WebCore {
 class Element;
 class MutableStyleProperties;
 
-class CSSComputedStyleDeclaration final : public CSSStyleDeclaration {
+class CSSComputedStyleDeclaration final : public CSSStyleDeclaration, public RefCounted<CSSComputedStyleDeclaration> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(CSSComputedStyleDeclaration, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT static Ref<CSSComputedStyleDeclaration> create(Element&, bool allowVisitedStyle = false, StringView pseudoElementName = StringView { });
-    virtual ~CSSComputedStyleDeclaration();
+    WEBCORE_EXPORT virtual ~CSSComputedStyleDeclaration();
 
-    WEBCORE_EXPORT void ref() final;
-    WEBCORE_EXPORT void deref() final;
+    void ref() final { RefCounted::ref(); }
+    void deref() final { RefCounted::deref(); }
 
     String getPropertyValue(CSSPropertyID) const;
 
@@ -73,7 +73,6 @@ private:
     mutable Ref<Element> m_element;
     PseudoId m_pseudoElementSpecifier;
     bool m_allowVisitedStyle;
-    unsigned m_refCount { 1 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRuleList.cpp
+++ b/Source/WebCore/css/CSSRuleList.cpp
@@ -22,26 +22,14 @@
 #include "config.h"
 #include "CSSRuleList.h"
 
-#include "CSSRule.h"
-
 namespace WebCore {
 
 CSSRuleList::CSSRuleList() = default;
 
 CSSRuleList::~CSSRuleList() = default;
 
-StaticCSSRuleList::StaticCSSRuleList() 
-    : m_refCount(1)
-{ 
-}
+StaticCSSRuleList::StaticCSSRuleList() = default;
 
 StaticCSSRuleList::~StaticCSSRuleList() = default;
-
-void StaticCSSRuleList::deref()
-{ 
-    ASSERT(m_refCount);
-    if (!--m_refCount)
-        delete this;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSRuleList.h
+++ b/Source/WebCore/css/CSSRuleList.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
 
@@ -30,7 +31,7 @@ class CSSRule;
 class CSSStyleSheet;
 
 class CSSRuleList {
-    WTF_MAKE_NONCOPYABLE(CSSRuleList); WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CSSRuleList);
 public:
     virtual ~CSSRuleList();
 
@@ -47,31 +48,31 @@ protected:
     CSSRuleList();
 };
 
-class StaticCSSRuleList final : public CSSRuleList {
+class StaticCSSRuleList final : public CSSRuleList, public RefCounted<StaticCSSRuleList> {
 public:
     static Ref<StaticCSSRuleList> create() { return adoptRef(*new StaticCSSRuleList); }
 
-    void ref() final { ++m_refCount; }
-    void deref() final;
+    void ref() final { RefCounted::ref(); }
+    void deref() final { RefCounted::deref(); }
 
     Vector<RefPtr<CSSRule>>& rules() { return m_rules; }
     
     CSSStyleSheet* styleSheet() const final { return nullptr; }
 
+    ~StaticCSSRuleList();
 private:    
     StaticCSSRuleList();
-    ~StaticCSSRuleList();
 
     unsigned length() const final { return m_rules.size(); }
     CSSRule* item(unsigned index) const final { return index < m_rules.size() ? m_rules[index].get() : nullptr; }
 
     Vector<RefPtr<CSSRule>> m_rules;
-    unsigned m_refCount;
 };
 
 // The rule owns the live list.
 template <class Rule>
 class LiveCSSRuleList final : public CSSRuleList {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     LiveCSSRuleList(Rule& rule)
         : m_rule(rule)

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -58,6 +58,7 @@ static Style::Scope& styleScopeFor(ContainerNode& treeScope)
 }
 
 class StyleSheetCSSRuleList final : public CSSRuleList {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     StyleSheetCSSRuleList(CSSStyleSheet* sheet) : m_styleSheet(sheet) { }
     

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp
@@ -376,7 +376,6 @@ Ref<MutableStyleProperties> PropertySetCSSStyleDeclaration::copyProperties() con
     
 StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration(MutableStyleProperties& propertySet, CSSRule& parentRule)
     : PropertySetCSSStyleDeclaration(propertySet)
-    , m_refCount(1)
     , m_parentRuleType(parentRule.styleRuleType())
     , m_parentRule(&parentRule)
 {
@@ -386,18 +385,6 @@ StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration(MutableStylePropertie
 StyleRuleCSSStyleDeclaration::~StyleRuleCSSStyleDeclaration()
 {
     m_propertySet->deref();
-}
-
-void StyleRuleCSSStyleDeclaration::ref()
-{ 
-    ++m_refCount;
-}
-
-void StyleRuleCSSStyleDeclaration::deref()
-{ 
-    ASSERT(m_refCount);
-    if (!--m_refCount)
-        delete this;
 }
 
 bool StyleRuleCSSStyleDeclaration::willMutate()

--- a/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
+++ b/Source/WebCore/css/PropertySetCSSStyleDeclaration.h
@@ -90,7 +90,7 @@ private:
     virtual void didMutate(MutationType) { }
 };
 
-class StyleRuleCSSStyleDeclaration final : public PropertySetCSSStyleDeclaration {
+class StyleRuleCSSStyleDeclaration final : public PropertySetCSSStyleDeclaration, public RefCounted<StyleRuleCSSStyleDeclaration> {
     WTF_MAKE_ISO_ALLOCATED(StyleRuleCSSStyleDeclaration);
 public:
     static Ref<StyleRuleCSSStyleDeclaration> create(MutableStyleProperties& propertySet, CSSRule& parentRule)
@@ -100,9 +100,9 @@ public:
     virtual ~StyleRuleCSSStyleDeclaration();
 
     void clearParentRule() { m_parentRule = nullptr; }
-    
-    void ref() final;
-    void deref() final;
+
+    void ref() final { RefCounted::ref(); }
+    void deref() final { RefCounted::deref(); }
 
     void reattach(MutableStyleProperties&);
 
@@ -117,7 +117,6 @@ private:
     void didMutate(MutationType) final;
     CSSParserContext cssParserContext() const final;
 
-    unsigned m_refCount;
     StyleRuleType m_parentRuleType;
     CSSRule* m_parentRule;
 };

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -97,6 +97,7 @@ static void moveWidgetToParentSoon(Widget& child, LocalFrameView* parent)
 RenderWidget::RenderWidget(HTMLFrameOwnerElement& element, RenderStyle&& style)
     : RenderReplaced(element, WTFMove(style))
 {
+    relaxAdoptionRequirement();
     setInline(false);
 }
 
@@ -120,10 +121,7 @@ void RenderWidget::willBeDestroyed()
     RenderReplaced::willBeDestroyed();
 }
 
-RenderWidget::~RenderWidget()
-{
-    ASSERT(!m_refCount);
-}
+RenderWidget::~RenderWidget() = default;
 
 // Widgets are always placed on integer boundaries, so rounding the size is actually
 // the desired behavior. This function is here because it's otherwise seldom what we

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -62,7 +62,7 @@ inline void WidgetHierarchyUpdatesSuspensionScope::scheduleWidgetToMove(Widget& 
     widgetNewParentMap().set(&widget, frame);
 }
 
-class RenderWidget : public RenderReplaced, private OverlapTestRequestClient {
+class RenderWidget : public RenderReplaced, private OverlapTestRequestClient, public RefCounted<RenderWidget> {
     WTF_MAKE_ISO_ALLOCATED(RenderWidget);
 public:
     virtual ~RenderWidget();
@@ -81,9 +81,6 @@ public:
     bool requiresAcceleratedCompositing() const;
 
     RemoteFrame* remoteFrame() const;
-
-    void ref() { ++m_refCount; }
-    void deref();
 
 protected:
     RenderWidget(HTMLFrameOwnerElement&, RenderStyle&&);
@@ -113,15 +110,7 @@ private:
 
     RefPtr<Widget> m_widget;
     IntRect m_clipRect; // The rectangle needs to remain correct after scrolling, so it is stored in content view coordinates, and not clipped to window.
-    unsigned m_refCount { 1 };
 };
-
-inline void RenderWidget::deref()
-{
-    ASSERT(m_refCount);
-    if (!--m_refCount)
-        delete this;
-}
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 35296e904fb2aa582e24b156559458cdd04a77e0
<pre>
StyleRuleCSSStyleDeclaration should use RefCounted instead of re-implementing the same thing
<a href="https://bugs.webkit.org/show_bug.cgi?id=258087">https://bugs.webkit.org/show_bug.cgi?id=258087</a>
rdar://110795757

Reviewed by Chris Dumez.

Do the same thing with a few other classes.
No change in behavior.

* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::StyleRuleCSSStyleDeclaration::StyleRuleCSSStyleDeclaration):
(WebCore::StyleRuleCSSStyleDeclaration::ref): Deleted.
(WebCore::StyleRuleCSSStyleDeclaration::deref): Deleted.
* Source/WebCore/css/PropertySetCSSStyleDeclaration.h:

Canonical link: <a href="https://commits.webkit.org/266165@main">https://commits.webkit.org/266165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05218b932cc6018683c6a75557cab325d283c763

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15116 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15223 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18836 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16003 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1483 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->