### PR TITLE
[MQ5] Implement `scripting` media feature

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Should be known: '(scripting)'
+PASS Should be known: '(scripting: enabled)'
+PASS Should be known: '(scripting: initial-only)'
+PASS Should be known: '(scripting: none)'
+PASS Should be parseable: '(scripting: 0)'
+PASS Should be unknown: '(scripting: 0)'
+PASS Should be parseable: '(scripting: 10px)'
+PASS Should be unknown: '(scripting: 10px)'
+PASS Should be parseable: '(scripting: invalid)'
+PASS Should be unknown: '(scripting: invalid)'
+PASS Check that scripting currently matches 'enabled'
+PASS Check that scripting currently evaluates to true in the boolean context
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<noscript>
+  Script is disabled
+</noscript>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<noscript>
+  Script is disabled
+</noscript>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/mediaqueries/#scripting">
+<link rel="match" href="scripting-print-noscript-ref.html">
+<style>
+  @media (scripting) {
+    #noscript {
+      display: none;
+    }
+  }
+</style>
+<div id="noscript">
+  Script is disabled
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div>
+  Script is enabled
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div>
+  Script is enabled
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/mediaqueries/#scripting">
+<link rel="match" href="scripting-print-script-ref.html">
+<style>
+  #script {
+    display: none;
+  }
+
+  @media (scripting) {
+    #script {
+      display: block;
+    }
+  }
+</style>
+<div id="script">
+  Script is enabled
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/mediaqueries-5/#scripting">
+<script type="text/javascript" src="/resources/testharness.js"></script>
+<script type="text/javascript" src="/resources/testharnessreport.js"></script>
+<script type="text/javascript" src="resources/matchmedia-utils.js"></script>
+
+<script>
+query_should_be_known("(scripting)");
+query_should_be_known("(scripting: enabled)");
+query_should_be_known("(scripting: initial-only)");
+query_should_be_known("(scripting: none)");
+
+query_should_be_unknown("(scripting: 0)");
+query_should_be_unknown("(scripting: 10px)");
+query_should_be_unknown("(scripting: invalid)");
+
+test(() => {
+  let match_enabled = window.matchMedia("(scripting: enabled)");
+  assert_true(match_enabled.matches);
+}, "Check that scripting currently matches 'enabled'");
+
+test(() => {
+  let booleanContext = window.matchMedia("(scripting)");
+  assert_true(booleanContext.matches);
+}, "Check that scripting currently evaluates to true in the boolean context");
+</script>

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1243,6 +1243,11 @@ active
 // scroll
 paged
 
+// (scripting:) media feature.
+enabled
+initial-only
+// none
+
 // blend modes
 // normal
 multiply

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1410,7 +1410,13 @@ applet, embed, object, img {
     border-width: 0px;
 }
 
-/* noscript is handled internally, as it depends on settings. */
+/* noscript support */
+
+@media (scripting) {
+    noscript {
+        display: none !important;
+    }
+}
 
 /* Default support for "Smart Invert" where all content color except media is inverted. */ 
 @media (inverted-colors) {

--- a/Source/WebCore/css/query/MediaQueryFeatures.h
+++ b/Source/WebCore/css/query/MediaQueryFeatures.h
@@ -57,6 +57,7 @@ const FeatureSchema& prefersDarkInterface();
 const FeatureSchema& prefersReducedMotion();
 const FeatureSchema& resolution();
 const FeatureSchema& scan();
+const FeatureSchema& scripting();
 const FeatureSchema& transform2d();
 const FeatureSchema& transform3d();
 const FeatureSchema& transition();

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -778,11 +778,7 @@ void HTMLElement::setTranslate(bool enable)
 
 bool HTMLElement::rendererIsEverNeeded()
 {
-    if (hasTagName(noscriptTag)) {
-        RefPtr frame { document().frame() };
-        if (frame && frame->script().canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
-            return false;
-    } else if (hasTagName(noembedTag)) {
+    if (hasTagName(noembedTag)) {
         RefPtr frame { document().frame() };
         if (frame && frame->arePluginsEnabled())
             return false;


### PR DESCRIPTION
#### d447cfd08147b9b7d33a70d7c0c39c0205b70db7
<pre>
[MQ5] Implement `scripting` media feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=258218">https://bugs.webkit.org/show_bug.cgi?id=258218</a>
rdar://110949545

Reviewed by Darin Adler.

<a href="https://drafts.csswg.org/mediaqueries-5/#scripting">https://drafts.csswg.org/mediaqueries-5/#scripting</a>

initial-only matches for printing, none matches when script is disabled, enabled matches the remainder of the time.

Also implement noscript using CSS.

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-noscript.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting-print-script.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/scripting.html: Added.
Import related WPTs.

* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/html.css:
(@media (scripting) noscript):
Implement noscript using CSS, this matches Firefox.

!important so author stylesheets can&apos;t override the display value (like before and like other browsers).

* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::scripting):
* Source/WebCore/css/query/MediaQueryFeatures.h:
Add scripting media query feature.

* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::rendererIsEverNeeded):
Implement noscript using CSS, this matches Firefox.

Canonical link: <a href="https://commits.webkit.org/265278@main">https://commits.webkit.org/265278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eae2ff8560eefafb464caed7da845964b1c565c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10488 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/10716 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12128 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10500 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/13037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10672 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10647 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12527 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/8852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/9371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1173 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->