### PR TITLE
[JSC] Cache last YearMonthDay computation results in DateCache

### DIFF
--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -160,6 +160,13 @@ private:
         LocalTimeOffsetCache* m_after;
     };
 
+    struct YearMonthDayCache {
+        int32_t m_days { 0 };
+        int32_t m_year { 0 };
+        int32_t m_month { 0 };
+        int32_t m_day { 0 };
+    };
+
     void timeZoneCacheSlow();
     LocalTimeOffset localTimeOffset(int64_t millisecondsFromEpoch, WTF::TimeType inputTimeType = WTF::UTCTime)
     {
@@ -177,8 +184,11 @@ private:
         return m_timeZoneCache.get();
     }
 
+    std::tuple<int32_t, int32_t, int32_t> yearMonthDayFromDaysWithCache(int32_t days);
+
     std::unique_ptr<OpaqueICUTimeZone, OpaqueICUTimeZoneDeleter> m_timeZoneCache;
     std::array<DSTCache, 2> m_caches;
+    std::optional<YearMonthDayCache> m_yearMonthDayCache;
     String m_cachedDateString;
     double m_cachedDateStringValue;
     DateInstanceCache m_dateInstanceCache;

--- a/Source/WTF/wtf/GregorianDateTime.cpp
+++ b/Source/WTF/wtf/GregorianDateTime.cpp
@@ -56,7 +56,7 @@ GregorianDateTime::GregorianDateTime(double ms, LocalTimeOffset localTime)
         setYear(year);
     }
     setIsDST(localTime.isDST);
-    setUTCOffsetInMinute(localTime.offset / WTF::msPerMinute);
+    setUTCOffsetInMinute(localTime.offset / WTF::Int64Milliseconds::msPerMinute);
 }
 
 void GregorianDateTime::setToCurrentLocalTime()

--- a/Source/WTF/wtf/GregorianDateTime.h
+++ b/Source/WTF/wtf/GregorianDateTime.h
@@ -37,6 +37,19 @@ class GregorianDateTime final {
 public:
     GregorianDateTime() = default;
     WTF_EXPORT_PRIVATE explicit GregorianDateTime(double ms, LocalTimeOffset);
+    explicit GregorianDateTime(int year, int month, int yearDay, int monthDay, int weekDay, int hour, int minute, int second, int utcOffsetInMinute, bool isDST)
+        : m_year(year)
+        , m_month(month)
+        , m_yearDay(yearDay)
+        , m_monthDay(monthDay)
+        , m_weekDay(weekDay)
+        , m_hour(hour)
+        , m_minute(minute)
+        , m_second(second)
+        , m_utcOffsetInMinute(utcOffsetInMinute)
+        , m_isDST(isDST)
+    {
+    }
 
     inline int year() const { return m_year; }
     inline int month() const { return m_month; }


### PR DESCRIPTION
#### c5df085fea8f416379d2aca2557a82f77997535e
<pre>
[JSC] Cache last YearMonthDay computation results in DateCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=258224">https://bugs.webkit.org/show_bug.cgi?id=258224</a>
rdar://110923070

Reviewed by Justin Michaud.

yearMonthDayFromDays is very costly operation, so DateCache should cache the last result based on the days.
This patch adds a cache inspired from V8&apos;s cache. We will further extend our DateCache to purge Ref&lt;DateInstanceData&gt; next.

* Source/JavaScriptCore/runtime/JSDateMath.cpp:
(JSC::DateCache::yearMonthDayFromDaysWithCache):
(JSC::DateCache::msToGregorianDateTime):
(JSC::DateCache::resetIfNecessarySlow):
* Source/JavaScriptCore/runtime/JSDateMath.h:
* Source/WTF/wtf/GregorianDateTime.cpp:
(WTF::GregorianDateTime::GregorianDateTime):
* Source/WTF/wtf/GregorianDateTime.h:

Canonical link: <a href="https://commits.webkit.org/265261@main">https://commits.webkit.org/265261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0361da80988dff61ae2032e3ab647b26620c946

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10419 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10650 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12060 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10603 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11364 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12458 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9431 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8797 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12833 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10016 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10547 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9174 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13430 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10837 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1165 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9877 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2677 "Passed tests") | 
<!--EWS-Status-Bubble-End-->