### PR TITLE
Adjust the opportunistic task scheduling heuristic after 265178@main

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5891,11 +5891,6 @@ void LocalFrameView::fireLayoutRelatedMilestonesIfNeeded()
             addPaintPendingMilestones(DidFirstMeaningfulPaint);
             if (requestedMilestones & DidFirstVisuallyNonEmptyLayout)
                 milestonesAchieved.add(DidFirstVisuallyNonEmptyLayout);
-
-            if (m_frame->isMainFrame()) {
-                if (auto* page = m_frame->page())
-                    page->didFirstMeaningfulPaint();
-            }
         }
     }
 
@@ -5934,6 +5929,10 @@ void LocalFrameView::firePaintRelatedMilestonesIfNeeded()
     if (m_milestonesPendingPaint & DidFirstMeaningfulPaint) {
         if (page->requestedLayoutMilestones() & DidFirstMeaningfulPaint)
             milestonesAchieved.add(DidFirstMeaningfulPaint);
+        if (m_frame->isMainFrame()) {
+            if (auto* page = m_frame->page())
+                page->didFirstMeaningfulPaint();
+        }
     }
 
     m_milestonesPendingPaint = { };

--- a/Source/WebCore/page/OpportunisticTaskScheduler.cpp
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.cpp
@@ -87,13 +87,11 @@ void OpportunisticTaskScheduler::runLoopObserverFired()
     if (!deadline)
         return;
 
-    auto currentTime = MonotonicTime::now();
-    auto remainingTime = deadline - currentTime;
-    if (remainingTime <= 0_ms)
+    if (ApproximateTime::now().secondsSinceEpoch() > deadline.secondsSinceEpoch())
         return;
 
     if (auto page = m_page.get())
-        page->performOpportunisticallyScheduledTasks(currentTime + remainingTime);
+        page->performOpportunisticallyScheduledTasks(deadline);
 }
 
 void OpportunisticTaskScheduler::incrementDeferralCount()

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2025,8 +2025,8 @@ void Page::renderingUpdateCompleted()
         m_unfulfilledRequestedSteps = { };
     }
 
-    if (!isUtilityPage() && m_displayNominalFramesPerSecond)
-        m_opportunisticTaskScheduler->reschedule(m_lastRenderingUpdateTimestamp + Seconds(1. / *m_displayNominalFramesPerSecond));
+    if (!isUtilityPage())
+        m_opportunisticTaskScheduler->reschedule(m_lastRenderingUpdateTimestamp + preferredRenderingUpdateInterval());
 }
 
 void Page::willStartRenderingUpdateDisplay()


### PR DESCRIPTION
#### f23a7b1306cf98373ce8345ead29d28bf4aff570
<pre>
Adjust the opportunistic task scheduling heuristic after 265178@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=258144">https://bugs.webkit.org/show_bug.cgi?id=258144</a>

Reviewed by Simon Fraser.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fireLayoutRelatedMilestonesIfNeeded):
(WebCore::LocalFrameView::firePaintRelatedMilestonesIfNeeded):

Move the call to `didFirstMeaningfulPaint()` from `fireLayoutRelatedMilestonesIfNeeded()` to
`firePaintRelatedMilestonesIfNeeded()`, so that it actually tracks the completion of first
meaningful paint rather than the first visually non-empty layout.

* Source/WebCore/page/OpportunisticTaskScheduler.cpp:
(WebCore::OpportunisticTaskScheduler::runLoopObserverFired):

Use `ApproximateTime` instead of `MonotonicTime` here, when determining whether or not the
`deadline` is already in the past by the time we&apos;re idle.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::renderingUpdateCompleted):

Use `preferredRenderingUpdateInterval` instead of `m_displayNominalFramesPerSecond`; the former
actually tracks the rendering update lifecycle cadence, which may differ from the true screen
refresh rate (for instance, due to throttling).

Canonical link: <a href="https://commits.webkit.org/265221@main">https://commits.webkit.org/265221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb651876fccabbaf28afe143278a3b45f92af4a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12293 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16576 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9558 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9438 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9898 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9057 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2467 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->