### PR TITLE
Reject with AbortSignal's reason when the signal is already aborted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Aborting rejects with AbortError
-FAIL Aborting rejects with abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Aborting rejects with abort reason
 PASS Aborting rejects with AbortError - no-cors
 PASS TypeError from request constructor takes priority - RequestInit's window is not null
 PASS TypeError from request constructor takes priority - Input URL is not valid
@@ -20,7 +20,7 @@ PASS TypeError from request constructor takes priority - Bad cache init paramete
 PASS TypeError from request constructor takes priority - Bad redirect init parameter value
 PASS Request objects have a signal property
 PASS Signal on request object
-FAIL Signal on request object should also have abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Signal on request object should also have abort reason
 PASS Signal on request object created from request object
 PASS Signal on request object created from request object, with signal on second request
 PASS Signal on request object created from request object, with signal on second request overriding another

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.serviceworker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Aborting rejects with AbortError
-FAIL Aborting rejects with abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Aborting rejects with abort reason
 PASS Aborting rejects with AbortError - no-cors
 PASS TypeError from request constructor takes priority - RequestInit's window is not null
 PASS TypeError from request constructor takes priority - Input URL is not valid
@@ -20,7 +20,7 @@ PASS TypeError from request constructor takes priority - Bad cache init paramete
 PASS TypeError from request constructor takes priority - Bad redirect init parameter value
 PASS Request objects have a signal property
 PASS Signal on request object
-FAIL Signal on request object should also have abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Signal on request object should also have abort reason
 PASS Signal on request object created from request object
 PASS Signal on request object created from request object, with signal on second request
 PASS Signal on request object created from request object, with signal on second request overriding another

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.sharedworker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Aborting rejects with AbortError
-FAIL Aborting rejects with abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Aborting rejects with abort reason
 PASS Aborting rejects with AbortError - no-cors
 PASS TypeError from request constructor takes priority - RequestInit's window is not null
 PASS TypeError from request constructor takes priority - Input URL is not valid
@@ -20,7 +20,7 @@ PASS TypeError from request constructor takes priority - Bad cache init paramete
 PASS TypeError from request constructor takes priority - Bad redirect init parameter value
 PASS Request objects have a signal property
 PASS Signal on request object
-FAIL Signal on request object should also have abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Signal on request object should also have abort reason
 PASS Signal on request object created from request object
 PASS Signal on request object created from request object, with signal on second request
 PASS Signal on request object created from request object, with signal on second request overriding another

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Aborting rejects with AbortError
-FAIL Aborting rejects with abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Aborting rejects with abort reason
 PASS Aborting rejects with AbortError - no-cors
 PASS TypeError from request constructor takes priority - RequestInit's window is not null
 PASS TypeError from request constructor takes priority - Input URL is not valid
@@ -20,7 +20,7 @@ PASS TypeError from request constructor takes priority - Bad cache init paramete
 PASS TypeError from request constructor takes priority - Bad redirect init parameter value
 PASS Request objects have a signal property
 PASS Signal on request object
-FAIL Signal on request object should also have abort reason promise_rejects_exactly: fetch() should reject with abort reason function "function() { throw e }" threw object "AbortError: Request signal is aborted" but we expected it to throw object "error1: error1"
+PASS Signal on request object should also have abort reason
 PASS Signal on request object created from request object
 PASS Signal on request object created from request object, with signal on second request
 PASS Signal on request object created from request object, with signal on second request overriding another

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -51,7 +51,12 @@ static void doFetch(ScriptExecutionContext& scope, FetchRequest::Info&& input, F
 
     auto request = requestOrException.releaseReturnValue();
     if (request->signal().aborted()) {
-        promise.reject(Exception { AbortError, "Request signal is aborted"_s });
+        auto reason = request->signal().reason().getValue();
+        if (reason.isUndefined())
+            promise.reject(Exception { AbortError, "Request signal is aborted"_s });
+        else
+            promise.rejectType<IDLAny>(reason);
+
         return;
     }
 


### PR DESCRIPTION
#### 718ac9d814039371b482827bd17238a0ea7e1cc0
<pre>
Reject with AbortSignal&apos;s reason when the signal is already aborted
<a href="https://bugs.webkit.org/show_bug.cgi?id=258187">https://bugs.webkit.org/show_bug.cgi?id=258187</a>

Reviewed by Ryosuke Niwa.

Previously, WebKit always reject fetch with AbortError when the signal
is already aborted. However, based on the spec, when the abort reason
is given, we should reject the promise with the given reason.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/api/abort/general.any.worker-expected.txt:
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
(WebCore::doFetch):

Canonical link: <a href="https://commits.webkit.org/267033@main">https://commits.webkit.org/267033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd1031f6c7454b6cc203e4cdb3f59d57a2810a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15616 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16041 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11700 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19312 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10847 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12226 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->