### PR TITLE
[GTK] Use EGL_MESA_image_dma_buf_export if available when GBM is disabled

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -321,6 +321,7 @@ void PlatformDisplay::initializeEGLDisplay()
         m_eglExtensions.KHR_surfaceless_context = findExtension("EGL_KHR_surfaceless_context"_s);
         m_eglExtensions.EXT_image_dma_buf_import = findExtension("EGL_EXT_image_dma_buf_import"_s);
         m_eglExtensions.EXT_image_dma_buf_import_modifiers = findExtension("EGL_EXT_image_dma_buf_import_modifiers"_s);
+        m_eglExtensions.MESA_image_dma_buf_export = findExtension("EGL_MESA_image_dma_buf_export"_s);
     }
 
     if (!m_eglDisplayOwned)

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -107,6 +107,7 @@ public:
         bool KHR_surfaceless_context { false };
         bool EXT_image_dma_buf_import { false };
         bool EXT_image_dma_buf_import_modifiers { false };
+        bool MESA_image_dma_buf_export { false };
     };
     const EGLExtensions& eglExtensions() const;
 


### PR DESCRIPTION
#### f77a16895905dd5aecab8d22f7819888f06f6e31
<pre>
[GTK] Use EGL_MESA_image_dma_buf_export if available when GBM is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=258193">https://bugs.webkit.org/show_bug.cgi?id=258193</a>

Reviewed by Alejandro G. Castro.

We currently fall back to read pixels and shared memory when GBM is not
available, but we can actually use EGL_MESA_image_dma_buf_export
extension if available which is a lot more efficient.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::initializeEGLDisplay):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::~RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::RenderTargetColorBuffer):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::~RenderTargetColorBuffer):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::willRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::RenderTargetTexture):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::~RenderTargetTexture):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::willRenderFrame const):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::clientResize):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::didRenderFrame): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::didDisplayFrame): Deleted.
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/265327@main">https://commits.webkit.org/265327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6c328dc4fad630b21d4017d3e8a34b9b7252cd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13211 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/10838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12667 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8995 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16849 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12993 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10206 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8285 "Exiting early after 60 failures. 68330 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13624 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1185 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->