### PR TITLE
MarkedText::Type should be an enum class

### DIFF
--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -125,7 +125,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
 
                     auto [highlightStart, highlightEnd] = highlightData.rangeForTextBox(renderer, selectableRange);
                     if (highlightStart < highlightEnd)
-                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::Highlight, nullptr, highlight.key });
+                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::Type::Highlight, nullptr, highlight.key });
                 }
             }
         }
@@ -140,7 +140,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
 
                     auto [highlightStart, highlightEnd] = highlightData.rangeForTextBox(renderer, selectableRange);
                     if (highlightStart < highlightEnd)
-                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::FragmentHighlight });
+                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::Type::FragmentHighlight });
                 }
             }
         }
@@ -156,7 +156,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
 
                     auto [highlightStart, highlightEnd] = highlightData.rangeForTextBox(renderer, selectableRange);
                     if (highlightStart < highlightEnd)
-                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::AppHighlight });
+                        markedTexts.append({ highlightStart, highlightEnd, MarkedText::Type::AppHighlight });
                 }
             }
         }
@@ -175,21 +175,21 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
     auto markedTextTypeForMarkerType = [] (DocumentMarker::MarkerType type) {
         switch (type) {
         case DocumentMarker::Spelling:
-            return MarkedText::SpellingError;
+            return MarkedText::Type::SpellingError;
         case DocumentMarker::Grammar:
-            return MarkedText::GrammarError;
+            return MarkedText::Type::GrammarError;
         case DocumentMarker::CorrectionIndicator:
-            return MarkedText::Correction;
+            return MarkedText::Type::Correction;
         case DocumentMarker::TextMatch:
-            return MarkedText::TextMatch;
+            return MarkedText::Type::TextMatch;
         case DocumentMarker::DictationAlternatives:
-            return MarkedText::DictationAlternatives;
+            return MarkedText::Type::DictationAlternatives;
 #if PLATFORM(IOS_FAMILY)
         case DocumentMarker::DictationPhraseWithAlternatives:
-            return MarkedText::DictationPhraseWithAlternatives;
+            return MarkedText::Type::DictationPhraseWithAlternatives;
 #endif
         default:
-            return MarkedText::Unmarked;
+            return MarkedText::Type::Unmarked;
         }
     };
 
