### PR TITLE
Revert [265216@main] Improve Canvas ImageData noise injection algorithm

### DIFF
--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -44,47 +44,25 @@ static inline bool isIndexInBounds(int size, int index)
     return index < size;
 }
 
-static inline bool setTightnessBounds(const std::span<uint8_t>& bytes, std::array<int, 4>& tightestBoundingDiff, int index1, int index2, int index3)
+static inline void setTightnessBounds(const std::span<uint8_t>& bytes, std::array<int, 4>& tightestBoundingDiff, int index1, int index2)
 {
-    int boundingRedDiff = std::abs(static_cast<int>(bytes[index1]) - static_cast<int>(bytes[index3]));
-    int boundingGreenDiff = std::abs(static_cast<int>(bytes[index1 + 1]) - static_cast<int>(bytes[index3 + 1]));
-    int boundingBlueDiff = std::abs(static_cast<int>(bytes[index1 + 2]) - static_cast<int>(bytes[index3 + 2]));
-    int boundingAlphaDiff = std::abs(static_cast<int>(bytes[index1 + 3]) - static_cast<int>(bytes[index3 + 3]));
+    int redDiff = bytes[index1] - bytes[index2];
+    int greenDiff = bytes[index1 + 1] - bytes[index2 + 1];
+    int blueDiff = bytes[index1 + 2] - bytes[index2 + 2];
+    int alphaDiff = bytes[index1 + 3] - bytes[index2 + 3];
 
-    int neighborRedDiff1 = std::abs(static_cast<int>(bytes[index1]) - static_cast<int>(bytes[index2]));
-    int neighborGreenDiff1 = std::abs(static_cast<int>(bytes[index1 + 1]) - static_cast<int>(bytes[index2 + 1]));
-    int neighborBlueDiff1 = std::abs(static_cast<int>(bytes[index1 + 2]) - static_cast<int>(bytes[index2 + 2]));
-    int neighborAlphaDiff1 = std::abs(static_cast<int>(bytes[index1 + 3]) - static_cast<int>(bytes[index2 + 3]));
-
-    int neighborRedDiff2 = std::abs(static_cast<int>(bytes[index2]) - static_cast<int>(bytes[index3]));
-    int neighborGreenDiff2 = std::abs(static_cast<int>(bytes[index2 + 1]) - static_cast<int>(bytes[index3 + 1]));
-    int neighborBlueDiff2 = std::abs(static_cast<int>(bytes[index2 + 2]) - static_cast<int>(bytes[index3 + 2]));
-    int neighborAlphaDiff2 = std::abs(static_cast<int>(bytes[index2 + 3]) - static_cast<int>(bytes[index3 + 3]));
-
-    bool updatedTightnessBounds { false };
-
-    if (boundingRedDiff <= 1 && boundingGreenDiff <= 1 && boundingBlueDiff <= 1 && boundingAlphaDiff <= 1
-        && neighborRedDiff1 <= 1 && neighborGreenDiff1 <= 1 && neighborBlueDiff1 <= 1 && neighborAlphaDiff1 <= 1
-        && neighborRedDiff2 <= 1 && neighborGreenDiff2 <= 1 && neighborBlueDiff2 <= 1 && neighborAlphaDiff2 <= 1) {
-        tightestBoundingDiff[0] = 0;
-        tightestBoundingDiff[1] = 0;
-        tightestBoundingDiff[2] = 0;
-        tightestBoundingDiff[3] = 0;
-        updatedTightnessBounds = true;
-    } else if (boundingRedDiff < tightestBoundingDiff[0]
-        && boundingGreenDiff < tightestBoundingDiff[1]
-        && boundingBlueDiff < tightestBoundingDiff[2]
-        && boundingAlphaDiff < tightestBoundingDiff[3]) {
-        tightestBoundingDiff[0] = boundingRedDiff;
-        tightestBoundingDiff[1] = boundingGreenDiff;
-        tightestBoundingDiff[2] = boundingBlueDiff;
-        tightestBoundingDiff[3] = boundingAlphaDiff;
-        updatedTightnessBounds = true;
+    if (redDiff < tightestBoundingDiff[0]
+        && greenDiff < tightestBoundingDiff[1]
+        && blueDiff < tightestBoundingDiff[2]
+        && alphaDiff < tightestBoundingDiff[3]) {
+        tightestBoundingDiff[0] = redDiff;
+        tightestBoundingDiff[1] = greenDiff;
+        tightestBoundingDiff[2] = blueDiff;
+        tightestBoundingDiff[3] = alphaDiff;
     }
-    return updatedTightnessBounds;
 }
 
-static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int index, const std::span<uint8_t>& bytes, const IntSize& size)
+static std::optional<std::pair<int, int>> getGradientNeighbors(int index, const std::span<uint8_t>& bytes, const IntSize& size)
 {
     constexpr auto bytesPerPixel = 4U;
     auto bufferSize = bytes.size_bytes();
@@ -97,6 +75,9 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     bool isInBottomLeftCorner = isInBottomRow && isInLeftColumn;
     bool isInTopRightCorner = isInTopRow && isInRightColumn;
     bool isInBotomRightCorner = isInBottomRow && isInRightColumn;
+
+    if (isInTopLeftCorner || isInBottomLeftCorner || isInTopRightCorner || isInBotomRightCorner)
+        return std::nullopt;
 
     constexpr auto leftOffset = -bytesPerPixel;
     constexpr auto rightOffset = bytesPerPixel;
@@ -116,68 +97,54 @@ static std::pair<std::array<int, 4>, std::array<int, 4>> boundingNeighbors(int i
     const int belowLeftIndex = index + belowLeftOffset;
     const int belowRightIndex = index + belowRightOffset;
 
-    const auto areColorsRelated = [&bytes, bufferSize](int index1, int index2, int index3) {
-        constexpr auto maxDistanceThreshold = 8;
+    const auto areColorsDescending = [&bytes, bufferSize](int index1, int index2, int index3) {
         if (!isIndexInBounds(bufferSize, index1) || !isIndexInBounds(bufferSize, index1 + 3))
             return false;
         if (!isIndexInBounds(bufferSize, index2) || !isIndexInBounds(bufferSize, index2 + 3))
             return false;
         if (!isIndexInBounds(bufferSize, index3) || !isIndexInBounds(bufferSize, index3 + 3))
             return false;
-        bool isColorNearBoundingColor1 = std::abs(static_cast<int>(bytes[index1]) - static_cast<int>(bytes[index2])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index1 + 1]) - static_cast<int>(bytes[index2 + 1])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index1 + 2]) - static_cast<int>(bytes[index2 + 2])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index1 + 3]) - static_cast<int>(bytes[index2 + 3])) <= maxDistanceThreshold;
-
-        bool isColorNearBoundingColor2 =  std::abs(static_cast<int>(bytes[index3]) - static_cast<int>(bytes[index2])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index3 + 1]) - static_cast<int>(bytes[index2 + 1])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index3 + 2]) - static_cast<int>(bytes[index2 + 2])) <= maxDistanceThreshold
-            && std::abs(static_cast<int>(bytes[index3 + 3]) - static_cast<int>(bytes[index2 + 3])) <= maxDistanceThreshold;
-
-        return isColorNearBoundingColor1 || isColorNearBoundingColor2;
+        return bytes[index1] <= bytes[index2] && bytes[index2] <= bytes[index3]
+            && bytes[index1 + 1] <= bytes[index2 + 1] && bytes[index2 + 1] <= bytes[index3 + 1]
+            && bytes[index1 + 2] <= bytes[index2 + 2] && bytes[index2 + 2] <= bytes[index3 + 2]
+            && bytes[index1 + 3] <= bytes[index2 + 3] && bytes[index2 + 3] <= bytes[index3 + 3];
     };
 
