### PR TITLE
[JSC] JSScope::resolveScopeForHoistingFuncDeclInEval() should skip simple parameter catch scopes

### DIFF
--- a/JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js
+++ b/JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js
@@ -1,0 +1,38 @@
+var err = new Error();
+
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+function shouldThrow(func, errorMessage) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+
+    if (!error)
+        throw new Error(`Didn't throw!`);
+    if (String(error) !== errorMessage)
+        throw new Error(`Bad error: ${error}`);
+}
+
+(function() {
+    var e = 1;
+    try {
+        throw err;
+    } catch (e) {
+        eval(`function e() { return 1; }`); // no error
+    }
+})();
+
+shouldThrow(function() {
+    var e = 2;
+    try {
+        throw err;
+    } catch ({e}) {
+        eval(`function e() { return 1; }`); // syntax error
+    }
+}, "SyntaxError: Can't create duplicate variable in eval: 'e'");

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -197,8 +197,6 @@ test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-
   default: 'Test262Error: An initialized binding is not created following evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/annexB/language/eval-code/direct/global-switch-dflt-eval-global-skip-early-err-try.js:
   default: 'Test262Error: An initialized binding is not created prior to evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
-test/annexB/language/eval-code/direct/var-env-lower-lex-catch-non-strict.js:
-  default: "SyntaxError: Can't create duplicate variable in eval: 'err'"
 test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-block.js:
   default: 'Test262Error: An initialized binding is not created following evaluation Expected a ReferenceError to be thrown but no exception was thrown at all'
 test/annexB/language/eval-code/indirect/global-block-decl-eval-global-skip-early-err-for-in.js:

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -2064,6 +2064,9 @@ void BytecodeGenerator::pushLexicalScopeInternal(VariableEnvironment& environmen
     case ScopeType::CatchScope:
         symbolTable->setScopeType(SymbolTable::ScopeType::CatchScope);
         break;
+    case ScopeType::CatchScopeWithSimpleParameter:
+        symbolTable->setScopeType(SymbolTable::ScopeType::CatchScopeWithSimpleParameter);
+        break;
     case ScopeType::LetConstScope:
     case ScopeType::ClassScope:
         symbolTable->setScopeType(SymbolTable::ScopeType::LexicalScope);
@@ -4142,9 +4145,9 @@ void BytecodeGenerator::popLocalControlFlowScope()
     m_localScopeDepth--;
 }
 
