### PR TITLE
REGRESSION(263967@main): [GTK][WPE] WTR: not possible to run WebKitTestRunner from any directory

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
@@ -43,9 +43,6 @@ void activateFonts()
     if (g_getenv("WEBKIT_SKIP_WEBKITTESTRUNNER_FONTCONFIG_INITIALIZATION"))
         return;
 
-    GUniquePtr<gchar> relativeFontsDir(g_build_filename("Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
-    GUniquePtr<gchar> absoluteFontsDir(g_canonicalize_filename(relativeFontsDir.get(), nullptr));
-
     FcInit();
 
     // If a test resulted a font being added or removed via the @font-face rule, then
@@ -54,6 +51,8 @@ void activateFonts()
     FcFontSet* appFontSet = FcConfigGetFonts(0, FcSetApplication);
     if (appFontSet && numFonts && appFontSet->nfont == numFonts)
         return;
+
+    GUniquePtr<gchar> absoluteFontsDir(g_build_filename(TOP_LEVEL_DIR, "Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
 
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.

--- a/Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp
@@ -37,9 +37,6 @@ void activateFonts()
     if (g_getenv("WEBKIT_SKIP_WEBKITTESTRUNNER_FONTCONFIG_INITIALIZATION"))
         return;
 
-    GUniquePtr<gchar> relativeFontsDir(g_build_filename("Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
-    GUniquePtr<gchar> absoluteFontsDir(g_canonicalize_filename(relativeFontsDir.get(), nullptr));
-
     FcInit();
 
     // If a test resulted a font being added or removed via the @font-face rule, then
@@ -48,6 +45,8 @@ void activateFonts()
     FcFontSet* appFontSet = FcConfigGetFonts(0, FcSetApplication);
     if (appFontSet && numFonts && appFontSet->nfont == numFonts)
         return;
+
+    GUniquePtr<gchar> absoluteFontsDir(g_build_filename(TOP_LEVEL_DIR, "Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
 
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.


### PR DESCRIPTION
#### 35ced2711f1af9ac8728eacf8e62895f0be8ffd6
<pre>
REGRESSION(263967@main): [GTK][WPE] WTR: not possible to run WebKitTestRunner from any directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=258202">https://bugs.webkit.org/show_bug.cgi?id=258202</a>

Reviewed by Michael Catanzaro.

Since 263967@main the fonts path is resolved using current working
directory, so it only works when called from top dir. We can simply use
TOP_LEVEL_DIR to build the fonts path.

* Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp:
(WTR::activateFonts):
* Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp:
(WTR::activateFonts):

Canonical link: <a href="https://commits.webkit.org/265294@main">https://commits.webkit.org/265294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/899851a28d3fe32b1a4087d6303daeeb5ed73146

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12904 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12391 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16642 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12772 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9967 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8091 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9126 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13377 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1175 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->