### PR TITLE
[WebCore] Background may get the wrong color after toggling dark mode

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3464,6 +3464,9 @@ void LocalFrameView::setBaseBackgroundColor(const Color& backgroundColor)
     if (m_baseBackgroundColor == newBaseBackgroundColor)
         return;
 
+#if ENABLE(DARK_MODE_CSS)
+    m_styleColorOptions = styleColorOptions();
+#endif
     m_baseBackgroundColor = newBaseBackgroundColor;
 
     if (!isViewForDocumentInFrame())


### PR DESCRIPTION
#### 05e6c002f080627580b29faef87b9c188967f2d6
<pre>
[WebCore] Background may get the wrong color after toggling dark mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=258210">https://bugs.webkit.org/show_bug.cgi?id=258210</a>
rdar://107385637

Reviewed by Aditya Keerthi.

The background color and style color options can get out of sync between changing
appearance and changing the background color (through drawsBackground).
Consider the following scenario:
1. start from light mode with drawsBackground enabled
2. turn off drawsBackground and switch to dark mode
3. turn on drawsBackground: the compute color of the background becomes dark
4. switch to light mode before any layout happens
5. now, a layour happens, and since styleColorOptions hasn&apos;t changed (the last
   layout was still in light mode), the background isn&apos;t recomputed, and we draw
   a dark background in light mode.

The source of the issue is that `WebPage::setBackgroundColor` calls `LocalFrameView::updateBackgroundRecursively`
directly, resulting in a change to the background color without changing `m_styleColorOptions`.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setBaseBackgroundColor):

Canonical link: <a href="https://commits.webkit.org/265299@main">https://commits.webkit.org/265299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f84c2de3048679a4aec4916ff7f03229afa958

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11632 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16780 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10133 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9289 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->