### PR TITLE
REGRESSION(264826@main): [GStreamer] Fill information on the gst GL context

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -128,6 +128,7 @@ public:
     EGLConfig config() const { return m_config; }
 
     WEBCORE_EXPORT bool makeContextCurrent();
+    bool unmakeContextCurrent();
     WEBCORE_EXPORT void swapBuffers();
     GCGLContext platformContext() const;
 
@@ -144,6 +145,22 @@ public:
             EGLSurface drawSurface { nullptr };
         } m_previous;
         std::unique_ptr<GLContext> m_context;
+    };
+
+    class ScopedGLContextCurrent {
+        WTF_MAKE_NONCOPYABLE(ScopedGLContextCurrent);
+    public:
+        explicit ScopedGLContextCurrent(GLContext&);
+        ~ScopedGLContextCurrent();
+    private:
+        struct {
+            GLContext* glContext { nullptr };
+            EGLDisplay display { nullptr };
+            EGLContext context { nullptr };
+            EGLSurface readSurface { nullptr };
+            EGLSurface drawSurface { nullptr };
+        } m_previous;
+        GLContext& m_context;
     };
 
 private:


### PR DESCRIPTION
#### 06c5a9867e9b074ec7e24668cec249ff45bc280f
<pre>
REGRESSION(264826@main): [GStreamer] Fill information on the gst GL context
<a href="https://bugs.webkit.org/show_bug.cgi?id=258199">https://bugs.webkit.org/show_bug.cgi?id=258199</a>

Reviewed by Miguel Gomez.

In 264826@main I removed the activate and fill of the gst GL context,
confused by the API docs of gst_gl_context_fill_info() that says that
it&apos;s typically used with wrapped contexts to allow wrapped contexts to
be used as regular GstGLContexts. We don&apos;t want it to be used as a
regular context, but the regular context uses the filled information of
the sharing context to get the EGL config.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::unmakeContextCurrent):
(WebCore::GLContext::ScopedGLContextCurrent::ScopedGLContextCurrent):
(WebCore::GLContext::ScopedGLContextCurrent::~ScopedGLContextCurrent):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp:
(WebCore::PlatformDisplay::gstGLContext const):

Canonical link: <a href="https://commits.webkit.org/265302@main">https://commits.webkit.org/265302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a97125b352ed372e67332e6fd5bbd466a86bed5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11992 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9373 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16650 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12781 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9964 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8088 "1 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13374 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1177 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->