-    const auto compareColorsAndSetBounds = [&areColorsRelated](const auto& bytes, auto& tightestBoundingColors, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
-        if (areColorsRelated(neighborIndex1, colorIndex, neighborIndex2)) {
-            if (setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, colorIndex, neighborIndex2)) {
-                if (WTF::allOf(tightestBoundingDiff, [](auto& item) { return !item; })) {
-                    tightestBoundingColors = {
-                        { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] },
-                        { bytes[colorIndex], bytes[colorIndex + 1], bytes[colorIndex + 2], bytes[colorIndex + 3] }
-                    };
-                } else {
-                    tightestBoundingColors = {
-                        { bytes[neighborIndex1], bytes[neighborIndex1 + 1], bytes[neighborIndex1 + 2], bytes[neighborIndex1 + 3] },
-                        { bytes[neighborIndex2], bytes[neighborIndex2 + 1], bytes[neighborIndex2 + 2], bytes[neighborIndex2 + 3] }
-                    };
-                }
-            }
+    const auto compareColorsAndSetBounds = [&areColorsDescending](const auto& bytes, auto& tightestBoundingIndices, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
+        if (areColorsDescending(neighborIndex1, colorIndex, neighborIndex2)) {
+            tightestBoundingIndices = { neighborIndex1, neighborIndex2 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, neighborIndex2);
+        } else if (areColorsDescending(neighborIndex2, colorIndex, neighborIndex1)) {
+            tightestBoundingIndices = { neighborIndex2, neighborIndex1 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex2, neighborIndex1);
         }
-
-        return tightestBoundingColors;
     };
 
