### PR TITLE
[MQ] Negative resolutions in media queries should not be known

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-001.html
@@ -18,8 +18,6 @@ div {
     and
     (min-height: -100px)
     and
-    (min-resolution: -1dpi)
-    and
     (min-color: -10)
     and
     (min-color-index: -10)

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-002.html
@@ -18,8 +18,6 @@ div {
     and
     (not (max-height: -100px))
     and
-    (not (max-resolution: -1dpi))
-    and
     (not (max-color: -10))
     and
     (not (max-color-index: -10))

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt
@@ -1144,9 +1144,11 @@ PASS expression_should_be_known: resolution: 1.5dppx
 PASS expression_should_be_known: resolution: 1.5x
 PASS expression_should_be_known: resolution: 2.0dppx
 PASS expression_should_be_known: resolution: 0dpi
-PASS expression_should_be_known: resolution: -3dpi
 PASS expression_should_be_known: resolution: 0dppx
 PASS expression_should_be_known: resolution: 0x
+PASS expression_should_be_known: resolution: calc(6x / 2)
+PASS expression_should_be_parseable: resolution: -3dpi
+PASS expression_should_be_unknown: resolution: -3dpi
 PASS expression_should_be_known: min-resolution: 3dpi
 PASS expression_should_be_known: min-resolution:3dpi
 PASS expression_should_be_known: min-resolution: 3.0dpi
@@ -1158,9 +1160,11 @@ PASS expression_should_be_known: min-resolution: 1.5dppx
 PASS expression_should_be_known: min-resolution: 1.5x
 PASS expression_should_be_known: min-resolution: 2.0dppx
 PASS expression_should_be_known: min-resolution: 0dpi
-PASS expression_should_be_known: min-resolution: -3dpi
 PASS expression_should_be_known: min-resolution: 0dppx
 PASS expression_should_be_known: min-resolution: 0x
+PASS expression_should_be_known: min-resolution: calc(6x / 2)
+PASS expression_should_be_parseable: min-resolution: -3dpi
+PASS expression_should_be_unknown: min-resolution: -3dpi
 PASS expression_should_be_known: max-resolution: 3dpi
 PASS expression_should_be_known: max-resolution:3dpi
 PASS expression_should_be_known: max-resolution: 3.0dpi
@@ -1172,9 +1176,11 @@ PASS expression_should_be_known: max-resolution: 1.5dppx
 PASS expression_should_be_known: max-resolution: 1.5x
 PASS expression_should_be_known: max-resolution: 2.0dppx
 PASS expression_should_be_known: max-resolution: 0dpi
-PASS expression_should_be_known: max-resolution: -3dpi
 PASS expression_should_be_known: max-resolution: 0dppx
 PASS expression_should_be_known: max-resolution: 0x
+PASS expression_should_be_known: max-resolution: calc(6x / 2)
+PASS expression_should_be_parseable: max-resolution: -3dpi
+PASS expression_should_be_unknown: max-resolution: -3dpi
 PASS find_resolution
 PASS resolution is exact: should_apply: (resolution: ${resolution}dpi)
 PASS resolution is exact: should_apply: (resolution: ${Math.floor(resolution/96)}dppx)
@@ -1260,7 +1266,8 @@ PASS expression_should_be_known: overflow-block
 PASS expression_should_be_known: overflow-block: none
 PASS expression_should_be_known: overflow-block: paged
 PASS expression_should_be_known: overflow-block: scroll
-FAIL expression_should_be_known: overflow-block: optional-paged assert_true: expected true got false
+PASS expression_should_be_parseable: overflow-block: optional-paged
+PASS expression_should_be_unknown: overflow-block: optional-paged
 PASS expression_should_be_parseable: overflow-block: some-random-invalid-thing
 PASS expression_should_be_unknown: overflow-block: some-random-invalid-thing
 PASS Sanity check for overflow-block

--- a/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries.html
@@ -463,9 +463,10 @@ setup({ "explicit_done": true });
       expression_should_be_known(feature + ": 1.5x");
       expression_should_be_known(feature + ": 2.0dppx");
       expression_should_be_known(feature + ": 0dpi");
-      expression_should_be_known(feature + ": -3dpi");
       expression_should_be_known(feature + ": 0dppx");
       expression_should_be_known(feature + ": 0x");
+      expression_should_be_known(feature + ": calc(6x / 2)");
+      expression_should_be_unknown(feature + ": -3dpi");
     }
 
     // Find the resolution using max-resolution
@@ -589,7 +590,7 @@ setup({ "explicit_done": true });
     expression_should_be_known("overflow-block: none")
     expression_should_be_known("overflow-block: paged")
     expression_should_be_known("overflow-block: scroll")
-    expression_should_be_known("overflow-block: optional-paged")
+    expression_should_be_unknown("overflow-block: optional-paged")
     expression_should_be_unknown("overflow-block: some-random-invalid-thing")
 
     // Sanity check for overflow-block

--- a/Source/WebCore/css/query/GenericMediaQueryParser.cpp
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.cpp
@@ -250,7 +250,7 @@ bool GenericMediaQueryParserBase::validateFeatureAgainstSchema(Feature& feature,
             return primitiveValue->isLength();
 
         case FeatureSchema::ValueType::Resolution:
-            return primitiveValue && primitiveValue->isResolution();
+            return primitiveValue && primitiveValue->isResolution() && primitiveValue->doubleValue() >= 0;
 
         case FeatureSchema::ValueType::Identifier:
             return primitiveValue && primitiveValue->isValueID() && schema.valueIdentifiers.contains(primitiveValue->valueID());


### PR DESCRIPTION
#### a62f8b084d0a2c47115ea6f16d836acd46369bdd
<pre>
[MQ] Negative resolutions in media queries should not be known
<a href="https://bugs.webkit.org/show_bug.cgi?id=258250">https://bugs.webkit.org/show_bug.cgi?id=258250</a>
rdar://110948170

Reviewed by Darin Adler.

As per <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a> negative
resolutions are always invalid, even in media queries.

Sync relevant WPT from commit: <a href="https://github.com/web-platform-tests/wpt/commit/79cb3ca220e106346a6e64c09019e48e291a6ab6">https://github.com/web-platform-tests/wpt/commit/79cb3ca220e106346a6e64c09019e48e291a6ab6</a>

* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/mq-negative-range-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries.html:
* Source/WebCore/css/query/GenericMediaQueryParser.cpp:
(WebCore::MQ::GenericMediaQueryParserBase::validateFeatureAgainstSchema):

Canonical link: <a href="https://commits.webkit.org/265279@main">https://commits.webkit.org/265279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/751f4edc3c177287cf11b781952c7c9ae3910b65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10507 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13010 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12534 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8864 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12885 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10087 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9377 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->