### PR TITLE
Make ISO parse() methods testable

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -256,17 +256,31 @@ bool ISOFairPlayStreamingPsshBox::parse(JSC::DataView& view, unsigned& offset)
 
 ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox() = default;
 ISOFairPlayStreamingInfoBox::ISOFairPlayStreamingInfoBox(const ISOFairPlayStreamingInfoBox&) = default;
+ISOFairPlayStreamingInfoBox::~ISOFairPlayStreamingInfoBox() = default;
+
+ISOFairPlayStreamingKeyRequestInfoBox::ISOFairPlayStreamingKeyRequestInfoBox() = default;
+ISOFairPlayStreamingKeyRequestInfoBox::~ISOFairPlayStreamingKeyRequestInfoBox() = default;
+
+ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox() = default;
 ISOFairPlayStreamingKeyAssetIdBox::ISOFairPlayStreamingKeyAssetIdBox(const ISOFairPlayStreamingKeyAssetIdBox&) = default;
 ISOFairPlayStreamingKeyAssetIdBox::~ISOFairPlayStreamingKeyAssetIdBox() = default;
+
+ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox() = default;
 ISOFairPlayStreamingKeyContextBox::ISOFairPlayStreamingKeyContextBox(const ISOFairPlayStreamingKeyContextBox&) = default;
 ISOFairPlayStreamingKeyContextBox::~ISOFairPlayStreamingKeyContextBox() = default;
+
+ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox() = default;
 ISOFairPlayStreamingKeyVersionListBox::ISOFairPlayStreamingKeyVersionListBox(const ISOFairPlayStreamingKeyVersionListBox&) = default;
 ISOFairPlayStreamingKeyVersionListBox::~ISOFairPlayStreamingKeyVersionListBox() = default;
+
+ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox() = default;
 ISOFairPlayStreamingKeyRequestBox::ISOFairPlayStreamingKeyRequestBox(const ISOFairPlayStreamingKeyRequestBox&) = default;
 ISOFairPlayStreamingKeyRequestBox::~ISOFairPlayStreamingKeyRequestBox() = default;
+
 ISOFairPlayStreamingInitDataBox::ISOFairPlayStreamingInitDataBox() = default;
 ISOFairPlayStreamingInitDataBox::~ISOFairPlayStreamingInitDataBox() = default;
+
 ISOFairPlayStreamingPsshBox::ISOFairPlayStreamingPsshBox() = default;
 ISOFairPlayStreamingPsshBox::~ISOFairPlayStreamingPsshBox() = default;
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
+++ b/Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,33 +34,37 @@ public:
     WEBCORE_EXPORT ISOFairPlayStreamingInfoBox();
     WEBCORE_EXPORT ISOFairPlayStreamingInfoBox(const ISOFairPlayStreamingInfoBox&);
     ISOFairPlayStreamingInfoBox(ISOFairPlayStreamingInfoBox&&);
