### PR TITLE
[JSC] Optimize parseFloat(number)

### DIFF
--- a/JSTests/stress/parse-float-double.js
+++ b/JSTests/stress/parse-float-double.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function parseFloatDouble(value) {
+    return parseFloat(value);
+}
+noInline(parseFloatDouble);
+
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(Object.is(parseFloatDouble(0.0), 0), true);
+    shouldBe(Object.is(parseFloatDouble(-0.0), 0), true); // Not -0 since -0.0.toString() is "0".
+    shouldBe(Object.is(parseFloatDouble(-1.0), -1.0), true);
+    shouldBe(Object.is(parseFloatDouble(-0.01), -0.01), true);
+    shouldBe(Object.is(parseFloatDouble(-1.1), -1.1), true);
+    shouldBe(Object.is(parseFloatDouble(-1.0), -1.0), true);
+    shouldBe(Object.is(parseFloatDouble(-0.9), -0.9), true);
+    shouldBe(Object.is(parseFloatDouble(-1.000000001), -1.000000001), true);
+    shouldBe(Object.is(parseFloatDouble(-0.000000001), -0.000000001), true);
+    shouldBe(Object.is(parseFloatDouble(0.000000001), 0.000000001), true);
+    shouldBe(Object.is(parseFloatDouble(0.000001), 0.000001), true);
+    shouldBe(Object.is(parseFloatDouble(0.000001), 0.000001), true);
+    shouldBe(Object.is(parseFloatDouble(0.0000001), 0.0000001), true);
+    shouldBe(Object.is(parseFloatDouble(-0.0000001), -0.0000001), true);
+    shouldBe(Object.is(parseFloatDouble(1e+21), 1e+21), true);
+    shouldBe(Object.is(parseFloatDouble(1e+20), 1e+20), true);
+    shouldBe(Object.is(parseFloatDouble(NaN), NaN), true);
+    shouldBe(Object.is(parseFloatDouble(Infinity), Infinity), true);
+    shouldBe(Object.is(parseFloatDouble(-Infinity), -Infinity), true);
+}

--- a/JSTests/stress/parse-int-double-radix-undefined.js
+++ b/JSTests/stress/parse-int-double-radix-undefined.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function parseIntDouble(value) {
+    return parseInt(value);
+}
+noInline(parseIntDouble);
+
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(Object.is(parseIntDouble(-0.0), 0), true); // Not -0 since -0.0.toString() is "0".
+    shouldBe(Object.is(parseIntDouble(-1.0), -1.0), true);
+    shouldBe(Object.is(parseIntDouble(-0.01), -0), true);
+    shouldBe(Object.is(parseIntDouble(-1.1), -1.0), true);
+    shouldBe(Object.is(parseIntDouble(-1.0), -1.0), true);
+    shouldBe(Object.is(parseIntDouble(-0.9), -0.0), true);
+    shouldBe(Object.is(parseIntDouble(-1.000000001), -1.0), true);
+    shouldBe(Object.is(parseIntDouble(-0.000000001), -1), true); // Since it is -1e-9.
+    shouldBe(Object.is(parseIntDouble(0.000000001), 1), true); // Since it is 1e-9.
+    shouldBe(Object.is(parseIntDouble(0.000001), 0), true);
+    shouldBe(Object.is(parseIntDouble(0.000001), 0), true);
+    shouldBe(Object.is(parseIntDouble(0.0000001), 1), true); // Since it is 1e-6.
+    shouldBe(Object.is(parseIntDouble(-0.0000001), -1), true); // Since it is -1e-6.
+    shouldBe(Object.is(parseIntDouble(1e+21), 1), true); // Since it is 1e+21.
+    shouldBe(Object.is(parseIntDouble(1e+20), 1e+20), true);
+    shouldBe(Object.is(parseIntDouble(NaN), NaN), true);
+    shouldBe(Object.is(parseIntDouble(Infinity), NaN), true);
+    shouldBe(Object.is(parseIntDouble(-Infinity), NaN), true);
+}


### PR DESCRIPTION
#### c6ee90f3c7461b16db32d57700d1de4a264489a8
<pre>
[JSC] Optimize parseFloat(number)
<a href="https://bugs.webkit.org/show_bug.cgi?id=258115">https://bugs.webkit.org/show_bug.cgi?id=258115</a>
rdar://110822592

Reviewed by Mark Lam.

parseFloat(String(double)) can generate the exact same double *except for -0.0*.
This patch adds a fast path returning double when parseFloat&apos;s input is double.
We also extend parseInt optimization in C++ runtime function, which can now accept
radix = 10 cases too (it is already handled in DFG and FTL, but expand it for lower tiers).

* JSTests/stress/parse-float-double.js: Added.
(shouldBe):
(parseFloatDouble):
* JSTests/stress/parse-int-double-radix-undefined.js: Added.
(shouldBe):
(parseIntDouble):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/265189@main">https://commits.webkit.org/265189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb8675571cdc0f6e9088981b09259f948af29e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11824 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11090 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9224 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16509 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8594 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12615 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9655 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10312 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/8993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13233 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10593 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9654 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2624 "Passed tests") | 
<!--EWS-Status-Bubble-End-->