### PR TITLE
background-image filter() function does not do retina scaling

### DIFF
--- a/LayoutTests/fast/hidpi/background-filter-image-expected.html
+++ b/LayoutTests/fast/hidpi/background-filter-image-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>This tests that background images with filters scale properly.</title>
+<script src="resources/ensure-hidpi.js"></script>
+<script>
+	if (window.internals)
+    	internals.settings.setCoreImageAcceleratedFilterRenderEnabled(false);
+</script>
+<style>
+  body {
+    margin: 0;
+  }
+
+  img {
+    width: 100px;
+    height: 100px;
+    filter: sepia(1);
+  }
+</style>
+</head>
+<body>
+  <img src="../replaced/resources/compass.jpg">
+</body>
+</html>

--- a/LayoutTests/fast/hidpi/background-filter-image.html
+++ b/LayoutTests/fast/hidpi/background-filter-image.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>This tests that background images with filters scale properly.</title>
+<script src="resources/ensure-hidpi.js"></script>
+<script>
+	if (window.internals)
+    	internals.settings.setCoreImageAcceleratedFilterRenderEnabled(false);
+</script>
+<style>
+  body {
+    margin: 0;
+  }
+
+  div {
+    background-image: filter(url(../replaced/resources/compass.jpg), sepia(1));
+    background-size: 100px 100px;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+</head>
+<body>
+  <div></div>
+</body>
+</html>


### PR DESCRIPTION
#### 3b61294f88e34da95d5134670b848950dee3d8a0
<pre>
background-image filter() function does not do retina scaling
<a href="https://bugs.webkit.org/show_bug.cgi?id=216111">https://bugs.webkit.org/show_bug.cgi?id=216111</a>
rdar://68244885

Reviewed by NOBODY (OOPS!).

On a retina display, the current filter() implementation does not scale the
source image to the true display resolution before applying the filter. Fix
this by scaling the source image before applying the filter.

* LayoutTests/fast/hidpi/background-filter-image-expected.html: Added.
* LayoutTests/fast/hidpi/background-filter-image.html: Added.
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b61294f88e34da95d5134670b848950dee3d8a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10877 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12525 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13324 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11036 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11940 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12929 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9823 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17063 "6 flakes 148 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10304 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9975 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13217 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10429 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8514 "13 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9596 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9714 "Exiting early after 10 failures. 10 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->