### PR TITLE
Win32Handle must use move semantics for IPC

### DIFF
--- a/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
@@ -32,11 +32,6 @@
 
 namespace IPC {
 
-void ArgumentCoder<Win32Handle>::encode(Encoder& encoder, const Win32Handle& handle)
-{
-    encoder << Win32Handle { handle };
-}
-
 void ArgumentCoder<Win32Handle>::encode(Encoder& encoder, Win32Handle&& handle)
 {
     encoder << reinterpret_cast<uint64_t>(handle.leak());

--- a/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.h
+++ b/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.h
@@ -34,7 +34,6 @@ class Win32Handle;
 namespace IPC {
 
 template<> struct ArgumentCoder<WTF::Win32Handle> {
-    static void encode(Encoder&, const WTF::Win32Handle&);
     static void encode(Encoder&, WTF::Win32Handle&&);
     static std::optional<WTF::Win32Handle> decode(Decoder&);
 };

--- a/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp
@@ -79,7 +79,7 @@ bool Semaphore::waitFor(Timeout timeout)
 
 void Semaphore::encode(Encoder& encoder) const
 {
-    encoder << m_semaphoreHandle;
+    encoder << Win32Handle { m_semaphoreHandle };
 }
 
 std::optional<Semaphore> Semaphore::decode(Decoder& decoder)

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -143,6 +143,8 @@ def types_that_must_be_moved():
         'WebKit::ShareableResource::Handle',
         'WebKit::SharedMemory::Handle',
         'WebKit::UpdateInfo',
+        'Win32Handle',
+        'std::optional<Win32Handle>'
     ]
 
 


### PR DESCRIPTION
#### d2700e00b8421158a5c71f78f5fd4dc935bbcba1
<pre>
Win32Handle must use move semantics for IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=258147">https://bugs.webkit.org/show_bug.cgi?id=258147</a>

Reviewed by Fujii Hironori.

Mark `Win32Handle` as a type that needs to use move semantics when
generating messages. Remove encoder for `const Win32Handle&amp;`. Update
encoding of `Semaphore` to copy the handle before encoding.

* Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp:
* Source/WebKit/Platform/IPC/win/ArgumentCodersWin.h:
* Source/WebKit/Platform/IPC/win/IPCSemaphoreWin.cpp:
(IPC::Semaphore::encode const):
* Source/WebKit/Scripts/webkit/messages.py:

Canonical link: <a href="https://commits.webkit.org/265251@main">https://commits.webkit.org/265251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3a52badeda75c9474d36be5502f66c229b93b57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9875 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12818 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11146 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12281 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/10355 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8452 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16570 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9890 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8024 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9049 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2492 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->