### PR TITLE
[GTK] Do not use the WebPage identifier as surface identifier for DMA-BUF renderer

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -28,7 +28,6 @@
 #include "AcceleratedSurface.h"
 
 #include "MessageReceiver.h"
-#include <WebCore/PageIdentifier.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 #if USE(GBM)
@@ -84,9 +83,8 @@ private:
         virtual void didDisplayFrame();
 
     protected:
-        explicit RenderTarget(WebCore::PageIdentifier, const WebCore::IntSize&);
+        explicit RenderTarget(const WebCore::IntSize&);
 
-        WebCore::PageIdentifier m_pageID;
         unsigned m_backColorBuffer { 0 };
         unsigned m_frontColorBuffer { 0 };
         unsigned m_displayColorBuffer { 0 };
@@ -96,8 +94,8 @@ private:
 #if USE(GBM)
     class RenderTargetEGLImage final : public RenderTarget {
     public:
-        static std::unique_ptr<RenderTarget> create(WebCore::PageIdentifier, const WebCore::IntSize&);
-        RenderTargetEGLImage(WebCore::PageIdentifier, const WebCore::IntSize&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
+        static std::unique_ptr<RenderTarget> create(uint64_t, const WebCore::IntSize&);
+        RenderTargetEGLImage(uint64_t, const WebCore::IntSize&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
         ~RenderTargetEGLImage();
 
     private:
@@ -112,8 +110,8 @@ private:
 
     class RenderTargetSHMImage final : public RenderTarget {
     public:
-        static std::unique_ptr<RenderTarget> create(WebCore::PageIdentifier, const WebCore::IntSize&);
-        RenderTargetSHMImage(WebCore::PageIdentifier, const WebCore::IntSize&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&);
+        static std::unique_ptr<RenderTarget> create(uint64_t, const WebCore::IntSize&);
+        RenderTargetSHMImage(uint64_t, const WebCore::IntSize&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&);
         ~RenderTargetSHMImage() = default;
 
     private:
@@ -125,6 +123,7 @@ private:
         Ref<ShareableBitmap> m_displayBitmap;
     };
 
+    uint64_t m_id { 0 };
     unsigned m_fbo { 0 };
     std::unique_ptr<RenderTarget> m_target;
 };


### PR DESCRIPTION
#### ad8cdbb4844427a1f52aaec9d0bddf6920835c9e
<pre>
[GTK] Do not use the WebPage identifier as surface identifier for DMA-BUF renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=258197">https://bugs.webkit.org/show_bug.cgi?id=258197</a>

Reviewed by Michael Catanzaro.

The web page identifier is reused when doing history navigation, so it
can happen that the old surface is destroyed after the new one is
created, and the message receiver is removed because the same ID is
used. Because of this, sometimes the web view is no longer updated after
a history navigation. Use our own identifier for every surface to fix
the problem.

* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::generateID):
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::didCreateCompositingRunLoop):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyCompositingRunLoop):
(WebKit::AcceleratedSurfaceDMABuf::surfaceID const):
(WebKit::AcceleratedSurfaceDMABuf::clientResize):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/265295@main">https://commits.webkit.org/265295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a55724237ac1d1d1ed678aabc13e0169992f277

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9941 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12386 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8585 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12771 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9963 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8087 "4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13373 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1176 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->