### PR TITLE
[Flatpak SDK] Update libjxl to 0.8.x

### DIFF
--- a/Tools/buildstream/elements/sdk/highway.bst
+++ b/Tools/buildstream/elements/sdk/highway.bst
@@ -5,12 +5,13 @@ build-depends:
 
 variables:
   cmake-local: |
-    -DBUILD_TESTING=OFF \
     -DHWY_WARNINGS_ARE_ERRORS=OFF \
     -DHWY_ENABLE_EXAMPLES=OFF \
+    -DHWY_ENABLE_CONTRIB=OFF \
+    -DHWY_ENABLE_TESTS=OFF \
     -DHWY_ENABLE_INSTALL=ON
 
 sources:
 - kind: tar
-  url: https://github.com/google/highway/archive/refs/tags/0.15.0.tar.gz
-  ref: 4bbd4439eae08cf038f1c5cc5d9ebc6a1a50f2c610c13a1483adccacfa24c150
+  url: https://github.com/google/highway/archive/refs/tags/1.0.4.tar.gz
+  ref: faccd343935c9e98afd1016e9d20e0b8b89d908508d1af958496f8c2d3004ac2

--- a/Tools/buildstream/elements/sdk/libjxl.bst
+++ b/Tools/buildstream/elements/sdk/libjxl.bst
@@ -6,6 +6,8 @@ build-depends:
 
 depends:
 - freedesktop-sdk.bst:components/brotli.bst
+- freedesktop-sdk.bst:components/jpeg.bst
+- freedesktop-sdk.bst:components/libpng.bst
 
 variables:
   cmake-local: |
@@ -16,6 +18,7 @@ variables:
     -DJPEGXL_ENABLE_MANPAGES=OFF \
     -DJPEGXL_ENABLE_BENCHMARK=OFF \
     -DJPEGXL_ENABLE_EXAMPLES=OFF \
+    -DJPEGXL_ENABLE_JPEGLI=OFF \
     -DJPEGXL_ENABLE_JNI=OFF \
     -DJPEGXL_ENABLE_VIEWERS=OFF \
     -DJPEGXL_ENABLE_TCMALLOC=OFF \
@@ -29,7 +32,8 @@ variables:
     -DJPEGXL_ENABLE_SKCMS=ON \
     -DJPEGXL_FORCE_SYSTEM_BROTLI=ON \
     -DJPEGXL_FORCE_SYSTEM_GTEST=ON \
-    -DJPEGXL_FORCE_SYSTEM_HWY=ON
+    -DJPEGXL_FORCE_SYSTEM_HWY=ON \
+    -DJPEGXL_BUNDLE_LIBPNG=OFF
 
 config:
   # libhwy is used only internally and linked statically, yet the
@@ -43,22 +47,10 @@ config:
 
 sources:
 - kind: tar
-  url: https://github.com/libjxl/libjxl/archive/refs/tags/v0.6.1.tar.gz
-  ref: ccbd5a729d730152303be399f033b905e608309d5802d77a61a95faa092592c5
-- kind: remote
-  url: https://github.com/lvandeve/lodepng/raw/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.h
-  ref: e6cb1736b11217209873f02b8859256e662e14d297f1f9346fbf1778d5efadbb
-  directory: third_party/lodepng
-- kind: remote
-  url: https://github.com/lvandeve/lodepng/raw/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/lodepng.cpp
-  ref: 6c61ad12196fde3d2cbb2e5ce689db414ae7f64c98f709b227928b451280ed1b
-  directory: third_party/lodepng
-- kind: remote
-  url: https://github.com/lvandeve/lodepng/raw/8c6a9e30576f07bf470ad6f09458a2dcd7a6a84a/LICENSE
-  ref: bdafa318b8e637d600ca1b60545e894881977a16a16b74809c95e805701621e3
-  directory: third_party/lodepng
+  url: https://github.com/libjxl/libjxl/archive/refs/tags/v0.8.2.tar.gz
+  ref: c70916fb3ed43784eb840f82f05d390053a558e2da106e40863919238fa7b420
 - kind: git
   url: https://skia.googlesource.com/skcms
-  ref: 64374756e03700d649f897dbd98c95e78c30c7da
+  ref: b25b07b4b07990811de121c0356155b2ba0f4318
   directory: third_party/skcms
   checkout-submodules: False


### PR DESCRIPTION
#### cab3d34441b5de284aaf72c0c6578ba89acb4d4d
<pre>
[Flatpak SDK] Update libjxl to 0.8.x
<a href="https://bugs.webkit.org/show_bug.cgi?id=258221">https://bugs.webkit.org/show_bug.cgi?id=258221</a>

Reviewed by Philippe Normand.

* Tools/buildstream/elements/sdk/highway.bst: Update to version 1.0.4,
  adapt CMake local options accordingly.
* Tools/buildstream/elements/sdk/libjxl.bst: Update to version 0.8.4,
  adapt CMake local options, add libjpeg/libpng dependencies as this
  version cannot use a bundled copy of lodepng, update skcms submodule
  to match.

Canonical link: <a href="https://commits.webkit.org/265276@main">https://commits.webkit.org/265276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d806ef187ba90e9f9402fba5f76af17ebdbba5b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9987 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12955 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12450 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8659 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10011 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8119 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13424 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1172 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->