### PR TITLE
[MQ][CQ] Schemas should use FixedVector instead of Vector

### DIFF
--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -35,7 +35,7 @@ namespace WebCore::CQ::Features {
 using namespace MQ;
 
 struct SizeFeatureSchema : public FeatureSchema {
-    SizeFeatureSchema(const AtomString& name, Type type, ValueType valueType, Vector<CSSValueID>&& valueIdentifiers = { })
+    SizeFeatureSchema(const AtomString& name, Type type, ValueType valueType, FixedVector<CSSValueID>&& valueIdentifiers = { })
         : FeatureSchema(name, type, valueType, WTFMove(valueIdentifiers))
     { }
 

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -86,11 +86,11 @@ struct FeatureSchema {
     AtomString name;
     Type type;
     ValueType valueType;
-    Vector<CSSValueID> valueIdentifiers;
+    FixedVector<CSSValueID> valueIdentifiers;
 
     virtual EvaluationResult evaluate(const Feature&, const FeatureEvaluationContext&) const { return EvaluationResult::Unknown; }
 
-    FeatureSchema(const AtomString& name, Type type, ValueType valueType, Vector<CSSValueID>&& valueIdentifiers = { })
+    FeatureSchema(const AtomString& name, Type type, ValueType valueType, FixedVector<CSSValueID>&& valueIdentifiers = { })
         : name(name)
         , type(type)
         , valueType(valueType)

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -150,7 +150,7 @@ using MatchingIdentifiers = Vector<CSSValueID, 1>;
 struct IdentifierSchema : public FeatureSchema {
     using ValueFunction = Function<MatchingIdentifiers(const FeatureEvaluationContext&)>;
 
-    IdentifierSchema(const AtomString& name, Vector<CSSValueID>&& valueIdentifiers, ValueFunction&& valueFunction)
+    IdentifierSchema(const AtomString& name, FixedVector<CSSValueID>&& valueIdentifiers, ValueFunction&& valueFunction)
         : FeatureSchema(name, FeatureSchema::Type::Discrete, FeatureSchema::ValueType::Identifier, WTFMove(valueIdentifiers))
         , valueFunction(WTFMove(valueFunction))
     { }
@@ -200,7 +200,7 @@ const FeatureSchema& anyHover()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "any-hover"_s,
-        Vector { CSSValueNone, CSSValueHover },
+        FixedVector { CSSValueNone, CSSValueHover },
         [](auto& context) {
             auto* page = context.document.frame()->page();
             bool isSupported = page && page->chrome().client().hoverSupportedByAnyAvailablePointingDevice();
@@ -214,7 +214,7 @@ const FeatureSchema& anyPointer()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "any-pointer"_s,
-        Vector { CSSValueNone, CSSValueFine, CSSValueCoarse },
+        FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         [](auto& context) {
             auto* page = context.document.frame()->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfAllAvailablePointingDevices() : OptionSet<PointerCharacteristics>();
@@ -262,7 +262,7 @@ const FeatureSchema& colorGamut()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "color-gamut"_s,
-        Vector { CSSValueSRGB, CSSValueP3, CSSValueRec2020 },
+        FixedVector { CSSValueSRGB, CSSValueP3, CSSValueRec2020 },
         [](auto& context) {
             auto& frame = *context.document.frame();
 
@@ -343,7 +343,7 @@ const FeatureSchema& dynamicRange()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "dynamic-range"_s,
-        Vector { CSSValueStandard, CSSValueHigh },
+        FixedVector { CSSValueStandard, CSSValueHigh },
         [](auto& context) {
             bool supportsHighDynamicRange = [&] {
                 auto& frame = *context.document.frame();
@@ -369,7 +369,7 @@ const FeatureSchema& forcedColors()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "forced-colors"_s,
-        Vector { CSSValueNone, CSSValueActive },
+        FixedVector { CSSValueNone, CSSValueActive },
         [](auto&) {
             return MatchingIdentifiers { CSSValueNone };
         }
@@ -404,7 +404,7 @@ const FeatureSchema& hover()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "hover"_s,
-        Vector { CSSValueNone, CSSValueHover },
+        FixedVector { CSSValueNone, CSSValueHover },
         [](auto& context) {
             auto* page = context.document.frame()->page();
             bool isSupported =  page && page->chrome().client().hoverSupportedByPrimaryPointingDevice();
@@ -418,7 +418,7 @@ const FeatureSchema& invertedColors()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "inverted-colors"_s,
-        Vector { CSSValueNone, CSSValueInverted },
+        FixedVector { CSSValueNone, CSSValueInverted },
         [](auto& context) {
             bool isInverted = [&] {
                 auto& frame = *context.document.frame();
@@ -462,7 +462,7 @@ const FeatureSchema& orientation()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "orientation"_s,
-        Vector { CSSValueLandscape, CSSValuePortrait },
+        FixedVector { CSSValueLandscape, CSSValuePortrait },
         [](auto& context) {
             auto& view = *context.document.view();
             // Square viewport is portrait.
@@ -477,7 +477,7 @@ const FeatureSchema& pointer()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "pointer"_s,
-        Vector { CSSValueNone, CSSValueFine, CSSValueCoarse },
+        FixedVector { CSSValueNone, CSSValueFine, CSSValueCoarse },
         [](auto& context) {
             auto* page = context.document.frame()->page();
             auto pointerCharacteristics = page ? page->chrome().client().pointerCharacteristicsOfPrimaryPointingDevice() : OptionSet<PointerCharacteristics>();
@@ -505,7 +505,7 @@ const FeatureSchema& prefersContrast()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "prefers-contrast"_s,
-        Vector { CSSValueNoPreference, CSSValueMore, CSSValueLess },
+        FixedVector { CSSValueNoPreference, CSSValueMore, CSSValueLess },
         [](auto& context) {
             bool userPrefersContrast = [&] {
                 auto& frame = *context.document.frame();
@@ -534,7 +534,7 @@ const FeatureSchema& prefersDarkInterface()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "prefers-dark-interface"_s,
-        Vector { CSSValueNoPreference, CSSValuePrefers },
+        FixedVector { CSSValueNoPreference, CSSValuePrefers },
         [](auto& context) {
             auto& frame = *context.document.frame();
             bool prefersDarkInterface = frame.page()->useSystemAppearance() && frame.page()->useDarkAppearance();
@@ -549,7 +549,7 @@ const FeatureSchema& prefersReducedMotion()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "prefers-reduced-motion"_s,
-        Vector { CSSValueNoPreference, CSSValueReduce },
+        FixedVector { CSSValueNoPreference, CSSValueReduce },
         [](auto& context) {
             bool userPrefersReducedMotion = [&] {
                 auto& frame = *context.document.frame();
@@ -589,7 +589,7 @@ const FeatureSchema& scan()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "scan"_s,
-        Vector { CSSValueInterlace, CSSValueProgressive },
+        FixedVector { CSSValueInterlace, CSSValueProgressive },
         [](auto&) {
             return MatchingIdentifiers { };
         }
@@ -601,7 +601,7 @@ const FeatureSchema& scripting()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "scripting"_s,
-        Vector { CSSValueNone, CSSValueInitialOnly, CSSValueEnabled },
+        FixedVector { CSSValueNone, CSSValueInitialOnly, CSSValueEnabled },
         [](auto& context) {
             auto& frame = *context.document.frame();
 
@@ -657,7 +657,7 @@ const FeatureSchema& update()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "update"_s,
-        Vector { CSSValueNone, CSSValueSlow, CSSValueFast },
+        FixedVector { CSSValueNone, CSSValueSlow, CSSValueFast },
         [](auto& context) {
             auto& frame = *context.document.frame();
             auto* frameView = frame.view();
@@ -702,7 +702,7 @@ const FeatureSchema& displayMode()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "display-mode"_s,
-        Vector { CSSValueFullscreen, CSSValueStandalone, CSSValueMinimalUi, CSSValueBrowser },
+        FixedVector { CSSValueFullscreen, CSSValueStandalone, CSSValueMinimalUi, CSSValueBrowser },
         [](auto& context) {
             auto identifier = [&] {
                 auto& frame = *context.document.frame();
@@ -735,7 +735,7 @@ const FeatureSchema& overflowBlock()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "overflow-block"_s,
-        Vector { CSSValueNone, CSSValueScroll, CSSValuePaged },
+        FixedVector { CSSValueNone, CSSValueScroll, CSSValuePaged },
         [](auto& context) {
             // FIXME: Match none when scrollEnabled is set to false by UIKit.
             bool matchesPaged = [&] {
@@ -755,7 +755,7 @@ const FeatureSchema& overflowInline()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "overflow-inline"_s,
-        Vector { CSSValueNone, CSSValueScroll },
+        FixedVector { CSSValueNone, CSSValueScroll },
         [](auto&) {
             // FIXME: Match none when scrollEnabled is set to false by UIKit.
             return MatchingIdentifiers { CSSValueScroll };
@@ -769,7 +769,7 @@ const FeatureSchema& prefersColorScheme()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
         "prefers-color-scheme"_s,
-        Vector { CSSValueLight, CSSValueDark },
+        FixedVector { CSSValueLight, CSSValueDark },
         [](auto& context) {
             auto& frame = *context.document.frame();
             bool useDarkAppearance = frame.page()->useDarkAppearance();


### PR DESCRIPTION
#### 1756a621d7942720c9f7ad1a007d33a8f0a6a4ff
<pre>
[MQ][CQ] Schemas should use FixedVector instead of Vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=258260">https://bugs.webkit.org/show_bug.cgi?id=258260</a>
rdar://110955636

Reviewed by Ryosuke Niwa.

The list of identifiers is fixed size, use a FixedVector which is more optimized for this case.

* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::Features::SizeFeatureSchema::SizeFeatureSchema):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
(WebCore::MQ::FeatureSchema::FeatureSchema):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::IdentifierSchema::IdentifierSchema):
(WebCore::MQ::Features::anyHover):
(WebCore::MQ::Features::anyPointer):
(WebCore::MQ::Features::colorGamut):
(WebCore::MQ::Features::dynamicRange):
(WebCore::MQ::Features::forcedColors):
(WebCore::MQ::Features::hover):
(WebCore::MQ::Features::invertedColors):
(WebCore::MQ::Features::orientation):
(WebCore::MQ::Features::pointer):
(WebCore::MQ::Features::prefersContrast):
(WebCore::MQ::Features::prefersDarkInterface):
(WebCore::MQ::Features::prefersReducedMotion):
(WebCore::MQ::Features::scan):
(WebCore::MQ::Features::scripting):
(WebCore::MQ::Features::update):
(WebCore::MQ::Features::displayMode):
(WebCore::MQ::Features::overflowBlock):
(WebCore::MQ::Features::overflowInline):
(WebCore::MQ::Features::prefersColorScheme):

Canonical link: <a href="https://commits.webkit.org/265282@main">https://commits.webkit.org/265282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a85b575613241623f5cb2312282b71b972c7ac99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10071 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13013 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12540 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16747 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12888 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9252 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->