### PR TITLE
[MQ4] Implement `update` media feature

### DIFF
--- a/LayoutTests/fast/css/media-query-overflow-block-paged-print-expected.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-paged-print-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html style="color: green;"><p>This text should be green in paginated mode.</p></html>

--- a/LayoutTests/fast/css/media-query-overflow-block-paged-print.html
+++ b/LayoutTests/fast/css/media-query-overflow-block-paged-print.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+    :root {
+        color: blue;
+    }
+    @media (overflow-block: paged) {
+        :root {
+            color: green;
+        }
+    }
+    @media (overflow-block: scroll) {
+        :root {
+            color: red;
+        }
+    }
+    @media (overflow-block: none) {
+        :root {
+            color: red;
+        }
+    }
+</style>
+<p>This text should be green in paginated mode.</p>
+<script>
+if (window.internals)
+    internals.settings.setMediaTypeOverride("print");
+</script>
+</html>

--- a/LayoutTests/fast/css/media-query-update-none-expected.html
+++ b/LayoutTests/fast/css/media-query-update-none-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<p style="color: green">This text should be green when printing.</p>

--- a/LayoutTests/fast/css/media-query-update-none.html
+++ b/LayoutTests/fast/css/media-query-update-none.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<style>
+    :root {
+        color: blue;
+    }
+    @media (update: none) {
+        :root {
+            color: green;
+        }
+    }
+    @media (update: fast) {
+        :root {
+            color: red;
+        }
+    }
+    @media (update: slow) {
+        :root {
+            color: red;
+        }
+    }
+</style>
+<p>This text should be green when printing.</p>
+<script>
+if (window.internals)
+    internals.settings.setMediaTypeOverride("print");
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -1270,13 +1270,13 @@ PASS expression_should_be_known: overflow-inline: scroll
 PASS expression_should_be_parseable: overflow-inline: some-random-invalid-thing
 PASS expression_should_be_unknown: overflow-inline: some-random-invalid-thing
 PASS Sanity check for overflow-inline
-FAIL expression_should_be_known: update assert_true: expected true got false
-FAIL expression_should_be_known: update: none assert_true: expected true got false
-FAIL expression_should_be_known: update: slow assert_true: expected true got false
-FAIL expression_should_be_known: update: fast assert_true: expected true got false
+PASS expression_should_be_known: update
+PASS expression_should_be_known: update: none
+PASS expression_should_be_known: update: slow
+PASS expression_should_be_known: update: fast
 PASS expression_should_be_parseable: update: some-random-invalid-thing
 PASS expression_should_be_unknown: update: some-random-invalid-thing
-FAIL Sanity check for update assert_not_equals: update should be equivalent to not (update: none) got disallowed value false
+PASS Sanity check for update
 PASS expression_should_be_known: hover
 PASS expression_should_be_known: hover: hover
 PASS expression_should_be_known: hover: none

--- a/Source/WebCore/css/query/MediaQueryFeatures.h
+++ b/Source/WebCore/css/query/MediaQueryFeatures.h
@@ -60,6 +60,7 @@ const FeatureSchema& scan();
 const FeatureSchema& transform2d();
 const FeatureSchema& transform3d();
 const FeatureSchema& transition();
+const FeatureSchema& update();
 const FeatureSchema& videoPlayableInline();
 const FeatureSchema& width();
 #if ENABLE(APPLICATION_MANIFEST)


### PR DESCRIPTION
#### 777e46fb410533678d520e4a0dc6bb441d243661
<pre>
[MQ4] Implement `update` media feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=180245">https://bugs.webkit.org/show_bug.cgi?id=180245</a>
rdar://35799713

Reviewed by Darin Adler.

From <a href="https://drafts.csswg.org/mediaqueries/#update">https://drafts.csswg.org/mediaqueries/#update</a> :
The update media feature is used to query the ability of the output device to modify the appearance of content once it has been rendered. It accepts the following values:

- none
Once it has been rendered, the layout can no longer be updated. Example: documents printed on paper.
- slow
The layout may change dynamically according to the usual rules of CSS, but the output device is not able to render or display changes quickly enough for them to be perceived as a smooth animation. Example: E-ink screens or severely under-powered devices.
- fast
The layout may change dynamically according to the usual rules of CSS, and the output device is not unusually constrained in speed, so regularly-updating things like CSS Animations can be used. Example: computer screens.

This is part of Interop 2023.

Also update overflow-block: paged to match on print mediums.

* LayoutTests/fast/css/media-query-overflow-block-paged-print-expected.html: Added.
* LayoutTests/fast/css/media-query-overflow-block-paged-print.html: Added.
* LayoutTests/fast/css/media-query-update-none-expected.html: Added.
* LayoutTests/fast/css/media-query-update-none.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::update):
(WebCore::MQ::Features::overflowBlock):
* Source/WebCore/css/query/MediaQueryFeatures.h:

Canonical link: <a href="https://commits.webkit.org/265277@main">https://commits.webkit.org/265277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6eb5cc7fb9b7a19e9b9b812fe008ac3ad39f94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12998 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12519 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16732 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12872 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10073 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2511 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->