### PR TITLE
[Cocoa] Crash in VideoFullscreenModelContext::removeClient

### DIFF
--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -129,7 +129,7 @@ private:
     if (_fullscreenModel)
         _fullscreenModel->addClient(*_fullscreenModelClient);
 
-    self.videoDimensions = _fullscreenModel->videoDimensions();
+    self.videoDimensions = _fullscreenModel ? _fullscreenModel->videoDimensions() : CGSizeZero;
 #if !RELEASE_LOG_DISABLED
     _logIdentifier = _fullscreenModel ? _fullscreenModel->nextChildIdentifier() : nullptr;
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -454,6 +454,7 @@ void VideoFullscreenManagerProxy::invalidate()
         interface->invalidate();
         [model->layerHostView() removeFromSuperview];
         model->setLayerHostView(nullptr);
+        model->playerLayer().fullscreenModel = nullptr;
     }
 }
 


### PR DESCRIPTION
#### 078f6383edca4bfd40395d3dd2c49504908fb4ff
<pre>
[Cocoa] Crash in VideoFullscreenModelContext::removeClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=258098">https://bugs.webkit.org/show_bug.cgi?id=258098</a>
rdar://110390000

Reviewed by Jer Noble.

When VideoFullscreenModelContext&apos;s destructor is called it releases its reference to a
WebAVPlayerLayer. If that was the last reference then -[WebAVPlayerLayer dealloc] is called, which
calls back to VideoFullscreenModelContext::removeClient via a WeakPtr that is still valid because
VideoFullscreenModelContext&apos;s superclass destructors have not yet been called. However,
VideoFullscreenModelContext::m_client *has* already been destroyed, leading to a crash.

Fixed by explicitly setting WebAVPlayerLayer&apos;s fullscreenModel to nullptr in
VideoFullscreenManagerProxy::invalidate.

* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setFullscreenModel:]):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::invalidate):

Canonical link: <a href="https://commits.webkit.org/265182@main">https://commits.webkit.org/265182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c44d383de23b60313dc3aac958258302a7371b34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11786 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12170 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16483 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12586 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2435 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->