-    std::pair<std::array<int, 4>, std::array<int, 4>> tightestBoundingColors {
-        { 0, 0, 0, 0 },
-        { 255, 255, 255, 255 }
-    };
+    if (isInTopRow || isInBottomRow) {
+        if (areColorsDescending(leftIndex, index, rightIndex))
+            return { { leftIndex, rightIndex } };
+        if (areColorsDescending(rightIndex, index, leftIndex))
+            return { { rightIndex, leftIndex } };
+        return std::nullopt;
+    }
+
+    if (isInLeftColumn || isInRightColumn) {
+        if (areColorsDescending(aboveIndex, index, belowIndex))
+            return { { aboveIndex, belowIndex } };
+        if (areColorsDescending(belowIndex, index, aboveIndex))
+            return { { belowIndex, aboveIndex } };
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<int, int>> tightestBoundingIndices;
     std::array<int, 4> tightestBoundingDiff { 255, 255, 255, 255 };
 
-    if (isInTopLeftCorner || isInBottomLeftCorner || isInTopRightCorner || isInBotomRightCorner)
-        return tightestBoundingColors;
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, leftIndex, rightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveIndex, belowIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveLeftIndex, belowRightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveRightIndex, belowLeftIndex);
 
-    if (isInTopRow || isInBottomRow)
-        return compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, leftIndex, rightIndex);
-
-    if (isInLeftColumn || isInRightColumn)
-        return compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, aboveIndex, belowIndex);
-
-    compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, leftIndex, rightIndex);
-    compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, aboveIndex, belowIndex);
-    compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, aboveLeftIndex, belowRightIndex);
-    compareColorsAndSetBounds(bytes, tightestBoundingColors, tightestBoundingDiff, index, aboveRightIndex, belowLeftIndex);
-
-    return tightestBoundingColors;
+    return tightestBoundingIndices;
 }
 
 void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer, NoiseInjectionHashSalt salt)
@@ -196,48 +163,9 @@ void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer
         return;
 
     if (postProcessPixelBufferResults(*pixelBuffer, salt)) {
-        imageBuffer->putPixelBuffer(*pixelBuffer, { IntPoint::zero(), m_postProcessDirtyRect.size() }, m_postProcessDirtyRect.location());
+        imageBuffer->putPixelBuffer(*pixelBuffer, m_postProcessDirtyRect, m_postProcessDirtyRect.location());
         m_postProcessDirtyRect = { };
     }
