### PR TITLE
[Curl] Restrict available HTTP/Proxy authentication methods

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -738,6 +738,8 @@ std::optional<long long> CurlHandle::getContentLength()
 
 std::optional<long> CurlHandle::getHttpAuthAvail()
 {
+    auto allowedAuthMethods = CURLAUTH_DIGEST | CURLAUTH_BASIC;
+
     if (!m_handle)
         return std::nullopt;
 
@@ -746,11 +748,13 @@ std::optional<long> CurlHandle::getHttpAuthAvail()
     if (errorCode != CURLE_OK)
         return std::nullopt;
 
-    return httpAuthAvailable;
+    return httpAuthAvailable & allowedAuthMethods;
 }
 
 std::optional<long> CurlHandle::getProxyAuthAvail()
 {
+    auto allowedAuthMethods = CURLAUTH_DIGEST | CURLAUTH_BASIC;
+
     if (!m_handle)
         return std::nullopt;
 
@@ -759,7 +763,7 @@ std::optional<long> CurlHandle::getProxyAuthAvail()
     if (errorCode != CURLE_OK)
         return std::nullopt;
 
-    return proxyAuthAvailable;
+    return proxyAuthAvailable & allowedAuthMethods;
 }
 
 std::optional<long> CurlHandle::getHttpVersion()


### PR DESCRIPTION
#### 10330490fe57452b7c58cb88e613b52a557d45b0
<pre>
[Curl] Restrict available HTTP/Proxy authentication methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=258190">https://bugs.webkit.org/show_bug.cgi?id=258190</a>

Reviewed by Michael Catanzaro.

CURLINFO_HTTPAUTH_AVAIL and CURLINFO_PROXYAUTH_AVAIL may return
authentication method values ​​that curl port does not support.
Such values ​​may cause unintended authentication challenges.
Therefore, do not set any value other than the permitted value.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::getHttpAuthAvail):
(WebCore::CurlHandle::getProxyAuthAvail):

Canonical link: <a href="https://commits.webkit.org/265290@main">https://commits.webkit.org/265290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/352988b29a8ab56808148a3a2a9a597f35b6e001

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12376 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16635 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12764 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9112 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13363 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1174 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->