### PR TITLE
[JSC] Drop Imm64 in Air and extend ARM64 Imm

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -731,16 +731,6 @@ private:
         return Arg();
     }
 
-    Arg imm64(Value* value)
-    {
-        if (value->hasInt()) {
-            int64_t intValue = value->asInt();
-            if (Arg::isValidImm64Form(intValue))
-                return Arg::imm64(intValue);
-        }
-        return Arg();
-    }
-
     Arg bitImm(Value* value)
     {
         if (value->hasInt()) {
@@ -999,21 +989,6 @@ private:
                 // A non-commutative operation could have an immediate in left.
                 if (imm(left)) {
                     append(opcode, imm(left), tmp(right), result);
-                    return;
-                }
-            }
-        }
-
-        if (isValidForm(opcode, Arg::Imm64, Arg::Tmp, Arg::Tmp)) {
-            if (commutativity == Commutative) {
-                if (imm64(right)) {
-                    append(opcode, imm64(right), tmp(left), result);
-                    return;
-                }
-            } else {
-                // A non-commutative operation could have an immediate in left.
-                if (imm64(left)) {
-                    append(opcode, imm64(left), tmp(right), result);
                     return;
                 }
             }

--- a/Source/JavaScriptCore/b3/air/AirArg.cpp
+++ b/Source/JavaScriptCore/b3/air/AirArg.cpp
@@ -112,7 +112,6 @@ unsigned Arg::jsHash() const
     case WidthArg:
         result += static_cast<unsigned>(m_offset);
         break;
-    case Imm64:
     case BigImm:
     case BitImm64:
         result += static_cast<unsigned>(m_offset);
@@ -157,9 +156,6 @@ void Arg::dump(PrintStream& out) const
         return;
     case Imm:
         out.print("$", m_offset);
-        return;
-    case Imm64:
-        out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
         return;
     case BigImm:
         out.printf("$0x%llx", static_cast<long long unsigned>(m_offset));
@@ -249,9 +245,6 @@ void printInternal(PrintStream& out, Arg::Kind kind)
         return;
     case Arg::Imm:
         out.print("Imm");
-        return;
-    case Arg::Imm64:
-        out.print("Imm64");
         return;
     case Arg::BigImm:
         out.print("BigImm");

--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -68,7 +68,6 @@ public:
         // OSR exit and tail calls.
         // BitImm is an immediate for Bitwise operation (And, Xor, etc).
         Imm,
-        Imm64,
         BigImm,
         BitImm,
         BitImm64,
@@ -525,14 +524,6 @@ public:
         return result;
     }
 
-    static Arg imm64(int64_t value)
-    {
-        Arg result;
-        result.m_kind = Imm64;
-        result.m_offset = value;
-        return result;
-    }
-
     static Arg bigImm(int64_t value)
     {
         if constexpr (is32Bit())
@@ -807,11 +798,6 @@ public:
         return kind() == Imm;
     }
 
