### PR TITLE
Catalyst build fix: Rename WebCore WKRetain/WKRelease to avoid overshadowing WebKit

### DIFF
--- a/Source/WebCore/platform/ios/wak/WAKClipView.m
+++ b/Source/WebCore/platform/ios/wak/WAKClipView.m
@@ -40,7 +40,7 @@
 {
     WKViewRef view = WKViewCreateWithFrame(rect, &viewContext);
     self = [self _initWithViewRef:view];
-    WKRelease(view);
+    WAKRelease(view);
     return self;
 }
 

--- a/Source/WebCore/platform/ios/wak/WAKScrollView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKScrollView.mm
@@ -70,7 +70,7 @@ static void _notificationCallback(WKViewRef v, WKViewNotificationType type, void
     viewContext.notificationCallback = _notificationCallback;
     viewContext.notificationUserInfo = self;
     self = [super _initWithViewRef:(WKViewRef)view];
-    WKRelease(view);
+    WAKRelease(view);
 
     _contentView = [[WAKClipView alloc] initWithFrame:rect];
     [self addSubview:_contentView];

--- a/Source/WebCore/platform/ios/wak/WAKView.mm
+++ b/Source/WebCore/platform/ios/wak/WAKView.mm
@@ -209,7 +209,7 @@ static void invalidateGStateCallback(WKViewRef view)
     if (!self)
         return nil;
 
-    viewRef = static_cast<WKViewRef>(const_cast<void*>(WKRetain(viewR)));
+    viewRef = static_cast<WKViewRef>(const_cast<void*>(WAKRetain(viewR)));
     viewRef->wrapper = (void *)self;
 
     return self;
@@ -232,7 +232,7 @@ static void invalidateGStateCallback(WKViewRef view)
         viewContext.willRemoveSubviewCallback = willRemoveSubviewCallback;
         viewContext.invalidateGStateCallback = invalidateGStateCallback;
     }
-    WKRelease(view);
+    WAKRelease(view);
     return self;
 }
 
@@ -243,7 +243,7 @@ static void invalidateGStateCallback(WKViewRef view)
     if (viewRef) {
         _WKViewSetViewContext (viewRef, 0);
         viewRef->wrapper = NULL;
-        WKRelease (viewRef);
+        WAKRelease (viewRef);
     }
     
     [subviewReferences release];

--- a/Source/WebCore/platform/ios/wak/WKUtilities.c
+++ b/Source/WebCore/platform/ios/wak/WKUtilities.c
@@ -36,10 +36,10 @@ const CFSetCallBacks WKCollectionSetCallBacks = { 0, WKCollectionRetain, WKColle
 const void *WKCollectionRetain (CFAllocatorRef allocator, const void *value)
 {
     UNUSED_PARAM(allocator);
-    return WKRetain (value);
+    return WAKRetain (value);
 }
 
-const void *WKRetain(const void *o)
+const void *WAKRetain(const void *o)
 {
     WAKObjectRef object = (WAKObjectRef)(uintptr_t)o;
     
@@ -51,10 +51,10 @@ const void *WKRetain(const void *o)
 void WKCollectionRelease (CFAllocatorRef allocator, const void *value)
 {
     UNUSED_PARAM(allocator);
-    WKRelease (value);
+    WAKRelease (value);
 }
 
-void WKRelease(const void *o)
+void WAKRelease(const void *o)
 {
     WAKObjectRef object = (WAKObjectRef)(uintptr_t)o;
 
@@ -90,7 +90,7 @@ const void *WKCreateObjectWithSize (size_t size, WKClassInfo *info)
 
     object->classInfo = info;
     
-    WKRetain(object);
+    WAKRetain(object);
     
     return object;
 }

--- a/Source/WebCore/platform/ios/wak/WKUtilities.h
+++ b/Source/WebCore/platform/ios/wak/WKUtilities.h
@@ -59,8 +59,10 @@ struct _WAKObject
 };
 
 const void *WKCreateObjectWithSize (size_t size, WKClassInfo *info);
-const void *WKRetain(const void *object);
-void WKRelease(const void *object);
+// These functions use the WAK prefix to avoid breaking InstallAPI in Mac
+// Catalyst: https://bugs.webkit.org/show_bug.cgi?id=257560
+const void *WAKRetain(const void *object);
+void WAKRelease(const void *object);
 
 const void *WKCollectionRetain (CFAllocatorRef allocator, const void *value);
 void WKCollectionRelease (CFAllocatorRef allocator, const void *value);


### PR DESCRIPTION
#### 159993b6159767023613bcc8705a0ae0848b7872
<pre>
Catalyst build fix: Rename WebCore WKRetain/WKRelease to avoid overshadowing WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=257560">https://bugs.webkit.org/show_bug.cgi?id=257560</a>
rdar://103361403

Reviewed by Alexey Proskuryakov.

In the Mac Catalyst build:

- WebCore implements WKRetain/WKRelease as part of the WAK library. The
  symbols are hidden (but present in the debug build&apos;s symbol table).

- WebKit implements its own WKRetain/WKRelease, which is exported. It
  also reexports WebCore, which it only does on macOS.

- During the InstallAPI verification phase, TAPI ignores any symbols
  from headers that are implemented from a reexported framework. This
  means that even though it parses WebKit&apos;s WKRetain/WKRelease
  declarations, it refuses to use them, failing with

    error: no declaration found for exported symbol &apos;_WKRelease&apos; in dynamic library
    error: no declaration found for exported symbol &apos;_WKRetain&apos; in dynamic library

This doesn&apos;t happen in production builds, because they stubify WebCore
before WebKit begins building, so TAPI only reads re-exported symbols
from WebCore.tbd.

Since WebCore&apos;s WKRetain/WKRelease are hidden, just rename them.

* Source/WebCore/platform/ios/wak/WAKClipView.m:
(-[WAKClipView initWithFrame:]):
* Source/WebCore/platform/ios/wak/WAKScrollView.mm:
(-[WAKScrollView initWithFrame:]):
* Source/WebCore/platform/ios/wak/WAKView.mm:
(-[WAKView _initWithViewRef:]):
(-[WAKView initWithFrame:]):
(-[WAKView dealloc]):
* Source/WebCore/platform/ios/wak/WKUtilities.c:
(WAKRetain):
(WKCollectionRelease):
(WAKRelease):
(WKRetain): Deleted.
(WKRelease): Deleted.
* Source/WebCore/platform/ios/wak/WKUtilities.h:

Canonical link: <a href="https://commits.webkit.org/265255@main">https://commits.webkit.org/265255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7935587ddd3794f0011660dddda2ccc22f897cf8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10306 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10492 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12867 "96 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12336 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16609 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9928 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8058 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9087 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2466 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13338 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1163 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->