### PR TITLE
Use different amplitudes per channel in `LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html`

### DIFF
--- a/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt
+++ b/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt
@@ -5,14 +5,14 @@ Tests dynamic updates of the 'amplitude' attribute of the SVGFEComponentTransfer
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS feRFunc.getAttribute('amplitude') is "3"
-PASS feGFunc.getAttribute('amplitude') is "3"
-PASS feBFunc.getAttribute('amplitude') is "3"
-PASS feAFunc.getAttribute('amplitude') is "3"
 PASS feRFunc.getAttribute('amplitude') is "1"
-PASS feGFunc.getAttribute('amplitude') is "1"
-PASS feBFunc.getAttribute('amplitude') is "1"
-PASS feAFunc.getAttribute('amplitude') is "1"
+PASS feGFunc.getAttribute('amplitude') is "2"
+PASS feBFunc.getAttribute('amplitude') is "3"
+PASS feAFunc.getAttribute('amplitude') is "4"
+PASS feRFunc.getAttribute('amplitude') is "5"
+PASS feGFunc.getAttribute('amplitude') is "6"
+PASS feBFunc.getAttribute('amplitude') is "7"
+PASS feAFunc.getAttribute('amplitude') is "8"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html
+++ b/LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html
@@ -19,12 +19,12 @@ createSVGTestCase();
 var feRFunc = createSVGElement("feFuncR");
 feRFunc.setAttribute("id", "fr");
 feRFunc.setAttribute("type", "gamma");
-feRFunc.setAttribute("amplitude", "3");
+feRFunc.setAttribute("amplitude", "1");
 
 var feGFunc = createSVGElement("feFuncG");
 feGFunc.setAttribute("id", "fg");
 feGFunc.setAttribute("type", "gamma");
-feGFunc.setAttribute("amplitude", "3");
+feGFunc.setAttribute("amplitude", "2");
 
 var feBFunc = createSVGElement("feFuncB");
 feBFunc.setAttribute("id", "fb");
@@ -34,7 +34,7 @@ feBFunc.setAttribute("amplitude", "3");
 var feAFunc = createSVGElement("feFuncA");
 feAFunc.setAttribute("id", "fb");
 feAFunc.setAttribute("type", "gamma");
-feAFunc.setAttribute("amplitude", "3");
+feAFunc.setAttribute("amplitude", "4");
 
 var feComponentTransferElement = createSVGElement("feComponentTransfer");
 feComponentTransferElement.appendChild(feRFunc);
@@ -66,21 +66,21 @@ rootSVGElement.appendChild(imageElement);
 rootSVGElement.setAttribute("width", "400");
 rootSVGElement.setAttribute("height", "200");
 
-shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "3");
-shouldBeEqualToString("feGFunc.getAttribute('amplitude')", "3");
+shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "1");
+shouldBeEqualToString("feGFunc.getAttribute('amplitude')", "2");
 shouldBeEqualToString("feBFunc.getAttribute('amplitude')", "3");
-shouldBeEqualToString("feAFunc.getAttribute('amplitude')", "3");
+shouldBeEqualToString("feAFunc.getAttribute('amplitude')", "4");
 
 function repaintTest() {
-    feRFunc.setAttribute("amplitude", "1");
-	feGFunc.setAttribute("amplitude", "1");
-	feBFunc.setAttribute("amplitude", "1");
-	feAFunc.setAttribute("amplitude", "1");
+    feRFunc.setAttribute("amplitude", "5");
+    feGFunc.setAttribute("amplitude", "6");
+    feBFunc.setAttribute("amplitude", "7");
+    feAFunc.setAttribute("amplitude", "8");
 
-    shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "1");
-	shouldBeEqualToString("feGFunc.getAttribute('amplitude')", "1");
-	shouldBeEqualToString("feBFunc.getAttribute('amplitude')", "1");
-	shouldBeEqualToString("feAFunc.getAttribute('amplitude')", "1");
+    shouldBeEqualToString("feRFunc.getAttribute('amplitude')", "5");
+    shouldBeEqualToString("feGFunc.getAttribute('amplitude')", "6");
+    shouldBeEqualToString("feBFunc.getAttribute('amplitude')", "7");
+    shouldBeEqualToString("feAFunc.getAttribute('amplitude')", "8");
 
     completeTest();
 }


### PR DESCRIPTION
#### 5b3a80e263160410767442939b0b7b498fc36b45
<pre>
Use different amplitudes per channel in `LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html`
<a href="https://bugs.webkit.org/show_bug.cgi?id=258211">https://bugs.webkit.org/show_bug.cgi?id=258211</a>

Reviewed by Nikolas Zimmermann.

In <a href="https://commits.webkit.org/265239@main">https://commits.webkit.org/265239@main</a> @nikolaszimmermann suggested
using different amplitudes per channel to make them more distinct in
the output.

* LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr-expected.txt:
* LayoutTests/svg/dynamic-updates/SVGFEComponentTransferElement-dom-amplitude-attr.html:

Canonical link: <a href="https://commits.webkit.org/265348@main">https://commits.webkit.org/265348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5e8ddc2c375df46e8ccf9f8162ef66df2a02546

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10257 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13170 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12750 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9652 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10137 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13053 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2552 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->