### PR TITLE
[GStreamer] Add support for I420A VideoFrames

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1138,13 +1138,6 @@ webkit.org/b/239750 media/media-source/media-mp4-xhe-aac.html [ Skip ]
 # Apple baseline.
 media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
 
-# I420A support.
-imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.html [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.html [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-copyTo.any.worker.html [ Failure ]
-http/wpt/webcodecs/I420A-and-canvas.html [ Failure ]
-
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
 # Likely bugs related with dav1ddec.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -21,14 +21,14 @@ PASS Test invalid buffer constructed VideoFrames
 PASS Test Uint8Array(ArrayBuffer) constructed I420 VideoFrame
 PASS Test ArrayBuffer constructed I420 VideoFrame
 PASS Test planar constructed I420 VideoFrame with colorSpace
-FAIL Test planar constructed I420 VideoFrame with null colorSpace values Type error
-FAIL Test buffer constructed I420+Alpha VideoFrame VideoPixelFormat is not supported
+PASS Test planar constructed I420 VideoFrame with null colorSpace values
+PASS Test buffer constructed I420+Alpha VideoFrame
 PASS Test buffer constructed NV12 VideoFrame
 PASS Test buffer constructed RGB VideoFrames
 PASS Test VideoFrame constructed VideoFrame
 PASS Test we can construct a VideoFrame from an offscreen canvas.
 PASS Test I420 VideoFrame with odd visible size
-FAIL Test I420A VideoFrame and alpha={keep,discard} VideoPixelFormat is not supported
+PASS Test I420A VideoFrame and alpha={keep,discard}
 PASS Test RGBA, BGRA VideoFrames with alpha={keep,discard}
 PASS Test a VideoFrame constructed from canvas can drop the alpha channel.
 


### PR DESCRIPTION
#### fb1ba7de16f21af493d0962d48ea510b1dd11bb6
<pre>
[GStreamer] Add support for I420A VideoFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=258138">https://bugs.webkit.org/show_bug.cgi?id=258138</a>

Reviewed by Xabier Rodriguez-Calvar.

I420A is 4:2:0 Y, U, V, A layout, so like I420, but with an additional plane for alpha, which maps
to GStreamer&apos;s A420 format.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrame::createI420A):
(WebCore::VideoFrame::copyTo):

Canonical link: <a href="https://commits.webkit.org/265243@main">https://commits.webkit.org/265243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0539ab7ef26fb5daa28329011f58dfb09131fd04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9852 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12252 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16553 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9409 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12663 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9865 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8005 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9024 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2484 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->