### PR TITLE
Window named getter behaves incorrectly in some cases when there are duplicate frame names

### DIFF
--- a/LayoutTests/http/tests/frames/frames-with-same-name-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/frames/frames-with-same-name-cross-origin-expected.txt
@@ -1,0 +1,11 @@
+Make sure that frame lookup by name has correct ordering when duplicate names are involved.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS crossOriginWindow.foo === crossOriginWindow[0] is true
+PASS open('', 'foo') === crossOriginWindow.foo is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/frames/frames-with-same-name-cross-origin.html
+++ b/LayoutTests/http/tests/frames/frames-with-same-name-cross-origin.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<iframe id="crossOriginFrame" src="http://localhost:8000/frames/resources/frames-with-same-name-cross-origin-frame.html"></iframe>
+<script>
+description("Make sure that frame lookup by name has correct ordering when duplicate names are involved.");
+
+onload = () => {
+    crossOriginWindow = document.getElementById("crossOriginFrame").contentWindow;
+    // Both frames have the same name "foo" so window.foo should return the first one in tree order, even
+    // though the name of the first frame gets set after the name of the second frame.
+    shouldBeTrue("crossOriginWindow.foo === crossOriginWindow[0]");
+    shouldBeTrue("open('', 'foo') === crossOriginWindow.foo");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/frames/frames-with-same-name-expected.txt
+++ b/LayoutTests/http/tests/frames/frames-with-same-name-expected.txt
@@ -1,0 +1,11 @@
+Make sure that frame lookup by name has correct ordering when duplicate names are involved.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS window.foo is document.getElementById('firstFrame').contentWindow
+PASS open('', 'foo') is window.foo
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/frames/frames-with-same-name.html
+++ b/LayoutTests/http/tests/frames/frames-with-same-name.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<iframe id="firstFrame" src="resources/set-window-name-to-foo.html"></iframe>
+<iframe name="foo"></iframe>
+<script>
+description("Make sure that frame lookup by name has correct ordering when duplicate names are involved.");
+
+onload = () => {
+    // Both frames have the same name "foo" so window.foo should return the first one in tree order, even
+    // though the name of the first frame gets set after the name of the second frame.
+    shouldBe("window.foo", "document.getElementById('firstFrame').contentWindow");
+    shouldBe("open('', 'foo')", "window.foo");
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/frames/resources/frames-with-same-name-cross-origin-frame.html
+++ b/LayoutTests/http/tests/frames/resources/frames-with-same-name-cross-origin-frame.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<iframe src="set-window-name-to-foo.html"></iframe>
+<iframe name="foo"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/frames/resources/set-window-name-to-foo.html
+++ b/LayoutTests/http/tests/frames/resources/set-window-name-to-foo.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<script>
+window.name = "foo";
+</script>

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -46,7 +46,7 @@ const ClassInfo JSDOMWindowProperties::s_info = { "WindowProperties"_s, &Base::s
 static bool jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter(JSDOMWindowProperties* thisObject, LocalDOMWindow& window, JSGlobalObject* lexicalGlobalObject, PropertyName propertyName, PropertySlot& slot)
 {
     if (auto* frame = window.frame()) {
-        if (auto* scopedChild = dynamicDowncast<LocalFrame>(frame->tree().scopedChild(propertyNameToAtomString(propertyName)))) {
+        if (auto* scopedChild = dynamicDowncast<LocalFrame>(frame->tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
             slot.setValue(thisObject, static_cast<unsigned>(PropertyAttribute::DontEnum), toJS(lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;
         }

--- a/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp
@@ -158,7 +158,7 @@ bool jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess(JSDOMGlobalObject* thisO
     // FIXME: Add support to named attributes on RemoteFrames.
     auto* frame = window.frame();
     if (frame && is<LocalFrame>(*frame)) {
-        if (auto* scopedChild = dynamicDowncast<LocalFrame>(downcast<LocalFrame>(*frame).tree().scopedChild(propertyNameToAtomString(propertyName)))) {
+        if (auto* scopedChild = dynamicDowncast<LocalFrame>(downcast<LocalFrame>(*frame).tree().scopedChildBySpecifiedName(propertyNameToAtomString(propertyName)))) {
             slot.setValue(thisObject, PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum, toJS(&lexicalGlobalObject, scopedChild->document()->domWindow()));
             return true;
         }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -680,7 +680,7 @@ void FrameLoader::clear(RefPtr<Document>&& newDocument, bool clearWindowProperti
         m_frame.windowProxy().clearJSWindowProxiesNotMatchingDOMWindow(newDocument->domWindow(), m_frame.document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
 
         if (shouldClearWindowName(m_frame, *newDocument))
-            m_frame.tree().setName(nullAtom());
+            m_frame.tree().setSpecifiedName(nullAtom());
     }
 
     m_frame.eventHandler().clear();
@@ -3806,7 +3806,7 @@ void FrameLoader::continueLoadAfterNewWindowPolicy(const ResourceRequest& reques
         mainFrame->loader().forceSandboxFlags(sandboxFlags);
 
     if (!isBlankTargetFrameName(frameName))
-        mainFrame->tree().setName(frameName);
+        mainFrame->tree().setSpecifiedName(frameName);
 
     mainFrame->page()->setOpenedByDOM();
     mainFrame->loader().m_client->dispatchShow();
@@ -3969,7 +3969,7 @@ LocalFrame* FrameLoader::findFrameForNavigation(const AtomString& name, Document
     if (!activeDocument)
         return nullptr;
 
-    auto* frame = dynamicDowncast<LocalFrame>(m_frame.tree().find(name, activeDocument->frame() ? *activeDocument->frame() : m_frame));
+    auto* frame = dynamicDowncast<LocalFrame>(m_frame.tree().findBySpecifiedName(name, activeDocument->frame() ? *activeDocument->frame() : m_frame));
 
     if (!activeDocument->canNavigate(frame))
         return nullptr;
@@ -4399,7 +4399,7 @@ RefPtr<LocalFrame> createWindow(LocalFrame& openerFrame, LocalFrame& lookupFrame
         frame->loader().forceSandboxFlags(openerFrame.document()->sandboxFlags());
 
     if (!isBlankTargetFrameName(request.frameName()))
-        frame->tree().setName(request.frameName());
+        frame->tree().setSpecifiedName(request.frameName());
 
     page->chrome().setToolbarsVisible(features.toolBarVisible || features.locationBarVisible);
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -763,7 +763,7 @@ void FrameLoader::HistoryController::recursiveSetProvisionalItem(HistoryItem& it
         if (!fromChildItem)
             continue;
 
-        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().child(childFrameName)))
+        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().childByUniqueName(childFrameName)))
             childFrame->loader().history().recursiveSetProvisionalItem(childItem, fromChildItem);
     }
 }
@@ -785,7 +785,7 @@ void FrameLoader::HistoryController::recursiveGoToItem(HistoryItem& item, Histor
         if (!fromChildItem)
             continue;
 
-        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().child(childFrameName)))
+        if (auto* childFrame = dynamicDowncast<LocalFrame>(m_frame.tree().childByUniqueName(childFrameName)))
             childFrame->loader().history().recursiveGoToItem(childItem, fromChildItem, type, shouldTreatAsContinuingLoad);
     }
 }
@@ -816,7 +816,7 @@ bool FrameLoader::HistoryController::currentFramesMatchItem(HistoryItem& item) c
         return false;
     
     for (auto& item : childItems) {
-        if (!m_frame.tree().child(item->target()))
+        if (!m_frame.tree().childByUniqueName(item->target()))
             return false;
     }
     

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -41,9 +41,9 @@ public:
 
     ~FrameTree();
 
-    const AtomString& name() const { return m_name; }
+    const AtomString& specifiedName() const { return m_specifiedName; }
     const AtomString& uniqueName() const { return m_uniqueName; }
-    WEBCORE_EXPORT void setName(const AtomString&);
+    WEBCORE_EXPORT void setSpecifiedName(const AtomString&);
     WEBCORE_EXPORT void clearName();
     WEBCORE_EXPORT Frame* parent() const;
 
@@ -71,15 +71,17 @@ public:
     WEBCORE_EXPORT void removeChild(Frame&);
 
     Frame* child(unsigned index) const;
-    Frame* child(const AtomString& name) const;
-    WEBCORE_EXPORT Frame* find(const AtomString& name, Frame& activeFrame) const;
+    Frame* childByUniqueName(const AtomString& name) const;
+    WEBCORE_EXPORT Frame* findByUniqueName(const AtomString&, Frame& activeFrame) const;
+    WEBCORE_EXPORT Frame* findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT Frame& top() const;
     unsigned depth() const;
 
     WEBCORE_EXPORT Frame* scopedChild(unsigned index) const;
-    WEBCORE_EXPORT Frame* scopedChild(const AtomString& name) const;
+    WEBCORE_EXPORT Frame* scopedChildByUniqueName(const AtomString&) const;
+    Frame* scopedChildBySpecifiedName(const AtomString& name) const;
     unsigned scopedChildCount() const;
 
     void resetFrameIdentifiers() { m_frameIDGenerator = 0; }
@@ -91,8 +93,10 @@ private:
 
     bool scopedBy(TreeScope*) const;
     Frame* scopedChild(unsigned index, TreeScope*) const;
-    Frame* scopedChild(const AtomString& name, TreeScope*) const;
+    Frame* scopedChild(const Function<bool(const FrameTree&)>& isMatch, TreeScope*) const;
     unsigned scopedChildCount(TreeScope*) const;
+
+    Frame* find(const AtomString& name, const Function<const AtomString&(const FrameTree&)>& nameGetter, Frame& activeFrame) const;
 
     AtomString uniqueChildName(const AtomString& requestedName) const;
     AtomString generateUniqueName() const;
@@ -100,7 +104,7 @@ private:
     Frame& m_thisFrame;
 
     WeakPtr<Frame> m_parent;
-    AtomString m_name; // The actual frame name (may be empty).
+    AtomString m_specifiedName; // The actual frame name (may be empty).
     AtomString m_uniqueName;
 
     RefPtr<Frame> m_nextSibling;

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1472,7 +1472,7 @@ AtomString LocalDOMWindow::name() const
     if (!frame)
         return nullAtom();
 
-    return frame->tree().name();
+    return frame->tree().specifiedName();
 }
 
 void LocalDOMWindow::setName(const AtomString& string)
@@ -1481,7 +1481,7 @@ void LocalDOMWindow::setName(const AtomString& string)
     if (!frame)
         return;
 
-    frame->tree().setName(string);
+    frame->tree().setSpecifiedName(string);
 }
 
 void LocalDOMWindow::setStatus(const String& string)

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -192,7 +192,7 @@ LocalFrame* HitTestResult::targetFrame() const
     if (!frame)
         return nullptr;
 
-    return dynamicDowncast<LocalFrame>(frame->tree().find(m_innerURLElement->target(), *frame));
+    return dynamicDowncast<LocalFrame>(frame->tree().findBySpecifiedName(m_innerURLElement->target(), *frame));
 }
 
 bool HitTestResult::isSelected() const

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -568,7 +568,7 @@ void WebAutomationSessionProxy::resolveChildFrameWithName(WebCore::PageIdentifie
         return;
     }
 
-    auto* coreChildFrame = coreFrame->tree().scopedChild(AtomString { name });
+    auto* coreChildFrame = coreFrame->tree().scopedChildByUniqueName(AtomString { name });
     if (!coreChildFrame) {
         completionHandler(frameNotFoundErrorType, std::nullopt);
         return;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -396,7 +396,7 @@ WebCore::Document* WebFoundTextRangeController::documentForFoundTextRange(const 
     if (range.frameIdentifier.isEmpty())
         return mainFrame.document();
 
-    if (auto* frame = dynamicDowncast<WebCore::LocalFrame>(mainFrame.tree().find(AtomString { range.frameIdentifier }, mainFrame)))
+    if (auto* frame = dynamicDowncast<WebCore::LocalFrame>(mainFrame.tree().findByUniqueName(AtomString { range.frameIdentifier }, mainFrame)))
         return frame->document();
 
     return nullptr;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -121,7 +121,7 @@ void WebFrame::initWithCoreMainFrame(WebPage& page, Frame& coreFrame, bool recei
         page.send(Messages::WebPageProxy::DidCreateMainFrame(frameID()));
 
     m_coreFrame = coreFrame;
-    m_coreFrame->tree().setName(nullAtom());
+    m_coreFrame->tree().setSpecifiedName(nullAtom());
     if (auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame))
         localFrame->init();
 }
@@ -136,7 +136,7 @@ Ref<WebFrame> WebFrame::createSubframe(WebPage& page, WebFrame& parent, const At
 
     page.send(Messages::WebPageProxy::DidCreateSubframe(parent.frameID(), coreFrame->frameID()));
 
-    coreFrame->tree().setName(frameName);
+    coreFrame->tree().setSpecifiedName(frameName);
     ASSERT(ownerElement.document().frame());
     coreFrame->init();
 
@@ -237,7 +237,7 @@ FrameInfoData WebFrame::info() const
         // FIXME: This should use the full request.
         ResourceRequest(url()),
         SecurityOriginData::fromFrame(dynamicDowncast<LocalFrame>(m_coreFrame.get())),
-        m_coreFrame ? m_coreFrame->tree().name().string() : String(),
+        m_coreFrame ? m_coreFrame->tree().specifiedName().string() : String(),
         frameID(),
         parent ? std::optional<WebCore::FrameIdentifier> { parent->frameID() } : std::nullopt,
     };

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -308,7 +308,7 @@ WebView *getWebView(WebFrame *webFrame)
     auto coreFrame = WebCore::LocalFrame::createSubframe(page, makeUniqueRef<WebFrameLoaderClient>(frame.get()), WebCore::FrameIdentifier::generate(), ownerElement);
     frame->_private->coreFrame = coreFrame.ptr();
 
-    coreFrame.get().tree().setName(name);
+    coreFrame.get().tree().setSpecifiedName(name);
 
     coreFrame.get().init();
 
@@ -328,7 +328,7 @@ WebView *getWebView(WebFrame *webFrame)
     frame->_private->coreFrame = localMainFrame;
     static_cast<WebFrameLoaderClient&>(localMainFrame->loader().client()).setWebFrame(*frame.get());
 
-    localMainFrame->tree().setName(name);
+    localMainFrame->tree().setSpecifiedName(name);
     localMainFrame->init();
 
     [webView _setZoomMultiplier:[webView _realZoomMultiplier] isTextOnly:[webView _realZoomMultiplierIsTextOnly]];
@@ -2528,7 +2528,7 @@ static NSURL *createUniqueWebDataURL()
     auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return nil;
-    return kit(dynamicDowncast<WebCore::LocalFrame>(coreFrame->tree().find(name, *coreFrame)));
+    return kit(dynamicDowncast<WebCore::LocalFrame>(coreFrame->tree().findByUniqueName(name, *coreFrame)));
 }
 
 - (WebFrame *)parentFrame


### PR DESCRIPTION
#### d3e11a7a1e593d505b2f582ccd48635f4d7ee56c
<pre>
Window named getter behaves incorrectly in some cases when there are duplicate frame names
<a href="https://bugs.webkit.org/show_bug.cgi?id=258108">https://bugs.webkit.org/show_bug.cgi?id=258108</a>

Reviewed by Darin Adler and Ryosuke Niwa.

When several frames gave the same name, WebKit will generate unique frame names
internally. As a result, if a frame gets created with the name &quot;foo&quot;, it will
get &quot;foo&quot; as unique name. If a second frame gets created with the name &quot;foo&quot;,
we will generate a unique name for this frame (in the &quot;&lt;!-- frame1 --&gt;&quot; format)
instead if using the already taken &quot;foo&quot; name.

The issue is that this is Web-observable when using the named property getter
on Window. `window.foo` is supposed to return the *first* frame with the name
&quot;foo&quot; in tree order. WebKit was previously looking up the frame &quot;foo&quot; via its
unique name, as a result, it would return the frame was assigned the name &quot;foo&quot;
first, which is not necessarily the first frame with the name &quot;foo&quot; in tree
order. The same issue affects `window.open(&apos;&apos;, &apos;foo&apos;)`.

To address the issue, we now look up the frame by name instead of unique name.

This aligns our behavior with both Chrome and Firefox. The newly added tests
are passing in Chrome &amp; Firefox but fails in shipping Safari.

* LayoutTests/http/tests/frames/frames-with-same-name-cross-origin-expected.txt: Added.
* LayoutTests/http/tests/frames/frames-with-same-name-cross-origin.html: Added.
* LayoutTests/http/tests/frames/frames-with-same-name-expected.txt: Added.
* LayoutTests/http/tests/frames/frames-with-same-name.html: Added.
* LayoutTests/http/tests/frames/resources/frames-with-same-name-cross-origin-frame.html: Added.
* LayoutTests/http/tests/frames/resources/set-window-name-to-foo.html: Added.
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
(WebCore::jsDOMWindowPropertiesGetOwnPropertySlotNamedItemGetter):
* Source/WebCore/bindings/js/JSLocalDOMWindowCustom.cpp:
(WebCore::jsLocalDOMWindowGetOwnPropertySlotRestrictedAccess):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::scopedChildByUniqueName const):
(WebCore::FrameTree::scopedChildByName const):
* Source/WebCore/page/FrameTree.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithName):

Canonical link: <a href="https://commits.webkit.org/265211@main">https://commits.webkit.org/265211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06fe341de90c2624bf91327039e2d6ba66ec8306

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12820 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12287 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9288 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16574 "4 flakes 116 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9439 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9894 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2462 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->