### PR TITLE
Serialization algorithms should not be changed in the middle of a serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Template element content is correctly serialized
-FAIL HTML fragment serialization algorithm should be applied to the template content assert_equals: expected "<div xml:lang=\"en-us\" p:attr=\"v\"></div>" but got "<div xmlns=\"xx\" xml:lang=\"en-us\" xmlns:p=\"uri2\" p:attr=\"v\"/>"
+PASS HTML fragment serialization algorithm should be applied to the template content
 

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -145,7 +145,7 @@ static bool elementCannotHaveEndTag(const Node& node)
 // 4. Other elements self-close.
 static bool shouldSelfClose(const Element& element, SerializationSyntax syntax)
 {
-    if (syntax != SerializationSyntax::XML && element.document().isHTMLDocument())
+    if (syntax != SerializationSyntax::XML)
         return false;
     if (element.hasChildNodes())
         return false;
@@ -374,7 +374,7 @@ OptionSet<EntityMask> MarkupAccumulator::entityMaskForText(const Text& text) con
 {
     using namespace ElementNames;
 
-    if (!text.document().isHTMLDocument() || inXMLFragmentSerialization())
+    if (inXMLFragmentSerialization())
         return EntityMaskInPCDATA;
 
     if (auto* element = text.parentElement()) {
@@ -464,7 +464,7 @@ void MarkupAccumulator::appendOpenTag(StringBuilder& result, const Element& elem
         }
     }
     result.append(element.nodeNamePreservingCase());
-    if ((inXMLFragmentSerialization() || !element.document().isHTMLDocument()) && namespaces && shouldAddNamespaceElement(element))
+    if (inXMLFragmentSerialization() && namespaces && shouldAddNamespaceElement(element))
         appendNamespace(result, element.prefix(), element.namespaceURI(), *namespaces, inXMLFragmentSerialization());
 }
 
@@ -536,7 +536,7 @@ QualifiedName MarkupAccumulator::xmlAttributeSerialization(const Attribute& attr
 
 void MarkupAccumulator::appendAttribute(StringBuilder& result, const Element& element, const Attribute& attribute, Namespaces* namespaces)
 {
-    bool isSerializingHTML = element.document().isHTMLDocument() && !inXMLFragmentSerialization();
+    bool isSerializingHTML = !inXMLFragmentSerialization();
 
     std::optional<QualifiedName> effectiveXMLPrefixedName;
 

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -64,7 +64,7 @@ constexpr auto EntityMaskInHTMLAttributeValue = { EntityMask::Amp, EntityMask::Q
 class MarkupAccumulator {
     WTF_MAKE_NONCOPYABLE(MarkupAccumulator);
 public:
-    MarkupAccumulator(Vector<Node*>*, ResolveURLs, SerializationSyntax = SerializationSyntax::HTML);
+    MarkupAccumulator(Vector<Node*>*, ResolveURLs, SerializationSyntax);
     virtual ~MarkupAccumulator();
 
     String serializeNodes(Node& targetNode, SerializedNodes, Vector<QualifiedName>* tagNamesToSkip = nullptr);

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -432,7 +432,7 @@ private:
 inline StyledMarkupAccumulator::StyledMarkupAccumulator(const Position& start, const Position& end, Vector<Node*>* nodes, ResolveURLs resolveURLs,
     SerializeComposedTree serializeComposedTree, IgnoreUserSelectNone ignoreUserSelectNone, AnnotateForInterchange annotate,
     StandardFontFamilySerializationMode standardFontFamilySerializationMode, MSOListMode msoListMode, bool needsPositionStyleConversion, Node* highestNodeToBeSerialized)
-    : MarkupAccumulator(nodes, resolveURLs)
+    : MarkupAccumulator(nodes, resolveURLs, start.document()->isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML)
     , m_start(start)
     , m_end(end)
     , m_annotate(annotate)
@@ -1183,9 +1183,11 @@ Ref<DocumentFragment> createFragmentFromMarkup(Document& document, const String&
     return fragment;
 }
 
-String serializeFragment(const Node& node, SerializedNodes root, Vector<Node*>* nodes, ResolveURLs resolveURLs, Vector<QualifiedName>* tagNamesToSkip, SerializationSyntax serializationSyntax)
+String serializeFragment(const Node& node, SerializedNodes root, Vector<Node*>* nodes, ResolveURLs resolveURLs, Vector<QualifiedName>* tagNamesToSkip, std::optional<SerializationSyntax> serializationSyntax)
 {
-    MarkupAccumulator accumulator(nodes, resolveURLs, serializationSyntax);
+    if (!serializationSyntax)
+        serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;
+    MarkupAccumulator accumulator(nodes, resolveURLs, *serializationSyntax);
     return accumulator.serializeNodes(const_cast<Node&>(node), root, tagNamesToSkip);
 }
 

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -98,7 +98,7 @@ String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs 
 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };
-WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Node*>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, SerializationSyntax = SerializationSyntax::HTML);
+WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Node*>* = nullptr, ResolveURLs = ResolveURLs::No, Vector<QualifiedName>* tagNamesToSkip = nullptr, std::optional<SerializationSyntax> = std::nullopt);
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -113,7 +113,7 @@ private:
 };
 
 PageSerializer::SerializerMarkupAccumulator::SerializerMarkupAccumulator(PageSerializer& serializer, Document& document, Vector<Node*>* nodes)
-    : MarkupAccumulator(nodes, ResolveURLs::Yes)
+    : MarkupAccumulator(nodes, ResolveURLs::Yes, document.isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML)
     , m_serializer(serializer)
     , m_document(document)
 {


### PR DESCRIPTION
#### bb36b71707e3e11d6ced5ce2438d9aa69d53ccfb
<pre>
Serialization algorithms should not be changed in the middle of a serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=258154">https://bugs.webkit.org/show_bug.cgi?id=258154</a>

Reviewed by Darin Adler.

Some of the code in MarkupAccumulator would rely on the node&apos;s document to
determine whether or not to use the XML or HTML serialization algorithm instead
of using the serialization algorithm passed to the MarkupAccumulator
constructor. This is often fine but leads to behavior changes when the node is
a &lt;template&gt; since they have their own template document.

This meant that we may start serialization as HTML and then switch to XML for
serialization a particular template node.

To address the issue, we now make sure to pass the correct serialization
algorithm to the MarkupAccumulator and use this value consistently during
serialization, without checking the document of the node currently being
serialized.

This aligns our behavior with Chrome and Firefox, which were already passing
the corresponding WPT test.

Corresponding Blink change:
- <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1640584">https://chromium-review.googlesource.com/c/chromium/src/+/1640584</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/template-expected.txt:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::shouldSelfClose):
(WebCore::MarkupAccumulator::appendOpenTag):
(WebCore::MarkupAccumulator::appendAttribute):
* Source/WebCore/editing/MarkupAccumulator.h:
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::StyledMarkupAccumulator):
(WebCore::serializePreservingVisualAppearanceInternal):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::SerializerMarkupAccumulator::SerializerMarkupAccumulator):

Canonical link: <a href="https://commits.webkit.org/265248@main">https://commits.webkit.org/265248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07bf4d2273247c731a212aafb765949855c909c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10366 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12923 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11312 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12407 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9389 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12794 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9982 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9141 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2488 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->