+    WEBCORE_EXPORT ~ISOFairPlayStreamingInfoBox();
 
     static FourCC boxTypeName() { return "fpsi"; }
 
     FourCC scheme() const { return m_scheme; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     FourCC m_scheme;
 };
 
 class ISOFairPlayStreamingKeyRequestInfoBox final : public ISOFullBox {
 public:
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestInfoBox();
+    WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestInfoBox();
+
     static FourCC boxTypeName() { return "fkri"; }
 
     using KeyID = Vector<uint8_t, 16>;
     const KeyID& keyID() const { return m_keyID; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     KeyID m_keyID;
 };
 
 class ISOFairPlayStreamingKeyAssetIdBox final : public ISOBox {
 public:
-    ISOFairPlayStreamingKeyAssetIdBox() = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyAssetIdBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyAssetIdBox(const ISOFairPlayStreamingKeyAssetIdBox&);
     ISOFairPlayStreamingKeyAssetIdBox(ISOFairPlayStreamingKeyAssetIdBox&&) = default;
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyAssetIdBox();
@@ -71,15 +75,15 @@ public:
     static FourCC boxTypeName() { return "fkai"; }
     const Vector<uint8_t> data() const { return m_data; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     Vector<uint8_t> m_data;
 };
 
 class ISOFairPlayStreamingKeyContextBox final : public ISOBox {
 public:
-    ISOFairPlayStreamingKeyContextBox() = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyContextBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyContextBox(const ISOFairPlayStreamingKeyContextBox&);
     ISOFairPlayStreamingKeyContextBox(ISOFairPlayStreamingKeyContextBox&&) = default;
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyContextBox();
@@ -90,15 +94,15 @@ public:
     static FourCC boxTypeName() { return "fkcx"; }
     const Vector<uint8_t> data() const { return m_data; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     Vector<uint8_t> m_data;
 };
 
 class ISOFairPlayStreamingKeyVersionListBox final : public ISOBox {
 public:
-    ISOFairPlayStreamingKeyVersionListBox() = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyVersionListBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyVersionListBox(const ISOFairPlayStreamingKeyVersionListBox&);
     ISOFairPlayStreamingKeyVersionListBox(ISOFairPlayStreamingKeyVersionListBox&&) = default;
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyVersionListBox();
@@ -109,15 +113,15 @@ public:
     static FourCC boxTypeName() { return "fkvl"; }
     const Vector<uint8_t> versions() const { return m_versions; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     Vector<uint8_t> m_versions;
 };
 
 class ISOFairPlayStreamingKeyRequestBox final : public ISOBox {
 public:
-    ISOFairPlayStreamingKeyRequestBox() = default;
+    WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestBox();
     WEBCORE_EXPORT ISOFairPlayStreamingKeyRequestBox(const ISOFairPlayStreamingKeyRequestBox&);
     ISOFairPlayStreamingKeyRequestBox(ISOFairPlayStreamingKeyRequestBox&&) = default;
     WEBCORE_EXPORT ~ISOFairPlayStreamingKeyRequestBox();
@@ -129,9 +133,9 @@ public:
     const std::optional<ISOFairPlayStreamingKeyContextBox>& content() const { return m_context; }
     const std::optional<ISOFairPlayStreamingKeyVersionListBox>& versionList() const { return m_versionList; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     ISOFairPlayStreamingKeyRequestInfoBox m_requestInfo;
     std::optional<ISOFairPlayStreamingKeyAssetIdBox> m_assetID;
     std::optional<ISOFairPlayStreamingKeyContextBox> m_context;
@@ -148,9 +152,9 @@ public:
     const ISOFairPlayStreamingInfoBox& info() const { return m_info; }
     const Vector<ISOFairPlayStreamingKeyRequestBox>& requests() const { return m_requests; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     ISOFairPlayStreamingInfoBox m_info;
     Vector<ISOFairPlayStreamingKeyRequestBox> m_requests;
 };
@@ -164,9 +168,9 @@ public:
 
     const ISOFairPlayStreamingInitDataBox& initDataBox() { return m_initDataBox; }
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) final;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) final;
 
+private:
     ISOFairPlayStreamingInitDataBox m_initDataBox;
 };
 

--- a/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOOriginalFormatBox::ISOOriginalFormatBox() = default;
+ISOOriginalFormatBox::~ISOOriginalFormatBox() = default;
 
 bool ISOOriginalFormatBox::parse(DataView& view, unsigned& offset)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,13 +31,16 @@ namespace WebCore {
 
 class WEBCORE_EXPORT ISOOriginalFormatBox final : public ISOBox {
 public:
+    ISOOriginalFormatBox();
+    ~ISOOriginalFormatBox();
+
     static FourCC boxTypeName() { return "frma"; }
 
     FourCC dataFormat() const { return m_dataFormat; }
 
-private:
     bool parse(JSC::DataView&, unsigned& offset) override;
 
+private:
     FourCC m_dataFormat;
 };
 

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOProtectionSchemeInfoBox::ISOProtectionSchemeInfoBox() = default;
+ISOProtectionSchemeInfoBox::~ISOProtectionSchemeInfoBox() = default;
 
 bool ISOProtectionSchemeInfoBox::parse(DataView& view, unsigned& offset)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,15 +34,18 @@ class ISOSchemeInformationBox;
 
 class WEBCORE_EXPORT ISOProtectionSchemeInfoBox final : public ISOBox {
 public:
+    ISOProtectionSchemeInfoBox();
+    ~ISOProtectionSchemeInfoBox();
+
     static FourCC boxTypeName() { return "sinf"; }
 
     const ISOOriginalFormatBox& originalFormatBox() const { return m_originalFormatBox; }
     const ISOSchemeTypeBox* schemeTypeBox() const { return m_schemeTypeBox.get(); }
     const ISOSchemeInformationBox* schemeInformationBox() const { return m_schemeInformationBox.get(); }
 
-private:
     bool parse(JSC::DataView&, unsigned& offset) override;
 
+private:
     ISOOriginalFormatBox m_originalFormatBox;
     std::unique_ptr<ISOSchemeTypeBox> m_schemeTypeBox;
     std::unique_ptr<ISOSchemeInformationBox> m_schemeInformationBox;

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2018 Metrological Group B.V.
  * Copyright (C) 2018 Igalia S.L
  *
@@ -33,6 +33,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOProtectionSystemSpecificHeaderBox::ISOProtectionSystemSpecificHeaderBox() = default;
+ISOProtectionSystemSpecificHeaderBox::~ISOProtectionSystemSpecificHeaderBox() = default;
 
 std::optional<Vector<uint8_t>> ISOProtectionSystemSpecificHeaderBox::peekSystemID(JSC::DataView& view, unsigned offset)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2018 Metrological Group B.V.
  * Copyright (C) 2018 Igalia S.L
  *
@@ -34,6 +34,10 @@ namespace WebCore {
 class WEBCORE_EXPORT ISOProtectionSystemSpecificHeaderBox : public ISOFullBox {
 public:
     using KeyID = Vector<uint8_t>;
+
+    ISOProtectionSystemSpecificHeaderBox();
+    ~ISOProtectionSystemSpecificHeaderBox();
+
     static FourCC boxTypeName() { return "pssh"; }
 
     static std::optional<Vector<uint8_t>> peekSystemID(JSC::DataView&, unsigned offset);
@@ -42,9 +46,9 @@ public:
     Vector<KeyID> keyIDs() const { return m_keyIDs; }
     Vector<uint8_t> data() const { return m_data; }
 
-protected:
     bool parse(JSC::DataView&, unsigned& offset) override;
 
+protected:
     Vector<uint8_t> m_systemID;
     Vector<KeyID> m_keyIDs;
     Vector<uint8_t> m_data;

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOSchemeInformationBox::ISOSchemeInformationBox() = default;
+ISOSchemeInformationBox::~ISOSchemeInformationBox() = default;
 
 bool ISOSchemeInformationBox::parse(DataView& view, unsigned& offset)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,13 +31,16 @@ namespace WebCore {
 
 class WEBCORE_EXPORT ISOSchemeInformationBox final : public ISOBox {
 public:
+    ISOSchemeInformationBox();
+    ~ISOSchemeInformationBox();
+
     static FourCC boxTypeName() { return "schi"; }
 
     const ISOBox* schemeSpecificData() const { return m_schemeSpecificData.get(); }
 
-private:
     bool parse(JSC::DataView&, unsigned& offset) override;
 
+private:
     std::unique_ptr<ISOBox> m_schemeSpecificData;
 };
 

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOSchemeTypeBox::ISOSchemeTypeBox() = default;
+ISOSchemeTypeBox::~ISOSchemeTypeBox() = default;
 
 bool ISOSchemeTypeBox::parse(DataView& view, unsigned& offset)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,14 +31,17 @@ namespace WebCore {
 
 class WEBCORE_EXPORT ISOSchemeTypeBox final : public ISOFullBox {
 public:
+    ISOSchemeTypeBox();
+    ~ISOSchemeTypeBox();
+
     static FourCC boxTypeName() { return "schm"; }
 
     FourCC schemeType() const { return m_schemeType; }
     uint32_t schemeVersion() const { return m_schemeVersion; }
 
-private:
     bool parse(JSC::DataView&, unsigned& offset) override;
 
+private:
     FourCC m_schemeType;
     uint32_t m_schemeVersion { 0 };
 };

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@
 using JSC::DataView;
 
 namespace WebCore {
+
+ISOTrackEncryptionBox::ISOTrackEncryptionBox() = default;
+ISOTrackEncryptionBox::~ISOTrackEncryptionBox() = default;
 
 bool ISOTrackEncryptionBox::parseWithoutTypeAndSize(DataView& view)
 {

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@ namespace WebCore {
 
 class WEBCORE_EXPORT ISOTrackEncryptionBox final : public ISOFullBox {
 public:
+    ISOTrackEncryptionBox();
+    ~ISOTrackEncryptionBox();
+
     static FourCC boxTypeName() { return "tenc"; }
 
     std::optional<int8_t> defaultCryptByteBlock() const { return m_defaultCryptByteBlock; }
@@ -42,8 +45,9 @@ public:
 
     bool parseWithoutTypeAndSize(JSC::DataView&);
 
-private:
     bool parse(JSC::DataView&, unsigned& offset) override;
+
+private:
     bool parsePayload(JSC::DataView&, unsigned& offset);
 
     std::optional<int8_t> m_defaultCryptByteBlock;

--- a/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
+++ b/Source/WebCore/platform/graphics/iso/ISOVTTCue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,9 +63,9 @@ public:
 
     String toJSONString() const;
 
-private:
-    bool parse(JSC::DataView&, unsigned& offset) override;
+    WEBCORE_EXPORT bool parse(JSC::DataView&, unsigned& offset) override;
 
+private:
     MediaTime m_presentationTime;
     MediaTime m_duration;
 


### PR DESCRIPTION
#### 6954cec8768da448615eb6b380081eb1a27b8d06
<pre>
Make ISO parse() methods testable
<a href="https://bugs.webkit.org/show_bug.cgi?id=258155">https://bugs.webkit.org/show_bug.cgi?id=258155</a>

Reviewed by Eric Carlson.

Export constructor, destructor and parse() methods to make them
testable.  If the whole class is exported, implement default
constructor and destructor in the source file.

* Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.cpp:
* Source/WebCore/platform/graphics/avfoundation/ISOFairPlayStreamingPsshBox.h:
* Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOOriginalFormatBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOProtectionSchemeInfoBox.h:
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.h:
* Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOSchemeTypeBox.h:
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h:
* Source/WebCore/platform/graphics/iso/ISOVTTCue.h:

Canonical link: <a href="https://commits.webkit.org/265263@main">https://commits.webkit.org/265263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8cda6fd6b76f4b331d4dab344f632a7fcb4c13d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12419 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16668 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9993 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8105 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13403 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1167 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->