### PR TITLE
[WebGPU] PipelineLayout::makeInvalid may call clear on empty optional value

### DIFF
--- a/Source/WebGPU/WebGPU/PipelineLayout.h
+++ b/Source/WebGPU/WebGPU/PipelineLayout.h
@@ -60,7 +60,7 @@ public:
     bool operator==(const PipelineLayout&) const;
 
     bool isAutoLayout() const { return !m_bindGroupLayouts.has_value(); }
-    size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts->size(); }
+    size_t numberOfBindGroupLayouts() const { return m_bindGroupLayouts ? m_bindGroupLayouts->size() : 0; }
     BindGroupLayout& bindGroupLayout(size_t) const;
 
     Device& device() const { return m_device; }


### PR DESCRIPTION
#### 55abb9066ef57f3375e3b3a8159f5e628e812b34
<pre>
[WebGPU] PipelineLayout::makeInvalid may call clear on empty optional value
<a href="https://bugs.webkit.org/show_bug.cgi?id=258082">https://bugs.webkit.org/show_bug.cgi?id=258082</a>
&lt;radar://110786601&gt;

Unreviewed - relanding missing commit from 265179@main

265139@main made m_bindGroupLayouts an optional, but a check to make
sure the value exists was missing.

* Source/WebGPU/WebGPU/PipelineLayout.h:
(WebGPU::PipelineLayout::numberOfBindGroupLayouts const):

Canonical link: <a href="https://commits.webkit.org/265183@main">https://commits.webkit.org/265183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb99e03bb99cc8a2d050fee58f0c301c4f873e4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11816 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12746 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12199 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8385 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12611 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2433 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->