### PR TITLE
Fix termination for ApplyStyleCommand::applyRelativeFontStyleChange

### DIFF
--- a/LayoutTests/fast/editing/editing-with-design-mode-crash-expected.txt
+++ b/LayoutTests/fast/editing/editing-with-design-mode-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/editing/editing-with-design-mode-crash.html
+++ b/LayoutTests/fast/editing/editing-with-design-mode-crash.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+    <style>
+        :empty {
+            background: #000;
+        }
+
+        * {
+            -webkit-user-modify: read;
+        }
+    </style>
+    <script>
+      onload = () => {
+        if (window.testRunner)
+          testRunner.dumpAsText();
+        let span0 = document.createElement('span');
+        span0.append('PASS if no crash');
+        document.documentElement.prepend(span0);
+        document.designMode = 'on';
+        document.execCommand('SelectAll');
+        document.execCommand('FontSizeDelta', false, '1');
+      };
+    </script>
+</head>
+</html>

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -405,7 +405,7 @@ void ApplyStyleCommand::applyRelativeFontStyleChange(EditingStyle* style)
             auto span = createStyleSpanElement(document());
             if (!surroundNodeRangeWithElement(*node, *node, span))
                 continue;
-            reachedEnd = node->isDescendantOf(beyondEnd.get());
+            reachedEnd = node->isDescendantOf(beyondEnd.get()) || !node->parentElement();
             element = WTFMove(span);
         }  else {
             // Only handle HTML elements and text nodes.


### PR DESCRIPTION
#### 4257443adecd96d4b749c44bb898c2eada6d1497
<pre>
Fix termination for ApplyStyleCommand::applyRelativeFontStyleChange
<a href="https://bugs.webkit.org/show_bug.cgi?id=258145">https://bugs.webkit.org/show_bug.cgi?id=258145</a>
rdar://110319440

Reviewed by Ryosuke Niwa.

This change fixes applyRelativeFontStyleChange in case where a node is
removed when we try to add a surrounding span, but we cannot add the
node back as removal makes it so that the surrounding span isn&apos;t
editable. The fix ensures that we terminate the loop when the node in
question doesn&apos;t have any parent.

* LayoutTests/fast/editing/editing-with-design-mode-crash-expected.txt: Added.
* LayoutTests/fast/editing/editing-with-design-mode-crash.html: Added.
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyRelativeFontStyleChange):

Canonical link: <a href="https://commits.webkit.org/265226@main">https://commits.webkit.org/265226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6fe2814e5497a6b52679d2e502dd3daeda5b6fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12275 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16565 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12678 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9885 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8019 "1 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9044 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9172 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->