-    bool isImm64() const
-    {
-        return kind() == Imm64;
-    }
-
     bool isBigImm() const
     {
         return kind() == BigImm;
@@ -836,7 +822,6 @@ public:
     {
         switch (kind()) {
         case Imm:
-        case Imm64:
         case BigImm:
         case BitImm:
         case BitImm64:
@@ -1138,7 +1123,6 @@ public:
     {
         switch (kind()) {
         case Imm:
-        case Imm64:
         case BigImm:
         case BitImm:
         case BitImm64:
@@ -1172,7 +1156,6 @@ public:
     {
         switch (kind()) {
         case Imm:
-        case Imm64:
         case BitImm:
         case BitImm64:
         case RelCond:
@@ -1205,7 +1188,6 @@ public:
     {
         switch (kind()) {
         case Imm:
-        case Imm64:
         case BitImm:
         case BitImm64:
         case Special:
@@ -1287,15 +1269,6 @@ public:
     {
         if (isX86())
             return B3::isRepresentableAs<int32_t>(value);
-        if (isARM64())
-            return isUInt12(value) || isUInt12(toTwosComplement(value));
-        if (isARM_THUMB2())
-            return isValidARMThumb2Immediate(value);
-        return false;
-    }
-
-    static bool isValidImm64Form(int64_t value)
-    {
         if (isARM64()) {
             if (isUInt12(value) || isUInt12(toTwosComplement(value)))
                 return true;
@@ -1304,6 +1277,8 @@ public:
                 return isUInt12(shifted) || isUInt12(toTwosComplement(shifted));
             return false;
         }
+        if (isARM_THUMB2())
+            return isValidARMThumb2Immediate(value);
         return false;
     }
 
@@ -1415,8 +1390,6 @@ public:
             return true;
         case Imm:
             return isValidImmForm(value());
-        case Imm64:
-            return isValidImm64Form(value());
         case BigImm:
             return true;
         case BitImm:
@@ -1525,7 +1498,7 @@ public:
     {
         if constexpr (is32Bit())
             UNREACHABLE_FOR_PLATFORM();
-        ASSERT(isBigImm() || isImm64() || isBitImm64());
+        ASSERT(isBigImm() || isBitImm64());
         return MacroAssembler::TrustedImm64(value());
     }
 

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -39,7 +39,6 @@
 # Argument kinds:
 # Tmp => temporary or register
 # Imm => 32-bit immediate int
-# Imm64 => 64-bit immediate int with special-shift
 # BigImm => TrustedImm64 on 64-bit targets, TrustedImm32 on 32-bit targets
 # Addr => address as temporary/register+offset
 # Index => BaseIndex address
@@ -147,7 +146,6 @@ x86: Add16 U:G:16, UD:G:16
     x86: Imm, Addr
     x86: Imm, Index
     Imm, Tmp
-    arm64: Imm64, Tmp
     x86: Addr, Tmp
     x86: Index, Tmp
     x86: Tmp, Addr
@@ -156,7 +154,6 @@ x86: Add16 U:G:16, UD:G:16
 64: Add64 U:G:64, U:G:64, D:G:64
     Imm, Tmp, Tmp
     Tmp, Tmp, Tmp
-    arm64: Imm64, Tmp, Tmp
 
 # note that this pseudoinstruction (and others like it) exist right now because
 # air doesn't track live flags: we do support 64-bit addition on e.g. armv7
@@ -206,7 +203,6 @@ arm: Sub32 U:G:32, U:G:32, ZD:G:32
     x86: Imm, Addr
     x86: Imm, Index
     Imm, Tmp
-    arm64: Imm64, Tmp
     x86: Addr, Tmp
     x86: Index, Tmp
     x86: Tmp, Addr
@@ -215,7 +211,6 @@ arm: Sub32 U:G:32, U:G:32, ZD:G:32
 arm64: Sub64 U:G:64, U:G:64, D:G:64
     Tmp, Tmp, Tmp
     Tmp, Imm, Tmp
-    Tmp, Imm64, Tmp
 
 # note see note above, on Add64
 32: Sub64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, D:G:32
@@ -1466,7 +1461,6 @@ Compare32 U:G:32, U:G:32, U:G:32, ZD:G:32
 64: Compare64 U:G:32, U:G:64, U:G:64, ZD:G:32
     RelCond, Tmp, Tmp, Tmp
     RelCond, Tmp, Imm, Tmp
-    arm64: RelCond, Tmp, Imm64, Tmp
 
 Test32 U:G:32, U:G:32, U:G:32, ZD:G:32
     x86: ResCond, Addr, Imm, Tmp
@@ -1511,7 +1505,6 @@ Branch32 U:G:32, U:G:32, U:G:32 /branch
     x86: RelCond, Addr, Tmp
     x86: RelCond, Addr, Imm
     x86: RelCond, Index, Tmp
-    arm64: RelCond, Tmp, Imm64
 
 BranchTest8 U:G:32, U:G:8, U:G:8 /branch
     x86: ResCond, Addr, BitImm
@@ -1622,7 +1615,6 @@ BranchNeg32 U:G:32, UZD:G:32 /branch
 64: MoveConditionally64 U:G:32, U:G:64, U:G:64, U:G:Ptr, U:G:Ptr, D:G:Ptr
     RelCond, Tmp, Tmp, Tmp, Tmp, Tmp
     RelCond, Tmp, Imm, Tmp, Tmp, Tmp
-    arm64: RelCond, Tmp, Imm64, Tmp, Tmp, Tmp
 
 64: MoveConditionallyTest32 U:G:32, U:G:32, U:G:32, U:G:Ptr, UD:G:Ptr
     ResCond, Tmp, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -229,7 +229,7 @@ def isGF(token)
 end
 
 def isKind(token)
-    token =~ /\A((Tmp)|(Imm)|(Imm64)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond)|(SIMDInfo))\Z/
+    token =~ /\A((Tmp)|(Imm)|(BigImm)|(BitImm)|(BitImm64)|(ZeroReg)|(SimpleAddr)|(Addr)|(ExtendedOffsetAddr)|(Index)|(PreIndex)|(PostIndex)|(RelCond)|(ResCond)|(DoubleCond)|(StatusCond)|(SIMDInfo))\Z/
 end
 
 def isArch(token)
@@ -303,7 +303,7 @@ class Parser
 
     def consumeKind
         result = token.string
-        parseError("Expected kind (Imm, Imm64, BigImm, BitImm, BitImm64, ZeroReg, Tmp, SimpleAddr, Addr, ExtendedOffsetAddr, Index, PreIndex, PostIndex, RelCond, ResCond, DoubleCond, or StatusCond)") unless isKind(result)
+        parseError("Expected kind (Imm, BigImm, BitImm, BitImm64, ZeroReg, Tmp, SimpleAddr, Addr, ExtendedOffsetAddr, Index, PreIndex, PostIndex, RelCond, ResCond, DoubleCond, or StatusCond)") unless isKind(result)
         advance
         result
     end
@@ -471,7 +471,7 @@ class Parser
                         parseError("Form has wrong number of arguments for overload") unless kinds.length == signature.length
                         kinds.each_with_index {
                             | kind, index |
-                            if kind.name == "Imm" or kind.name == "Imm64" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64"
+                            if kind.name == "Imm" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64"
                                 if signature[index].role != "U"
                                     parseError("Form has an immediate for a non-use argument")
                                 end
@@ -585,14 +585,14 @@ def matchForms(outp, speed, forms, columnIndex, columnGetter, filter, callback)
     outp.puts "switch (#{columnGetter[columnIndex]}) {"
     groups.each_pair {
         | key, value |
-        outp.puts "#if USE(JSVALUE64)" if key == "Imm64" || key == "BitImm64"
+        outp.puts "#if USE(JSVALUE64)" if key == "BitImm64"
         Kind.argKinds(key).each {
             | argKind |
             outp.puts "case Arg::#{argKind}:"
         }
         matchForms(outp, speed, value, columnIndex + 1, columnGetter, filter, callback)
         outp.puts "break;"
-        outp.puts "#endif // USE(JSVALUE64)" if key == "Imm64" || key == "BitImm64"
+        outp.puts "#endif // USE(JSVALUE64)" if key == "BitImm64"
     }
     outp.puts "default:"
     outp.puts "break;"
@@ -936,9 +936,6 @@ writeH("OpcodeGenerated") {
                 when "Imm"
                     outp.puts "if (!Arg::isValidImmForm(args[#{index}].value()))"
                     outp.puts "OPGEN_RETURN(false);"
-                when "Imm64"
-                    outp.puts "if (!Arg::isValidImm64Form(args[#{index}].value()))"
-                    outp.puts "OPGEN_RETURN(false);"
                 when "BitImm"
                     outp.puts "if (!Arg::isValidBitImmForm(args[#{index}].value()))"
                     outp.puts "OPGEN_RETURN(false);"
@@ -1270,7 +1267,7 @@ writeH("OpcodeGenerated") {
                     outp.print "args[#{index}].asTrustedImm32()"
                 when "BigImm"
                     outp.print "args[#{index}].asTrustedBigImm()"
-                when "Imm64", "BitImm64"
+                when "BitImm64"
                     outp.print "args[#{index}].asTrustedImm64()"
                 when "ZeroReg"
                     outp.print "args[#{index}].asZeroReg()"


### PR DESCRIPTION
#### dea264bd949dc97e63e12e4845dd219018e69d11
<pre>
[JSC] Drop Imm64 in Air and extend ARM64 Imm
<a href="https://bugs.webkit.org/show_bug.cgi?id=258103">https://bugs.webkit.org/show_bug.cgi?id=258103</a>
rdar://110811740

Reviewed by Mark Lam.

It turned out that Imm64 concept is not necessary in ARM64. All Imm places can take 12-shifted Imm too.
So, this patch just extends ARM64 Imm in Air to accept 12-bit shifted value too. And remove Imm64 concept from Air.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add32):
(JSC::MacroAssemblerARM64::add64):
(JSC::MacroAssemblerARM64::sub32):
(JSC::MacroAssemblerARM64::sub64):
(JSC::MacroAssemblerARM64::moveConditionally32):
(JSC::MacroAssemblerARM64::moveConditionally64):
(JSC::MacroAssemblerARM64::moveDoubleConditionally32):
(JSC::MacroAssemblerARM64::moveDoubleConditionally64):
(JSC::MacroAssemblerARM64::branch32):
(JSC::MacroAssemblerARM64::branch64):
(JSC::MacroAssemblerARM64::branchAdd32):
(JSC::MacroAssemblerARM64::branchAdd64):
(JSC::MacroAssemblerARM64::branchSub32):
(JSC::MacroAssemblerARM64::branchSub64):
(JSC::MacroAssemblerARM64::compare32):
(JSC::MacroAssemblerARM64::compare64):
(JSC::MacroAssemblerARM64::tryFoldBaseAndOffsetPart):
(JSC::MacroAssemblerARM64::tryExtractShiftedImm):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirArg.cpp:
(JSC::B3::Air::Arg::jsHash const):
(JSC::B3::Air::Arg::dump const):
(WTF::printInternal):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isSomeImm const):
(JSC::B3::Air::Arg::isGP const):
(JSC::B3::Air::Arg::isFP const):
(JSC::B3::Air::Arg::hasBank const):
(JSC::B3::Air::Arg::isValidImmForm):
(JSC::B3::Air::Arg::isValidForm const):
(JSC::B3::Air::Arg::imm64): Deleted.
(JSC::B3::Air::Arg::isImm64 const): Deleted.
(JSC::B3::Air::Arg::isValidImm64Form): Deleted.
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:

Canonical link: <a href="https://commits.webkit.org/265191@main">https://commits.webkit.org/265191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6650a75a6c5b46680a9d06f53306d636eaa22255

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11837 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10348 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12220 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/8403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8607 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9668 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9841 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10325 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9000 "Failed to checkout and rebase branch from PR 14983") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13246 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10606 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1144 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9667 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->