### PR TITLE
Web Inspector: REGRESSION(264158@main) Sources tab never shows files when inspecting JS Context

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -1252,7 +1252,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         // Target main resource.
         if (WI.sharedApp.debuggableType !== WI.DebuggableType.JavaScript && WI.sharedApp.debuggableType !== WI.DebuggableType.ITML) {
-            if (script.target !== WI.pageTarget) {
+            if (script.target.type === WI.TargetType.Worker) {
                 if (script.isMainResource()) {
                     this._addWorkerTargetWithMainResource(script.target);
                     this._addBreakpointsForSourceCode(script);
@@ -1309,7 +1309,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
     _addWorkerTargetWithMainResource(target)
     {
-        console.assert(target.type === WI.TargetType.Worker || target.type === WI.TargetType.ServiceWorker);
+        console.assert(target.type === WI.TargetType.Worker);
 
         if (this._workerTargetTreeElementMap.has(target))
             return;
@@ -2383,7 +2383,7 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
         }
 
         for (let target of WI.targets) {
-            if (target !== WI.pageTarget) {
+            if (target.type === WI.TargetType.Worker) {
                 this._addWorkerTargetWithMainResource(target);
                 this._addBreakpointsForSourceCode(target.mainResource);
                 this._addIssuesForSourceCode(target.mainResource);

--- a/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/WorkerTreeElement.js
@@ -31,7 +31,7 @@ WI.WorkerTreeElement = class WorkerTreeElement extends WI.ScriptTreeElement
     constructor(target)
     {
         console.assert(target instanceof WI.Target);
-        console.assert(target.type === WI.TargetType.Worker || target.type === WI.TargetType.ServiceWorker);
+        console.assert(target.type === WI.TargetType.Worker);
         console.assert(target.mainResource instanceof WI.Script);
 
         let options = {};


### PR DESCRIPTION
#### 1ea561941b3734c55e84711becbc9d2292166228
<pre>
Web Inspector: REGRESSION(264158@main) Sources tab never shows files when inspecting JS Context
<a href="https://bugs.webkit.org/show_bug.cgi?id=258136">https://bugs.webkit.org/show_bug.cgi?id=258136</a>
rdar://110119826

Reviewed by Devin Rousso and Patrick Angle.

When inspecting a JSContext, `WI.pageTarget` is null.
A JSContex&apos;s target type is `WI.TargetType.JavaScript`.

At this point, the `target.mainResource` is `null`,
tripping assertions and causing a crash later down the call stack
when attempting to render the tree element for the assumed worker script.

Fix this by explicitly checking for the target type of `WI.TargetType.Worker`
before attempting to continue rendering source tree elements for worker targets.

* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourcesNavigationSidebarPanel.prototype._handleResourceGroupingModeChanged):

Canonical link: <a href="https://commits.webkit.org/265209@main">https://commits.webkit.org/265209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c25c9365ca88b262fe086156a5ecf9cf5021a083

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11902 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12821 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12288 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9285 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16573 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9555 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12688 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2460 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->