### PR TITLE
[JSC] Add V8 style ICU DST offset cache

### DIFF
--- a/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
- * Copyright (C) 2006-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2010 &yet, LLC. (nate@andyet.net)
@@ -41,7 +41,7 @@
  * If you do not delete the provisions above, a recipient may use your
  * version of this file under any of the LGPL, the MPL or the GPL.
 
- * Copyright 2006-2008 the V8 project authors. All rights reserved.
+ * Copyright 2006-2012 the V8 project authors. All rights reserved.
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
@@ -75,6 +75,7 @@
 #include "ExceptionHelpers.h"
 #include "VM.h"
 #include <limits>
+#include <wtf/DateMath.h>
 #include <wtf/Language.h>
 #include <wtf/unicode/CharacterNames.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
@@ -99,6 +100,9 @@
 #endif
 
 namespace JSC {
+namespace JSDateMathInternal {
+static constexpr bool verbose = false;
+}
 
 #if PLATFORM(COCOA)
 std::atomic<uint64_t> lastTimeZoneID { 1 };
@@ -185,103 +189,181 @@ LocalTimeOffset DateCache::calculateLocalTimeOffset(double millisecondsFromEpoch
     return { !!dstOffset, rawOffset + dstOffset };
 }
 
-LocalTimeOffset DateCache::localTimeOffset(double millisecondsFromEpoch, WTF::TimeType inputTimeType)
+LocalTimeOffsetCache* DateCache::DSTCache::leastRecentlyUsed(LocalTimeOffsetCache* exclude)
 {
-    LocalTimeOffsetCache& cache = inputTimeType == WTF::LocalTime ? m_localTimeOffsetCache : m_utcTimeOffsetCache;
+    LocalTimeOffsetCache* result = nullptr;
+    for (auto& cache : m_entries) {
+        if (&cache == exclude)
+            continue;
+        if (!result) {
+            result = &cache;
+            continue;
+        }
+        if (result->epoch > cache.epoch)
+            result = &cache;
+    }
+    *result = LocalTimeOffsetCache { };
+    return result;
+}
 
-    double start = cache.start;
-    double end = cache.end;
+std::tuple<LocalTimeOffsetCache*, LocalTimeOffsetCache*> DateCache::DSTCache::probe(int64_t millisecondsFromEpoch)
+{
+    LocalTimeOffsetCache* before = nullptr;
+    LocalTimeOffsetCache* after = nullptr;
+    for (auto& cache : m_entries) {
+        if (cache.start <= millisecondsFromEpoch) {
+            if (!before || before->start < cache.start)
+                before = &cache;
+        } else if (millisecondsFromEpoch < cache.end) {
+            if (!after || after->end > cache.end)
+                after = &cache;
+        }
+    }
 
-    auto resetCache = [&]() {
+    if (!before) {
+        if (m_before->isEmpty())
+            before = m_before;
+        else
+            before = leastRecentlyUsed(after);
+    }
+    if (!after) {
+        if (m_after->isEmpty() && before != m_after)
+            after = m_after;
+        else
+            after = leastRecentlyUsed(before);
+    }
+
+    m_before = before;
+    m_after = after;
+    return std::tuple { before, after };
+}
+
+void DateCache::DSTCache::extendTheAfterCache(int64_t millisecondsFromEpoch, LocalTimeOffset offset)
+{
+    if (m_after->offset == offset && m_after->start - defaultDSTDeltaInMilliseconds <= millisecondsFromEpoch && millisecondsFromEpoch <= m_after->end) {
+        // Extend the m_after cache.
+        m_after->start = millisecondsFromEpoch;
+        dataLogLnIf(JSDateMathInternal::verbose, "Cache extended1 from ", millisecondsFromEpoch, " to ", m_after->end, " ", offset.offset, " ", offset.isDST);
+    } else {
+        // The m_after cache is either invalid or starts too late.
+        if (!m_after->isEmpty()) {
+            // If the m_after cache is valid, replace it with a new cache.
+            m_after = leastRecentlyUsed(m_before);
+        }
+        m_after->start = millisecondsFromEpoch;
+        m_after->end = millisecondsFromEpoch;
+        m_after->offset = offset;
+        m_after->epoch = bumpEpoch();
+        dataLogLnIf(JSDateMathInternal::verbose, "Cache miss, recompute2 ", millisecondsFromEpoch, " ", offset.offset, " ", offset.isDST);
+    }
+}
+
+LocalTimeOffset DateCache::DSTCache::localTimeOffset(DateCache& dateCache, int64_t millisecondsFromEpoch, WTF::TimeType inputTimeType)
+{
+    if (millisecondsFromEpoch >= WTF::Int64Milliseconds::minECMAScriptTime && millisecondsFromEpoch <= WTF::Int64Milliseconds::maxECMAScriptTime) {
+        // Do nothing. Use millisecondsFromEpoch directly
+    } else {
+        // Adjust to equivalent time.
+        int64_t newTime = WTF::equivalentTime(millisecondsFromEpoch);
+        dataLogLnIf(JSDateMathInternal::verbose, "Equivalent time conversion from ", millisecondsFromEpoch, " to ", newTime);
+        millisecondsFromEpoch = newTime;
+    }
+
+    if (UNLIKELY(m_epoch > UINT32_MAX)) {
+        dataLogLnIf(JSDateMathInternal::verbose, "reset DSTCache");
+        reset();
+    }
+
+    // If the time fits in the cached interval in the last cache hit, return the cached offset.
+    if (m_before->start <= millisecondsFromEpoch && millisecondsFromEpoch <= m_before->end) {
+        dataLogLnIf(JSDateMathInternal::verbose, "Previous Cache Hit");
+        m_before->epoch = bumpEpoch();
+        return m_before->offset;
+    }
+
+    probe(millisecondsFromEpoch);
+
+    ASSERT(m_before->isEmpty() || m_before->start <= millisecondsFromEpoch);
+    ASSERT(m_after->isEmpty() || millisecondsFromEpoch < m_after->start);
+
+    if (m_before->isEmpty()) {
+        // Cache miss!
         // Compute the DST offset for the time and shrink the cache interval
         // to only contain the time. This allows fast repeated DST offset
         // computations for the same time.
-        LocalTimeOffset offset = calculateLocalTimeOffset(millisecondsFromEpoch, inputTimeType);
-        cache.offset = offset;
-        cache.start = millisecondsFromEpoch;
-        cache.end = millisecondsFromEpoch;
-        cache.incrementStart = WTF::msPerMonth;
-        cache.incrementEnd = WTF::msPerMonth;
+        LocalTimeOffset offset = dateCache.calculateLocalTimeOffset(millisecondsFromEpoch, inputTimeType);
+        m_before->offset = offset;
+        m_before->start = millisecondsFromEpoch;
+        m_before->end = millisecondsFromEpoch;
+        m_before->epoch = bumpEpoch();
+        dataLogLnIf(JSDateMathInternal::verbose, "Cache miss, recompute1 ", millisecondsFromEpoch, " ", offset.offset, " ", offset.isDST);
         return offset;
-    };
+    }
 
+    // Cache hit!
     // If the time fits in the cached interval, return the cached offset.
-    if (start <= millisecondsFromEpoch && millisecondsFromEpoch <= end)
-        return cache.offset;
+    if (millisecondsFromEpoch <= m_before->end) {
+        dataLogLnIf(JSDateMathInternal::verbose, "Cache hit, simple ", millisecondsFromEpoch, " ", m_before->offset.offset, " ", m_before->offset.isDST);
+        m_before->epoch = bumpEpoch();
+        return m_before->offset;
+    }
 
-    if (start <= millisecondsFromEpoch) {
-        // Compute a possible new interval end.
-        double newEnd = end + cache.incrementEnd;
-        if (!(millisecondsFromEpoch <= newEnd))
-            return resetCache();
-
-        LocalTimeOffset endOffset = calculateLocalTimeOffset(newEnd, inputTimeType);
-        if (cache.offset == endOffset) {
-            // If the offset at the end of the new interval still matches
-            // the offset in the cache, we grow the cached time interval
-            // and return the offset.
-            cache.end = newEnd;
-            cache.incrementStart = WTF::msPerMonth;
-            cache.incrementEnd = WTF::msPerMonth;
-            return endOffset;
-        }
-        LocalTimeOffset offset = calculateLocalTimeOffset(millisecondsFromEpoch, inputTimeType);
-        if (offset == endOffset) {
-            // The offset at the given time is equal to the offset at the
-            // new end of the interval, so that means that we've just skipped
-            // the point in time where the DST offset change occurred. Update
-            // the interval to reflect this and reset the increment.
-            cache.start = millisecondsFromEpoch;
-            cache.end = newEnd;
-            cache.incrementStart = WTF::msPerMonth;
-            cache.incrementEnd = WTF::msPerMonth;
-        } else {
-            // The interval contains a DST offset change and the given time is
-            // before it. Adjust the increment to avoid a linear search for
-            // the offset change point and change the end of the interval.
-            cache.incrementEnd /= 3;
-            cache.end = millisecondsFromEpoch;
-        }
-        // Update the offset in the cache and return it.
-        cache.offset = offset;
+    if ((millisecondsFromEpoch - defaultDSTDeltaInMilliseconds) > m_before->end) {
+        LocalTimeOffset offset = dateCache.calculateLocalTimeOffset(millisecondsFromEpoch, inputTimeType);
+        extendTheAfterCache(millisecondsFromEpoch, offset);
+        std::swap(m_before, m_after);
+        dataLogLnIf(JSDateMathInternal::verbose, "Cache hit, extend ", millisecondsFromEpoch, " ", offset.offset, " ", offset.isDST);
         return offset;
     }
 
-    // Compute a possible new interval start.
-    double newStart = start - cache.incrementStart;
-    if (!(newStart <= millisecondsFromEpoch))
-        return resetCache();
+    m_before->epoch = bumpEpoch();
 
-    LocalTimeOffset startOffset = calculateLocalTimeOffset(newStart, inputTimeType);
-    if (cache.offset == startOffset) {
-        // If the offset at the start of the new interval still matches
-        // the offset in the cache, we grow the cached time interval
-        // and return the offset.
-        cache.start = newStart;
-        cache.incrementStart = WTF::msPerMonth;
-        cache.incrementEnd = WTF::msPerMonth;
-        return startOffset;
-    }
-    LocalTimeOffset offset = calculateLocalTimeOffset(millisecondsFromEpoch, inputTimeType);
-    if (offset == startOffset) {
-        // The offset at the given time is equal to the offset at the
-        // new start of the interval, so that means that we've just skipped
-        // the point in time where the DST offset change occurred. Update
-        // the interval to reflect this and reset the increment.
-        cache.start = newStart;
-        cache.end = millisecondsFromEpoch;
-        cache.incrementStart = WTF::msPerMonth;
-        cache.incrementEnd = WTF::msPerMonth;
+    // Check if m_after is invalid or starts too late.
+    // Note that start of invalid caches is maxECMAScriptTime.
+    int64_t newAfterStart = m_before->end < WTF::Int64Milliseconds::maxECMAScriptTime - defaultDSTDeltaInMilliseconds ? m_before->end + defaultDSTDeltaInMilliseconds : WTF::Int64Milliseconds::maxECMAScriptTime;
+    if (newAfterStart <= m_after->start) {
+        LocalTimeOffset offset = dateCache.calculateLocalTimeOffset(newAfterStart, inputTimeType);
+        extendTheAfterCache(newAfterStart, offset);
     } else {
-        // The interval contains a DST offset change and the given time is
-        // before it. Adjust the increment to avoid a linear search for
-        // the offset change point and change the end of the interval.
-        cache.incrementStart /= 3;
-        cache.start = millisecondsFromEpoch;
+        // Update the usage counter of m_after since it is going to be used.
+        ASSERT(!m_after->isEmpty());
+        m_after->epoch = bumpEpoch();
     }
-    // Update the offset in the cache and return it.
-    cache.offset = offset;
-    return offset;
+
+    // Now the millisecondsFromEpoch is between m_before->end and m_after->start.
+    // Only one daylight savings offset change can occur in this interval.
+
+    if (m_before->offset == m_after->offset) {
+        // Merge two caches if they have the same offset.
+        m_before->end = m_after->end;
+        *m_after = LocalTimeOffsetCache { };
+        return m_before->offset;
+    }
+
+    // Binary search for daylight savings offset change point,
+    // but give up if we don't find it in five iterations.
+    for (int i = 4; i >= 0; --i) {
+        int64_t delta = m_after->start - m_before->end;
+        int64_t middle = !i ? millisecondsFromEpoch : m_before->end + delta / 2;
+        LocalTimeOffset offset = dateCache.calculateLocalTimeOffset(middle, inputTimeType);
+        if (m_before->offset == offset) {
+            m_before->end = middle;
+            dataLogLnIf(JSDateMathInternal::verbose, "Cache extended2 from ", m_before->start , " to ", m_before->end, " ", offset.offset, " ", offset.isDST);
+            if (millisecondsFromEpoch <= m_before->end)
+                return offset;
+        } else {
+            ASSERT(m_after->offset == offset);
+            m_after->start = middle;
+            dataLogLnIf(JSDateMathInternal::verbose, "Cache extended3 from ", m_after->start , " to ", m_after->end, " ", offset.offset, " ", offset.isDST);
+            if (millisecondsFromEpoch >= m_after->start) {
+                // This swap helps the optimistic fast check in subsequent invocations.
+                std::swap(m_before, m_after);
+                return offset;
+            }
+        }
+    }
+
+    return { };
 }
 
 double DateCache::gregorianDateTimeToMS(const GregorianDateTime& t, double milliseconds, WTF::TimeType inputTimeType)
@@ -290,23 +372,24 @@ double DateCache::gregorianDateTimeToMS(const GregorianDateTime& t, double milli
     double ms = timeToMS(t.hour(), t.minute(), t.second(), milliseconds);
     double localTimeResult = (day * WTF::msPerDay) + ms;
 
-    double localToUTCTimeOffset = inputTimeType == WTF::LocalTime ? localTimeOffset(localTimeResult, inputTimeType).offset : 0;
-
-    return localTimeResult - localToUTCTimeOffset;
+    if (inputTimeType == WTF::LocalTime && std::isfinite(localTimeResult))
+        return localTimeResult - localTimeOffset(static_cast<int64_t>(localTimeResult), inputTimeType).offset;
+    return localTimeResult;
 }
 
 double DateCache::localTimeToMS(double milliseconds, WTF::TimeType inputTimeType)
 {
-    double localToUTCTimeOffset = inputTimeType == WTF::LocalTime ? localTimeOffset(milliseconds, inputTimeType).offset : 0;
-    return milliseconds - localToUTCTimeOffset;
+    if (inputTimeType == WTF::LocalTime && std::isfinite(milliseconds))
+        return milliseconds - localTimeOffset(static_cast<int64_t>(milliseconds), inputTimeType).offset;
+    return milliseconds;
 }
 
 // input is UTC
 void DateCache::msToGregorianDateTime(double millisecondsFromEpoch, WTF::TimeType outputTimeType, GregorianDateTime& tm)
 {
     LocalTimeOffset localTime;
-    if (outputTimeType == WTF::LocalTime) {
-        localTime = localTimeOffset(millisecondsFromEpoch);
+    if (outputTimeType == WTF::LocalTime && std::isfinite(millisecondsFromEpoch)) {
+        localTime = localTimeOffset(static_cast<int64_t>(millisecondsFromEpoch));
         millisecondsFromEpoch += localTime.offset;
     }
     tm = GregorianDateTime(millisecondsFromEpoch, localTime);
@@ -341,8 +424,8 @@ double DateCache::parseDate(JSGlobalObject* globalObject, VM& vm, const String& 
         if (std::isnan(value))
             value = WTF::parseDateFromNullTerminatedCharacters(dateString, isLocalTime);
 
-        if (isLocalTime)
-            value -= localTimeOffset(value, WTF::LocalTime).offset;
+        if (isLocalTime && std::isfinite(value))
+            value -= localTimeOffset(static_cast<int64_t>(value), WTF::LocalTime).offset;
 
         return value;
     };
@@ -489,8 +572,8 @@ void DateCache::resetIfNecessarySlow()
     // FIXME: We should clear it only when we know the timezone has been changed on Non-Cocoa platforms.
     // https://bugs.webkit.org/show_bug.cgi?id=218365
     m_timeZoneCache.reset();
-    m_utcTimeOffsetCache = LocalTimeOffsetCache();
-    m_localTimeOffsetCache = LocalTimeOffsetCache();
+    for (auto& cache : m_caches)
+        cache.reset();
     m_cachedDateString = String();
     m_cachedDateStringValue = std::numeric_limits<double>::quiet_NaN();
     m_dateInstanceCache.reset();

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -2,6 +2,7 @@
  * Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2012 the V8 project authors. All rights reserved.
  * Copyright (C) 2010 Research In Motion Limited. All rights reserved.
  *
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
@@ -45,6 +46,7 @@
 #include "DateInstanceCache.h"
 #include <wtf/DateMath.h>
 #include <wtf/GregorianDateTime.h>
+#include <wtf/SaturatedArithmetic.h>
 
 namespace JSC {
 
@@ -67,11 +69,12 @@ struct OpaqueICUTimeZoneDeleter {
 struct LocalTimeOffsetCache {
     LocalTimeOffsetCache() = default;
 
-    LocalTimeOffset offset;
-    double start { 0.0 };
-    double end { -1.0 };
-    double incrementStart { 0.0 };
-    double incrementEnd { 0.0 };
+    bool isEmpty() { return start > end; }
+
+    LocalTimeOffset offset { };
+    int64_t start { WTF::Int64Milliseconds::maxECMAScriptTime };
+    int64_t end { WTF::Int64Milliseconds::minECMAScriptTime };
+    uint64_t epoch { 0 };
 };
 
 class DateCache {
@@ -107,15 +110,64 @@ public:
     Ref<DateInstanceData> cachedDateInstanceData(double millisecondsFromEpoch);
 
     void msToGregorianDateTime(double millisecondsFromEpoch, WTF::TimeType outputTimeType, GregorianDateTime&);
-    double gregorianDateTimeToMS(const GregorianDateTime&, double milliseconds, WTF::TimeType inputTimeType);
-    double localTimeToMS(double milliseconds, WTF::TimeType inputTimeType);
+    double gregorianDateTimeToMS(const GregorianDateTime&, double milliseconds, WTF::TimeType);
+    double localTimeToMS(double milliseconds, WTF::TimeType);
     JS_EXPORT_PRIVATE double parseDate(JSGlobalObject*, VM&, const WTF::String&);
 
     static void timeZoneChanged();
 
 private:
+    class DSTCache {
+    public:
+        static constexpr unsigned cacheSize = 32;
+        // The implementation relies on the fact that no time zones have
+        // more than one daylight savings offset change per 19 days.
+        // In Egypt in 2010 they decided to suspend DST during Ramadan. This
+        // led to a short interval where DST is in effect from September 10 to
+        // September 30.
+        static constexpr int64_t defaultDSTDeltaInMilliseconds = 19 * WTF::Int64Milliseconds::secondsPerDay * 1000;
+
+        DSTCache()
+            : m_before(m_entries.data())
+            , m_after(m_entries.data() + 1)
+        {
+        }
+
+        uint64_t bumpEpoch()
+        {
+            ++m_epoch;
+            return m_epoch;
+        }
+
+        void reset()
+        {
+            m_entries.fill(LocalTimeOffsetCache { });
+            m_before = m_entries.data();
+            m_after = m_entries.data() + 1;
+            m_epoch = 0;
+        }
+
+        LocalTimeOffset localTimeOffset(DateCache&, int64_t millisecondsFromEpoch, WTF::TimeType);
+
+    private:
+        LocalTimeOffsetCache* leastRecentlyUsed(LocalTimeOffsetCache* exclude);
+        std::tuple<LocalTimeOffsetCache*, LocalTimeOffsetCache*> probe(int64_t millisecondsFromEpoch);
+        void extendTheAfterCache(int64_t millisecondsFromEpoch, LocalTimeOffset);
+
+        uint64_t m_epoch { 0 };
+        std::array<LocalTimeOffsetCache, cacheSize> m_entries { };
+        LocalTimeOffsetCache* m_before;
+        LocalTimeOffsetCache* m_after;
+    };
+
     void timeZoneCacheSlow();
-    LocalTimeOffset localTimeOffset(double millisecondsFromEpoch, WTF::TimeType inputTimeType = WTF::UTCTime);
+    LocalTimeOffset localTimeOffset(int64_t millisecondsFromEpoch, WTF::TimeType inputTimeType = WTF::UTCTime)
+    {
+        static_assert(!WTF::UTCTime);
+        static_assert(WTF::LocalTime == 1);
+        return m_caches[static_cast<unsigned>(inputTimeType)].localTimeOffset(*this, millisecondsFromEpoch, inputTimeType);
+    }
+
     LocalTimeOffset calculateLocalTimeOffset(double millisecondsFromEpoch, WTF::TimeType inputTimeType);
 
     OpaqueICUTimeZone* timeZoneCache()
@@ -126,8 +178,7 @@ private:
     }
 
     std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter> m_timeZoneCache;
-    LocalTimeOffsetCache m_utcTimeOffsetCache;
-    LocalTimeOffsetCache m_localTimeOffsetCache;
+    std::array<DSTCache, 2> m_caches;
     String m_cachedDateString;
     double m_cachedDateStringValue;
     DateInstanceCache m_dateInstanceCache;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -118,6 +118,10 @@ const int firstDayOfMonth[2][12] = {
     {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}
 };
 
+const int8_t daysInMonths[12] = {
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+};
+
 #if !OS(WINDOWS) || HAVE(TM_GMTOFF)
 static inline void getLocalTime(const time_t* localTime, struct tm* localTM)
 {

--- a/Source/WTF/wtf/GregorianDateTime.cpp
+++ b/Source/WTF/wtf/GregorianDateTime.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012, 2014 Patrick Gansterer <paroga@paroga.com>
+ * Copyright (C) 2012 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,47 +38,23 @@ namespace WTF {
 
 GregorianDateTime::GregorianDateTime(double ms, LocalTimeOffset localTime)
 {
-    if (ms >= 0
-#if OS(WINDOWS) && CPU(X86)
-            // The VS Compiler for 32-bit builds generates a floating point error when attempting to cast
-            // from an infinity to a 64-bit integer. We leave this routine with the floating point error
-            // left in a register, causing undefined behavior in later floating point operations.
-            //
-            // To avoid this issue, we check for infinity here, and return false in that case.
-            && !std::isinf(ms)
-#endif
-        ) {
-        int64_t integer = static_cast<int64_t>(ms);
-        if (static_cast<double>(integer) == ms && integer <= maxECMAScriptTime) {
-            // Positive integer fast path.
-            WTF::TimeClippedPositiveMilliseconds timeClipped(integer);
-            const int year = msToYear(ms);
-            setSecond(msToSeconds(timeClipped));
-            setMinute(msToMinutes(timeClipped));
-            setHour(msToHours(timeClipped));
-            setWeekDay(msToWeekDay(timeClipped));
-            int yearDay = dayInYear(timeClipped, year);
-            bool leapYear = isLeapYear(year);
-            setYearDay(yearDay);
-            setMonthDay(dayInMonthFromDayInYear(yearDay, leapYear));
-            setMonth(monthFromDayInYear(yearDay, leapYear));
-            setYear(year);
-            setIsDST(localTime.isDST);
-            setUTCOffsetInMinute(localTime.offset / WTF::msPerMinute);
-            return;
-        }
+    if (std::isfinite(ms)) {
+        WTF::Int64Milliseconds timeClipped(static_cast<int64_t>(ms));
+        int32_t days = msToDays(timeClipped);
+        int32_t timeInDayMS = timeInDay(timeClipped, days);
+        auto [year, month, day] = yearMonthDayFromDays(days);
+        int32_t hour = timeInDayMS / (60 * 60 * 1000);
+        int32_t minute = (timeInDayMS / (60 * 1000)) % 60;
+        int32_t second = (timeInDayMS / 1000) % 60;
+        setSecond(second);
+        setMinute(minute);
+        setHour(hour);
+        setWeekDay(WTF::weekDay(days));
+        setYearDay(dayInYear(year, month, day));
+        setMonthDay(day);
+        setMonth(month);
+        setYear(year);
     }
-    const int year = msToYear(ms);
-    setSecond(msToSeconds(ms));
-    setMinute(msToMinutes(ms));
-    setHour(msToHours(ms));
-    setWeekDay(msToWeekDay(ms));
-    int yearDay = dayInYear(ms, year);
-    bool leapYear = isLeapYear(year);
-    setYearDay(yearDay);
-    setMonthDay(dayInMonthFromDayInYear(yearDay, leapYear));
-    setMonth(monthFromDayInYear(yearDay, leapYear));
-    setYear(year);
     setIsDST(localTime.isDST);
     setUTCOffsetInMinute(localTime.offset / WTF::msPerMinute);
 }


### PR DESCRIPTION
#### 1f84372b0336751caf1a2ae482a1331e754e6b51
<pre>
[JSC] Add V8 style ICU DST offset cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=258186">https://bugs.webkit.org/show_bug.cgi?id=258186</a>
rdar://110879575

Reviewed by Mark Lam.

This patch adds V8 style ICU DST offset cache into our DateCache.
Previously, we had one-way cache. But in some benchmarks, we observed
that frequent fallback to ICU due to cache miss. So we extend the cache
to 32-way LRU, which is what V8 is doing. So long as we hit this cache,
we do not need to query to ICU about DST offset.

* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::DSTCache::leastRecentlyUsed):
(JSC::DateCache::DSTCache::extendTheAfterCache):
(JSC::DateCache::DSTCache::localTimeOffset):
(JSC::DateCache::resetIfNecessarySlow):
(JSC::DateCache::localTimeOffset): Deleted.
* Source/JavaScriptCore/runtime/JSDateMath.h:
(JSC::LocalTimeOffsetCache::isEmpty):
(JSC::DateCache::DSTCache::DSTCache):
(JSC::DateCache::DSTCache::bumpEpoch):
(JSC::DateCache::DSTCache::reset):
(JSC::DateCache::localTimeOffset):

Canonical link: <a href="https://commits.webkit.org/265258@main">https://commits.webkit.org/265258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b313b10f4d6d24cf341ced07a0d11121bd8cf703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10413 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10919 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10597 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10571 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12452 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/8665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8792 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9869 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10013 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10542 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9171 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13426 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10831 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1164 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9872 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->