### PR TITLE
Setting the "vector-effect" attribute in the SVG <text> tag to "non-scaling-stroke" has no effect

### DIFF
--- a/LayoutTests/fast/repaint/resources/async-text-based-repaint.js
+++ b/LayoutTests/fast/repaint/resources/async-text-based-repaint.js
@@ -1,0 +1,39 @@
+// Version of text-based-repaint.js that runs the repaint test asynchronously.
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function runRepaintTest()
+{
+    if (window.testRunner && window.internals) {
+        window.testRunner.dumpAsText(false);
+
+        if (document.body)
+            document.body.offsetTop;
+        else if (document.documentElement)
+            document.documentElement.offsetTop;
+
+        window.internals.startTrackingRepaints();
+        setTimeout(repaintTest, 0)
+    } else {
+        setTimeout(repaintTest, 100);
+    }
+}
+
+function finishRepaintTest()
+{
+    // force a style recalc.
+    var dummy = document.body.offsetTop;
+
+    if (!window.internals)
+        return;
+
+    var repaintRects = window.internals.repaintRectsAsText();
+
+    window.internals.stopTrackingRepaints();
+
+    var pre = document.createElement('pre');
+    document.body.appendChild(pre);
+    pre.innerHTML = repaintRects;
+
+    testRunner.notifyDone();
+}

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1541,6 +1541,13 @@ svg/transforms/translation-tiny-element.svg [ ImageOnlyFailure ]
 # The following test only works with LBSE activated -- text transform changes fail to repaint using the legacy engine.
 svg/repaint/text-repainting-after-modifying-transform.html [ ImageOnlyFailure ]
 
+# Gradient+text have placing issues in gtk/wpe.
+webkit.org/b/139322 svg/stroke/non-scaling-stroke-gradient-text.html [ ImageOnlyFailure ]
+
+# 'text-rendering: geometricPrecision' different ligatures/kerning used in actual/expected reftest - probably a different font in the test could help, postponing for further investigation.
+webkit.org/b/139322 svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg [ ImageOnlyFailure ]
+webkit.org/b/139322 svg/text/non-scaling-stroke-textRendering-geometricPrecision.svg [ ImageOnlyFailure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of SVG-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 29)
+  (rect 9 12 4 29)
+  (rect 53 12 4 29)
+  (rect 9 12 48 4)
+  (rect 9 37 48 4)
+)
+

--- a/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 29)
+  (rect 9 12 4 29)
+  (rect 53 12 4 29)
+  (rect 9 12 48 4)
+  (rect 9 37 48 4)
+)
+

--- a/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 29)
+  (rect 9 12 4 29)
+  (rect 53 12 4 29)
+  (rect 9 12 48 4)
+  (rect 9 37 48 4)
+)
+

--- a/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 29)
+  (rect 9 12 4 29)
+  (rect 53 12 4 29)
+  (rect 9 12 48 4)
+  (rect 9 37 48 4)
+)
+

--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,0 +1,6 @@
+Hello
+ (repaint rects
+  (rect 13 16 40 22)
+  (rect 9 12 48 30)
+)
+

