### PR TITLE
REGRESSION(264618@main): Infinite mutual recursion in SVGRenderSupport::layoutDifferentRootIfNeeded

### DIFF
--- a/LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash-expected.txt
+++ b/LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS - WebKit did not crash

--- a/LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash.html
+++ b/LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<svg><marker id="x21" viewBox="0,0,0,0"><marker style="clip-path: url(#x18);"></marker></svg>
+<svg id="x22"><clipPath id="x18"><line marker-start="url(#x21)"></clipPath></svg>
+<script>
+window?.testRunner.dumpAsText();
+document.querySelector('line').getBoundingClientRect();
+document.body.textContent = 'PASS - WebKit did not crash';
+</script>

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -218,11 +218,8 @@ void SVGContainerLayout::verifyLayoutLocationConsistency(const RenderLayerModelO
 
 void SVGContainerLayout::layoutDifferentRootIfNeeded(const RenderElement& renderer)
 {
-    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
-        auto* svgRoot = SVGRenderSupport::findTreeRootObject(renderer);
-        ASSERT(svgRoot);
-        resources->layoutDifferentRootIfNeeded(svgRoot);
-    }
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer))
+        resources->layoutReferencedRootIfNeeded();
 }
 
 void SVGContainerLayout::invalidateResourcesOfChildren(RenderElement& renderer)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -232,11 +232,8 @@ bool SVGRenderSupport::transformToRootChanged(RenderElement* ancestor)
 
 void SVGRenderSupport::layoutDifferentRootIfNeeded(const RenderElement& renderer)
 {
-    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
-        auto* svgRoot = SVGRenderSupport::findTreeRootObject(renderer);
-        ASSERT(svgRoot);
-        resources->layoutDifferentRootIfNeeded(svgRoot);
-    }
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer))
+        resources->layoutReferencedRootIfNeeded();
 }
 
 void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout)

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -311,25 +311,22 @@ bool SVGResources::buildCachedResources(const RenderElement& renderer, const Ren
     return foundResources;
 }
 
-void SVGResources::layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot* svgRoot)
+void SVGResources::layoutReferencedRootIfNeeded()
 {
-    if (clipper() && svgRoot != SVGRenderSupport::findTreeRootObject(*clipper()))
-        clipper()->layoutIfNeeded();
-
-    if (masker() && svgRoot != SVGRenderSupport::findTreeRootObject(*masker()))
-        masker()->layoutIfNeeded();
-
-    if (filter() && svgRoot != SVGRenderSupport::findTreeRootObject(*filter()))
-        filter()->layoutIfNeeded();
-
-    if (markerStart() && svgRoot != SVGRenderSupport::findTreeRootObject(*markerStart()))
-        markerStart()->layoutIfNeeded();
-
-    if (markerMid() && svgRoot != SVGRenderSupport::findTreeRootObject(*markerMid()))
-        markerMid()->layoutIfNeeded();
-
-    if (markerEnd() && svgRoot != SVGRenderSupport::findTreeRootObject(*markerEnd()))
-        markerEnd()->layoutIfNeeded();
+    auto layoutDifferentRootIfNeeded = [&](RenderElement* container) {
+        if (!container)
+            return;
+        auto* root = SVGRenderSupport::findTreeRootObject(*container);
+        if (root->isInLayout())
+            return;
+        container->layoutIfNeeded();
+    };
+    layoutDifferentRootIfNeeded(clipper());
+    layoutDifferentRootIfNeeded(masker());
+    layoutDifferentRootIfNeeded(filter());
+    layoutDifferentRootIfNeeded(markerStart());
+    layoutDifferentRootIfNeeded(markerMid());
+    layoutDifferentRootIfNeeded(markerEnd());
 }
 
 bool SVGResources::markerReverseStart() const

--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -45,7 +45,7 @@ public:
     SVGResources();
 
     bool buildCachedResources(const RenderElement&, const RenderStyle&);
-    void layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot*);
+    void layoutReferencedRootIfNeeded();
 
     // Ordinary resources
     RenderSVGResourceClipper* clipper() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->clipper.get() : nullptr; }


### PR DESCRIPTION
#### 0d62c4b9488c26e3e1c97771e9cb06c397fe5fad
<pre>
REGRESSION(264618@main): Infinite mutual recursion in SVGRenderSupport::layoutDifferentRootIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=258171">https://bugs.webkit.org/show_bug.cgi?id=258171</a>

Reviewed by Darin Adler.

Prevent infinite recursion in SVGRenderSupport::layoutDifferentRootIfNeeded by checking
whether the target root is already in layout or not. Also removed the now unused svgRoot argument
from layoutDifferentRootIfNeeded and renamed the function to layoutReferencedRootIfNeeded.

* LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash-expected.txt: Added.
* LayoutTests/svg/markers/marker-clip-path-mutual-reference-crash.html: Added.
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutDifferentRootIfNeeded):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::layoutDifferentRootIfNeeded):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::layoutReferencedRootIfNeeded): Renamed from layoutDifferentRootIfNeeded.
* Source/WebCore/rendering/svg/SVGResources.h:

Canonical link: <a href="https://commits.webkit.org/265249@main">https://commits.webkit.org/265249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d25081db639cc3ca8f04d9a80992ee685397a806

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12348 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16618 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12746 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9937 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8067 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9096 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9241 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->