### PR TITLE
[motion-path] Make <ray-size> optional in ray()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5272,7 +5272,6 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
 
 # CSS motion path tests for missing <position> support in ray().
-imported/w3c/web-platform-tests/css/motion/offset-path-ray-010.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-011.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-012.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/motion/offset-path-ray-013.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-supports-calc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-supports-calc-expected.txt
@@ -1,6 +1,6 @@
 
 PASS offset-position supports calc
-FAIL offset-path supports calc assert_equals: expected "ray(270deg)" but got "ray(270deg closest-side)"
+PASS offset-path supports calc
 PASS offset-distance supports calc
 PASS offset-rotate supports calc
 PASS offset-anchor supports calc

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-computed-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Property offset-path value 'none'
-FAIL Property offset-path value 'ray(0deg)' assert_true: 'ray(0deg)' is a supported value for offset-path. expected true got false
-FAIL Property offset-path value 'ray(0rad closest-side)' assert_equals: expected "ray(0deg)" but got "ray(0deg closest-side)"
+PASS Property offset-path value 'ray(0deg)'
+PASS Property offset-path value 'ray(0rad closest-side)'
 PASS Property offset-path value 'ray(0.25turn closest-corner contain)'
 PASS Property offset-path value 'ray(200grad farthest-side)'
 PASS Property offset-path value 'ray(270deg farthest-corner contain)'

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-parsing-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-parsing-valid-expected.txt
@@ -1,7 +1,7 @@
 
 PASS e.style['offset-path'] = "none" should set the property value
-FAIL e.style['offset-path'] = "ray(0deg)" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['offset-path'] = "ray(0rad closest-side)" should set the property value assert_equals: serialization should be canonical expected "ray(0rad)" but got "ray(0rad closest-side)"
+PASS e.style['offset-path'] = "ray(0deg)" should set the property value
+PASS e.style['offset-path'] = "ray(0rad closest-side)" should set the property value
 PASS e.style['offset-path'] = "ray(0.25turn closest-corner contain)" should set the property value
 PASS e.style['offset-path'] = "ray(200grad farthest-side)" should set the property value
 PASS e.style['offset-path'] = "ray(270deg farthest-corner contain)" should set the property value