-}
-
-static std::pair<int, int> lowerAndUpperBound(int component1, int component2, int component3)
-{
-    if (component1 <= component3) {
-        if (component1 == component2 || component2 == component3)
-            return { component2, component2 };
-        if (component1 <= component2 && component2 <= component3)
-            return { component1, component3 };
-        if (component1 >= component2 && component2 <= component3)
-            return { component2, component1 };
-        if (component1 <= component2 && component2 >= component3)
-            return { component3, component2 };
-    } else if (component1 > component3) {
-        if (component1 < component2 && component2 > component3)
-            return { component3, component1 };
-        if (component1 > component2 && component2 < component3)
-            return { component2, component3 };
-        if (component1 < component2 && component2 > component3)
-            return { component1, component2 };
-    }
-    return { component2, component2 };
-}
-
-static void adjustNeighborColorBounds(std::array<int, 4>& neighborColor1, const std::array<int, 4>& color, std::array<int, 4>& neighborColor2)
-{
-    auto [redLowerBound, redUpperBound] = lowerAndUpperBound(neighborColor1[0], color[0], neighborColor2[0]);
-    auto [greenLowerBound, greenUpperBound] = lowerAndUpperBound(neighborColor1[1], color[1], neighborColor2[1]);
-    auto [blueLowerBound, blueUpperBound] = lowerAndUpperBound(neighborColor1[2], color[2], neighborColor2[2]);
-    auto [alphaLowerBound, alphaUpperBound] = lowerAndUpperBound(neighborColor1[3], color[3], neighborColor2[3]);
-
-    neighborColor1[0] = redLowerBound;
-    neighborColor2[0] = redUpperBound;
-    neighborColor1[1] = greenLowerBound;
-    neighborColor2[1] = greenUpperBound;
-    neighborColor1[2] = blueLowerBound;
-    neighborColor2[2] = blueUpperBound;
-    neighborColor1[3] = alphaLowerBound;
-    neighborColor2[3] = alphaUpperBound;
 }
 
 bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffer, NoiseInjectionHashSalt salt) const
@@ -259,45 +187,42 @@ bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffe
         if (!alphaChannel)
             continue;
 
-        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue, int minValue, int maxValue) {
-            if (originalComponentValue > maxValue)
-                maxValue = 255;
-            if (originalComponentValue < minValue)
-                minValue = 0;
-            if (colorComponentOffset + originalComponentValue > maxValue)
-                colorComponentOffset = maxValue - originalComponentValue;
-            else if (colorComponentOffset + originalComponentValue < minValue)
-                colorComponentOffset = minValue - originalComponentValue;
+        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
+        // +/- 3 is roughly ~1% of the 255 max value.
+        const auto clampedOnePercent = static_cast<int8_t>(((pixelHash * 6) / std::numeric_limits<uint32_t>::max()) - 3);
+
+        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue, int minBoundingColor, int maxBoundingColor) {
+            if (colorComponentOffset + originalComponentValue > maxBoundingColor)
+                return maxBoundingColor - originalComponentValue;
+            if (colorComponentOffset + originalComponentValue < minBoundingColor)
+                return minBoundingColor - originalComponentValue;
             return colorComponentOffset;
         };
 
