### PR TITLE
[ANGLE] Support BGRA_SRBGB_ANGLE for framebuffer blits

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -307,11 +307,11 @@ index 0000000000000000000000000000000000000000..8b96dc01357fa9a2bdc54e5ddb3bbfd4
 +#endif
 diff --git a/src/common/ANGLEShaderProgramVersion.h b/src/common/ANGLEShaderProgramVersion.h
 new file mode 100644
-index 0000000000000000000000000000000000000000..06407afeb0dd3c254b797ecee28b2a2a91edd4b2
+index 0000000000000000000000000000000000000000..1f43ebd21c99481abda24a141a89c472b3faafd0
 --- /dev/null
 +++ b/src/common/ANGLEShaderProgramVersion.h
 @@ -0,0 +1,2 @@
-+#define ANGLE_PROGRAM_VERSION "a069fe5b0e6792a4ee1b2f07b537c3d7"
++#define ANGLE_PROGRAM_VERSION "fcbd6f5c2e75312e4bd4001f421d223b"
 +#define ANGLE_PROGRAM_VERSION_HASH_SIZE 16
 diff --git a/src/common/utilities.cpp b/src/common/utilities.cpp
 index 7a0a706519887e596a18e2dbd3489051c78c7ba0..f11469503fd488b856e448c8ed8385d01cc522f1 100644
@@ -414,6 +414,24 @@ index 396d83b1947cbc732a99b3350e534aab763a18a0..64ae01bcaa63f54f37189cd042db26f9
  #include "libANGLE/State.h"
  
  #include <string.h>
+diff --git a/src/libANGLE/formatutils.cpp b/src/libANGLE/formatutils.cpp
+index f2845dc9f9a81fe072fc4ae790c6bb3dfac5b5d8..e2b5cd91e8ce813c10d42aaf6540422b6cdc984b 100644
+--- a/src/libANGLE/formatutils.cpp
++++ b/src/libANGLE/formatutils.cpp
+@@ -609,6 +609,13 @@ static GLenum EquivalentBlitInternalFormat(GLenum internalformat)
+         return GL_RGB8;
+     }
+ 
++    // Treat ANGLE's BGRA8_SRGB as SRGB8_ALPHA8 since it's just a swizzled version
++    // with the same components.
++    if (internalformat == GL_BGRA8_SRGB_ANGLEX)
++    {
++        return GL_SRGB8_ALPHA8_EXT;
++    }
++
+     return internalformat;
+ }
+ 
 diff --git a/src/libANGLE/renderer/driver_utils.h b/src/libANGLE/renderer/driver_utils.h
 index 744a5b14dbae742db62b06ca4d28314d0f7affdf..f560fa7a45e42b79bd2cfb2d607a7a9ae9276835 100644
 --- a/src/libANGLE/renderer/driver_utils.h

--- a/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp
@@ -609,6 +609,13 @@ static GLenum EquivalentBlitInternalFormat(GLenum internalformat)
         return GL_RGB8;
     }
 
+    // Treat ANGLE's BGRA8_SRGB as SRGB8_ALPHA8 since it's just a swizzled version
+    // with the same components.
+    if (internalformat == GL_BGRA8_SRGB_ANGLEX)
+    {
+        return GL_SRGB8_ALPHA8_EXT;
+    }
+
     return internalformat;
 }
 


### PR DESCRIPTION
#### e05b9c978c96e378382231758e0f708cb93ea1de
<pre>
[ANGLE] Support BGRA_SRBGB_ANGLE for framebuffer blits
<a href="https://bugs.webkit.org/show_bug.cgi?id=258104">https://bugs.webkit.org/show_bug.cgi?id=258104</a>
rdar://110811770

Reviewed by Dean Jackson.

For WebGL content, WebKit needs to perform MSAA resolve on the WebGL
buffer before compositing via a blit. On Apple platforms, this draw
buffer is usually in BGRA8_SRGB_ANGLEX as it is the native format for
the windowing system&apos;s compositor, so SRGB8_ALPHA8 needs coercion for
WebGL to work with multisample sRGB content.

This is a cherry-pick of ANGLE issue
8208 (<a href="https://bugs.chromium.org/p/angleproject/issues/detail?id=8208)">https://bugs.chromium.org/p/angleproject/issues/detail?id=8208)</a>

* Source/ThirdParty/ANGLE/src/libANGLE/formatutils.cpp:
(gl::EquivalentBlitInternalFormat):

Canonical link: <a href="https://commits.webkit.org/265219@main">https://commits.webkit.org/265219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7becac960841efc256b653fef0e9827e5d2a9310

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9817 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12179 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16489 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12593 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9819 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7973 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13216 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1150 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->