### PR TITLE
Multiple typos in `svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html`

### DIFF
--- a/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt
+++ b/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt
@@ -6,9 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS feRFunc.getAttribute('amplitude') is "3"
-PASS feRFunc.getAttribute('amplitude') is "3"
-PASS feRFunc.getAttribute('amplitude') is "3"
-PASS feRFunc.getAttribute('amplitude') is "3"
+PASS feGFunc.getAttribute('amplitude') is "3"
+PASS feBFunc.getAttribute('amplitude') is "3"
+PASS feAFunc.getAttribute('amplitude') is "3"
 PASS feRFunc.getAttribute('amplitude') is "1"
 PASS feGFunc.getAttribute('amplitude') is "1"
 PASS feBFunc.getAttribute('amplitude') is "1"

--- a/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html
+++ b/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html
@@ -24,12 +24,12 @@ feRFunc.setAttribute("amplitude", "3");
 var feGFunc = createSVGElement("feFuncG");
 feGFunc.setAttribute("id", "fg");
 feGFunc.setAttribute("type", "gamma");
-feRFunc.setAttribute("amplitude", "3");
+feGFunc.setAttribute("amplitude", "3");
 
 var feBFunc = createSVGElement("feFuncB");
 feBFunc.setAttribute("id", "fb");
 feBFunc.setAttribute("type", "gamma");
-feRFunc.setAttribute("amplitude", "3");
+feBFunc.setAttribute("amplitude", "3");
 
 var feAFunc = createSVGElement("feFuncA");
 feAFunc.setAttribute("id", "fb");
@@ -67,9 +67,9 @@ rootSVGElement.setAttribute("width", "400");
 rootSVGElement.setAttribute("height", "200");
 
 shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "3");
-shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "3");
-shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "3");
-shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "3");
+shouldBeEqualToString("feGFunc.getAttribute('amplitude')", "3");
+shouldBeEqualToString("feBFunc.getAttribute('amplitude')", "3");
+shouldBeEqualToString("feAFunc.getAttribute('amplitude')", "3");
 
 function repaintTest() {
     feRFunc.setAttribute("amplitude", "1");


### PR DESCRIPTION
#### b80bca1b418abb5be2cdf5428624f1d75f3fd08d
<pre>
Multiple typos in `svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html`
<a href="https://bugs.webkit.org/show_bug.cgi?id=258188">https://bugs.webkit.org/show_bug.cgi?id=258188</a>

Reviewed by Nikolas Zimmermann.

Looks like copy-paste issue.

* LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html:
* LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt:

Canonical link: <a href="https://commits.webkit.org/265239@main">https://commits.webkit.org/265239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bef023e5beb4984dc98f59f17bf9c5c78172939

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9936 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12381 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12762 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9958 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2481 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->