### PR TITLE
The HTMLPreloadScanner ignores the referrerpolicy attribute for img elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/img-src-referrerpolicy-no-referrer.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/img-src-referrerpolicy-no-referrer.tentative.sub-expected.txt
@@ -1,9 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: non-speculative case did not fetch got disallowed value ""
 
     <!-- speculative case in document.write -->
-    <img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=32d64278-69fa-4d07-8ddf-cae47213b6ec&amp;encodingcheck=&Gbreve;" referrerpolicy=no-referrer>
+    <img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=428087c3-550b-4511-af1c-110cee235448&amp;encodingcheck=&Gbreve;" referrerpolicy=no-referrer>
 
 
 
-FAIL Speculative parsing, document.write(): img-src-referrerpolicy-no-referrer Unhandled rejection: assert_not_equals: non-speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, document.write(): img-src-referrerpolicy-no-referrer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/img-src-referrerpolicy-no-referrer.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/img-src-referrerpolicy-no-referrer.tentative-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_equals: expected the same number of headers between speculative and non-speculative expected 2 but got 3
 
 
-FAIL Speculative parsing, page load: img-src-referrerpolicy-no-referrer Unhandled rejection: assert_equals: expected the same number of headers between speculative and non-speculative expected 2 but got 3
+PASS Speculative parsing, page load: img-src-referrerpolicy-no-referrer
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -210,6 +210,10 @@ private:
                 m_fetchPriorityHint = parseEnumerationFromString<RequestPriority>(attributeValue.toString()).value_or(RequestPriority::Auto);
                 break;
             }
+            if (match(attributeName, referrerpolicyAttr)) {
+                m_referrerPolicy = parseReferrerPolicy(attributeValue, ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
+                break;
+            }
             if (m_document.settings().lazyImageLoadingEnabled()) {
                 if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
                     m_lazyloadAttribute = attributeValue.toString();


### PR DESCRIPTION
#### 2835282d4f2190142498038dcc670c7562d1b1ae
<pre>
The HTMLPreloadScanner ignores the referrerpolicy attribute for img elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=258164">https://bugs.webkit.org/show_bug.cgi?id=258164</a>

Reviewed by Ryosuke Niwa.

Parse the referrerpolicy attribute for img tags inside the HTMLPreloadScanner,
like we already do for some other tags.

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/img-src-referrerpolicy-no-referrer.tentative.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/img-src-referrerpolicy-no-referrer.tentative-expected.txt:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):

Canonical link: <a href="https://commits.webkit.org/265223@main">https://commits.webkit.org/265223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62deb6c4fb237526324998bb7676cf782b180b58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12334 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9302 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9069 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2468 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->