### PR TITLE
Make Win32Handle require an explicit copy constructor to be copied

### DIFF
--- a/Source/WTF/wtf/win/Win32Handle.cpp
+++ b/Source/WTF/wtf/win/Win32Handle.cpp
@@ -74,16 +74,6 @@ Win32Handle::~Win32Handle()
     closeHandle(m_handle);
 }
 
-Win32Handle& Win32Handle::operator=(const Win32Handle& other)
-{
-    if (this != &other) {
-        closeHandle(m_handle);
-        m_handle = duplicateHandle(other.get());
-    }
-
-    return *this;
-}
-
 Win32Handle& Win32Handle::operator=(Win32Handle&& other)
 {
     if (this != &other) {
@@ -92,11 +82,6 @@ Win32Handle& Win32Handle::operator=(Win32Handle&& other)
     }
 
     return *this;
-}
-
-Win32Handle Win32Handle::copy() const
-{
-    return Win32Handle(duplicateHandle(m_handle));
 }
 
 HANDLE Win32Handle::leak()

--- a/Source/WTF/wtf/win/Win32Handle.h
+++ b/Source/WTF/wtf/win/Win32Handle.h
@@ -36,18 +36,16 @@ public:
     WTF_EXPORT_PRIVATE static Win32Handle adopt(HANDLE);
 
     Win32Handle() = default;
-    WTF_EXPORT_PRIVATE Win32Handle(const Win32Handle&);
+    WTF_EXPORT_PRIVATE explicit Win32Handle(const Win32Handle&);
     WTF_EXPORT_PRIVATE Win32Handle(Win32Handle&&);
     WTF_EXPORT_PRIVATE ~Win32Handle();
 
-    WTF_EXPORT_PRIVATE Win32Handle& operator=(const Win32Handle&);
     WTF_EXPORT_PRIVATE Win32Handle& operator=(Win32Handle&&);
 
     explicit operator bool() const { return m_handle != INVALID_HANDLE_VALUE; }
 
     HANDLE get() const { return m_handle; }
 
-    WTF_EXPORT_PRIVATE Win32Handle copy() const;
     WTF_EXPORT_PRIVATE HANDLE leak() WARN_UNUSED_RETURN;
 
 private:

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -113,7 +113,7 @@ RefPtr<SharedMemory> Data::tryCreateSharedMemory() const
     if (isNull() || !isMap())
         return nullptr;
 
-    auto newHandle = std::get<FileSystem::MappedFileData>(*m_buffer).fileMapping();
+    auto newHandle = Win32Handle { std::get<FileSystem::MappedFileData>(*m_buffer).fileMapping() };
     if (!newHandle)
         return nullptr;
 

--- a/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
@@ -34,7 +34,7 @@ namespace IPC {
 
 void ArgumentCoder<Win32Handle>::encode(Encoder& encoder, const Win32Handle& handle)
 {
-    encoder << handle.copy();
+    encoder << Win32Handle { handle };
 }
 
 void ArgumentCoder<Win32Handle>::encode(Encoder& encoder, Win32Handle&& handle)


### PR DESCRIPTION
#### 0315de95257defdb7121160cfaf41203487a275c
<pre>
Make Win32Handle require an explicit copy constructor to be copied
<a href="https://bugs.webkit.org/show_bug.cgi?id=258105">https://bugs.webkit.org/show_bug.cgi?id=258105</a>

Reviewed by Kimmo Kinnunen.

Copying Win32Handle is expensive so make sure this isn&apos;t done by
accident. Remove `operator=` as a means of copying. Also remove the
`copy` method as well so everything goes through the copy constructor.

* Source/WTF/wtf/win/Win32Handle.cpp:
(WTF::Win32Handle::copy const): Deleted.
* Source/WTF/wtf/win/Win32Handle.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::Data::tryCreateSharedMemory const):
* Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp:
(IPC::ArgumentCoder&lt;Win32Handle&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/265203@main">https://commits.webkit.org/265203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/666a985c7348ba4e95b0220c8c76876045be1207

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9820 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12734 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11064 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12184 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16492 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8578 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12597 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9822 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7975 "3 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10287 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8981 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2455 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13219 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10567 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9631 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2619 "Passed tests") | 
<!--EWS-Status-Bubble-End-->