### PR TITLE
REGRESSION(264515@main): [GStreamer] Use of WeakPtr for m_player in MediaPlayerPrivateGStreamer looks unsafe

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -34,6 +34,7 @@
 #include "MainThreadNotifier.h"
 #include "MediaPlayerPrivate.h"
 #include "PlatformLayer.h"
+#include "PlatformMediaResourceLoader.h"
 #include "TrackPrivateBaseGStreamer.h"
 #include <glib.h>
 #include <gst/gst.h>
@@ -613,6 +614,8 @@ private:
     HashMap<String, String> m_codecs;
 
     bool isSeamlessSeekingEnabled() const { return m_seekFlags & (1 << GST_SEEK_FLAG_SEGMENT); }
+
+    RefPtr<PlatformMediaResourceLoader> m_loader;
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -25,7 +25,6 @@
 
 #include "GStreamerCommon.h"
 #include "HTTPHeaderNames.h"
-#include "MediaPlayer.h"
 #include "PlatformMediaResourceLoader.h"
 #include "PolicyChecker.h"
 #include "ResourceError.h"
@@ -131,10 +130,10 @@ struct WebKitWebSrcPrivate {
         bool doesHaveEOS; // Set both when we reach stopPosition and on errors (including on responseReceived).
         bool isDownloadSuspended { false }; // Set to true from the network handler when the high water level is reached.
 
-        // Obtained by means of GstContext queries before making the first HTTP request.
-        // We use it for getting access to WebKit networking objects: the PlatformMediaResourceLoader factory [createResourceLoader()]
-        // and the player HTTP referrer string.
-        WebCore::MediaPlayer* player;
+        // Obtained by means of GstContext queries before making the first HTTP request, unless it
+        // was explicitely set using webKitWebSrcSetResourceLoader() by the playbin source-setup
+        // signal handler in MediaPlayerPrivateGStreamer.
+        RefPtr<WebCore::PlatformMediaResourceLoader> loader;
 
         // MediaPlayer referrer cached value. The corresponding method has to be called from the
         // main thread, so the value needs to be cached before use in non-main thread.
@@ -156,7 +155,6 @@ struct WebKitWebSrcPrivate {
 
         bool isRequestPending { true };
 
-        RefPtr<PlatformMediaResourceLoader> loader;
         RefPtr<PlatformMediaResource> resource;
     };
     DataMutex<StreamingMembers> dataMutex;
@@ -376,10 +374,10 @@ static void webKitWebSrcSetContext(GstElement* element, GstContext* context)
     WebKitWebSrcPrivate* priv = src->priv;
 
     GST_DEBUG_OBJECT(src, "context type: %s", gst_context_get_context_type(context));
-    if (gst_context_has_context_type(context, WEBKIT_WEB_SRC_PLAYER_CONTEXT_TYPE_NAME)) {
-        const GValue* value = gst_structure_get_value(gst_context_get_structure(context), "player");
+    if (gst_context_has_context_type(context, WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME)) {
+        const GValue* value = gst_structure_get_value(gst_context_get_structure(context), "loader");
         DataMutexLocker members { priv->dataMutex };
-        members->player = reinterpret_cast<MediaPlayer*>(g_value_get_pointer(value));
+        members->loader = reinterpret_cast<WebCore::PlatformMediaResourceLoader*>(g_value_get_pointer(value));
     }
     GST_ELEMENT_CLASS(parent_class)->set_context(element, context);
 }
@@ -463,27 +461,27 @@ static GstFlowReturn webKitWebSrcCreate(GstPushSrc* pushSrc, GstBuffer** buffer)
     WebKitWebSrcPrivate* priv = src->priv;
     DataMutexLocker members { priv->dataMutex };
 
-    // We need members->player to make requests. There are two mechanisms for this.
+    // We need members->loader to make requests. There are two mechanisms for this.
     //
-    // 1) webKitWebSrcSetMediaPlayer() is called by MediaPlayerPrivateGStreamer by means of hooking playbin's
+    // 1) webKitWebSrcSetResourceLoader() is called by MediaPlayerPrivateGStreamer by means of hooking playbin's
     //    "source-setup" event. This doesn't work for additional WebKitWebSrc elements created by adaptivedemux.
     //
     // 2) A GstContext query made here.
-    if (!members->player) {
+    if (!members->loader) {
         members.runUnlocked([src, baseSrc]() {
-            GRefPtr<GstQuery> query = adoptGRef(gst_query_new_context(WEBKIT_WEB_SRC_PLAYER_CONTEXT_TYPE_NAME));
+            GRefPtr<GstQuery> query = adoptGRef(gst_query_new_context(WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME));
             if (gst_pad_peer_query(GST_BASE_SRC_PAD(baseSrc), query.get())) {
                 GstContext* context;
 
                 gst_query_parse_context(query.get(), &context);
                 gst_element_set_context(GST_ELEMENT_CAST(src), context);
             } else
-                gst_element_post_message(GST_ELEMENT_CAST(src), gst_message_new_need_context(GST_OBJECT_CAST(src), WEBKIT_WEB_SRC_PLAYER_CONTEXT_TYPE_NAME));
+                gst_element_post_message(GST_ELEMENT_CAST(src), gst_message_new_need_context(GST_OBJECT_CAST(src), WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME));
         });
         if (members->isFlushing)
             return GST_FLOW_FLUSHING;
     }
-    if (!members->player) {
+    if (!members->loader) {
         GST_ERROR_OBJECT(src, "Couldn't obtain WebKitWebSrcPlayerContext, which is necessary to make network requests");
         return GST_FLOW_ERROR;
     }
@@ -704,9 +702,6 @@ static void webKitWebSrcMakeRequest(WebKitWebSrc* src, DataMutexLocker<WebKitWeb
             GST_DEBUG_OBJECT(protector.get(), "Skipping R%u, current request number is %u", requestNumber, members->requestNumber);
             return;
         }
-
-        if (!members->loader)
-            members->loader = members->player->createResourceLoader();
 
         PlatformMediaResourceLoader::LoadOptions loadOptions = 0;
         members->resource = members->loader->requestResource(ResourceRequest(request), loadOptions);
@@ -930,11 +925,16 @@ static void webKitWebSrcUriHandlerInit(gpointer gIface, gpointer)
     iface->set_uri = webKitWebSrcSetUri;
 }
 
-void webKitWebSrcSetMediaPlayer(WebKitWebSrc* src, WebCore::MediaPlayer* player, const String& referrer)
+void webKitWebSrcSetResourceLoader(WebKitWebSrc* src, RefPtr<WebCore::PlatformMediaResourceLoader>&& loader)
 {
-    ASSERT(player);
+    ASSERT(loader);
     DataMutexLocker members { src->priv->dataMutex };
-    members->player = player;
+    members->loader = WTFMove(loader);
+}
+
+void webKitWebSrcSetReferrer(WebKitWebSrc* src, const String& referrer)
+{
+    DataMutexLocker members { src->priv->dataMutex };
     members->referrer = referrer;
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h
@@ -20,6 +20,7 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+#include "PlatformMediaResourceLoader.h"
 #include <gst/base/gstpushsrc.h>
 #include <gst/gst.h>
 #include <wtf/Forward.h>
@@ -38,7 +39,7 @@ G_BEGIN_DECLS
 #define WEBKIT_IS_WEB_SRC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), WEBKIT_TYPE_WEB_SRC))
 #define WEBKIT_WEB_SRC_CAST(obj)       ((WebKitWebSrc*)(obj))
 
-#define WEBKIT_WEB_SRC_PLAYER_CONTEXT_TYPE_NAME  "webkit.media-player"
+#define WEBKIT_WEB_SRC_RESOURCE_LOADER_CONTEXT_TYPE_NAME  "webkit.resource-loader"
 
 struct WebKitWebSrcPrivate;
 
@@ -53,7 +54,8 @@ struct WebKitWebSrcClass {
 };
 
 GType webkit_web_src_get_type(void);
-void webKitWebSrcSetMediaPlayer(WebKitWebSrc*, WebCore::MediaPlayer*, const String&);
+void webKitWebSrcSetResourceLoader(WebKitWebSrc*, RefPtr<WebCore::PlatformMediaResourceLoader>&&);
+void webKitWebSrcSetReferrer(WebKitWebSrc*, const String&);
 bool webKitSrcPassedCORSAccessCheck(WebKitWebSrc*);
 bool webKitSrcIsCrossOrigin(WebKitWebSrc*, const WebCore::SecurityOrigin&);
 


### PR DESCRIPTION
#### 1ddda51c805979ebb13deeebecb12bd2f321f82e
<pre>
REGRESSION(264515@main): [GStreamer] Use of WeakPtr for m_player in MediaPlayerPrivateGStreamer looks unsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=258129">https://bugs.webkit.org/show_bug.cgi?id=258129</a>

Reviewed by Xabier Rodriguez-Calvar.

The player now creates a single media resource loader and shares it with adaptivedemux-spawned
webkit HTTP sources using GstContext.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
(WebCore::MediaPlayerPrivateGStreamer::sourceSetup):
(WebCore::MediaPlayerPrivateGStreamer::handleNeedContextMessage):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp:
(webKitWebSrcSetContext):
(webKitWebSrcCreate):
(webKitWebSrcMakeRequest):
(webKitWebSrcSetResourceLoader):
(webKitWebSrcSetReferrer):
(webKitWebSrcSetMediaPlayer): Deleted.
* Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/265236@main">https://commits.webkit.org/265236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7458d118d6b0ba67cd90438937c4055f9858008f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9851 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10231 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12790 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12250 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16544 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9524 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9863 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8004 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9022 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2479 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->