### PR TITLE
Do not change the value of a disabled `SELECT` element

### DIFF
--- a/LayoutTests/fast/forms/select/select-disabled.html
+++ b/LayoutTests/fast/forms/select/select-disabled.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/common.js"></script>
 </head>
 <body>
 
@@ -17,8 +18,21 @@
 <option>c</option>
 </select>
 
+<select id=select3>
+<option selected>a</option>
+</select>
+
+<select id=select4>
+<option selected>a</option>
+<option>b</option>
+<option>c</option>
+</select>
+
+<input id="text"></input>
+
 <script>
 description('Tests that user cannot change disabled select by keyboard');
+jsTestIsAsync = true;
 
 var select1 = document.getElementById('select1');
 select1.focus();
@@ -42,7 +56,26 @@ shouldBeEqualToString('select2.value', 'b');
 eventSender.keyDown('c');
 shouldBeEqualToString('select2.value', 'b');
 
+debug('Tests on select disable, popup menu is hidden');
+var select3 = document.getElementById('select3');
+clickElement(select3);
+shouldBeTrue("internals.isSelectPopupVisible(select3)");
+select3.disabled = true;
+shouldBeFalse("internals.isSelectPopupVisible(select3)");
+select3.offsetLeft;
+setTimeout(() => {shouldBeFalse("internals.isSelectPopupVisible(select3)");
+
+debug('Tests on select disable, value cannot be changed');
+var select4 = document.getElementById('select4');
+select4.focus();
+eventSender.keyDown('b');
+shouldBeEqualToString('select4.value', 'b');
+select4.disabled = true;
+eventSender.keyDown('c');
+shouldBeEqualToString('select4.value', 'b');
+finishJSTest();
+}, 0);
+
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/mac/fast/forms/select/select-disabled-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/select/select-disabled-expected.txt
@@ -12,13 +12,14 @@ PASS select2.value is "b"
 PASS select2.value is "b"
 PASS select2.value is "b"
 Tests on select disable, popup menu is hidden
-PASS internals.isSelectPopupVisible(select3) is true
+FAIL internals.isSelectPopupVisible(select3) should be true. Was false.
 PASS internals.isSelectPopupVisible(select3) is false
 PASS internals.isSelectPopupVisible(select3) is false
 Tests on select disable, value cannot be changed
 PASS select4.value is "b"
 PASS select4.value is "b"
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 


### PR DESCRIPTION
<pre>
Do not change the value of a disabled `SELECT` element
<a href="https://bugs.webkit.org/show_bug.cgi?id=257554">https://bugs.webkit.org/show_bug.cgi?id=257554</a>
rdar://problem/110412448

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=167563">https://src.chromium.org/viewvc/blink?view=revision&revision=167563</a>

This patch adds new case for attribute change, which makes 'select' popup being closed once
element becomes disabled. Additionally, we added 'isDisabledFormControl' checks to 'menuListDefaultEventHandler'
and 'platformHandleKeydownEvent' functions since user events can be deliver to disabled elements.

NOTE: 'popupIsVisible' is ot available on 'iOS' platform, so adding 'Platform Flag'.

* Source/WebCore/html/HTMLSelectElement.cpp:
(HTMLSelectElement::attributeChanged): Add new case as described in commit message
(HTMLSelectElement::platformHandleKeydownEvent): 'isDisabledFormControl' check
(HTMLSelectElement::menuListDefaultEventHandler): Ditto
* LayoutTests/fast/forms/select/select-disabled.html: Update Test Case
* LayoutTests/fast/forms/select/select-disabled-expected.txt: Update Test Case Expectations
* LayoutTests/platform/mac/fast/forms/select/select-disabled-expected.txt: Add Platform Specific Expectation for 'mac'
since we lack support to hide 'popup' menu on mac platform
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/795b1eb95a2ed9eca7c33609bc688811d42cf97e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14389 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14810 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14831 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10865 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/19589 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18537 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11950 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14817 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10010 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11327 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->