### PR TITLE
REGRESSION(264714@main) 5% regression in Speedometer 3's Editor-TipTap suite

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
@@ -57,7 +57,10 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        m_string = createContextualizedCFString(string, priorContext);
+        if (priorContext.empty())
+            m_string = string.createCFStringWithoutCopying();
+        else
+            m_string = createContextualizedCFString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
     }

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -57,7 +57,7 @@ public:
             }
         }();
 
-        auto stringObject = createContextualizedCFString(string, priorContext);
+        auto stringObject = createString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
@@ -72,7 +72,7 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        auto stringObject = createContextualizedCFString(string, priorContext);
+        auto stringObject = createString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength));
@@ -114,6 +114,13 @@ public:
     }
 
 private:
+    RetainPtr<CFStringRef> createString(StringView string, StringView priorContext)
+    {
+        if (priorContext.empty())
+            return string.createCFStringWithoutCopying();
+        return createContextualizedCFString(string, priorContext);
+    }
+
     RetainPtr<CFStringTokenizerRef> m_stringTokenizer;
     unsigned long m_stringLength { 0 };
     unsigned long m_priorContextLength { 0 };


### PR DESCRIPTION
#### 34f838120c4799e51c5dccd4504e6945c5db67e1
<pre>
REGRESSION(264714@main) 5% regression in Speedometer 3&apos;s Editor-TipTap suite
<a href="https://bugs.webkit.org/show_bug.cgi?id=258259">https://bugs.webkit.org/show_bug.cgi?id=258259</a>
rdar://110926113

Reviewed by Ryosuke Niwa.

There&apos;s no need to use the fancy NSString subclass if there is no prior context.
The whole reason the NSString subclass exists is to deal with the prior context.
If we can use CFString directly, that&apos;s faster.

* Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h:
(WTF::TextBreakIteratorCFCharacterCluster::setText):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
(WTF::TextBreakIteratorCFStringTokenizer::setText):
(WTF::TextBreakIteratorCFStringTokenizer::createString):

Canonical link: <a href="https://commits.webkit.org/265280@main">https://commits.webkit.org/265280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7056bb30c22b1481439548249837c98a23a225f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13011 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11589 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12537 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9485 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8871 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12886 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9953 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10090 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10623 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9249 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2791 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2514 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13506 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10915 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9952 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2686 "Passed tests") | 
<!--EWS-Status-Bubble-End-->