-        std::array<int, 4> lowerBoundColor { 0, 0, 0, 0 };
-        std::array<int, 4> upperBoundColor { 255, 255, 255, 255 };
-        auto [neighborColor1, neighborColor2] = boundingNeighbors(i, bytes, pixelBuffer.size());
+        std::array<int, 4> minNeighborColor { 0, 0, 0, 0 };
+        std::array<int, 4> maxNeighborColor { 255, 255, 255, 255 };
+        if (auto neighbors = getGradientNeighbors(i, bytes, pixelBuffer.size())) {
+            auto [minNeighborColorIndex, maxNeighborColorIndex] = *neighbors;
+            minNeighborColor[0] = bytes[minNeighborColorIndex];
+            minNeighborColor[1] = bytes[minNeighborColorIndex + 1];
+            minNeighborColor[2] = bytes[minNeighborColorIndex + 2];
+            minNeighborColor[3] = bytes[minNeighborColorIndex + 3];
 
-        // +/- 1 is roughly ~0.5% of the 255 max value.
-        // +/- 3 is roughly ~1% of the 255 max value.
-        int maxNoiseValue = 3;
-        if (neighborColor1 != neighborColor2 && neighborColor1 != lowerBoundColor && neighborColor2 != upperBoundColor) {
-            maxNoiseValue = 1;
-            adjustNeighborColorBounds(neighborColor1, { redChannel, greenChannel, blueChannel, alphaChannel }, neighborColor2);
+            maxNeighborColor[0] = bytes[maxNeighborColorIndex];
+            maxNeighborColor[1] = bytes[maxNeighborColorIndex + 1];
+            maxNeighborColor[2] = bytes[maxNeighborColorIndex + 2];
+            maxNeighborColor[3] = bytes[maxNeighborColorIndex + 3];
         }
-
-        lowerBoundColor = neighborColor1;
-        upperBoundColor = neighborColor2;
-
-        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
-        auto noiseValue = static_cast<int8_t>(((pixelHash * 2 * maxNoiseValue) / std::numeric_limits<uint32_t>::max()) - maxNoiseValue);
 
         // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
         if (isBlack)
-            alphaChannel += clampedColorComponentOffset(noiseValue, alphaChannel, lowerBoundColor[3], upperBoundColor[3]);
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighborColor[3], maxNeighborColor[3]);
         else {
             // If alpha and any of the color channels are non-zero, then tweak all of the channels;
-            redChannel += clampedColorComponentOffset(noiseValue, redChannel, lowerBoundColor[0], upperBoundColor[0]);
-            greenChannel += clampedColorComponentOffset(noiseValue, greenChannel, lowerBoundColor[1], upperBoundColor[1]);
-            blueChannel += clampedColorComponentOffset(noiseValue, blueChannel, lowerBoundColor[2], upperBoundColor[2]);
-            alphaChannel += clampedColorComponentOffset(noiseValue, alphaChannel, lowerBoundColor[3], upperBoundColor[3]);
+            redChannel += clampedColorComponentOffset(clampedOnePercent, redChannel, minNeighborColor[0], maxNeighborColor[0]);
+            greenChannel += clampedColorComponentOffset(clampedOnePercent, greenChannel, minNeighborColor[1], maxNeighborColor[1]);
+            blueChannel += clampedColorComponentOffset(clampedOnePercent, blueChannel, minNeighborColor[2], maxNeighborColor[2]);
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighborColor[3], maxNeighborColor[3]);
         }
         wasPixelBufferModified = true;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -802,7 +802,7 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
         [webView2 callAsyncJavaScriptAndWait:scriptToRun]
     };
