### PR TITLE
JSC test stress/proxy-helper-this.js.default fails when built with cloop enabled

### DIFF
--- a/JSTests/stress/proxy-helper-this.js
+++ b/JSTests/stress/proxy-helper-this.js
@@ -3,14 +3,16 @@ function foo() {
   while (1);
 }
 
-let x = foo();
-let handler = {
-  'get': () => async () => {},
-};
-let proxy = new Proxy(x, handler);
+if ($vm.useJIT()) {
+    let x = foo();
+    let handler = {
+      'get': () => async () => {},
+    };
+    let proxy = new Proxy(x, handler);
 
-try {
-    for (let i = 0; i < 1000; i++) {
-      [] = proxy;
-    }
-} catch { }
+    try {
+        for (let i = 0; i < 1000; i++) {
+          [] = proxy;
+        }
+    } catch { }
+}


### PR DESCRIPTION
#### ab5348ee83f64ca66d9aa3ac50bfbdb38af2da13
<pre>
JSC test stress/proxy-helper-this.js.default fails when built with cloop enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=258179">https://bugs.webkit.org/show_bug.cgi?id=258179</a>

Reviewed by Yusuke Suzuki.

The test stress/proxy-helper-this.js.default fails when built with cloop
enabled because returnEarlyFromInfiniteLoopsForFuzzing is not
implemented.

It&apos;s not a perfect solution, but we&apos;ve dealt with this in the past (e.g.
bug #216406) by sabotaging the test whenever JIT is disabled.

* JSTests/stress/proxy-helper-this.js:
(vm.useJIT.async let):
(vm.useJIT):
(let.handler.string_appeared_here): Deleted.
(async let): Deleted.

Canonical link: <a href="https://commits.webkit.org/265323@main">https://commits.webkit.org/265323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d56019c31c1a08b6fc65fa9f79101ec07a41389

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12332 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8493 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16604 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8704 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12728 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9773 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8056 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10434 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9086 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2702 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13336 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10718 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1182 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9770 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2647 "Passed tests") | 
<!--EWS-Status-Bubble-End-->