--- a/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,0 +1,6 @@
+Hello
+ (repaint rects
+  (rect 13 16 40 22)
+  (rect 9 12 48 30)
+)
+

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 30)
+  (rect 9 12 4 30)
+  (rect 53 12 4 30)
+  (rect 9 12 48 4)
+  (rect 9 38 48 4)
+)
+

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration.html
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+<script src="../../fast/repaint/resources/async-text-based-repaint.js"></script>
+<script>
+window.onload = runRepaintTest;
+function repaintTest() {
+    document.getElementById('t').setAttribute("stroke", "blue");
+    document.getElementById('t').setAttribute("vector-effect", "non-scaling-stroke");
+    document.getElementById('t').setAttribute("stroke-width", "8");
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            finishRepaintTest();
+    });
+};
+</script>
+<body>
+<svg>
+    <g transform="scale(0.5 0.5)">
+       <text id="t" x="10" y="50" stroke="none" stroke-width="2" fill="none" font-size="36" vector-effect="none" text-decoration="underline">Hello</text>
+    </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,0 +1,9 @@
+Hello
+ (repaint rects
+  (rect 9 12 48 30)
+  (rect 9 12 4 30)
+  (rect 53 12 4 30)
+  (rect 9 12 48 4)
+  (rect 9 38 48 4)
+)
+

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text.html
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<script src="../../fast/repaint/resources/async-text-based-repaint.js"></script>
+<script>
+window.onload = runRepaintTest;
+function repaintTest() {
+    document.getElementById('t').setAttribute("stroke", "blue");
+    document.getElementById('t').setAttribute("vector-effect", "non-scaling-stroke");
+    document.getElementById('t').setAttribute("stroke-width", "8");
+    requestAnimationFrame(function() {
+        finishRepaintTest();
+    });
+};
+</script>
+<body>
+<svg>
+    <g transform="scale(0.5 0.5)">
+       <text id="t" x="10" y="50" stroke="none" stroke-width="2" fill="none" font-size="36" vector-effect="none">Hello</text>
+    </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-gradient-text-expected.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-gradient-text-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<svg>
+  <linearGradient id="g" x2="0" y2="1">
+    <stop offset="0" stop-color="green"/>
+    <stop offset="0.5" stop-color="green"/>
+    <stop offset="0.5" stop-color="blue"/>
+    <stop offset="1" stop-color="blue"/>
+  </linearGradient>
+  <g>
+     <text x="0" y="100" fill="url(#g)" stroke="url(#g)" stroke-width="2" font-size="72">Hello</text>
+  </g>
+</svg>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-gradient-text.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-gradient-text.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=2; totalPixels=1939" />
+</head>
+<body>
+<svg>
+  <linearGradient id="g" x2="0" y2="1">
+    <stop offset="0" stop-color="green"/>
+    <stop offset="0.5" stop-color="green"/>
+    <stop offset="0.5" stop-color="blue"/>
+    <stop offset="1" stop-color="blue"/>
+  </linearGradient>
+  <g transform="scale(2 2)">
+     <text x="0" y="50" fill="url(#g)" stroke="url(#g)" stroke-width="2" vector-effect="non-scaling-stroke" font-size="36">Hello</text>
+  </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-text-decoration-expected.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-text-decoration-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<svg>
+    <g>
+       <text x="0" y="100" stroke="blue" stroke-width="2" fill="none" font-size="72" text-decoration="underline">Hello</text>
+    </g>
+</svg>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-text-decoration.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-text-decoration.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<svg>
+    <g transform="scale(2 2)">
+       <text x="0" y="50" stroke="blue" stroke-width="2" fill="none" vector-effect="non-scaling-stroke" font-size="36" text-decoration="underline">Hello</text>
+    </g>
+</svg>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-text-expected.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-text-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<svg>
+    <g>
+       <text x="0" y="100" stroke="blue" stroke-width="2" fill="none" font-size="72">Hello</text>
+    </g>
+</svg>

--- a/LayoutTests/svg/stroke/non-scaling-stroke-text.html
+++ b/LayoutTests/svg/stroke/non-scaling-stroke-text.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<svg>
+    <g transform="scale(2 2)">
+       <text x="0" y="50" stroke="blue" stroke-width="2" fill="none" vector-effect="non-scaling-stroke" font-size="36">Hello</text>
+    </g>
+</svg>

--- a/LayoutTests/svg/text/non-scaling-stroke-textRendering-default-expected.svg
+++ b/LayoutTests/svg/text/non-scaling-stroke-textRendering-default-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 32px sans-serif" transform="translate(0, 100)">
+    <text x="100" y="100" fill="red" stroke="blue" stroke-width="3" >hello there</text>
+  </g>
+</svg>

--- a/LayoutTests/svg/text/non-scaling-stroke-textRendering-default.svg
+++ b/LayoutTests/svg/text/non-scaling-stroke-textRendering-default.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 16px sans-serif" transform="translate(0, 100) scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+</svg>

--- a/LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision-expected.svg
+++ b/LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision-expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 32px sans-serif; text-rendering: geometricPrecision" transform="translate(0, 100)">
+    <text x="100" y="100" fill="red" stroke="blue" stroke-width="3" >hello there</text>
+  </g>
+</svg>

--- a/LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision.svg
+++ b/LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 16px sans-serif; text-rendering: geometricPrecision" transform="translate(0, 100) scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+</svg>

--- a/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default-expected.svg
+++ b/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default-expected.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 32px sans-serif" transform="translate(0, 100)">
+    <text x="100" y="100" fill="red" stroke="blue" stroke-width="3" >hello there</text>
+  </g>
+
+  <defs>
+    <script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.eventSender) {
+        for (i = 0; i &lt; 4; ++i) {
+            eventSender.zoomPageIn();
+        }
+    }
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+    </script>
+  </defs>
+</svg>

--- a/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default.svg
+++ b/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 16px sans-serif" transform="translate(0, 100) scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+
+  <defs>
+    <script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.eventSender) {
+        for (i = 0; i &lt; 4; ++i) {
+            eventSender.zoomPageIn();
+        }
+    }
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+    </script>
+  </defs>
+</svg>