-void BytecodeGenerator::emitPushCatchScope(VariableEnvironment& environment)
+void BytecodeGenerator::emitPushCatchScope(VariableEnvironment& environment, ScopeType scopeType)
 {
-    pushLexicalScopeInternal(environment, TDZCheckOptimization::Optimize, NestedScopeType::IsNotNested, nullptr, TDZRequirement::UnderTDZ, ScopeType::CatchScope, ScopeRegisterType::Block);
+    pushLexicalScopeInternal(environment, TDZCheckOptimization::Optimize, NestedScopeType::IsNotNested, nullptr, TDZRequirement::UnderTDZ, scopeType, ScopeRegisterType::Block);
 }
 
 void BytecodeGenerator::emitPopCatchScope(VariableEnvironment& environment) 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -941,6 +941,8 @@ namespace JSC {
         void emitOutOfLineExceptionHandler(RegisterID* exceptionRegister, RegisterID* thrownValueRegister, RegisterID* completionTypeRegister, TryData*);
 
     public:
+        enum class ScopeType : uint8_t { CatchScope, CatchScopeWithSimpleParameter, LetConstScope, FunctionNameScope, ClassScope };
+
         void restoreScopeRegister();
         void restoreScopeRegister(int lexicalScopeIndex);
 
@@ -957,7 +959,7 @@ namespace JSC {
         void emitThrowRangeError(const Identifier& message);
         void emitThrowOutOfMemoryError();
 
-        void emitPushCatchScope(VariableEnvironment&);
+        void emitPushCatchScope(VariableEnvironment&, ScopeType);
         void emitPopCatchScope(VariableEnvironment&);
 
         void emitAwait(RegisterID*);
@@ -1035,7 +1037,6 @@ namespace JSC {
 
         enum class TDZCheckOptimization { Optimize, DoNotOptimize };
         enum class NestedScopeType { IsNested, IsNotNested };
-        enum class ScopeType { CatchScope, LetConstScope, FunctionNameScope, ClassScope };
     private:
         enum class TDZRequirement { UnderTDZ, NotUnderTDZ };
         enum class ScopeRegisterType { Var, Block };

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4840,7 +4840,7 @@ void TryNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         }
 
         if (m_catchPattern) {
-            generator.emitPushCatchScope(m_lexicalVariables);
+            generator.emitPushCatchScope(m_lexicalVariables, m_catchPattern->isBindingNode() ? BytecodeGenerator::ScopeType::CatchScopeWithSimpleParameter : BytecodeGenerator::ScopeType::CatchScope);
             m_catchPattern->bindValue(generator, thrownValueRegister.get());
         }
 

--- a/Source/JavaScriptCore/runtime/JSScope.h
+++ b/Source/JavaScriptCore/runtime/JSScope.h
@@ -70,6 +70,7 @@ public:
     bool isLexicalScope();
     bool isModuleScope();
     bool isCatchScope();
+    bool isCatchScopeWithSimpleParameter();
     bool isFunctionNameScopeObject();
 
     bool isNestedLexicalScope();

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -726,6 +726,7 @@ public:
         GlobalLexicalScope,
         LexicalScope,
         CatchScope,
+        CatchScopeWithSimpleParameter,
         FunctionNameScope
     };
     void setScopeType(ScopeType type) { m_scopeType = type; }


### PR DESCRIPTION
#### a6b9795636a4a1b2c984c2eb3de3be25b4a2cf55
<pre>
[JSC] JSScope::resolveScopeForHoistingFuncDeclInEval() should skip simple parameter catch scopes
<a href="https://bugs.webkit.org/show_bug.cgi?id=258049">https://bugs.webkit.org/show_bug.cgi?id=258049</a>
&lt;rdar://problem/110737558&gt;

Reviewed by Yusuke Suzuki.

Annex B 3.4 [1] loosens early error rules for a variable name clashing with a simple parameter of
outer catch scope, including top-level function declarations in eval().

This change implements only a part of the section [1], in particular precluding a SyntaxError from
being thrown when a top-level function declaration in eval() clashes with a simple parameter of
outer catch scope (that is the first modification of EvalDeclarationInstantiation).

To accomplish that, while still throwing an error for e.g. `catch ({x}) { eval(&quot;function x() {}&quot;) }`,
this patch introduces a new type of scope, while ensuring all the other code checks for both
catch scopes types, behaving identically.

While this change aligns JSC with the spec and other runtimes by not throwing a SyntaxError, both
top-level and block-level function declarations aren&apos;t being hoisted correctly from eval() if there
is an outer catch scope with identically named simple parameter, which will be fixed in a follow-up.

[1]: <a href="https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks">https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks</a>

* JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js: Added.
* JSTests/test262/expectations.yaml: Mark 1 test case as passing.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::pushLexicalScopeInternal):
(JSC::BytecodeGenerator::emitPushCatchScope):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::TryNode::emitBytecode):
* Source/JavaScriptCore/runtime/JSScope.cpp:
(JSC::JSScope::collectClosureVariablesUnderTDZ):
(JSC::JSScope::resolveScopeForHoistingFuncDeclInEval):
(JSC::JSScope::isCatchScope):
(JSC::JSScope::isCatchScopeWithSimpleParameter):
* Source/JavaScriptCore/runtime/JSScope.h:
* Source/JavaScriptCore/runtime/SymbolTable.h:

Canonical link: <a href="https://commits.webkit.org/265331@main">https://commits.webkit.org/265331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2482ef899aeb5a0156c2303d3fa4b8ca804c435d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10401 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12948 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12440 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/10506 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16687 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8784 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12825 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9858 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10005 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8140 "1 flakes 7 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10530 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9163 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9314 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2742 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13415 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10818 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1187 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9862 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2674 "Passed tests") | 
<!--EWS-Status-Bubble-End-->