### PR TITLE
Improve Canvas ImageData noise injection algorithm

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -802,7 +802,7 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
         [webView2 callAsyncJavaScriptAndWait:scriptToRun]
     };
-    EXPECT_WK_STREQ(values.first, values.second);
+    EXPECT_TRUE([values.first isEqualToString:values.second]);
 
     values = std::pair {
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
@@ -819,8 +819,8 @@ TEST(AdvancedPrivacyProtections, VerifyHashFromNoisyCanvas2DAPI)
 
 TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
 {
-    const auto zeroPrefix = 380;
-    const auto channelsPerPixel = 4;
+    constexpr auto zeroPrefix = 380;
+    constexpr auto channelsPerPixel = 4;
 
     auto testURL = [NSBundle.mainBundle URLForResource:@"canvas-fingerprinting" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
     auto resourcesURL = [NSBundle.mainBundle.bundleURL URLByAppendingPathComponent:@"TestWebKitAPI.resources"];
@@ -842,51 +842,70 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     [webViewWithPrivacyProtections2 loadFileRequest:[NSURLRequest requestWithURL:testURL] allowingReadAccessToURL:resourcesURL];
     [webViewWithPrivacyProtections2 _test_waitForDidFinishNavigation];
 
-    auto checkCanvasPixels = [&](NSString *functionName, size_t length, Function<void(NSString *, NSString *, int)> expect) {
+    auto checkCanvasPixels = [&](NSString *functionName, size_t length, Function<void(NSDictionary *, NSDictionary *, int, int)> expect) {
+        // This is a larger tolerance than we'd like, but the lossy nature of the premultiplied conversion doesn't give us many options.
+        constexpr auto maxPixelDifferenceTolerance = 8;
         auto scriptToRun = [NSString stringWithFormat:@"return %@(%zu)", functionName, length];
-        auto values = std::pair {
-            [webView1 callAsyncJavaScriptAndWait:scriptToRun],
-            [webView2 callAsyncJavaScriptAndWait:scriptToRun]
-        };
-        EXPECT_WK_STREQ(values.first, values.second);
-        EXPECT_NE(((NSString *)values.first).length, 0u);
-        EXPECT_NE(((NSString *)values.second).length, 0u);
-        EXPECT_EQ(((NSString *)values.first).length, ((NSString *)values.second).length);
 
-        values = std::pair {
-            [webView1 callAsyncJavaScriptAndWait:scriptToRun],
-            [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]
-        };
-        expect(values.first, values.second, __LINE__);
-        EXPECT_NE(((NSString *)values.first).length, 0u);
-        EXPECT_NE(((NSString *)values.second).length, 0u);
+        NSDictionary *arr1 = [webView1 callAsyncJavaScriptAndWait:scriptToRun];
+        NSDictionary *arr2 = [webView2 callAsyncJavaScriptAndWait:scriptToRun];
 
-        values = std::pair {
-            [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun],
-            [webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]
-        };
-        expect(values.first, values.second, __LINE__);
-        EXPECT_NE(((NSString *)values.first).length, 0u);
-        EXPECT_NE(((NSString *)values.second).length, 0u);
+        EXPECT_TRUE([arr1 isEqualToDictionary:arr2]);
+        EXPECT_NE(arr1.count, 0u);
+        EXPECT_NE(arr2.count, 0u);
+        EXPECT_EQ(arr1.count, arr2.count);
+
+        NSDictionary *arrWithPrivacyProtections1 = [webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun];
+
+        expect(arr1, arrWithPrivacyProtections1, maxPixelDifferenceTolerance, __LINE__);
+        EXPECT_NE(arrWithPrivacyProtections1.count, 0u);
+
+        NSDictionary *arrWithPrivacyProtections2 = [webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun];
+
+        expect(arr1, arrWithPrivacyProtections2, maxPixelDifferenceTolerance, __LINE__);
+        EXPECT_NE(arrWithPrivacyProtections2.count, 0u);
+
+        expect(arrWithPrivacyProtections1, arrWithPrivacyProtections2, maxPixelDifferenceTolerance * 2, __LINE__);
     };
 
     auto checkCanvasPixelsEqual = [&](NSString *functionName, int length, int primaryLine) {
-        checkCanvasPixels(functionName, length, [primaryLine](NSString *str1, NSString *str2, int secondaryLine) {
-            EXPECT_WK_STREQ(str1, str2) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nstr1: " << str1.UTF8String << "\nstr2: " << str2.UTF8String;
+        checkCanvasPixels(functionName, length, [primaryLine](NSDictionary *arr1, NSDictionary *arr2, int, int secondaryLine) {
+            EXPECT_TRUE([arr1 isEqualToDictionary:arr2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\narr1: " << arr1.description << "\narr2: " << arr2.description;
         });
     };
 
     auto checkCanvasPixelsNotEqual = [&](NSString *functionName, int length, int primaryLine) {
-        checkCanvasPixels(functionName, length, [primaryLine](NSString *str1, NSString *str2, int secondaryLine) {
-            EXPECT_FALSE([str1 isEqualToString:str2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nstr1: " << str1.UTF8String << "\nstr2: " << str2.UTF8String;
+        checkCanvasPixels(functionName, length, [primaryLine](NSDictionary *arr1, NSDictionary *arr2, int tolerance, int secondaryLine) {
+            EXPECT_FALSE([arr1 isEqualToDictionary:arr2]) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\narr1: " << arr1.description << "\narr2: " << arr2.description;
+            for (auto i = 0u; i < arr1.count; i += 4) {
+                auto* idx = [NSString stringWithFormat:@"%d", i];
+                auto* idxPlus1 = [NSString stringWithFormat:@"%d", i + 1];
+                auto* idxPlus2 = [NSString stringWithFormat:@"%d", i + 2];
+                auto* idxPlus3 = [NSString stringWithFormat:@"%d", i + 3];
+                int alpha1 = [[arr1 valueForKey:idxPlus3] intValue];
+                int alpha2 = [[arr2 valueForKey:idxPlus3] intValue];
+                EXPECT_LE(std::abs(alpha1 - alpha2), (tolerance / 2)) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nAlpha at index (+3): " << i << " is not within tolerance: " << (tolerance / 2) << ". arr1 value: " << alpha1 << ", arr2 value: " << alpha2;
+
+                auto red1 = [[arr1 valueForKey:idx] intValue];
+                auto red2 = [[arr2 valueForKey:idx] intValue];
+                EXPECT_LE(std::abs(std::round(static_cast<float>(red1 * alpha1) / 255) - std::round(static_cast<float>(red2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex: " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << red1 << " (alpha: " << alpha1 << "), arr2 value: " << red2 << " (alpha: " << alpha2 << ")";
+
+                auto green1 = [[arr1 valueForKey:idxPlus1] intValue];
+                auto green2 = [[arr2 valueForKey:idxPlus1] intValue];
+                EXPECT_LE(std::abs(std::round(static_cast<float>(green1 * alpha1) / 255) - std::round(static_cast<float>(green2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex (+1): " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << green1 << " (alpha: " << alpha1 << "), arr2 value: " << green2 << " (alpha: " << alpha2 << ")";
+
+                auto blue1 = [[arr1 valueForKey:idxPlus2] intValue];
+                auto blue2 = [[arr2 valueForKey:idxPlus2] intValue];
+                EXPECT_LE(std::abs(std::round(static_cast<float>(blue1 * alpha1) / 255) - std::round(static_cast<float>(blue2 * alpha2) / 255)), tolerance) << "Test at line " << primaryLine << " failed at line " << secondaryLine << "\nindex (+2): " << i << " is not within tolerance: " << tolerance << ". arr1 value: " << blue1 << " (alpha: " << alpha1 << "), arr2 value: " << blue2 << " (alpha: " << alpha2 << ")";
+            }
         });
     };
 
-    checkCanvasPixelsEqual(@"initialTextCanvasImageDataAsString", zeroPrefix * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialTextCanvasImageDataAsString", (300 * 200) * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialTextCanvasImageDataAsObject", zeroPrefix * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialTextCanvasImageDataAsObject", 300 * 200 * channelsPerPixel, __LINE__);
 
-    checkCanvasPixelsEqual(@"initialHorizontalLinearGradientCanvasImageDataAsString", 1 * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialHorizontalLinearGradientCanvasImageDataAsString", 8 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialHorizontalLinearGradientCanvasImageDataAsObject", 1 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialHorizontalLinearGradientCanvasImageDataAsObject", 30 * 2 * channelsPerPixel, __LINE__);
 
     auto scriptToRun = @"return isHorizontalLinearGradientCanvasGradient()";
     EXPECT_TRUE([webView1 callAsyncJavaScriptAndWait:scriptToRun]);
@@ -894,8 +913,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     EXPECT_TRUE([webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]);
     EXPECT_TRUE([webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]);
 
-    checkCanvasPixelsEqual(@"initialVerticalLinearGradientCanvasImageDataAsString", 2, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialVerticalLinearGradientCanvasImageDataAsString", 32 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialVerticalLinearGradientCanvasImageDataAsObject", 2, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialVerticalLinearGradientCanvasImageDataAsObject", 2 * 30 * channelsPerPixel, __LINE__);
 
     scriptToRun = @"return isVerticalLinearGradientCanvasGradient()";
     EXPECT_TRUE([webView1 callAsyncJavaScriptAndWait:scriptToRun]);
@@ -903,8 +922,8 @@ TEST(AdvancedPrivacyProtections, VerifyPixelsFromNoisyCanvas2DAPI)
     EXPECT_TRUE([webViewWithPrivacyProtections1 callAsyncJavaScriptAndWait:scriptToRun]);
     EXPECT_TRUE([webViewWithPrivacyProtections2 callAsyncJavaScriptAndWait:scriptToRun]);
 
-    checkCanvasPixelsEqual(@"initialRadialGradientCanvasImageDataAsString", 1 * channelsPerPixel, __LINE__);
-    checkCanvasPixelsNotEqual(@"initialRadialGradientCanvasImageDataAsString", 300 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsEqual(@"initialRadialGradientCanvasImageDataAsObject", 1 * channelsPerPixel, __LINE__);
+    checkCanvasPixelsNotEqual(@"initialRadialGradientCanvasImageDataAsObject", 300 * channelsPerPixel, __LINE__);
 }
 
 TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)
@@ -931,7 +950,7 @@ TEST(AdvancedPrivacyProtections, VerifyDataURLFromNoisyWebGLAPI)
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],
         [webView2 callAsyncJavaScriptAndWait:scriptToRun]
     };
-    EXPECT_WK_STREQ(values.first, values.second);
+    EXPECT_TRUE([values.first isEqualToString:values.second]);
 
     values = std::pair {
         [webView1 callAsyncJavaScriptAndWait:scriptToRun],

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html
@@ -98,15 +98,15 @@ function fullTextCanvasImageData() {
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
 }
 
-function initialCanvasImageDataAsString(imageData, length) {
-    let stringify = "";
+function initialCanvasImageDataAsObject(imageData, length) {
     if (length < 0)
-        return "";
+        return {};
     if (length > imageData.data.length)
         length = imageData.data.length;
-    for (i = 0; i < length; i++)
-        stringify += imageData.data[i] + ",";
-    return stringify;
+    let obj = {};
+    for (let i = 0; i < length; ++i)
+      obj[i] = imageData.data[i];
+    return obj;
 }
 
 function isHorizontalLinearGradientCanvasGradient() {
@@ -134,20 +134,20 @@ function isVerticalLinearGradientCanvasGradient() {
     return true;
 }
 
-function initialTextCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullTextCanvasImageData(), length);
+function initialTextCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullTextCanvasImageData(), length);
 }
 
-function initialHorizontalLinearGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullHorizontalLinearGradientCanvasImageData(), length);
+function initialHorizontalLinearGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullHorizontalLinearGradientCanvasImageData(), length);
 }
 
-function initialVerticalLinearGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullVerticalLinearGradientCanvasImageData(), length);
+function initialVerticalLinearGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullVerticalLinearGradientCanvasImageData(), length);
 }
 
-function initialRadialGradientCanvasImageDataAsString(length) {
-    return initialCanvasImageDataAsString(fullRadialGradientCanvasImageData(), length);
+function initialRadialGradientCanvasImageDataAsObject(length) {
+    return initialCanvasImageDataAsObject(fullRadialGradientCanvasImageData(), length);
 }
 
 async function fullCanvasHash(data) {


### PR DESCRIPTION
#### d89e7f323029abc0d06d022242485dcf44b39979
<pre>
Improve Canvas ImageData noise injection algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=257574">https://bugs.webkit.org/show_bug.cgi?id=257574</a>
rdar://109271231

Reviewed by Kimmo Kinnunen.

The current algorithm attempts to recognize gradients within a PixelBuffer, but
the logic for detecting a gradient is incorrect where it assumes a gradient
region always contain strictly increase (or decreasing) colors. This assumption
resulted in poor gradient detection and very visible anomalies in some cases.
In addition, in the case where the gradient was correctly detected, in some
cases the amount of added noise was too large and it cause a clustering effect
around some colors within the resulting image.

In this patch, I modified the noise-addition algorithm such that it provides
the best result for every pixel depending on its surrounding colors, instead of
restricting special behavior to gradients. We introduce a concept of &quot;related
colors&quot; which identifies two colors as related if the difference between each
of their RGBA components is not more than 8 - this threshold was mostly chosen
by experimentation.

The algorithm proceeds as follows:
1) For each color, identify if any of the immediately surrounding colors are related.
2) If any of the colors are related, then find the colors with the smallest distance.
3) If any related colors were identified, then those colors define the upper/lower
   bounds within which noise can be added.
4) Furthermore, if any related colors were identified, then noise is restricted
   to +/-1 (~0.5%), otherwise it is restricted to +/-3 (~1%);
5) After identifying the closest surrounding colors, we define the upper and lower
   bounds for each color component.
6) Finally, each color component is mutated by adding the noise value

* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::setTightnessBounds):
(WebCore::boundingNeighbors):
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::lowerAndUpperBound):
(WebCore::adjustNeighborColorBounds):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
(WebCore::getGradientNeighbors): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/canvas-fingerprinting.html:

Canonical link: <a href="https://commits.webkit.org/265333@main">https://commits.webkit.org/265333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb3d14fe2fd7b12bcb8779f37f0e8acc0e6e4eb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10699 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10629 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11508 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8807 "53 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12509 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16723 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12863 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10065 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8155 "1 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9224 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2543 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->