-    EXPECT_TRUE([values.first isEqualToString:values.second]);
+    EXPECT_WK_STREQ(values.first, values.second);
 
     values = std::pair {
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
@@ -819,8 +819,8 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
 
 TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
 {
-    constexpr auto zeroPrefix = 380;
-    constexpr auto channelsPerPixel = 4;
+    const auto zeroPrefix = 380;
+    const auto channelsPerPixel = 4;
 
     auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
     auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
@@ -842,70 +842,51 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     [webViewWithPrivacyProtections2 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
     [webViewWithPrivacyProtections2 _test_waitForDidFinishNavigation];
 
-    auto checkCanvasPixels = [&](NSString *functionName, size_t length, Function<void(NSDictionary *, NSDictionary *, int, int)> expect) {
-        // This is a larger tolerance than we'd like, but the lossy nature of the premultiplied conversion doesn't give us many options.
-        constexpr auto maxPixelDifferenceTolerance = 8;
+    auto checkCanvasPixels = [&](NSString *functionName, size_t length, Function<void(NSString *, NSString *, int)> expect) {
         auto scriptToRun = [NSString stringWithFormat:@"return %@(%zu)", functionName, length];
+        auto values = std::pair {
+            [webView1 callAsyncJavaScriptAndWait:scriptToRun],
+            [webView2 callAsyncJavaScriptAndWait:scriptToRun]
+        };
+        EXPECT_WK_STREQ(values.first, values.second);
+        EXPECT_NE(((NSString *)values.first).length, 0u);
+        EXPECT_NE(((NSString *)values.second).length, 0u);
+        EXPECT_EQ(((NSString *)values.first).length, ((NSString *)values.second).length);
 
-        NSDictionary *arr1 = [webView1 callAsyncJavaScriptAndWait:scriptToRun];
-        NSDictionary *arr2 = [webView2 callAsyncJavaScriptAndWait:scriptToRun];
+        values = std::pair {
+            [webView1 callAsyncJavaScriptAndWait:scriptToRun],
+            [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]
+        };
+        expect(values.first, values.second, __LINE__);
+        EXPECT_NE(((NSString *)values.first).length, 0u);
+        EXPECT_NE(((NSString *)values.second).length, 0u);
 
-        EXPECT_TRUE([arr1 isEqualToDictionary:arr2]);
-        EXPECT_NE(arr1.count, 0u);
-        EXPECT_NE(arr2.count, 0u);
-        EXPECT_EQ(arr1.count, arr2.count);
-
-        NSDictionary *arrWithPrivacyProtections1 = [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun];
-
-        expect(arr1, arrWithPrivacyProtections1, maxPixelDifferenceTolerance, __LINE__);
-        EXPECT_NE(arrWithPrivacyProtections1.count, 0u);
-
-        NSDictionary *arrWithPrivacyProtections2 = [webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun];
-
-        expect(arr1, arrWithPrivacyProtections2, maxPixelDifferenceTolerance, __LINE__);
-        EXPECT_NE(arrWithPrivacyProtections2.count, 0u);
-
-        expect(arrWithPrivacyProtections1, arrWithPrivacyProtections2, maxPixelDifferenceTolerance * 2, __LINE__);
+        values = std::pair {
+            [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun],
+            [webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]
+        };
+        expect(values.first, values.second, __LINE__);
+        EXPECT_NE(((NSString *)values.first).length, 0u);
+        EXPECT_NE(((NSString *)values.second).length, 0u);
     };
 
     auto checkCanvasPixelsEqual = [&](NSString *functionName, int length, int primaryLine) {
-        checkCanvasPixels(functionName, length, [primaryLine](NSDictionary *arr1, NSDictionary *arr2, int, int secondaryLine) {
-            EXPECT_TRUE([arr1 isEqualToDictionary:arr2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\narr1: " << arr1.description << "\narr2: " << arr2.description;
+        checkCanvasPixels(functionName, length, [primaryLine](NSString *str1, NSString *str2, int secondaryLine) {
+            EXPECT_WK_STREQ(str1, str2) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nstr1: " << str1.UTF8String << "\nstr2: " << str2.UTF8String;
         });
     };
 
     auto checkCanvasPixelsNotEqual = [&](NSString *functionName, int length, int primaryLine) {
-        checkCanvasPixels(functionName, length, [primaryLine](NSDictionary *arr1, NSDictionary *arr2, int tolerance, int secondaryLine) {
-            EXPECT_FALSE([arr1 isEqualToDictionary:arr2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\narr1: " << arr1.description << "\narr2: " << arr2.description;
-            for (auto i = 0u; i < arr1.count; i += 4) {
-                auto* idx = [NSString stringWithFormat:@"%d", i];
-                auto* idxPlus1 = [NSString stringWithFormat:@"%d", i + 1];
-                auto* idxPlus2 = [NSString stringWithFormat:@"%d", i + 2];
-                auto* idxPlus3 = [NSString stringWithFormat:@"%d", i + 3];
-                int alpha1 = [[arr1 valueForKey:idxPlus3] intValue];
-                int alpha2 = [[arr2 valueForKey:idxPlus3] intValue];
-                EXPECT_LE(std::abs(alpha1 - alpha2), (tolerance / 2)) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nAlpha at index (+3): " << i << " is not within tolerance: " << (tolerance / 2) << ". arr1 value: " << alpha1 << ", arr2 value: " << alpha2;
-
-                auto red1 = [[arr1 valueForKey:idx] intValue];
-                auto red2 = [[arr2 valueForKey:idx] intValue];
-                EXPECT_LE(std::abs(std::round(static_cast<float>(red1 * alpha1) / 255) - std::round(static_cast<float>(red2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex: " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << red1 << " (alpha: " << alpha1 << "), arr2 value: " << red2 << " (alpha: " << alpha2 << ")";
-
-                auto green1 = [[arr1 valueForKey:idxPlus1] intValue];
-                auto green2 = [[arr2 valueForKey:idxPlus1] intValue];
-                EXPECT_LE(std::abs(std::round(static_cast<float>(green1 * alpha1) / 255) - std::round(static_cast<float>(green2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex (+1): " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << green1 << " (alpha: " << alpha1 << "), arr2 value: " << green2 << " (alpha: " << alpha2 << ")";
-
-                auto blue1 = [[arr1 valueForKey:idxPlus2] intValue];
-                auto blue2 = [[arr2 valueForKey:idxPlus2] intValue];
-                EXPECT_LE(std::abs(std::round(static_cast<float>(blue1 * alpha1) / 255) - std::round(static_cast<float>(blue2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex (+2): " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << blue1 << " (alpha: " << alpha1 << "), arr2 value: " << blue2 << " (alpha: " << alpha2 << ")";
-            }
+        checkCanvasPixels(functionName, length, [primaryLine](NSString *str1, NSString *str2, int secondaryLine) {
+            EXPECT_FALSE([str1 isEqualToString:str2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nstr1: " << str1.UTF8String << "\nstr2: " << str2.UTF8String;
         });
     };
 
-    checkCanvasPixelsEqual(@"initialTextCanvasImageDataAsObject", zeroPrefix * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialTextCanvasImageDataAsObject", 300 * 200 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialTextCanvasImageDataAsString", zeroPrefix * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialTextCanvasImageDataAsString", (300 * 200) * channelsPerPixel, __LINE__);
 
-    checkCanvasPixelsEqual(@"initialHorizontalLinearGradientCanvasImageDataAsObject", 1 * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialHorizontalLinearGradientCanvasImageDataAsObject", 30 * 2 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialHorizontalLinearGradientCanvasImageDataAsString", 1 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialHorizontalLinearGradientCanvasImageDataAsString", 8 * channelsPerPixel, __LINE__);
 
     auto scriptToRun = @"return isHorizontalLinearGradientCanvasGradient()";
     EXPECT_TRUE([webView1 callAsyncJavaScriptAndWait:scriptToRun]);
@@ -913,8 +894,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     EXPECT_TRUE([webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]);
     EXPECT_TRUE([webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]);
 
-    checkCanvasPixelsEqual(@"initialVerticalLinearGradientCanvasImageDataAsObject", 2, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialVerticalLinearGradientCanvasImageDataAsObject", 2 * 30 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialVerticalLinearGradientCanvasImageDataAsString", 2, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialVerticalLinearGradientCanvasImageDataAsString", 32 * channelsPerPixel, __LINE__);
 
     scriptToRun = @"return isVerticalLinearGradientCanvasGradient()";
     EXPECT_TRUE([webView1 callAsyncJavaScriptAndWait:scriptToRun]);
@@ -922,8 +903,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     EXPECT_TRUE([webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]);
     EXPECT_TRUE([webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]);
 
-    checkCanvasPixelsEqual(@"initialRadialGradientCanvasImageDataAsObject", 1 * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialRadialGradientCanvasImageDataAsObject", 300 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialRadialGradientCanvasImageDataAsString", 1 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialRadialGradientCanvasImageDataAsString", 300 * channelsPerPixel, __LINE__);
 }
 
 TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)
@@ -950,19 +931,19 @@ TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
         [webView2 callAsyncJavaScriptAndWait:scriptToRun]
     };
-    EXPECT_TRUE([values.first isEqualTo:values.second]);
+    EXPECT_WK_STREQ(values.first, values.second);
 
     values = std::pair {
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
         [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]
     };
-    EXPECT_FALSE([values.first isEqualTo:values.second]);
+    EXPECT_FALSE([values.first isEqualToString:values.second]);
 
     values = std::pair {
         [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun],
         [webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun],
     };
-    EXPECT_FALSE([values.first isEqualTo:values.second]);
+    EXPECT_FALSE([values.first isEqualToString:values.second]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
@@ -98,15 +98,15 @@ function fullTextCanvasImageData() {
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
 }
 
-function initialCanvasImageDataAsObject(imageData, length) {
+function initialCanvasImageDataAsString(imageData, length) {
+    let stringify = "";
     if (length < 0)
-        return {};
+        return "";
     if (length > imageData.data.length)
         length = imageData.data.length;
-    let obj = {};
-    for (let i = 0; i < length; ++i)
-      obj[i] = imageData.data[i];
-    return obj;
+    for (i = 0; i < length; i++)
+        stringify += imageData.data[i] + ",";
+    return stringify;
 }
 
 function isHorizontalLinearGradientCanvasGradient() {
@@ -134,20 +134,20 @@ function isVerticalLinearGradientCanvasGradient() {
     return true;
 }
 
-function initialTextCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullTextCanvasImageData(), length);
+function initialTextCanvasImageDataAsString(length) {
+    return initialCanvasImageDataAsString(fullTextCanvasImageData(), length);
 }
 
-function initialHorizontalLinearGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullHorizontalLinearGradientCanvasImageData(), length);
+function initialHorizontalLinearGradientCanvasImageDataAsString(length) {
+    return initialCanvasImageDataAsString(fullHorizontalLinearGradientCanvasImageData(), length);
 }
 
-function initialVerticalLinearGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullVerticalLinearGradientCanvasImageData(), length);
+function initialVerticalLinearGradientCanvasImageDataAsString(length) {
+    return initialCanvasImageDataAsString(fullVerticalLinearGradientCanvasImageData(), length);
 }
 
-function initialRadialGradientCanvasImageDataAsObject(length) {
-    return initialCanvasImageDataAsObject(fullRadialGradientCanvasImageData(), length);
+function initialRadialGradientCanvasImageDataAsString(length) {
+    return initialCanvasImageDataAsString(fullRadialGradientCanvasImageData(), length);
 }
 
 async function fullCanvasHash(data) {


### PR DESCRIPTION
#### 197c3463813244d75eec4bfa4fcfc20169a25750
<pre>
Revert [265216@main] Improve Canvas ImageData noise injection algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=257574">https://bugs.webkit.org/show_bug.cgi?id=257574</a>
rdar://109271231

Unreviewed revert
This reverts because because it broke the build on the bots.

* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::setTightnessBounds):
(WebCore::getGradientNeighbors):
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
(WebCore::boundingNeighbors): Deleted.
(WebCore::lowerAndUpperBound): Deleted.
(WebCore::adjustNeighborColorBounds): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/197c3463813244d75eec4bfa4fcfc20169a25750

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11952 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10493 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11196 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12337 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8503 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9601 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1151 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->