--- a/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision-expected.svg
+++ b/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision-expected.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 32px sans-serif; text-rendering: geometricPrecision" transform="translate(0, 100)">
+    <text x="100" y="100" fill="red" stroke="blue" stroke-width="3" >hello there</text>
+  </g>
+
+  <defs>
+    <script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.eventSender) {
+        for (i = 0; i &lt; 4; ++i) {
+            eventSender.zoomPageIn();
+        }
+    }
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+    </script>
+  </defs>
+</svg>

--- a/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg
+++ b/LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="g" style="font: 16px sans-serif; text-rendering: geometricPrecision" transform="translate(0, 100) scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+
+  <defs>
+    <script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.eventSender) {
+        for (i = 0; i &lt; 4; ++i) {
+            eventSender.zoomPageIn();
+        }
+    }
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+    </script>
+  </defs>
+</svg>

--- a/LayoutTests/svg/zoom/page/text-with-non-scaling-stroke-expected.html
+++ b/LayoutTests/svg/zoom/page/text-with-non-scaling-stroke-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body style="margin: 0">
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="400">
+  <g id="g" style="font: 30px sans-serif" transform="scale(2)">
+    <text x="60" y="60" fill="red" stroke="blue" stroke-width="3.6">hello there</text>
+  </g>
+  <g id="g" style="font: 30px sans-serif" transform="translate(0, 120) scale(2)">
+    <text x="60" y="60" fill="red" stroke="blue" stroke-width="3.6" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/page/text-with-non-scaling-stroke.html
+++ b/LayoutTests/svg/zoom/page/text-with-non-scaling-stroke.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=1; totalPixels=4-45" />
+</head>
+<body style="margin: 0">
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="400">
+  <g id="g" style="font: 25px sans-serif" transform="scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3">hello there</text>
+  </g>
+  <g id="g" style="font: 25px sans-serif" transform="translate(0, 100) scale(2)">
+    <text x="50" y="50" fill="red" stroke="blue" stroke-width="3" vector-effect="non-scaling-stroke">hello there</text>
+  </g>
+
+  <defs>
+    <script>
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.eventSender)
+        eventSender.zoomPageIn();
+
+    requestAnimationFrame(function() {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+    </script>
+  </defs>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -207,20 +207,21 @@ void RenderSVGInlineText::updateScaledFont()
     computeNewScaledFontForStyle(*this, style(), m_scalingFactor, m_scaledFont);
 }
 
+float RenderSVGInlineText::computeScalingFactorForRenderer(const RenderObject& renderer)
+{
+#if ENABLE(LAYER_BASED_SVG_ENGINE)
+    if (renderer.document().settings().layerBasedSVGEngineEnabled()) {
+        if (const auto* layerRenderer = lineageOfType<RenderLayerModelObject>(renderer).first())
+            return SVGLayerTransformComputation(*layerRenderer).calculateScreenFontSizeScalingFactor();
+    }
+#endif
+    return SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
+}
+
 void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& renderer, const RenderStyle& style, float& scalingFactor, FontCascade& scaledFont)
 {
-    auto computeScalingFactor = [&renderer]() {
-#if ENABLE(LAYER_BASED_SVG_ENGINE)
-        if (renderer.document().settings().layerBasedSVGEngineEnabled()) {
-            if (const auto* layerRenderer = lineageOfType<RenderLayerModelObject>(renderer).first())
-                return SVGLayerTransformComputation(*layerRenderer).calculateScreenFontSizeScalingFactor();
-        }
-#endif
-        return SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
-    };
-
     // Alter font-size to the right on-screen value to avoid scaling the glyphs themselves, except when GeometricPrecision is specified
-    scalingFactor = computeScalingFactor();
+    scalingFactor = computeScalingFactorForRenderer(renderer);
     if (!scalingFactor || style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision) {
         scalingFactor = 1;
         scaledFont = style.fontCascade();

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -40,6 +40,11 @@ public:
     bool characterStartsNewTextChunk(int position) const;
     SVGTextLayoutAttributes* layoutAttributes() { return &m_layoutAttributes; }
 
+    // computeScalingFactor() returns the font-size scaling factor, ignoring the text-rendering mode.
+    // scalingFactor() takes it into account, and thus returns 1 whenever text-rendering is set to 'geometricPrecision'.
+    // Therefore if you need access to the vanilla scaling factor, use this method directly (e.g. for non-scaling-stroke).
+    static float computeScalingFactorForRenderer(const RenderObject&);
+
     float scalingFactor() const { return m_scalingFactor; }
     const FontCascade& scaledFont() const { return m_scaledFont; }
     void updateScaledFont();

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -357,8 +357,23 @@ bool SVGInlineTextBox::acquirePaintingResource(GraphicsContext*& context, float 
         }
     }
 
-    if (scalingFactor != 1 && paintingResourceMode().contains(RenderSVGResourceMode::ApplyToStroke))
-        context->setStrokeThickness(context->strokeThickness() * scalingFactor);
+    if (paintingResourceMode().contains(RenderSVGResourceMode::ApplyToStroke)) {
+        if (style.svgStyle().vectorEffect() == VectorEffect::NonScalingStroke) {
+            if (style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision)
+                scalingFactor = 1.0 / RenderSVGInlineText::computeScalingFactorForRenderer(renderer);
+            else
+                scalingFactor = 1.0;
+
+            if (auto zoomFactor = renderer.style().effectiveZoom(); zoomFactor != 1.0)
+                scalingFactor *= zoomFactor;
+
+            if (auto deviceScaleFactor = renderer.document().deviceScaleFactor(); deviceScaleFactor != 1.0)
+                scalingFactor *= deviceScaleFactor;
+        }
+
+        if (scalingFactor != 1.0)
+            context->setStrokeThickness(context->strokeThickness() * scalingFactor);
+    }
 
     return true;
 }


