### PR TITLE
Check feature flag default values at compile time

### DIFF
--- a/Source/WTF/Scripts/GeneratePreferences.rb
+++ b/Source/WTF/Scripts/GeneratePreferences.rb
@@ -159,7 +159,7 @@ class Preference
   end
 
   def apiStatus
-    "API::FeatureStatus::" + @status.capitalize
+    "API::FeatureConstant<API::FeatureStatus::#{@status.capitalize}>{}"
   end
 
   def apiCategory
@@ -334,6 +334,17 @@ class Preferences
     else
       FileUtils.remove_file(tempResultFile)
       FileUtils.uptodate?(resultFile, [templateFile]) or FileUtils.touch(resultFile)
+    end
+  end
+  
+  def constantize(value)
+    case value
+    when true
+      "std::true_type{}"
+    when false
+      "std::false_type{}"
+    else
+      value
     end
   end
 end

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -1043,3 +1043,11 @@
 #if !defined(ENABLE_WEBPROCESS_CACHE)
 #define ENABLE_WEBPROCESS_CACHE 0
 #endif
+
+#if !defined(ENABLE_FEATURE_DEFAULT_VALIDATION) \
+    && (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000)
+// FIXME: Check feature flag default values on other platforms once it's
+// possible to make feature status conditional.
+#define ENABLE_FEATURE_DEFAULT_VALIDATION 1
+#endif
+

--- a/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
+++ b/Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb
@@ -34,7 +34,7 @@
 #if <%= @pref.condition %>
 <%-   end -%>
 <%-   if @pref.defaultValues.size() == 1 -%>
-#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= @pref.defaultValues['default'] %>
+#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= constantize(@pref.defaultValues['default']) %>
 <%-   else -%>
 <%-     @pref.defaultValues.each_with_index do |(key, value), index| -%>
 <%-       if index == 0 -%>
@@ -44,7 +44,7 @@
 <%-       else -%>
 #else
 <%-       end -%>
-#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= value %>
+#define DEFAULT_VALUE_FOR_<%= @pref.name %> <%= constantize(value) %>
 <%-     end -%>
 #endif
 <%-   end -%>

