### PR TITLE
[GStreamer] MockDeviceProvider ifdefs are not consistent

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #include "GStreamerMockDeviceProvider.h"
 
-#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER_WEBRTC)
+#if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
 
 #include "GStreamerMockDevice.h"
 #include "MockRealtimeMediaSourceCenter.h"
@@ -70,4 +70,4 @@ static void webkit_mock_device_provider_class_init(GStreamerMockDeviceProviderCl
 
 #undef GST_CAT_DEFAULT
 
-#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER_WEBRTC)
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h
@@ -47,4 +47,4 @@ struct _GStreamerMockDeviceProviderClass {
 
 GType webkit_mock_device_provider_get_type(void);
 
-#endif // ENABLE(MEDIA_STREAM) &&  USE(GSTREAMER)
+#endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)


### PR DESCRIPTION
#### 67207eb341670c08b8cd04d928ff7067de947c1b
<pre>
[GStreamer] MockDeviceProvider ifdefs are not consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=258237">https://bugs.webkit.org/show_bug.cgi?id=258237</a>

Reviewed by Michael Catanzaro.

This code is not specific to GSTREAMER_WEBRTC.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h:

Canonical link: <a href="https://commits.webkit.org/265271@main">https://commits.webkit.org/265271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3753d76b49b396fab90d373dd0ea71f548d1a8a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10631 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/12978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10604 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12484 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/8776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12851 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10040 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13453 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1171 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->