### PR TITLE
Remote Web Inspector: [Cocoa] RemoteInspectorCocoa should not attempt to reconnect to (and thus relaunch) a relay that exited cleanly

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -239,6 +239,7 @@ private:
     void receivedAutomaticInspectionConfigurationMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
     void receivedAutomaticInspectionRejectMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
     void receivedAutomationSessionRequestMessage(NSDictionary *userInfo) WTF_REQUIRES_LOCK(m_mutex);
+    void receivedPingSuccessMessage() WTF_REQUIRES_LOCK(m_mutex);
 #endif
 #if USE(INSPECTOR_SOCKET_SERVER)
     HashMap<String, CallHandler>& dispatchMap() final;
@@ -276,7 +277,7 @@ private:
 
 #if PLATFORM(COCOA)
     RefPtr<RemoteInspectorXPCConnection> m_relayConnection;
-    bool m_shouldReconnectToRelayOnFailure { false };
+    bool m_shouldReconnectToRelayOnFailure WTF_GUARDED_BY_LOCK(m_mutex) { false };
 
     bool m_pendingMainThreadInitialization WTF_GUARDED_BY_LOCK(m_mutex) { false };
 #endif

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h
@@ -87,6 +87,8 @@
 #define WIRTypeWebPage                          @"WIRTypeWebPage"
 #define WIRAutomaticallyPause                   @"WIRAutomaticallyPause"
 #define WIRMessageDataTypeChunkSupportedKey     @"WIRMessageDataTypeChunkSupportedKey"
+#define WIRPingMessage                          @"WIRPingMessage"
+#define WIRPingSuccessMessage                   @"WIRPingSuccessMessage"
 
 // Allowed values for WIRMessageDataTypeKey.
 #define WIRMessageDataTypeFull                  @"WIRMessageDataTypeFull"

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -323,9 +323,7 @@ void RemoteInspector::setupXPCConnectionIfNeeded()
 
     if (m_relayConnection) {
         m_shouldReconnectToRelayOnFailure = true;
-
-        // Send a simple message to make sure the connection is still open.
-        m_relayConnection->sendMessage(@"check", nil);
+        m_relayConnection->sendMessage(WIRPingMessage, nil);
         return;
     }
 
@@ -410,6 +408,8 @@ void RemoteInspector::xpcConnectionReceivedMessage(RemoteInspectorXPCConnection*
         receivedAutomaticInspectionRejectMessage(userInfo);
     else if ([messageName isEqualToString:WIRAutomationSessionRequestMessage])
         receivedAutomationSessionRequestMessage(userInfo);
+    else if ([messageName isEqualToString:WIRPingSuccessMessage])
+        receivedPingSuccessMessage();
     else
         NSLog(@"Unrecognized RemoteInspector XPC Message: %@", messageName);
 }
@@ -833,6 +833,11 @@ void RemoteInspector::receivedAutomationSessionRequestMessage(NSDictionary *user
         return;
 
     m_client->requestAutomationSession(suggestedSessionIdentifier, sessionCapabilities);
+}
+
+void RemoteInspector::receivedPingSuccessMessage()
+{
+    m_shouldReconnectToRelayOnFailure = false;
 }
 
 } // namespace Inspector


### PR DESCRIPTION
#### d6b1aca616b96e2cbb89eb0160ddef87ea78fbe7
<pre>
Remote Web Inspector: [Cocoa] RemoteInspectorCocoa should not attempt to reconnect to (and thus relaunch) a relay that exited cleanly
<a href="https://bugs.webkit.org/show_bug.cgi?id=258084">https://bugs.webkit.org/show_bug.cgi?id=258084</a>
rdar://109617310

Reviewed by BJ Burg and Devin Rousso.

When handling the global notification that a relay has become available, we always first if our current connection to
the relay is valid, in which case we don&apos;t need to do any more work. However, for that check to work we set
m_shouldReconnectToRelayOnFailure to true so that upon a failure, we will attempt a single reconnect to a new relay.
This issue exists however where that check is successful and we don&apos;t have to reconnect, and therefore we don&apos;t have a
chance to set m_shouldReconnectToRelayOnFailure back to false.

To solve this, we have implemented a more formal version of the existing &quot;check&quot; message that expects a success response
from the relay if it doesn&apos;t fail, which lets us set the reconnect bit back to false to prevent some future exit of the
relay from causing a reconnection when we don&apos;t expect it to, causing a new relay to be started.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspectorConstants.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::xpcConnectionReceivedMessage):
(Inspector::RemoteInspector::receivedPingSuccessMessage):

Canonical link: <a href="https://commits.webkit.org/265173@main">https://commits.webkit.org/265173@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5145bea3cd603a86686eaaa0cb6dae9095dd8b70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11753 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12138 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16469 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8540 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9431 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12566 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9581 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9788 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10237 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8947 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2418 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13185 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10513 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9589 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2612 "Passed tests") | 
<!--EWS-Status-Bubble-End-->