### PR DESCRIPTION
#### 7eeb61cf4db43f5580bb7cc0b7df42128ee7a22e
<pre>
Setting the &quot;vector-effect&quot; attribute in the SVG &lt;text&gt; tag to &quot;non-scaling-stroke&quot; has no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=139322">https://bugs.webkit.org/show_bug.cgi?id=139322</a>

Reviewed by Rob Buis.

Add missing &lt;text&gt; support for vector-effect: non-scaling-stroke.
Take into account deviceScaleFactor / pageZoomFactor / text-rendering: geometricPrecision.

This brings us on-par with Gecko, which had excellent support for this feature,
and a bit further than Blink (which is broken when applying text-rendering: geometricPrecision
and vector-effect: non-scaling-stroke at the same time).

Cover all corner cases with tests: repaint rects, page zoom handling, gradients-on-text,
text decoration, etc.

* LayoutTests/fast/repaint/resources/async-text-based-repaint.js: Added.
(runRepaintTest):
(finishRepaintTest):
Like text-based-repaint.js, but supporting async execution.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt: Added.
* LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt: Added.
* LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt: Added.
* LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt: Added.
* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt: Added.
* LayoutTests/platform/mac-ventura-wk2-lbse-text/svg/repaint/repaint-non-scaling-stroke-text-expected.txt: Added.
Updated expectations / add new results based on EWS run.

* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt: Added.
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration.html: Added.
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt: Added.
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text.html: Added.
Imported from Blink -- modified to use &apos;async-text-based-repaint.js&apos;.

* LayoutTests/svg/stroke/non-scaling-stroke-gradient-text-expected.html: Added.
* LayoutTests/svg/stroke/non-scaling-stroke-gradient-text.html: Added.
* LayoutTests/svg/stroke/non-scaling-stroke-text-decoration-expected.html: Added.
* LayoutTests/svg/stroke/non-scaling-stroke-text-decoration.html: Added.
* LayoutTests/svg/stroke/non-scaling-stroke-text-expected.html: Added.
* LayoutTests/svg/stroke/non-scaling-stroke-text.html: Added.
Imported from Blink.

* LayoutTests/svg/text/non-scaling-stroke-textRendering-default-expected.svg: Added.
* LayoutTests/svg/text/non-scaling-stroke-textRendering-default.svg: Added.
* LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision-expected.svg: Added.
* LayoutTests/svg/text/non-scaling-stroke-textRendering-geometricPrecision.svg: Added.
* LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default-expected.svg: Added.
* LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-default.svg: Added.
* LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision-expected.svg: Added.
* LayoutTests/svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg: Added.
* LayoutTests/svg/zoom/page/text-with-non-scaling-stroke-expected.html: Added.
* LayoutTests/svg/zoom/page/text-with-non-scaling-stroke.html: Added.
New tests based on Said testcase.

* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::computeScalingFactorForRenderer): Expose, needed by SVGInlineTextBox.
(WebCore::RenderSVGInlineText::computeNewScaledFontForStyle): Turn lambda into exposed static function.
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::acquirePaintingResource): Handle non-scaling-stroke for text.

 * LayoutTests/svg/zoom/page/text-with-non-scaling-stroke.html:

Canonical link: <a href="https://commits.webkit.org/265204@main">https://commits.webkit.org/265204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa81f9b33e17f9a134fce31ac44f7506dcc9a74c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10381 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11124 "1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12254 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12668 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9867 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9154 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13274 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1147 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->