--- a/Source/WebKit/UIProcess/API/APIFeature.cpp
+++ b/Source/WebKit/UIProcess/API/APIFeature.cpp
@@ -28,7 +28,7 @@
 
 namespace API {
 
-Ref<Feature> Feature::create(const WTF::String& name, const WTF::String& key, FeatureStatus status, FeatureCategory category, const WTF::String& details, bool defaultValue, bool hidden)
+Ref<Feature> Feature::uncheckedCreate(const WTF::String& name, const WTF::String& key, FeatureStatus status, FeatureCategory category, const WTF::String& details, bool defaultValue, bool hidden)
 {
     return adoptRef(*new Feature(name, key, status, category, details, defaultValue, hidden));
 }

--- a/Source/WebKit/UIProcess/API/APIFeature.h
+++ b/Source/WebKit/UIProcess/API/APIFeature.h
@@ -34,7 +34,26 @@ namespace API {
 class Feature final : public ObjectImpl<Object::Type::Feature> {
 public:
 
-    static Ref<Feature> create(const WTF::String& name, const WTF::String& key, FeatureStatus, FeatureCategory, const WTF::String& details, bool defaultValue, bool hidden);
+    template <FeatureStatus Status, bool DefaultValue>
+    static Ref<Feature> create(const WTF::String& name, const WTF::String& key, FeatureConstant<Status> status, FeatureCategory category, const WTF::String& details, std::bool_constant<DefaultValue> defaultValue, bool hidden)
+    {
+#if ENABLE(FEATURE_DEFAULT_VALIDATION)
+        constexpr auto impliedDefaultValue = API::defaultValueForFeatureStatus(Status);
+        if constexpr (impliedDefaultValue && *impliedDefaultValue)
+            static_assert(defaultValue, "Feature's status implies it should be on by default");
+        else if constexpr (impliedDefaultValue && !*impliedDefaultValue)
+            static_assert(!defaultValue, "Feature's status implies it should be off by default");
+#endif
+
+        return uncheckedCreate(name, key, status, category, details, defaultValue, hidden);
+    }
+
+    template <FeatureStatus Status>
+    static Ref<Feature> create(const WTF::String& name, const WTF::String& key, FeatureConstant<Status> status, FeatureCategory category, const WTF::String& details, bool defaultValue, bool hidden)
+    {
+        return uncheckedCreate(name, key, status, category, details, defaultValue, hidden);
+    }
+
     virtual ~Feature() = default;
 
     WTF::String name() const { return m_name; }
@@ -47,6 +66,8 @@ public:
     
 private:
     explicit Feature(const WTF::String& name, const WTF::String& key, FeatureStatus, FeatureCategory, const WTF::String& details, bool defaultValue, bool hidden);
+
+    static Ref<Feature> uncheckedCreate(const WTF::String& name, const WTF::String& key, FeatureStatus, FeatureCategory, const WTF::String& details, bool defaultValue, bool hidden);
 
     WTF::String m_name;
     WTF::String m_key;

--- a/Source/WebKit/UIProcess/API/APIFeatureStatus.h
+++ b/Source/WebKit/UIProcess/API/APIFeatureStatus.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <optional>
+#include <type_traits>
+
 namespace API {
 enum class FeatureStatus : uint8_t {
     // For customizing WebKit behavior in embedding applications.
@@ -44,6 +47,32 @@ enum class FeatureStatus : uint8_t {
     // Enabled by default and in general use for more than a year.
     Mature
 };
+
+// Helper for representing feature status as a constant type. Used by the preferences generator to
+// validate feature configuration at compile time.
+template<API::FeatureStatus Status>
+class FeatureConstant : public std::integral_constant<API::FeatureStatus, Status> { };
+
+constexpr std::optional<bool> defaultValueForFeatureStatus(FeatureStatus status)
+{
+    switch (status) {
+    case FeatureStatus::Stable:
+    case FeatureStatus::Mature:
+        return true;
+    case FeatureStatus::Unstable:
+    case FeatureStatus::Developer:
+    case FeatureStatus::Testable:
+    case FeatureStatus::Preview:
+        return false;
+    case FeatureStatus::Embedder:
+    case FeatureStatus::Internal:
+        // Embedder features vary widely between platforms, so they have no
+        // implied default.
+        // FIXME: Internal features should be off by default, but they need
+        // additional auditing.
+        return { };
+    }
+}
 
 enum class FeatureCategory : uint8_t {
     None,


### PR DESCRIPTION
#### 80b7b85c4493d6cdc616efd9b10e2ba1914a0b17
<pre>
Check feature flag default values at compile time
<a href="https://bugs.webkit.org/show_bug.cgi?id=258041">https://bugs.webkit.org/show_bug.cgi?id=258041</a>
rdar://104759188

Reviewed by Darin Adler.

Feature flags which have a constant default value (true or false, not
determined at runtime) can be checked statically to ensure that their
default value corresponds with their feature status&apos;s implied default.

First, the preferences generator emits a std::bool_constant for boolean
literals when generating WebKit&apos;s feature default values. It also emits
the feature&apos;s status as a constant type.

Then, a new template overload to APIFeature::create() accepts a feature
status constant and a std::bool_constant default value, and
static-asserts that the default values match.

Assertion failures contain a template instation note, so it&apos;s easy to
see which feature caused the failure:

    In file included from /Volumes/Data/OpenSource/WebKitBuild/Debug/DerivedSources/WebKit/WebPreferencesFeatures.cpp:29:
    In file included from /Volumes/Data/OpenSource/Source/WebKit/UIProcess/WebPreferences.h:28:
    /Volumes/Data/OpenSource/Source/WebKit/UIProcess/API/APIFeature.h:48:13: error: static assertion failed due to requirement &apos;!defaultValue&apos;: Feature&apos;s status implies it should be off by default
                static_assert(!defaultValue, &quot;Feature&apos;s status implies it should be off by default&quot;);
                ^             ~~~~~~~~~~~~~
    /Volumes/Data/OpenSource/WebKitBuild/Debug/DerivedSources/WebKit/WebPreferencesFeatures.cpp:688:23: note: in instantiation of function template specialization &apos;API::Feature::create&lt;API::FeatureStatus::Developer, true&gt;&apos; requested here
            API::Feature::create(&quot;Prefer Page Rendering Updates near 60fps&quot;&quot;&quot;_s, &quot;PreferPageRenderingUpdatesNear60FPSEnabled&quot;_s, API::FeatureConstant&lt;API::FeatureStatus::Developer&gt;{}, API::FeatureCategory::DOM, &quot;Prefer page rendering updates near 60 frames per second rather than using the display&apos;s refresh rate&quot;&quot;&quot;_s, DEFAULT_VALUE_FOR_PreferPageRenderingUpdatesNear60FPSEnabled, false),
                          ^
    1 error generated.

This mechanism is controlled by a ENABLE(FEATURE_DEFAULT_VALIDATION)
flag, which is currently only enabled on PLATFORM(MAC).

* Source/WTF/Scripts/GeneratePreferences.rb:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Change the
  status of two features whose defaults are not aligned:
  - PreferPageRenderingUpdatesNear60FPSEnabled, developer -&gt; stable:
    It&apos;s on by default everywhere except visionOS.
  - MediaSourceInlinePaintingEnabled, unstable -&gt; stable: It&apos;s on for
    all Apple platforms since last year.
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesDefinitions.h.erb:
* Source/WebKit/UIProcess/API/APIFeature.cpp:
(API::Feature::uncheckedCreate):
(API::Feature::create): Deleted.
* Source/WebKit/UIProcess/API/APIFeature.h:
* Source/WebKit/UIProcess/API/APIFeatureStatus.h:
(API::defaultValueForFeatureStatus):

Canonical link: <a href="https://commits.webkit.org/269988@main">https://commits.webkit.org/269988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b55343d14e5b60c92fee110bfbb509eac9c0247c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/24198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/2307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/25280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/26330 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/22281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/3934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/24667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/22738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/24441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/1829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/20914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/26919 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/24369 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/1577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/21833 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/28055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/21043 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/22060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/22130 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/25835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/23496 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/1514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/19176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/30894 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/2167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/6779 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/5798 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/1920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/30858 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/1878 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/6454 "Passed tests") | 
<!--EWS-Status-Bubble-End-->