@@ -275,7 +275,7 @@ Vector<MarkedText> MarkedText::collectForDraggedContent(const RenderText& render
     auto draggedContentRanges = renderer.draggedContentRangesBetweenOffsets(selectableRange.start, selectableRange.start + selectableRange.length);
 
     return draggedContentRanges.map([&](const auto& range) -> MarkedText {
-        return { selectableRange.clamp(range.first), selectableRange.clamp(range.second), MarkedText::DraggedContent };
+        return { selectableRange.clamp(range.first), selectableRange.clamp(range.second), MarkedText::Type::DraggedContent };
     });
 }
 

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -37,7 +37,7 @@ struct TextBoxSelectableRange;
 
 struct MarkedText {
     // Sorted by paint order
-    enum Type {
+    enum class Type : uint8_t {
         Unmarked,
         GrammarError,
         Correction,

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -38,17 +38,17 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
 {
     auto style = baseStyle;
     switch (markedText.type) {
-    case MarkedText::Correction:
-    case MarkedText::DictationAlternatives:
+    case MarkedText::Type::Correction:
+    case MarkedText::Type::DictationAlternatives:
 #if PLATFORM(IOS_FAMILY)
     // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
-    case MarkedText::DictationPhraseWithAlternatives:
+    case MarkedText::Type::DictationPhraseWithAlternatives:
 #endif
-    case MarkedText::GrammarError:
-    case MarkedText::SpellingError:
-    case MarkedText::Unmarked:
+    case MarkedText::Type::GrammarError:
+    case MarkedText::Type::SpellingError:
+    case MarkedText::Type::Unmarked:
         break;
-    case MarkedText::Highlight:
+    case MarkedText::Type::Highlight:
         if (auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoId::Highlight, markedText.highlightName }, &renderer.style())) {
             style.backgroundColor = renderStyle->colorResolvingCurrentColor(renderStyle->backgroundColor());
             style.textStyles.fillColor = renderStyle->computedStrokeColor();
@@ -72,22 +72,22 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             }
         }
         break;
-    case MarkedText::FragmentHighlight: {
+    case MarkedText::Type::FragmentHighlight: {
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
         style.backgroundColor = renderer.theme().annotationHighlightColor(styleColorOptions);
         break;
     }
 #if ENABLE(APP_HIGHLIGHTS)
-    case MarkedText::AppHighlight: {
+    case MarkedText::Type::AppHighlight: {
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
         style.backgroundColor = renderer.theme().annotationHighlightColor(styleColorOptions);
         break;
     }
 #endif
-    case MarkedText::DraggedContent:
+    case MarkedText::Type::DraggedContent:
         style.alpha = 0.25;
         break;
-    case MarkedText::Selection: {
+    case MarkedText::Type::Selection: {
         style.textStyles = computeTextSelectionPaintStyle(style.textStyles, renderer, lineStyle, paintInfo, style.textShadow);
 
         Color selectionBackgroundColor = renderer.selectionBackgroundColor();
@@ -96,7 +96,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             style.backgroundColor = selectionBackgroundColor.invertedColorWithAlpha(1.0);
         break;
     }
-    case MarkedText::TextMatch: {
+    case MarkedText::Type::TextMatch: {
         // Text matches always use the light system appearance.
         OptionSet<StyleColorOptions> styleColorOptions = { StyleColorOptions::UseSystemAppearance };
 #if PLATFORM(MAC)
@@ -130,7 +130,7 @@ Vector<StyledMarkedText> StyledMarkedText::subdivideAndResolve(const Vector<Mark
     auto& lineStyle = isFirstLine ? renderer.firstLineStyle() : renderer.style();
     auto baseStyle = computeStyleForUnmarkedMarkedText(renderer, lineStyle, isFirstLine, paintInfo);
 
-    if (textsToSubdivide.size() == 1 && textsToSubdivide[0].type == MarkedText::Unmarked) {
+    if (textsToSubdivide.size() == 1 && textsToSubdivide[0].type == MarkedText::Type::Unmarked) {
         StyledMarkedText styledMarkedText = textsToSubdivide[0];
         styledMarkedText.style = WTFMove(baseStyle);
         return { styledMarkedText };

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -36,34 +36,34 @@ namespace WebCore {
 std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
 {
     switch (type) {
-    case MarkedText::Correction:
+    case MarkedText::Type::Correction:
         return os << "Correction";
-    case MarkedText::DictationAlternatives:
+    case MarkedText::Type::DictationAlternatives:
         return os << "DictationAlternatives";
 #if PLATFORM(IOS_FAMILY)
     // FIXME: See <rdar://problem/8933352>. Also, remove the PLATFORM(IOS_FAMILY)-guard.
-    case MarkedText::DictationPhraseWithAlternatives:
+    case MarkedText::Type::DictationPhraseWithAlternatives:
         return os << "DictationPhraseWithAlternatives";
 #endif
-    case MarkedText::DraggedContent:
+    case MarkedText::Type::DraggedContent:
         return os << "DraggedContent";
-    case MarkedText::GrammarError:
+    case MarkedText::Type::GrammarError:
         return os << "GrammarError";
-    case MarkedText::Selection:
+    case MarkedText::Type::Selection:
         return os << "Selection";
-    case MarkedText::SpellingError:
+    case MarkedText::Type::SpellingError:
         return os << "SpellingError";
-    case MarkedText::TextMatch:
+    case MarkedText::Type::TextMatch:
         return os << "TextMatch";
-    case MarkedText::Highlight:
+    case MarkedText::Type::Highlight:
         return os << "Highlight";
-    case MarkedText::FragmentHighlight:
+    case MarkedText::Type::FragmentHighlight:
         return os << "FragmentHighlight";
 #if ENABLE(APP_HIGHLIGHTS)
-    case MarkedText::AppHighlight:
+    case MarkedText::Type::AppHighlight:
         return os << "AppHighlight";
 #endif
-    case MarkedText::Unmarked:
+    case MarkedText::Type::Unmarked:
         return os << "Unmarked";
     }
 }
@@ -88,7 +88,7 @@ TEST(MarkedText, SubdivideEmpty)
 
 TEST(MarkedText, SubdivideSimple)
 {
-    MarkedText markedText { 0, 9, MarkedText::SpellingError };
+    MarkedText markedText { 0, 9, MarkedText::Type::SpellingError };
     auto results = MarkedText::subdivide({ markedText });
     ASSERT_EQ(1U, results.size());
     EXPECT_EQ(markedText, results[0]);
@@ -98,8 +98,8 @@ TEST(MarkedText, SubdivideSpellingAndGrammarSimple)
 {
     RenderedDocumentMarker grammarErrorMarker { DocumentMarker { DocumentMarker::Grammar, { 7, 8 } } };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { grammarErrorMarker.startOffset(), grammarErrorMarker.endOffset(), MarkedText::GrammarError, &grammarErrorMarker },
-        MarkedText { 22, 32, MarkedText::SpellingError },
+        MarkedText { grammarErrorMarker.startOffset(), grammarErrorMarker.endOffset(), MarkedText::Type::GrammarError, &grammarErrorMarker },
+        MarkedText { 22, 32, MarkedText::Type::SpellingError },
     };
     auto results = MarkedText::subdivide(expectedMarkedTexts);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());
@@ -110,19 +110,19 @@ TEST(MarkedText, SubdivideSpellingAndGrammarSimple)
 TEST(MarkedText, SubdivideSpellingAndGrammarOverlap)
 {
     Vector<MarkedText> markedTexts {
-        MarkedText { 0, 40, MarkedText::GrammarError },
-        MarkedText { 2, 17, MarkedText::SpellingError },
-        MarkedText { 20, 40, MarkedText::SpellingError },
-        MarkedText { 41, 45, MarkedText::SpellingError },
+        MarkedText { 0, 40, MarkedText::Type::GrammarError },
+        MarkedText { 2, 17, MarkedText::Type::SpellingError },
+        MarkedText { 20, 40, MarkedText::Type::SpellingError },
+        MarkedText { 41, 45, MarkedText::Type::SpellingError },
     };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { 0, 2, MarkedText::GrammarError },
-        MarkedText { 2, 17, MarkedText::GrammarError },
-        MarkedText { 2, 17, MarkedText::SpellingError },
-        MarkedText { 17, 20, MarkedText::GrammarError },
-        MarkedText { 20, 40, MarkedText::GrammarError },
-        MarkedText { 20, 40, MarkedText::SpellingError },
-        MarkedText { 41, 45, MarkedText::SpellingError },
+        MarkedText { 0, 2, MarkedText::Type::GrammarError },
+        MarkedText { 2, 17, MarkedText::Type::GrammarError },
+        MarkedText { 2, 17, MarkedText::Type::SpellingError },
+        MarkedText { 17, 20, MarkedText::Type::GrammarError },
+        MarkedText { 20, 40, MarkedText::Type::GrammarError },
+        MarkedText { 20, 40, MarkedText::Type::SpellingError },
+        MarkedText { 41, 45, MarkedText::Type::SpellingError },
     };
     auto results = MarkedText::subdivide(markedTexts);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());
@@ -133,17 +133,17 @@ TEST(MarkedText, SubdivideSpellingAndGrammarOverlap)
 TEST(MarkedText, SubdivideSpellingAndGrammarOverlapFrontmost)
 {
     Vector<MarkedText> markedTexts {
-        MarkedText { 0, 40, MarkedText::GrammarError },
-        MarkedText { 2, 17, MarkedText::SpellingError },
-        MarkedText { 20, 40, MarkedText::SpellingError },
-        MarkedText { 41, 45, MarkedText::SpellingError },
+        MarkedText { 0, 40, MarkedText::Type::GrammarError },
+        MarkedText { 2, 17, MarkedText::Type::SpellingError },
+        MarkedText { 20, 40, MarkedText::Type::SpellingError },
+        MarkedText { 41, 45, MarkedText::Type::SpellingError },
     };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { 0, 2, MarkedText::GrammarError },
-        MarkedText { 2, 17, MarkedText::SpellingError },
-        MarkedText { 17, 20, MarkedText::GrammarError },
-        MarkedText { 20, 40, MarkedText::SpellingError },
-        MarkedText { 41, 45, MarkedText::SpellingError },
+        MarkedText { 0, 2, MarkedText::Type::GrammarError },
+        MarkedText { 2, 17, MarkedText::Type::SpellingError },
+        MarkedText { 17, 20, MarkedText::Type::GrammarError },
+        MarkedText { 20, 40, MarkedText::Type::SpellingError },
+        MarkedText { 41, 45, MarkedText::Type::SpellingError },
     };
     auto results = MarkedText::subdivide(markedTexts, MarkedText::OverlapStrategy::Frontmost);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());
@@ -154,27 +154,27 @@ TEST(MarkedText, SubdivideSpellingAndGrammarOverlapFrontmost)
 TEST(MarkedText, SubdivideSpellingAndGrammarComplicatedFrontmost)
 {
     Vector<MarkedText> markedTexts {
-        MarkedText { 0, 6, MarkedText::SpellingError },
-        MarkedText { 0, 46, MarkedText::GrammarError },
-        MarkedText { 7, 16, MarkedText::SpellingError },
-        MarkedText { 22, 27, MarkedText::SpellingError },
-        MarkedText { 34, 44, MarkedText::SpellingError },
-        MarkedText { 46, 50, MarkedText::SpellingError },
-        MarkedText { 51, 58, MarkedText::SpellingError },
-        MarkedText { 59, 63, MarkedText::GrammarError },
+        MarkedText { 0, 6, MarkedText::Type::SpellingError },
+        MarkedText { 0, 46, MarkedText::Type::GrammarError },
+        MarkedText { 7, 16, MarkedText::Type::SpellingError },
+        MarkedText { 22, 27, MarkedText::Type::SpellingError },
+        MarkedText { 34, 44, MarkedText::Type::SpellingError },
+        MarkedText { 46, 50, MarkedText::Type::SpellingError },
+        MarkedText { 51, 58, MarkedText::Type::SpellingError },
+        MarkedText { 59, 63, MarkedText::Type::GrammarError },
     };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { 0, 6, MarkedText::SpellingError },
-        MarkedText { 6, 7, MarkedText::GrammarError },
-        MarkedText { 7, 16, MarkedText::SpellingError },
-        MarkedText { 16, 22, MarkedText::GrammarError },
-        MarkedText { 22, 27, MarkedText::SpellingError },
-        MarkedText { 27, 34, MarkedText::GrammarError },
-        MarkedText { 34, 44, MarkedText::SpellingError },
-        MarkedText { 44, 46, MarkedText::GrammarError },
-        MarkedText { 46, 50, MarkedText::SpellingError },
-        MarkedText { 51, 58, MarkedText::SpellingError },
-        MarkedText { 59, 63, MarkedText::GrammarError },
+        MarkedText { 0, 6, MarkedText::Type::SpellingError },
+        MarkedText { 6, 7, MarkedText::Type::GrammarError },
+        MarkedText { 7, 16, MarkedText::Type::SpellingError },
+        MarkedText { 16, 22, MarkedText::Type::GrammarError },
+        MarkedText { 22, 27, MarkedText::Type::SpellingError },
+        MarkedText { 27, 34, MarkedText::Type::GrammarError },
+        MarkedText { 34, 44, MarkedText::Type::SpellingError },
+        MarkedText { 44, 46, MarkedText::Type::GrammarError },
+        MarkedText { 46, 50, MarkedText::Type::SpellingError },
+        MarkedText { 51, 58, MarkedText::Type::SpellingError },
+        MarkedText { 59, 63, MarkedText::Type::GrammarError },
     };
     auto results = MarkedText::subdivide(markedTexts, MarkedText::OverlapStrategy::Frontmost);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());
@@ -185,17 +185,17 @@ TEST(MarkedText, SubdivideSpellingAndGrammarComplicatedFrontmost)
 TEST(MarkedText, SubdivideGrammarAndSelectionOverlap)
 {
     Vector<MarkedText> markedTexts {
-        MarkedText { 0, 40, MarkedText::GrammarError },
-        MarkedText { 2, 60, MarkedText::Selection },
-        MarkedText { 50, 60, MarkedText::GrammarError },
+        MarkedText { 0, 40, MarkedText::Type::GrammarError },
+        MarkedText { 2, 60, MarkedText::Type::Selection },
+        MarkedText { 50, 60, MarkedText::Type::GrammarError },
     };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { 0, 2, MarkedText::GrammarError },
-        MarkedText { 2, 40, MarkedText::GrammarError },
-        MarkedText { 2, 40, MarkedText::Selection },
-        MarkedText { 40, 50, MarkedText::Selection },
-        MarkedText { 50, 60, MarkedText::GrammarError },
-        MarkedText { 50, 60, MarkedText::Selection },
+        MarkedText { 0, 2, MarkedText::Type::GrammarError },
+        MarkedText { 2, 40, MarkedText::Type::GrammarError },
+        MarkedText { 2, 40, MarkedText::Type::Selection },
+        MarkedText { 40, 50, MarkedText::Type::Selection },
+        MarkedText { 50, 60, MarkedText::Type::GrammarError },
+        MarkedText { 50, 60, MarkedText::Type::Selection },
     };
     auto results = MarkedText::subdivide(markedTexts);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());
@@ -206,15 +206,15 @@ TEST(MarkedText, SubdivideGrammarAndSelectionOverlap)
 TEST(MarkedText, SubdivideGrammarAndSelectionOverlapFrontmost)
 {
     Vector<MarkedText> markedTexts {
-        MarkedText { 0, 40, MarkedText::GrammarError },
-        MarkedText { 2, 60, MarkedText::Selection },
-        MarkedText { 50, 60, MarkedText::GrammarError },
+        MarkedText { 0, 40, MarkedText::Type::GrammarError },
+        MarkedText { 2, 60, MarkedText::Type::Selection },
+        MarkedText { 50, 60, MarkedText::Type::GrammarError },
     };
     Vector<MarkedText> expectedMarkedTexts {
-        MarkedText { 0, 2, MarkedText::GrammarError },
-        MarkedText { 2, 40, MarkedText::Selection },
-        MarkedText { 40, 50, MarkedText::Selection },
-        MarkedText { 50, 60, MarkedText::Selection },
+        MarkedText { 0, 2, MarkedText::Type::GrammarError },
+        MarkedText { 2, 40, MarkedText::Type::Selection },
+        MarkedText { 40, 50, MarkedText::Type::Selection },
+        MarkedText { 50, 60, MarkedText::Type::Selection },
     };
     auto results = MarkedText::subdivide(markedTexts, MarkedText::OverlapStrategy::Frontmost);
     ASSERT_EQ(expectedMarkedTexts.size(), results.size());


### PR DESCRIPTION
#### b9d2ca0cd9ecf0999f088e8151cdb60faae37e26
<pre>
MarkedText::Type should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=258238">https://bugs.webkit.org/show_bug.cgi?id=258238</a>
rdar://110945040

Reviewed by Aditya Keerthi.

* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
(WebCore::MarkedText::collectForDocumentMarkers):
(WebCore::MarkedText::collectForDraggedContent):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
(WebCore::StyledMarkedText::subdivideAndResolve):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::createMarkedTextFromSelectionInBox):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintCompositionForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForegroundAndDecorations):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintForeground):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::createDecorationPainter):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265275@main">https://commits.webkit.org/265275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38ed60829e3f706aaa242289f6345f82931c107

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10463 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10636 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12490 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16716 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12856 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9203 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2510 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13459 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->