### PR TITLE
Rework feature flags for CSS white-space longhands

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1364,12 +1364,12 @@ CSSTextUnderlinePositionLeftRightEnabled:
     WebCore:
       default: false
 
-CSSTextWrapEnabled:
+CSSTextWrapNewValuesEnabled:
   type: bool
   status: testable
   category: css
-  humanReadableName: "CSS text-wrap property"
-  humanReadableDescription: "Enable text-wrap CSS property"
+  humanReadableName: "CSS text-wrap: balance stable pretty"
+  humanReadableDescription: "Enable text-wrap: balance/stable/pretty CSS support"
   defaultValue:
     WebKitLegacy:
       default: false
@@ -1421,12 +1421,12 @@ CSSTypedOMEnabled:
     WebCore:
       default: true
 
-CSSWhiteSpaceCollapseEnabled:
+CSSWhiteSpaceLonghandsEnabled:
   type: bool
   status: testable
   category: css
-  humanReadableName: "CSS white-space-collapse property"
-  humanReadableDescription: "Enable white-space-collapse CSS property"
+  humanReadableName: "CSS text-wrap & white-space-collapse properties"
+  humanReadableDescription: "Enable text-wrap & white-space-collapse CSS properties"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5854,12 +5854,21 @@
             "values": [
                 "wrap",
                 "nowrap",
-                "balance",
-                "stable",
-                "pretty"
+                {
+                    "value": "balance",
+                    "settings-flag": "cssTextWrapNewValuesEnabled"
+                },
+                {
+                    "value": "stable",
+                    "settings-flag": "cssTextWrapNewValuesEnabled"
+                },
+                {
+                    "value": "pretty",
+                    "settings-flag": "cssTextWrapNewValuesEnabled"
+                }
             ],
             "codegen-properties": {
-                "settings-flag": "cssTextWrapEnabled",
+                "settings-flag": "cssWhiteSpaceLonghandsEnabled",
                 "parser-grammar": "<<values>>"
             },
             "specification": {
@@ -6070,7 +6079,7 @@
                 "break-spaces"
             ],
             "codegen-properties": {
-                "settings-flag": "cssWhiteSpaceCollapseEnabled",
+                "settings-flag": "cssWhiteSpaceLonghandsEnabled",
                 "parser-grammar": "<<values>>"
             },
             "specification": {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -66,8 +66,7 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 #endif
     }
 
-    propertySettings.cssTextWrapEnabled = true;
-    propertySettings.cssWhiteSpaceCollapseEnabled = true;
+    propertySettings.cssWhiteSpaceLonghandsEnabled = true;
 
     StaticCSSValuePool::init();
 }
@@ -103,6 +102,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
 #endif
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
+    , cssTextWrapNewValuesEnabled { document.settings().cssTextWrapNewValuesEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -140,6 +140,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.cssNestingEnabled == b.cssNestingEnabled
         && a.cssPaintingAPIEnabled == b.cssPaintingAPIEnabled
         && a.cssTextUnderlinePositionLeftRightEnabled == b.cssTextUnderlinePositionLeftRightEnabled
+        && a.cssTextWrapNewValuesEnabled == b.cssTextWrapNewValuesEnabled
         && a.propertySettings == b.propertySettings
     ;
 }
@@ -171,7 +172,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssNestingEnabled                         << 20
         | context.cssPaintingAPIEnabled                     << 21
         | context.cssTextUnderlinePositionLeftRightEnabled  << 22
-        | (uint64_t)context.mode                            << 23; // This is multiple bits, so keep it last.
+        | context.cssTextWrapNewValuesEnabled               << 23
+        | (uint64_t)context.mode                            << 24; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -94,6 +94,7 @@ struct CSSParserContext {
     bool cssNestingEnabled { false };
     bool cssPaintingAPIEnabled { false };
     bool cssTextUnderlinePositionLeftRightEnabled { false };
+    bool cssTextWrapNewValuesEnabled { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;


### PR DESCRIPTION
#### 5ae444becdfd912aa5aeae6ea80cd5f5eae30a55
<pre>
Rework feature flags for CSS white-space longhands
<a href="https://bugs.webkit.org/show_bug.cgi?id=258234">https://bugs.webkit.org/show_bug.cgi?id=258234</a>
rdar://110937144

Reviewed by Brent Fulgham.

We want to be able to enable white-space-collapse &amp; text-wrap separately from text-wrap: balance/pretty/stable support.
To do so, re-work the preferences so they can be implemented independently.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::operator==):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:

Canonical link: <a href="https://commits.webkit.org/265341@main">https://commits.webkit.org/265341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f6f9579c60ab20cc08a7b03c0dc83fdf32a957

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12080 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10012 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12974 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11426 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8790 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12479 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16708 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8815 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12848 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9895 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10035 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8139 "5 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10567 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9193 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13448 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10857 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9896 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2683 "Passed tests") | 
<!--EWS-Status-Bubble-End-->