### PR TITLE
Mask clipping determination insufficient for <use> elements

### DIFF
--- a/LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text-expected.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../../resources/ahem.js"></script>
+<svg>
+  <defs>
+    <clipPath id="textclip">
+      <rect width="100" height="100"/>
+    </clipPath>
+    <text id="text" y="80" font-size="100" font-family="Ahem" clip-path="url(#textclip)">PASS</text>
+    <clipPath id="clip">
+      <use xlink:href="#text"/>
+    </clipPath>
+  </defs>
+  <rect width="400" height="200" fill="green" clip-path="url(#clip)"/>
+</svg>

--- a/LayoutTests/svg/clip-path/clip-path-use-referencing-text-expected.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-referencing-text-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/clip-path/clip-path-use-referencing-text.html
+++ b/LayoutTests/svg/clip-path/clip-path-use-referencing-text.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../../resources/ahem.js"></script>
+<svg>
+  <defs>
+    <text id="text" y="80" font-size="100" font-family="Ahem">X</text>
+    <clipPath id="clip">
+      <use xlink:href="#text"/>
+    </clipPath>
+  </defs>
+  <rect width="200" height="100" fill="green" clip-path="url(#clip)"/>
+</svg>


### PR DESCRIPTION
#### df148384b18a40059f52a6ad13f05f7c0612ade9
<pre>
Mask clipping determination insufficient for &lt;use&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=258168">https://bugs.webkit.org/show_bug.cgi?id=258168</a>

Reviewed by Rob Buis.

To determine if we need mask clipping or can use path clipping,
the renderer is queried for certain information. This is not
sufficient for &lt;use&gt; renderers -- the logic needs to extend to
the referenced renderer as well.

Previously when referencing e.g. a &lt;text&gt; element that is itself
clipped, from an &lt;use&gt; element (that is a child of &lt;clipPath&gt;)
we determined that path clipping is possible, leading to a
fully clipped object (net result: nothing visible).

Fix that issue, and handle &lt;use&gt; elements in the clip mask determination.

Covered by two new tests, exercising the &lt;use&gt; clipping peculiarities.

* LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text-expected.html: Added.
* LayoutTests/svg/clip-path/clip-path-use-referencing-clipped-text.html: Added.
* LayoutTests/svg/clip-path/clip-path-use-referencing-text-expected.html: Added.
* LayoutTests/svg/clip-path/clip-path-use-referencing-text.html: Added.
Imported from Blink.

* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::pathOnlyClipping):

Refactor the mask clipping determination logic into a helper lambda.
Re-use that lambda to check if the &lt;use&gt; referenced clip renderer
is required to use mask clipping, or if path clipping is possible.

Canonical link: <a href="https://commits.webkit.org/265238@main">https://commits.webkit.org/265238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6d920f61bb05ba77322b5b0b231cba3a0843a5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12850 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12321 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16595 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12716 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9919 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8049 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9078 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9214 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13328 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1157 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->