### PR TITLE
Micro-optimize Path IPC serialization / deserialization

### DIFF
--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -41,6 +41,12 @@
 
 namespace WebCore {
 
+static_assert(static_cast<uint8_t>(PathElementType::MoveToPoint) == static_cast<uint8_t>(EncodedPathElementType::MoveToPoint), "PathElementType and EncodedPathElementType should match");
+static_assert(static_cast<uint8_t>(PathElementType::AddLineToPoint) == static_cast<uint8_t>(EncodedPathElementType::AddLineToPoint), "PathElementType and EncodedPathElementType should match");
+static_assert(static_cast<uint8_t>(PathElementType::AddQuadCurveToPoint) == static_cast<uint8_t>(EncodedPathElementType::AddQuadCurveToPoint), "PathElementType and EncodedPathElementType should match");
+static_assert(static_cast<uint8_t>(PathElementType::AddCurveToPoint) == static_cast<uint8_t>(EncodedPathElementType::AddCurveToPoint), "PathElementType and EncodedPathElementType should match");
+static_assert(static_cast<uint8_t>(PathElementType::CloseSubpath) == static_cast<uint8_t>(EncodedPathElementType::CloseSubpath), "PathElementType and EncodedPathElementType should match");
+
 float Path::length() const
 {
     PathTraversalState traversalState(PathTraversalState::Action::TotalLength);
@@ -220,7 +226,7 @@ void Path::apply(const PathApplierFunction& function) const
     }
 #endif
 
-    applySlowCase(function);
+    applyIgnoringInlineData(function);
 }
 
 bool Path::isEmpty() const

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -461,7 +461,7 @@ bool Path::strokeContains(const FloatPoint& point, const Function<void(GraphicsC
     return cairo_in_stroke(m_path.get(), point.x(), point.y());
 }
 
-void Path::applySlowCase(const PathApplierFunction& function) const
+void Path::applyIgnoringInlineData(const PathApplierFunction& function) const
 {
     if (m_elements) {
         for (const auto& element : m_elements.value())

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -480,7 +480,7 @@ static void CGPathApplierToPathApplier(void* info, const CGPathElement* element)
     function(pathElement);
 }
 
-void Path::applySlowCase(const PathApplierFunction& function) const
+void Path::applyIgnoringInlineData(const PathApplierFunction& function) const
 {
     CGPathApply(platformPath(), (void*)&function, CGPathApplierToPathApplier);
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3585,9 +3585,13 @@ enum class WebCore::PreserveResolution : bool;
     CloseSubpath
 };
 
-header: <WebCore/Path.h>
-[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] class WebCore::EncodedPathElementType {
-    std::optional<WebCore::PathElementType> m_type;
+[AdditionalEncoder=StreamConnectionEncoder] enum class WebCore::EncodedPathElementType : uint8_t {
+    MoveToPoint,
+    AddLineToPoint,
+    AddQuadCurveToPoint,
+    AddCurveToPoint,
+    CloseSubpath,
+    EndOfPath
 };
 
 class WebCore::ProcessIdentity {


### PR DESCRIPTION
#### cf81ca21f2828619acff44933c6515551b50c3be
<pre>
Micro-optimize Path IPC serialization / deserialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=258220">https://bugs.webkit.org/show_bug.cgi?id=258220</a>

Reviewed by Wenson Hsieh.

Micro-optimize Path IPC serialization / deserialization:
1. The IPC encoder was first serializing inline data and falling back
   to calling apply() if the data isn&apos;t inline. However, apply() would
   check again for various types on inline data before calling
   applySlowCase() for the non-inline data. To optimize this, I renamed
   applySlowCase() to applyIgnoringInlineData() and call it directly
   from the IPC encoder.
2. To detect the end of the path during IPC deserialization, the decoder
   relied on serializing the type of each path Element as a
   std::optional&lt;PathElementType&gt; and we would know we reached the end
   when decoding std::nullopt. This was a bit inefficient was it would
   encode first a boolean (std::optional is set or not) and then a
   uint8_t (actual enum value) for each path Element. To optimize this,
   we now encode the end of the path as an enum value so that we only
   ending a uint8_t for each path element type.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::apply const):
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::encode const):
(WebCore::Path::decode):
(WebCore::EncodedPathElementType::EncodedPathElementType): Deleted.
(WebCore::EncodedPathElementType::isEndOfPath const): Deleted.
(WebCore::EncodedPathElementType::isValidPathElementType const): Deleted.
(WebCore::EncodedPathElementType::type const): Deleted.
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::Path::applyIgnoringInlineData const):
(WebCore::Path::applySlowCase const): Deleted.
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::Path::applyIgnoringInlineData const):
(WebCore::Path::applySlowCase const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/265260@main">https://commits.webkit.org/265260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d00153965ee9d2d368faf2f4d1f356d21e091662

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12441 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16685 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10006 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9164 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2502 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->