--- a/Source/WebCore/css/CSSRayValue.cpp
+++ b/Source/WebCore/css/CSSRayValue.cpp
@@ -33,25 +33,21 @@ namespace WebCore {
 
 String CSSRayValue::customCSSText() const
 {
-    StringBuilder builder;
+    bool isNonDefaultSize = m_size != CSSValueClosestSide;
 
-    builder.append("ray(");
-    builder.append(m_angle->cssText());
-    builder.append(" ");
-    builder.append(m_size->cssText());
-
-    if (m_isContaining)
-        builder.append(" contain");
-
-    builder.append(")");
-
-    return builder.toString();
+    return makeString(
+        "ray("_s, m_angle->cssText(),
+        isNonDefaultSize ? " "_s : ""_s,
+        isNonDefaultSize ? nameLiteral(m_size) : ""_s,
+        m_isContaining ? " contain"_s : ""_s,
+        ')'
+    );
 }
 
 bool CSSRayValue::equals(const CSSRayValue& other) const
 {
     return compareCSSValue(m_angle, other.m_angle)
-        && compareCSSValue(m_size, other.m_size)
+        && m_size == other.m_size
         && m_isContaining == other.m_isContaining;
 }
 

--- a/Source/WebCore/css/CSSRayValue.h
+++ b/Source/WebCore/css/CSSRayValue.h
@@ -36,32 +36,31 @@ namespace WebCore {
 // https://drafts.fxtf.org/motion-1/#funcdef-offset-path-ray.
 class CSSRayValue final : public CSSValue {
 public:
-    static Ref<CSSRayValue> create(Ref<CSSPrimitiveValue>&& angle, Ref<CSSPrimitiveValue>&& size, bool isContaining)
+    static Ref<CSSRayValue> create(Ref<CSSPrimitiveValue>&& angle, CSSValueID size, bool isContaining)
     {
-        return adoptRef(*new CSSRayValue(WTFMove(angle), WTFMove(size), isContaining));
+        return adoptRef(*new CSSRayValue(WTFMove(angle), size, isContaining));
     }
 
     String customCSSText() const;
 
     Ref<CSSPrimitiveValue> angle() const { return m_angle; }
-    Ref<CSSPrimitiveValue> size() const { return m_size; }
+    CSSValueID size() const { return m_size; }
     bool isContaining() const { return m_isContaining; }
 
     bool equals(const CSSRayValue&) const;
 
 private:
-    CSSRayValue(Ref<CSSPrimitiveValue>&& angle, Ref<CSSPrimitiveValue>&& size, bool isContaining)
+    CSSRayValue(Ref<CSSPrimitiveValue>&& angle, CSSValueID size, bool isContaining)
         : CSSValue(RayClass)
         , m_angle(WTFMove(angle))
-        , m_size(WTFMove(size))
+        , m_size(size)
         , m_isContaining(isContaining)
     {
         ASSERT(m_angle->isAngle());
-        ASSERT(m_size->isValueID());
     }
 
     Ref<CSSPrimitiveValue> m_angle;
-    Ref<CSSPrimitiveValue> m_size;
+    CSSValueID m_size;
     bool m_isContaining;
 };
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1704,9 +1704,8 @@ static Ref<CSSValue> valueForPathOperation(const RenderStyle& style, const PathO
         auto& ray = downcast<RayPathOperation>(*operation);
 
         auto angle = CSSPrimitiveValue::create(ray.angle(), CSSUnitType::CSS_DEG);
-        auto size = CSSPrimitiveValue::create(valueIDForRaySize(ray.size()));
 
-        return CSSRayValue::create(WTFMove(angle), WTFMove(size), ray.isContaining());
+        return CSSRayValue::create(WTFMove(angle), valueIDForRaySize(ray.size()), ray.isContaining());
     }
     }
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -723,7 +723,7 @@ inline RefPtr<PathOperation> BuilderConverter::convertPathOperation(BuilderState
         auto& rayValue = downcast<CSSRayValue>(value);
 
         RayPathOperation::Size size = RayPathOperation::Size::ClosestCorner;
-        switch (rayValue.size()->valueID()) {
+        switch (rayValue.size()) {
         case CSSValueClosestCorner:
             size = RayPathOperation::Size::ClosestCorner;
             break;


### PR DESCRIPTION
#### 1a13191fa42070e3a194e34eccb71d2be2a3d2c2
<pre>
[motion-path] Make &lt;ray-size&gt; optional in ray()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258110">https://bugs.webkit.org/show_bug.cgi?id=258110</a>
rdar://110818689

Reviewed by Antti Koivisto and Darin Adler.

In the updated motion path spec, the size in the offset path ray() function is now optional. If not specified, the size
parameter defaults to `closest-side`.

Also implement logic to omit `closest-side` when serializing, since we should always serialize to the shortest form.

Spec: <a href="https://drafts.fxtf.org/motion-1/#ray-function">https://drafts.fxtf.org/motion-1/#ray-function</a>

Fix pre-existing some unefficient idioms as well:
- Switch to consumeIdentRaw for parsing isContaining flag to avoid creating a CSSValue
- Make CSSRayValue store a CSSValueID for size instead of a CSSValue
- Make CSSRayValue use makeString for serialization

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-supports-calc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/parsing/offset-path-parsing-valid-expected.txt:
* Source/WebCore/css/CSSRayValue.cpp:
(WebCore::CSSRayValue::customCSSText const):
(WebCore::CSSRayValue::equals const):
* Source/WebCore/css/CSSRayValue.h:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForPathOperation):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeRayShape):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertPathOperation):

Canonical link: <a href="https://commits.webkit.org/265200@main">https://commits.webkit.org/265200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e0345b6dbe94842ff4f0d2b6b8138acdaae1fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11871 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12796 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11127 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9261 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12660 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9028 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2449 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->