### PR TITLE
XMLHttpRequest.responseXML.characterSet may be inaccurate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/charset/xhr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/charset/xhr-expected.txt
@@ -1,24 +1,24 @@
 
-FAIL Check after-1kb.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check after-1kb.html
 PASS Check after-bogus-after-1kb.html
-FAIL Check after-bogus.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check after-bogus.html
 PASS Check after-head-after-1kb-crlf.html
 PASS Check after-head-after-1kb.html
-FAIL Check after-head-in-1kb-crlf.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
-FAIL Check after-head-in-1kb.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
-FAIL Check baseline.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check after-head-in-1kb-crlf.html
+PASS Check after-head-in-1kb.html
+PASS Check baseline.html
 PASS Check document-write.html
 PASS Check in-comment.html
 PASS Check in-noscript-after-template-after-1kb.html
-FAIL Check in-object.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check in-object.html
 PASS Check in-script.html
 PASS Check in-style.html
-FAIL Check in-svg.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check in-svg.html
 PASS Check in-svg-in-cdata.html
 PASS Check in-template-after-1kb.html
-FAIL Check in-template.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check in-template.html
 PASS Check in-title.html
-FAIL Check ncr.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
-FAIL Check non-ascii-in-comment-before.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
-FAIL Check non-ascii-in-title-before.html assert_equals: Check characterSet expected "windows-1251" but got "UTF-8"
+PASS Check ncr.html
+PASS Check non-ascii-in-comment-before.html
+PASS Check non-ascii-in-title-before.html
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -190,6 +190,8 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
             responseDocument->setSecurityOriginPolicy(context.securityOriginPolicy());
             responseDocument->overrideMIMEType(mimeType);
             responseDocument->setContent(m_responseBuilder.toStringPreserveCapacity());
+            if (m_decoder)
+                responseDocument->setDecoder(m_decoder.copyRef());
 
             if (!responseDocument->wellFormed())
                 m_responseDocument = nullptr;


### PR DESCRIPTION
#### 64cb5c7438da9cd5fc4e639fe0a763a87a9b00a9
<pre>
XMLHttpRequest.responseXML.characterSet may be inaccurate
<a href="https://bugs.webkit.org/show_bug.cgi?id=258148">https://bugs.webkit.org/show_bug.cgi?id=258148</a>

Reviewed by Ryosuke Niwa.

When constructing a document in XMLHttpRequest::responseXML(), we would fail to pass
the TextDecoder we used on the new document (unlike what we do in the HTML parser).
This means that Document::characterSet() would not be able to determine the encoding
our decoder used and would always return UTF-8.

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/charset/xhr-expected.txt:
* Source/WebCore/xml/XMLHttpRequest.cpp:

Canonical link: <a href="https://commits.webkit.org/265210@main">https://commits.webkit.org/265210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9670b61919cde69e8a200ceef2bc6b0431fc66d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12813 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11143 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12276 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16568 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9886 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9045 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->