### PR TITLE
MediaPlayer should inherit from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<>

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -127,8 +127,8 @@ public:
 private:
     template<typename, DestructionThread> friend class ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;
     template<typename T>
-    explicit ThreadSafeWeakPtrControlBlock(T& object)
-        : m_object(&object) { }
+    explicit ThreadSafeWeakPtrControlBlock(T* object)
+        : m_object(object) { }
 
     mutable Lock m_lock;
     mutable size_t m_strongReferenceCount WTF_GUARDED_BY_LOCK(m_lock) { 1 };
@@ -165,7 +165,11 @@ protected:
 private:
     template<typename> friend class ThreadSafeWeakPtr;
     template<typename> friend class ThreadSafeWeakHashSet;
-    ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock(static_cast<T&>(*this)) };
+#if COMPILER(MSVC)
+    ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock((T*)this) };
+#else
+    ThreadSafeWeakPtrControlBlock& m_controlBlock { *new ThreadSafeWeakPtrControlBlock(static_cast<T*>(this)) };
+#endif
 };
 
 template<typename T>

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
@@ -353,12 +353,13 @@ std::optional<KeyHandleValueVariant> CDMProxy::getOrWaitForKeyValue(const KeyIDT
 void CDMInstanceProxy::startedWaitingForKey()
 {
     ASSERT(!isMainThread());
-    ASSERT(m_player);
+    ASSERT(m_player.get());
 
     bool wasWaitingForKey = m_numDecryptorsWaitingForKey > 0;
     m_numDecryptorsWaitingForKey++;
 
-    callOnMainThread([player = m_player, wasWaitingForKey] {
+    callOnMainThread([weakPlayer = m_player, wasWaitingForKey] {
+        auto player = weakPlayer.get();
         if (player && !wasWaitingForKey)
             player->waitingForKeyChanged();
     });
@@ -367,12 +368,13 @@ void CDMInstanceProxy::startedWaitingForKey()
 void CDMInstanceProxy::stoppedWaitingForKey()
 {
     ASSERT(!isMainThread());
-    ASSERT(m_player);
+    ASSERT(m_player.get());
     ASSERT(m_numDecryptorsWaitingForKey > 0);
     m_numDecryptorsWaitingForKey--;
     bool isNobodyWaitingForKey = !m_numDecryptorsWaitingForKey;
 
-    callOnMainThread([player = m_player, isNobodyWaitingForKey] {
+    callOnMainThread([weakPlayer = m_player, isNobodyWaitingForKey] {
+        auto player = weakPlayer.get();
         if (player && isNobodyWaitingForKey)
             player->waitingForKeyChanged();
     });

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -255,7 +255,7 @@ public:
     // Media player query methods - main thread only.
     const RefPtr<CDMProxy>& proxy() const { ASSERT(isMainThread()); return m_cdmProxy; }
     virtual bool isWaitingForKey() const { ASSERT(isMainThread()); return m_numDecryptorsWaitingForKey > 0; }
-    void setPlayer(WeakPtr<MediaPlayer>&& player) { ASSERT(isMainThread()); m_player = WTFMove(player); }
+    void setPlayer(ThreadSafeWeakPtr<MediaPlayer>&& player) { ASSERT(isMainThread()); m_player = WTFMove(player); }
 
     // Proxy methods - must be thread-safe.
     void startedWaitingForKey();
@@ -263,7 +263,7 @@ public:
 
 private:
     RefPtr<CDMProxy> m_cdmProxy;
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
 
     std::atomic<int> m_numDecryptorsWaitingForKey { 0 };
 };

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -45,10 +45,9 @@
 #include <wtf/HashSet.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/URL.h>
 #include <wtf/WallTime.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/StringHash.h>
 
 OBJC_CLASS AVPlayer;
@@ -303,12 +302,12 @@ public:
 #endif
 };
 
-class WEBCORE_EXPORT MediaPlayer : public MediaPlayerEnums, public ThreadSafeRefCounted<MediaPlayer, WTF::DestructionThread::Main>, public CanMakeWeakPtr<MediaPlayer> {
+class WEBCORE_EXPORT MediaPlayer : public MediaPlayerEnums, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MediaPlayer, WTF::DestructionThread::Main> {
     WTF_MAKE_NONCOPYABLE(MediaPlayer); WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<MediaPlayer> create(MediaPlayerClient&);
     static Ref<MediaPlayer> create(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
-    virtual ~MediaPlayer();
+    ~MediaPlayer();
 
     void invalidate();
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,6 @@
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/LoggerHelper.h>
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -308,8 +307,7 @@ protected:
 
     const String& assetURL() const { return m_assetURL.string(); }
 
-    MediaPlayer* player() { return m_player.get(); }
-    const MediaPlayer* player() const { return m_player.get(); }
+    RefPtr<MediaPlayer> player() const { return m_player.get(); }
 
     String engineDescription() const override { return "AVFoundation"_s; }
     long platformErrorCode() const override { return assetErrorCode(); }
@@ -334,7 +332,7 @@ protected:
     bool shouldEnableInheritURIQueryComponent() const;
 
 private:
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
 
     Function<void()> m_pendingSeek;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -634,6 +634,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     if (!m_avPlayer)
         return;
 
+    auto player = this->player();
+    if (!player)
+        return;
+
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_videoLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
@@ -642,12 +646,12 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     [m_videoLayer setName:@"MediaPlayerPrivate AVPlayerLayer"];
     [m_videoLayer addObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay" options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextAVPlayerLayer];
     updateVideoLayerGravity();
-    [m_videoLayer setContentsScale:player()->playerContentsScale()];
-    m_videoLayerManager->setVideoLayer(m_videoLayer.get(), player()->videoInlineSize());
+    [m_videoLayer setContentsScale:player->playerContentsScale()];
+    m_videoLayerManager->setVideoLayer(m_videoLayer.get(), player->videoInlineSize());
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     if ([m_videoLayer respondsToSelector:@selector(setPIPModeEnabled:)])
-        [m_videoLayer setPIPModeEnabled:(player()->fullscreenMode() & MediaPlayer::VideoFullscreenModePictureInPicture)];
+        [m_videoLayer setPIPModeEnabled:(player->fullscreenMode() & MediaPlayer::VideoFullscreenModePictureInPicture)];
 #endif
 
     setNeedsRenderingModeChanged();
@@ -726,7 +730,11 @@ void MediaPlayerPrivateAVFoundationObjC::notifyTrackModeChanged()
 
 void MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState()
 {
-    const auto& outOfBandTrackSources = player()->outOfBandTrackSources();
+    auto player = this->player();
+    if (!player)
+        return;
+
+    const auto& outOfBandTrackSources = player->outOfBandTrackSources();
 
     for (auto& textTrack : m_textTracks) {
         if (textTrack->textTrackCategory() != InbandTextTrackPrivateAVF::OutOfBand)
@@ -785,7 +793,11 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url)
         return;
     }
 
-    player()->getRawCookies(url, [this, weakThis = WeakPtr { *this }, options = WTFMove(options), url] (auto cookies) mutable {
+    auto player = this->player();
+    if (!player)
+        return;
+
+    player->getRawCookies(url, [this, weakThis = WeakPtr { *this }, options = WTFMove(options), url] (auto cookies) mutable {
         if (!weakThis)
             return;
 
@@ -869,6 +881,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    auto player = this->player();
+    if (!player)
+        return;
+
     m_createAssetPending = false;
 
     if (m_avAsset)
@@ -880,11 +896,11 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
 
     RetainPtr<NSMutableDictionary> headerFields = adoptNS([[NSMutableDictionary alloc] init]);
 
-    String referrer = player()->referrer();
+    String referrer = player->referrer();
     if (!referrer.isEmpty())
         [headerFields setObject:referrer forKey:@"Referer"];
 
-    String userAgent = player()->userAgent();
+    String userAgent = player->userAgent();
     if (!userAgent.isEmpty())
         [headerFields setObject:userAgent forKey:@"User-Agent"];
 
@@ -900,20 +916,20 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     else if (PAL::canLoad_AVFoundation_AVURLAssetRequiresCustomURLLoadingKey())
         [options setObject:@YES forKey:AVURLAssetRequiresCustomURLLoadingKey];
     // FIXME: rdar://problem/20354688
-    String identifier = player()->sourceApplicationIdentifier();
+    String identifier = player->sourceApplicationIdentifier();
     if (!identifier.isEmpty())
         [options setObject:identifier forKey:AVURLAssetClientBundleIdentifierKey];
 #endif
-    if (player()->prefersSandboxedParsing() && PAL::canLoad_AVFoundation_AVAssetPrefersSandboxedParsingOptionKey())
+    if (player->prefersSandboxedParsing() && PAL::canLoad_AVFoundation_AVAssetPrefersSandboxedParsingOptionKey())
         [options setObject:@YES forKey:AVAssetPrefersSandboxedParsingOptionKey];
 
-    auto type = player()->contentMIMEType();
+    auto type = player->contentMIMEType();
 
     // Don't advertise WebM MIME types or the format reader won't be loaded until rdar://72405127 is fixed.
     auto willUseWebMFormatReader = willUseWebMFormatReaderForType(type);
 
-    if (PAL::canLoad_AVFoundation_AVURLAssetOutOfBandMIMETypeKey() && !type.isEmpty() && !player()->contentMIMETypeWasInferredFromExtension() && !willUseWebMFormatReader) {
-        auto codecs = player()->contentTypeCodecs();
+    if (PAL::canLoad_AVFoundation_AVURLAssetOutOfBandMIMETypeKey() && !type.isEmpty() && !player->contentMIMETypeWasInferredFromExtension() && !willUseWebMFormatReader) {
+        auto codecs = player->contentTypeCodecs();
         if (!codecs.isEmpty()) {
             NSString *typeString = [NSString stringWithFormat:@"%@; codecs=\"%@\"", (NSString *)type, (NSString *)codecs];
             [options setObject:typeString forKey:AVURLAssetOutOfBandMIMETypeKey];
@@ -922,7 +938,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     }
 
 #if ENABLE(AVF_CAPTIONS)
-    auto outOfBandTrackSources = player()->outOfBandTrackSources();
+    auto outOfBandTrackSources = player->outOfBandTrackSources();
     if (!outOfBandTrackSources.isEmpty()) {
         auto outOfBandTracks = createNSArray(outOfBandTrackSources, [] (auto& trackSource) {
             return @{
@@ -940,22 +956,22 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    String networkInterfaceName = player()->mediaPlayerNetworkInterfaceName();
+    String networkInterfaceName = player->mediaPlayerNetworkInterfaceName();
     if (!networkInterfaceName.isEmpty())
         [options setObject:networkInterfaceName forKey:AVURLAssetBoundNetworkInterfaceName];
 #endif
 
-    bool usePersistentCache = player()->shouldUsePersistentCache();
+    bool usePersistentCache = player->shouldUsePersistentCache();
     [options setObject:@(!usePersistentCache) forKey:AVURLAssetUsesNoPersistentCacheKey];
 
     if (usePersistentCache) {
-        if (auto* assetCache = ensureAssetCacheExistsForPath(player()->mediaCacheDirectory()))
+        if (auto* assetCache = ensureAssetCacheExistsForPath(player->mediaCacheDirectory()))
             [options setObject:assetCache forKey:AVURLAssetCacheKey];
         else
             [options setObject:@NO forKey:AVURLAssetUsesNoPersistentCacheKey];
     }
 
-    auto allowedMediaContainerTypes = player()->allowedMediaContainerTypes();
+    auto allowedMediaContainerTypes = player->allowedMediaContainerTypes();
     if (allowedMediaContainerTypes && PAL::canLoad_AVFoundation_AVURLAssetAllowableTypeCategoriesKey()) {
         auto nsTypes = adoptNS([[NSMutableArray alloc] init]);
         for (auto type : *allowedMediaContainerTypes)
@@ -963,7 +979,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
         [options setObject:nsTypes.get() forKey:AVURLAssetAllowableTypeCategoriesKey];
     }
 
-    auto allowedMediaAudioCodecIDs = player()->allowedMediaAudioCodecIDs();
+    auto allowedMediaAudioCodecIDs = player->allowedMediaAudioCodecIDs();
     if (allowedMediaAudioCodecIDs && PAL::canLoad_AVFoundation_AVURLAssetAllowableAudioCodecTypesKey()) {
         auto nsTypes = adoptNS([[NSMutableArray alloc] init]);
         for (auto type : *allowedMediaAudioCodecIDs)
@@ -971,7 +987,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
         [options setObject:nsTypes.get() forKey:AVURLAssetAllowableAudioCodecTypesKey];
     }
 
-    auto allowedMediaVideoCodecIDs = player()->allowedMediaVideoCodecIDs();
+    auto allowedMediaVideoCodecIDs = player->allowedMediaVideoCodecIDs();
     if (allowedMediaVideoCodecIDs && PAL::canLoad_AVFoundation_AVURLAssetAllowableVideoCodecTypesKey()) {
         auto nsTypes = adoptNS([[NSMutableArray alloc] init]);
         for (auto type : *allowedMediaVideoCodecIDs)
@@ -979,7 +995,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
         [options setObject:nsTypes.get() forKey:AVURLAssetAllowableVideoCodecTypesKey];
     }
 
-    auto allowedMediaCaptionFormatTypes = player()->allowedMediaCaptionFormatTypes();
+    auto allowedMediaCaptionFormatTypes = player->allowedMediaCaptionFormatTypes();
     if (allowedMediaCaptionFormatTypes && PAL::canLoad_AVFoundation_AVURLAssetAllowableCaptionFormatsKey()) {
         auto nsTypes = adoptNS([[NSMutableArray alloc] init]);
         for (auto type : *allowedMediaCaptionFormatTypes)
@@ -1016,7 +1032,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
     AVAssetResourceLoader *resourceLoader = m_avAsset.get().resourceLoader;
     [resourceLoader setDelegate:m_loaderDelegate.get() queue:globalLoaderDelegateQueue()];
 
-    if (auto mediaResourceLoader = player()->createResourceLoader())
+    if (auto mediaResourceLoader = player->createResourceLoader())
         resourceLoader.URLSession = (NSURLSession *)adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:*mediaResourceLoader delegate:resourceLoader.URLSessionDataDelegate delegateQueue:resourceLoader.URLSessionDataDelegateQueue]).get();
 
     [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver.get() selector:@selector(chapterMetadataDidChange:) name:AVAssetChapterMetadataGroupsDidChangeNotification object:m_avAsset.get()];
@@ -1071,6 +1087,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
     if (m_avPlayer)
         return;
 
+    auto player = this->player();
+    if (!player)
+        return;
+
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setDelayCallbacks(true);
@@ -1085,11 +1105,11 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
     m_avPlayer.get().appliesMediaSelectionCriteriaAutomatically = NO;
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
     if ([m_avPlayer respondsToSelector:@selector(setVideoRangeOverride:)])
-        m_avPlayer.get().videoRangeOverride = convertDynamicRangeModeEnumToAVVideoRange(player()->preferredDynamicRangeMode());
+        m_avPlayer.get().videoRangeOverride = convertDynamicRangeModeEnumToAVVideoRange(player->preferredDynamicRangeMode());
 #endif
 
     if ([m_videoLayer respondsToSelector:@selector(setToneMapToStandardDynamicRange:)])
-        [m_videoLayer setToneMapToStandardDynamicRange:player()->shouldDisableHDR()];
+        [m_videoLayer setToneMapToStandardDynamicRange:player->shouldDisableHDR()];
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     updateDisableExternalPlayback();
@@ -1105,7 +1125,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
 #endif
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST)
-    setShouldDisableSleep(player()->shouldDisableSleep());
+    setShouldDisableSleep(player->shouldDisableSleep());
 
     if ([m_avPlayer respondsToSelector:@selector(setPreventsAutomaticBackgroundingDuringVideoPlayback:)])
         m_avPlayer.get().preventsAutomaticBackgroundingDuringVideoPlayback = NO;
@@ -1115,7 +1135,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
         [m_avPlayer setMuted:m_muted];
 
 #if HAVE(AVPLAYER_SUPRESSES_AUDIO_RENDERING)
-        if (player()->isVideoPlayer())
+        if (player->isVideoPlayer())
             m_avPlayer.get().suppressesAudioRendering = YES;
 #endif
     }
@@ -1124,7 +1144,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
         setAVPlayerItem(m_avPlayerItem.get());
 
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
-    auto audioOutputDeviceId = player()->audioOutputDeviceIdOverride();
+    auto audioOutputDeviceId = player->audioOutputDeviceIdOverride();
     if (!audioOutputDeviceId.isNull()) {
         if (audioOutputDeviceId.isEmpty())
             m_avPlayer.get().audioOutputDeviceUniqueID = nil;
@@ -1164,6 +1184,10 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
     if (m_avPlayerItem)
         return;
 
+    auto player = this->player();
+    if (!player)
+        return;
+
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setDelayCallbacks(true);
@@ -1181,7 +1205,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
         [m_avPlayerItem addObserver:m_objcObserver.get() forKeyPath:keyName options:options context:(void *)MediaPlayerAVFoundationObservationContextPlayerItem];
     }
 
-    [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player()->pitchCorrectionAlgorithm(), player()->preservesPitch(), m_requestedRate)];
+    [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate)];
 
 #if HAVE(AVFOUNDATION_INTERSTITIAL_EVENTS)
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
@@ -1475,7 +1499,8 @@ void MediaPlayerPrivateAVFoundationObjC::checkNewVideoFrameMetadata()
     if (!updateLastPixelBuffer() && !m_videoFrameMetadata)
         return;
 
-    player()->onNewVideoFrameMetadata(WTFMove(*m_videoFrameMetadata), m_lastPixelBuffer.get());
+    if (auto player = this->player())
+        player->onNewVideoFrameMetadata(WTFMove(*m_videoFrameMetadata), m_lastPixelBuffer.get());
 }
 
 void MediaPlayerPrivateAVFoundationObjC::stopVideoFrameMetadataGathering()
@@ -1641,7 +1666,8 @@ void MediaPlayerPrivateAVFoundationObjC::setPlayerRate(double rate, std::optiona
 {
     setDelayCallbacks(true);
 
-    [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player()->pitchCorrectionAlgorithm(), player()->preservesPitch(), m_requestedRate)];
+    if (auto player = this->player())
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate)];
 
     setShouldObserveTimeControlStatus(false);
 
@@ -1708,14 +1734,16 @@ double MediaPlayerPrivateAVFoundationObjC::liveUpdateInterval() const
 
 void MediaPlayerPrivateAVFoundationObjC::setPreservesPitch(bool preservesPitch)
 {
-    if (m_avPlayerItem)
-        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player()->pitchCorrectionAlgorithm(), preservesPitch, m_requestedRate)];
+    auto player = this->player();
+    if (m_avPlayerItem && player)
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), preservesPitch, m_requestedRate)];
 }
 
 void MediaPlayerPrivateAVFoundationObjC::setPitchCorrectionAlgorithm(MediaPlayer::PitchCorrectionAlgorithm pitchCorrectionAlgorithm)
 {
-    if (m_avPlayerItem)
-        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(pitchCorrectionAlgorithm, player()->preservesPitch(), m_requestedRate)];
+    auto player = this->player();
+    if (m_avPlayerItem && player)
+        [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(pitchCorrectionAlgorithm, player->preservesPitch(), m_requestedRate)];
 }
 
 const PlatformTimeRanges& MediaPlayerPrivateAVFoundationObjC::platformBufferedTimeRanges() const
@@ -1839,7 +1867,11 @@ bool MediaPlayerPrivateAVFoundationObjC::containsDisabledTracks() const
 
 bool MediaPlayerPrivateAVFoundationObjC::trackIsPlayable(AVAssetTrack* track) const
 {
-    if (player()->shouldCheckHardwareSupport() && !assetTrackMeetsHardwareDecodeRequirements(track, player()->mediaContentTypesRequiringHardwareSupport()))
+    auto player = this->player();
+    if (!player)
+        return false;
+
+    if (player->shouldCheckHardwareSupport() && !assetTrackMeetsHardwareDecodeRequirements(track, player->mediaContentTypesRequiringHardwareSupport()))
         return false;
 
     auto description = retainPtr((__bridge CMFormatDescriptionRef)track.formatDescriptions.firstObject);
@@ -1850,7 +1882,7 @@ bool MediaPlayerPrivateAVFoundationObjC::trackIsPlayable(AVAssetTrack* track) co
     auto codecType = FourCC { PAL::CMFormatDescriptionGetMediaSubType(description.get()) };
     switch (PAL::CMFormatDescriptionGetMediaType(description.get())) {
     case kCMMediaType_Video: {
-        auto& allowedMediaVideoCodecIDs = player()->allowedMediaVideoCodecIDs();
+        auto& allowedMediaVideoCodecIDs = player->allowedMediaVideoCodecIDs();
         if (allowedMediaVideoCodecIDs && !allowedMediaVideoCodecIDs->contains(codecType)) {
             ERROR_LOG(LOGIDENTIFIER, "Video track with codec type '", codecType, "' not contained in allowed codec list; blocking");
             return false;
@@ -1858,7 +1890,7 @@ bool MediaPlayerPrivateAVFoundationObjC::trackIsPlayable(AVAssetTrack* track) co
         return true;
     }
     case kCMMediaType_Audio: {
-        auto& allowedMediaAudioCodecIDs = player()->allowedMediaAudioCodecIDs();
+        auto& allowedMediaAudioCodecIDs = player->allowedMediaAudioCodecIDs();
         if (allowedMediaAudioCodecIDs && !allowedMediaAudioCodecIDs->contains(codecType)) {
             ERROR_LOG(LOGIDENTIFIER, "Audio track with codec type '", codecType, "' not contained in allowed codec list; blocking");
             return false;
@@ -1868,7 +1900,7 @@ bool MediaPlayerPrivateAVFoundationObjC::trackIsPlayable(AVAssetTrack* track) co
     case kCMMediaType_Text:
     case kCMMediaType_ClosedCaption:
     case kCMMediaType_Subtitle: {
-        auto& allowedMediaCaptionFormatTypes = player()->allowedMediaCaptionFormatTypes();
+        auto& allowedMediaCaptionFormatTypes = player->allowedMediaCaptionFormatTypes();
         if (allowedMediaCaptionFormatTypes && !allowedMediaCaptionFormatTypes->contains(codecType)) {
             ERROR_LOG(LOGIDENTIFIER, "Text track with codec type '", codecType, "' not contained in allowed codec list; blocking");
             return false;
@@ -2101,6 +2133,10 @@ static void fulfillRequestWithKeyData(AVAssetResourceLoadingRequest *request, Ar
 
 bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetResourceLoadingRequest* avRequest)
 {
+    auto player = this->player();
+    if (!player)
+        return false;
+
     String scheme = [[[avRequest request] URL] scheme];
     String keyURI = [[[avRequest request] URL] absoluteString];
 
@@ -2120,9 +2156,9 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
         keyURIArray->setRange(reinterpret_cast<const UniChar*>(StringView(keyURI).upconvertedCharacters().get()), keyURI.length() / sizeof(unsigned char), 0);
 
         auto initData = SharedBuffer::create(Vector<uint8_t> { static_cast<uint8_t*>(initDataBuffer->data()), byteLength });
-        player()->keyNeeded(initData);
+        player->keyNeeded(initData);
 #if ENABLE(ENCRYPTED_MEDIA)
-        if (!player()->shouldContinueAfterKeyNeeded())
+        if (!player->shouldContinueAfterKeyNeeded())
             return true;
 #endif
 #endif
@@ -2136,7 +2172,7 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
 
         RetainPtr<NSData> keyURIData = [keyURI dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
         m_keyID = SharedBuffer::create(keyURIData.get());
-        player()->initializationDataEncountered("skd"_s, m_keyID->tryCreateArrayBuffer());
+        player->initializationDataEncountered("skd"_s, m_keyID->tryCreateArrayBuffer());
         setWaitingForKey(true);
 #endif
         m_keyURIToRequestMap.set(keyURI, avRequest);
@@ -2150,15 +2186,15 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
         auto encodedKeyId = PAL::TextCodecUTF8::encodeUTF8(keyID);
         auto initData = SharedBuffer::create(WTFMove(encodedKeyId));
 
-        auto keyData = player()->cachedKeyForKeyId(keyID);
+        auto keyData = player->cachedKeyForKeyId(keyID);
         if (keyData) {
             fulfillRequestWithKeyData(avRequest, keyData.get());
             return false;
         }
 
-        player()->keyNeeded(initData);
+        player->keyNeeded(initData);
 
-        if (!player()->shouldContinueAfterKeyNeeded())
+        if (!player->shouldContinueAfterKeyNeeded())
             return false;
 
         m_keyURIToRequestMap.set(keyID, avRequest);
@@ -2247,6 +2283,7 @@ void MediaPlayerPrivateAVFoundationObjC::metadataLoaded()
 void MediaPlayerPrivateAVFoundationObjC::processChapterTracks()
 {
     ASSERT(m_avAsset);
+    auto player = this->player();
 
     for (NSLocale *locale in [m_avAsset availableChapterLocales]) {
 
@@ -2259,7 +2296,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         String language = [locale localeIdentifier];
         auto track = m_chapterTracks.ensure(language, [&]() {
             auto track = InbandChapterTrackPrivateAVFObjC::create(locale);
-            player()->addTextTrack(track.get());
+            if (player)
+                player->addTextTrack(track.get());
             return track;
         }).iterator->value;
 
@@ -2390,7 +2428,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateRotationSession()
 }
 
 template <typename RefT, typename PassRefT>
-void determineChangedTracksFromNewTracksAndOldItems(NSArray* tracks, NSString* trackType, Vector<RefT>& oldItems, RefT (*itemFactory)(AVPlayerItemTrack*), MediaPlayer* player, void (MediaPlayer::*removedFunction)(PassRefT), void (MediaPlayer::*addedFunction)(PassRefT))
+void determineChangedTracksFromNewTracksAndOldItems(NSArray* tracks, NSString* trackType, Vector<RefT>& oldItems, RefT (*itemFactory)(AVPlayerItemTrack*), RefPtr<MediaPlayer>& player, void (MediaPlayer::*removedFunction)(PassRefT), void (MediaPlayer::*addedFunction)(PassRefT))
 {
     RetainPtr<NSSet> newTracks = adoptNS([[NSSet alloc] initWithArray:[tracks objectsAtIndexes:[tracks indexesOfObjectsPassingTest:^(id track, NSUInteger, BOOL*){
         return [[[track assetTrack] mediaType] isEqualToString:trackType];
@@ -2426,15 +2464,17 @@ void determineChangedTracksFromNewTracksAndOldItems(NSArray* tracks, NSString* t
     replacementItems.appendVector(addedItems);
     oldItems.swap(replacementItems);
 
-    for (auto& removedItem : removedItems)
-        (player->*removedFunction)(*removedItem);
+    if (player) {
+        for (auto& removedItem : removedItems)
+            (player.get()->*removedFunction)(*removedItem);
 
-    for (auto& addedItem : addedItems)
-        (player->*addedFunction)(*addedItem);
+        for (auto& addedItem : addedItems)
+            (player.get()->*addedFunction)(*addedItem);
+    }
 }
 
 template <typename RefT, typename PassRefT>
-void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* group, Vector<RefT>& oldItems, const Vector<String>& characteristics, RefT (*itemFactory)(MediaSelectionOptionAVFObjC&), MediaPlayer* player, void (MediaPlayer::*removedFunction)(PassRefT), void (MediaPlayer::*addedFunction)(PassRefT))
+void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* group, Vector<RefT>& oldItems, const Vector<String>& characteristics, RefT (*itemFactory)(MediaSelectionOptionAVFObjC&), RefPtr<MediaPlayer>& player, void (MediaPlayer::*removedFunction)(PassRefT), void (MediaPlayer::*addedFunction)(PassRefT))
 {
     group->updateOptions(characteristics);
 
@@ -2486,27 +2526,33 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
     replacementItems.appendVector(addedItems);
     oldItems.swap(replacementItems);
 
-    for (auto& removedItem : removedItems)
-        (player->*removedFunction)(*removedItem);
+    if (player) {
+        for (auto& removedItem : removedItems)
+            (player.get()->*removedFunction)(*removedItem);
 
-    for (auto& addedItem : addedItems)
-        (player->*addedFunction)(*addedItem);
+        for (auto& addedItem : addedItems)
+            (player.get()->*addedFunction)(*addedItem);
+    }
 }
 
 void MediaPlayerPrivateAVFoundationObjC::updateAudioTracks()
 {
+    auto player = this->player();
+    if (!player)
+        return;
+
     size_t count = m_audioTracks.size();
 
-    Vector<String> characteristics = player()->preferredAudioCharacteristics();
+    Vector<String> characteristics = player->preferredAudioCharacteristics();
     if (!m_audibleGroup) {
         if (AVMediaSelectionGroup *group = safeMediaSelectionGroupForAudibleMedia())
             m_audibleGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group, characteristics);
     }
 
     if (m_audibleGroup)
-        determineChangedTracksFromNewTracksAndOldItems(m_audibleGroup.get(), m_audioTracks, characteristics, &AudioTrackPrivateAVFObjC::create, player(), &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
+        determineChangedTracksFromNewTracksAndOldItems(m_audibleGroup.get(), m_audioTracks, characteristics, &AudioTrackPrivateAVFObjC::create, player, &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
     else
-        determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeAudio, m_audioTracks, &AudioTrackPrivateAVFObjC::create, player(), &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
+        determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeAudio, m_audioTracks, &AudioTrackPrivateAVFObjC::create, player, &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
 
     for (auto& track : m_audioTracks)
         track->resetPropertiesFromTrack();
@@ -2516,9 +2562,13 @@ void MediaPlayerPrivateAVFoundationObjC::updateAudioTracks()
 
 void MediaPlayerPrivateAVFoundationObjC::updateVideoTracks()
 {
+    auto player = this->player();
+    if (!player)
+        return;
+
     size_t count = m_videoTracks.size();
 
-    determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeVideo, m_videoTracks, &VideoTrackPrivateAVFObjC::create, player(), &MediaPlayer::removeVideoTrack, &MediaPlayer::addVideoTrack);
+    determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeVideo, m_videoTracks, &VideoTrackPrivateAVFObjC::create, player, &MediaPlayer::removeVideoTrack, &MediaPlayer::addVideoTrack);
 
     if (!m_visualGroup) {
         if (AVMediaSelectionGroup *group = safeMediaSelectionGroupForVisualMedia())
@@ -2526,7 +2576,7 @@ void MediaPlayerPrivateAVFoundationObjC::updateVideoTracks()
     }
 
     if (m_visualGroup)
-        determineChangedTracksFromNewTracksAndOldItems(m_visualGroup.get(), m_videoTracks, Vector<String>(), &VideoTrackPrivateAVFObjC::create, player(), &MediaPlayer::removeVideoTrack, &MediaPlayer::addVideoTrack);
+        determineChangedTracksFromNewTracksAndOldItems(m_visualGroup.get(), m_videoTracks, Vector<String>(), &VideoTrackPrivateAVFObjC::create, player, &MediaPlayer::removeVideoTrack, &MediaPlayer::addVideoTrack);
 
     for (auto& track : m_videoTracks)
         track->resetPropertiesFromTrack();
@@ -2821,13 +2871,17 @@ RetainPtr<AVAssetResourceLoadingRequest> MediaPlayerPrivateAVFoundationObjC::tak
 
 void MediaPlayerPrivateAVFoundationObjC::keyAdded()
 {
+    auto player = this->player();
+    if (!player)
+        return;
+
     Vector<String> fulfilledKeyIds;
 
     for (auto& pair : m_keyURIToRequestMap) {
         const String& keyId = pair.key;
         const RetainPtr<AVAssetResourceLoadingRequest>& request = pair.value;
 
-        auto keyData = player()->cachedKeyForKeyId(keyId);
+        auto keyData = player->cachedKeyForKeyId(keyId);
         if (!keyData)
             continue;
 
@@ -2923,7 +2977,8 @@ void MediaPlayerPrivateAVFoundationObjC::setWaitingForKey(bool waitingForKey)
         return;
 
     m_waitingForKey = waitingForKey;
-    player()->waitingForKeyChanged();
+    if (auto player = this->player())
+        player->waitingForKeyChanged();
 }
 #endif
 
@@ -3070,7 +3125,8 @@ void MediaPlayerPrivateAVFoundationObjC::processMetadataTrack()
 
     m_metadataTrack = InbandMetadataTextTrackPrivateAVF::create(InbandTextTrackPrivate::Kind::Metadata, InbandTextTrackPrivate::CueFormat::Data);
     m_metadataTrack->setInBandMetadataTrackDispatchType("com.apple.streaming"_s);
-    player()->addTextTrack(*m_metadataTrack);
+    if (auto player = this->player())
+        player->addTextTrack(*m_metadataTrack);
 }
 
 void MediaPlayerPrivateAVFoundationObjC::processCue(NSArray *attributedStrings, NSArray *nativeSamples, const MediaTime& time)
@@ -3391,8 +3447,9 @@ void MediaPlayerPrivateAVFoundationObjC::updateDisableExternalPlayback()
     if (!m_avPlayer)
         return;
 
-    if ([m_avPlayer respondsToSelector:@selector(setUsesExternalPlaybackWhileExternalScreenIsActive:)])
-        [m_avPlayer setUsesExternalPlaybackWhileExternalScreenIsActive:(player()->fullscreenMode() == MediaPlayer::VideoFullscreenModeStandard) || player()->isVideoFullscreenStandby()];
+    auto player = this->player();
+    if (player && [m_avPlayer respondsToSelector:@selector(setUsesExternalPlaybackWhileExternalScreenIsActive:)])
+        [m_avPlayer setUsesExternalPlaybackWhileExternalScreenIsActive:(player->fullscreenMode() == MediaPlayer::VideoFullscreenModeStandard) || player->isVideoFullscreenStandby()];
 #endif
 }
 
@@ -3732,7 +3789,8 @@ void MediaPlayerPrivateAVFoundationObjC::timeControlStatusDidChange(int timeCont
     bool playerIsPlaying = m_cachedTimeControlStatus != AVPlayerTimeControlStatusPaused;
     if (playerIsPlaying != m_requestedPlaying) {
         m_requestedPlaying = playerIsPlaying;
-        player()->playbackStateChanged();
+        if (auto player = this->player())
+            player->playbackStateChanged();
     }
 #endif
 }
@@ -3851,9 +3909,10 @@ void MediaPlayerPrivateAVFoundationObjC::setShouldDisableHDR(bool shouldDisable)
 void MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged()
 {
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
-    if (!m_avPlayer || !player())
+    auto player = this->player();
+    if (!m_avPlayer || !player)
         return;
-    auto deviceId = player()->audioOutputDeviceId();
+    auto deviceId = player->audioOutputDeviceId();
     if (deviceId.isEmpty())
         m_avPlayer.get().audioOutputDeviceUniqueID = nil;
     else

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -315,7 +315,7 @@ private:
     };
     std::unique_ptr<PendingSeek> m_pendingSeek;
 
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     WeakPtrFactory<MediaPlayerPrivateMediaSourceAVFObjC> m_sizeChangeObserverWeakPtrFactory;
     RefPtr<MediaSourcePrivateAVFObjC> m_mediaSourcePrivate;
     RetainPtr<AVAsset> m_asset;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -235,7 +235,7 @@ private:
     LayerHostingContextID hostingContextID() const final;
     void setVideoInlineSizeFenced(const FloatSize&, const WTF::MachSendRight&) final;
 
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MediaStreamPrivate> m_mediaStreamPrivate;
     RefPtr<VideoTrackPrivateMediaStream> m_activeVideoTrack;
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -254,7 +254,7 @@ private:
     static void getSupportedTypes(HashSet<String, ASCIICaseInsensitiveHash>&);
     static MediaPlayer::SupportsType supportsType(const MediaEngineSupportParameters&);
 
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     RetainPtr<AVSampleBufferRenderSynchronizer> m_synchronizer;
     RetainPtr<id> m_durationObserver;
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -331,7 +331,7 @@ protected:
 #endif
 
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     String m_referrer;
     mutable std::optional<MediaTime> m_cachedPosition;
     mutable MediaTime m_cachedDuration;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -121,7 +121,8 @@ void MediaPlayerPrivateGStreamerMSE::load(const String&)
 {
     // This media engine only supports MediaSource URLs.
     m_networkState = MediaPlayer::NetworkState::FormatError;
-    m_player->networkStateChanged();
+    if (auto player = m_player.get())
+        player->networkStateChanged();
 }
 
 void MediaPlayerPrivateGStreamerMSE::load(const URL& url, const ContentType&, MediaSourcePrivateClient& mediaSource)
@@ -201,7 +202,8 @@ void MediaPlayerPrivateGStreamerMSE::setNetworkState(MediaPlayer::NetworkState n
     m_mediaSourceNetworkState = networkState;
     m_networkState = networkState;
     updateStates();
-    m_player->networkStateChanged();
+    if (auto player = m_player.get())
+        player->networkStateChanged();
 }
 
 void MediaPlayerPrivateGStreamerMSE::setReadyState(MediaPlayer::ReadyState mediaSourceReadyState)
@@ -232,12 +234,14 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
 
     m_readyState = m_mediaSourceReadyState;
     updateStates(); // Set the pipeline to PLAYING or PAUSED if necessary.
-    m_player->readyStateChanged();
+    auto player = m_player.get();
+    if (player)
+        player->readyStateChanged();
 
     // The readyState change may be a result of monitorSourceBuffers() finding that currentTime == duration, which
     // should cause the video to be marked as ended. Let's have the player check that.
-    if (!m_isWaitingForPreroll || currentMediaTime() == durationMediaTime())
-        m_player->timeChanged();
+    if (player && (!m_isWaitingForPreroll || currentMediaTime() == durationMediaTime()))
+        player->timeChanged();
 }
 
 void MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone()
@@ -264,7 +268,8 @@ void MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone()
         m_isSeeking = false;
         GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentMediaTime().toString().utf8().data());
         // By calling timeChanged(), m_isSeeking will be checked an a "seeked" event will be emitted.
-        m_player->timeChanged();
+        if (auto player = m_player.get())
+            player->timeChanged();
     }
 
     propagateReadyStateToPlayer();
@@ -318,8 +323,10 @@ void MediaPlayerPrivateGStreamerMSE::durationChanged()
 
     // Avoid emiting durationchanged in the case where the previous duration was 0 because that case is already handled
     // by the HTMLMediaElement.
-    if (m_mediaTimeDuration != previousDuration && m_mediaTimeDuration.isValid() && previousDuration.isValid())
-        m_player->durationChanged();
+    if (m_mediaTimeDuration != previousDuration && m_mediaTimeDuration.isValid() && previousDuration.isValid()) {
+        if (auto player = m_player.get())
+            player->durationChanged();
+    }
 }
 
 void MediaPlayerPrivateGStreamerMSE::setInitialVideoSize(const FloatSize& videoSize)

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -170,23 +170,27 @@ void MediaPlayerPrivateHolePunch::registerMediaEngine(MediaEngineRegistrar regis
 void MediaPlayerPrivateHolePunch::notifyReadyState()
 {
     // Notify the ready state so the GraphicsLayer gets created.
-    m_player->readyStateChanged();
+    if (auto player = m_player.get())
+        player->readyStateChanged();
 }
 
 void MediaPlayerPrivateHolePunch::setNetworkState(MediaPlayer::NetworkState networkState)
 {
     m_networkState = networkState;
-    m_player->networkStateChanged();
+    if (auto player = m_player.get())
+        player->networkStateChanged();
 }
 
 void MediaPlayerPrivateHolePunch::load(const String&)
 {
-    if (!m_player)
+    auto player = m_player.get();
+    if (!player)
         return;
 
-    auto mimeType = m_player->contentMIMEType();
+    auto mimeType = player->contentMIMEType();
     if (mimeType.isEmpty() || !mimeTypeCache().contains(mimeType))
         setNetworkState(MediaPlayer::NetworkState::FormatError);
 }
-}
+
+} // namespace WebCore
 #endif // USE(EXTERNAL_HOLEPUNCH)

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -107,7 +107,7 @@ private:
 
     void notifyReadyState();
 
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     IntSize m_size;
     RunLoop::Timer m_readyTimer;
     MediaPlayer::NetworkState m_networkState;

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -36,6 +36,7 @@
 #include "HostWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "MediaPlayer.h"
 #include "NotImplemented.h"
 #include <shlwapi.h>
 #include <wtf/MainThread.h>
@@ -197,6 +198,10 @@ MediaPlayer::SupportsType MediaPlayerPrivateMediaFoundation::supportsType(const 
 
 void MediaPlayerPrivateMediaFoundation::load(const String& url)
 {
+    auto player = m_player.get();
+    if (!player)
+        return;
+
     {
         Locker locker { m_cachedNaturalSizeLock };
         m_cachedNaturalSize = FloatSize();
@@ -205,9 +210,9 @@ void MediaPlayerPrivateMediaFoundation::load(const String& url)
     startCreateMediaSource(url);
 
     m_networkState = MediaPlayer::NetworkState::Loading;
-    m_player->networkStateChanged();
+    player->networkStateChanged();
     m_readyState = MediaPlayer::ReadyState::HaveNothing;
-    m_player->readyStateChanged();
+    player->readyStateChanged();
 }
 
 void MediaPlayerPrivateMediaFoundation::cancelLoad()
@@ -656,8 +661,9 @@ bool MediaPlayerPrivateMediaFoundation::addBranchToPartialTopology(int stream)
 
 HWND MediaPlayerPrivateMediaFoundation::hostWindow()
 {
-    if (m_player && m_player->cachedResourceLoader() && !m_player->cachedResourceLoader()->document()) {
-        auto* view = m_player->cachedResourceLoader()->document()->view();
+    auto player = m_player.get();
+    if (player && player->cachedResourceLoader() && !player->cachedResourceLoader()->document()) {
+        auto* view = player->cachedResourceLoader()->document()->view();
         if (view && view->hostWindow() && view->hostWindow()->platformPageClient())
             return view->hostWindow()->platformPageClient();
     }
@@ -666,7 +672,8 @@ HWND MediaPlayerPrivateMediaFoundation::hostWindow()
 
 void MediaPlayerPrivateMediaFoundation::invalidateVideoArea()
 {
-    m_player->repaint();
+    if (auto player = m_player.get())
+        player->repaint();
 }
 
 void MediaPlayerPrivateMediaFoundation::addListener(MediaPlayerListener* listener)
@@ -810,8 +817,10 @@ void MediaPlayerPrivateMediaFoundation::updateReadyState()
     else
         m_readyState = MediaPlayer::ReadyState::HaveCurrentData;
 
-    if (m_readyState != oldReadyState)
-        m_player->readyStateChanged();
+    if (m_readyState != oldReadyState) {
+        if (auto player = m_player.get())
+            player->readyStateChanged();
+    }
 }
 
 COMPtr<IMFVideoDisplayControl> MediaPlayerPrivateMediaFoundation::videoDisplay()
@@ -840,7 +849,8 @@ void MediaPlayerPrivateMediaFoundation::onCreatedMediaSource(COMPtr<IMFMediaSour
 void MediaPlayerPrivateMediaFoundation::onNetworkStateChanged(MediaPlayer::NetworkState state)
 {
     m_networkState = state;
-    m_player->networkStateChanged();
+    if (auto player = m_player.get())
+        player->networkStateChanged();
 }
 
 void MediaPlayerPrivateMediaFoundation::onTopologySet()
@@ -870,7 +880,8 @@ void MediaPlayerPrivateMediaFoundation::onSessionStarted()
         m_seeking = false;
         if (m_paused)
             m_mediaSession->Pause();
-        m_player->timeChanged();
+        if (auto player = m_player.get())
+            player->timeChanged();
         return;
     }
 
@@ -884,14 +895,19 @@ void MediaPlayerPrivateMediaFoundation::onSessionStarted()
 
 void MediaPlayerPrivateMediaFoundation::onSessionEnded()
 {
+    auto player = m_player.get();
+
     m_sessionEnded = true;
     m_networkState = MediaPlayer::NetworkState::Loaded;
-    m_player->networkStateChanged();
+    if (player)
+        player->networkStateChanged();
 
     m_paused = true;
-    m_player->playbackStateChanged();
+    if (player) {
+        player->playbackStateChanged();
 
-    m_player->timeChanged();
+        player->timeChanged();
+    }
 }
 
 MediaPlayerPrivateMediaFoundation::CustomVideoPresenter::CustomVideoPresenter(MediaPlayerPrivateMediaFoundation* mediaPlayer)

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h
@@ -118,7 +118,7 @@ protected:
 private:
 
     WeakPtr<MediaPlayerPrivateMediaFoundation> m_weakThis;
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     IntSize m_size;
     bool m_visible;
     bool m_loadingProgress;

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp
@@ -217,7 +217,8 @@ void MockMediaPlayerMediaSource::seekWithTolerance(const MediaTime& time, const 
         m_currentTime = m_mediaSourcePrivate->seekToTime(time, negativeTolerance, positiveTolerance);
 
     if (m_seekCompleted) {
-        m_player->timeChanged();
+        if (auto player = m_player.get())
+            player->timeChanged();
 
         if (m_playing)
             callOnMainThread([this, weakThis = WeakPtr { *this }] {
@@ -240,7 +241,8 @@ void MockMediaPlayerMediaSource::advanceCurrentTime()
 
     bool ignoreError;
     m_currentTime = std::min(m_duration, buffered.end(pos, ignoreError));
-    m_player->timeChanged();
+    if (auto player = m_player.get())
+        player->timeChanged();
 }
 
 void MockMediaPlayerMediaSource::updateDuration(const MediaTime& duration)
@@ -249,7 +251,8 @@ void MockMediaPlayerMediaSource::updateDuration(const MediaTime& duration)
         return;
 
     m_duration = duration;
-    m_player->durationChanged();
+    if (auto player = m_player.get())
+        player->durationChanged();
 }
 
 void MockMediaPlayerMediaSource::setReadyState(MediaPlayer::ReadyState readyState)
@@ -258,7 +261,8 @@ void MockMediaPlayerMediaSource::setReadyState(MediaPlayer::ReadyState readyStat
         return;
 
     m_readyState = readyState;
-    m_player->readyStateChanged();
+    if (auto player = m_player.get())
+        player->readyStateChanged();
 }
 
 void MockMediaPlayerMediaSource::setNetworkState(MediaPlayer::NetworkState networkState)
@@ -267,7 +271,8 @@ void MockMediaPlayerMediaSource::setNetworkState(MediaPlayer::NetworkState netwo
         return;
 
     m_networkState = networkState;
-    m_player->networkStateChanged();
+    if (auto player = m_player.get())
+        player->networkStateChanged();
 }
 
 void MockMediaPlayerMediaSource::waitForSeekCompleted()
@@ -281,7 +286,8 @@ void MockMediaPlayerMediaSource::seekCompleted()
         return;
     m_seekCompleted = true;
 
-    m_player->timeChanged();
+    if (auto player = m_player.get())
+        player->timeChanged();
 
     if (m_playing)
         callOnMainThread([this, weakThis = WeakPtr { *this }] {

--- a/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
+++ b/Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h
@@ -61,8 +61,8 @@ public:
     void seekCompleted();
 
 #if !RELEASE_LOG_DISABLED
-    const void* mediaPlayerLogIdentifier() { return m_player->mediaPlayerLogIdentifier(); }
-    const Logger& mediaPlayerLogger() { return m_player->mediaPlayerLogger(); }
+    const void* mediaPlayerLogIdentifier() { return m_player.get()->mediaPlayerLogIdentifier(); }
+    const Logger& mediaPlayerLogger() { return m_player.get()->mediaPlayerLogger(); }
 #endif
 
 private:
@@ -92,7 +92,7 @@ private:
     std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
     DestinationColorSpace colorSpace() override;
 
-    WeakPtr<MediaPlayer> m_player;
+    ThreadSafeWeakPtr<MediaPlayer> m_player;
     RefPtr<MockMediaSourcePrivate> m_mediaSourcePrivate;
 
     MediaTime m_currentTime;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -148,12 +148,12 @@ MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote()
 
 void MediaPlayerPrivateRemote::prepareForPlayback(bool privateMode, MediaPlayer::Preload preload, bool preservesPitch, bool prepare)
 {
-    RefPtr player = m_player.get();
+    auto player = m_player.get();
     if (!player)
         return;
 
     auto scale = player->playerContentsScale();
-    auto preferredDynamicRangeMode = m_player->preferredDynamicRangeMode();
+    auto preferredDynamicRangeMode = player->preferredDynamicRangeMode();
     auto presentationSize = player->presentationSize();
     auto pitchCorrectionAlgorithm = player->pitchCorrectionAlgorithm();
 
@@ -187,7 +187,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         if (!createExtension()) {
             WTFLogAlways("Unable to create sandbox extension handle for GPUProcess url.\n");
             m_cachedState.networkState = MediaPlayer::NetworkState::FormatError;
-            if (RefPtr player = m_player.get())
+            if (auto player = m_player.get())
                 player->networkStateChanged();
             return;
         }
@@ -195,11 +195,11 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         sandboxExtensionHandle = WTFMove(handle);
     }
 
-    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, sandboxExtensionHandle, contentType, keySystem, m_player->requiresRemotePlayback()), [weakThis = WeakPtr { *this }, this](auto&& configuration) {
+    connection().sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, sandboxExtensionHandle, contentType, keySystem, m_player.get()->requiresRemotePlayback()), [weakThis = WeakPtr { *this }, this](auto&& configuration) {
         if (!weakThis)
             return;
 
-        RefPtr player = m_player.get();
+        auto player = m_player.get();
         if (!player)
             return;
 
@@ -332,21 +332,21 @@ MediaPlayer::MovieLoadType MediaPlayerPrivateRemote::movieLoadType() const
 void MediaPlayerPrivateRemote::networkStateChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->networkStateChanged();
 }
 
 void MediaPlayerPrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
 {
     m_cachedState.readyState = readyState;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->readyStateChanged();
 }
 
 void MediaPlayerPrivateRemote::readyStateChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (RefPtr player = m_player.get()) {
+    if (auto player = m_player.get()) {
         player->readyStateChanged();
         checkAcceleratedRenderingState();
     }
@@ -355,14 +355,14 @@ void MediaPlayerPrivateRemote::readyStateChanged(RemoteMediaPlayerState&& state)
 void MediaPlayerPrivateRemote::volumeChanged(double volume)
 {
     m_volume = volume;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->volumeChanged(volume);
 }
 
 void MediaPlayerPrivateRemote::muteChanged(bool muted)
 {
     m_muted = muted;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->muteChanged(muted);
 }
 
@@ -370,21 +370,21 @@ void MediaPlayerPrivateRemote::timeChanged(RemoteMediaPlayerState&& state)
 {
     m_seeking = false;
     updateCachedState(WTFMove(state));
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->timeChanged();
 }
 
 void MediaPlayerPrivateRemote::durationChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->durationChanged();
 }
 
 void MediaPlayerPrivateRemote::rateChanged(double rate)
 {
     m_rate = rate;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->rateChanged();
 }
 
@@ -393,28 +393,28 @@ void MediaPlayerPrivateRemote::playbackStateChanged(bool paused, MediaTime&& med
     m_cachedState.paused = paused;
     m_cachedMediaTime = mediaTime;
     m_cachedMediaTimeQueryTime = wallTime;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->playbackStateChanged();
 }
 
 void MediaPlayerPrivateRemote::engineFailedToLoad(int64_t platformErrorCode)
 {
     m_platformErrorCode = platformErrorCode;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->remoteEngineFailedToLoad();
 }
 
 void MediaPlayerPrivateRemote::characteristicChanged(RemoteMediaPlayerState&& state)
 {
     updateCachedState(WTFMove(state));
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->characteristicChanged();
 }
 
 void MediaPlayerPrivateRemote::sizeChanged(WebCore::FloatSize naturalSize)
 {
     m_cachedState.naturalSize = naturalSize;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->sizeChanged();
 }
 
@@ -430,7 +430,7 @@ void MediaPlayerPrivateRemote::currentTimeChanged(const MediaTime& mediaTime, co
 
     if (reverseJump
         || (timeIsProgressing != m_timeIsProgressing && m_cachedMediaTime != oldCachedTime && !m_cachedState.paused)) {
-        if (RefPtr player = m_player.get())
+        if (auto player = m_player.get())
             player->timeChanged();
     }
 }
@@ -438,14 +438,14 @@ void MediaPlayerPrivateRemote::currentTimeChanged(const MediaTime& mediaTime, co
 void MediaPlayerPrivateRemote::firstVideoFrameAvailable()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->firstVideoFrameAvailable();
 }
 
 void MediaPlayerPrivateRemote::renderingModeChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->renderingModeChanged();
 }
 
@@ -476,8 +476,8 @@ bool MediaPlayerPrivateRemote::supportsAcceleratedRendering() const
 
 void MediaPlayerPrivateRemote::acceleratedRenderingStateChanged()
 {
-    if (m_player) {
-        m_renderingCanBeAccelerated = m_player->renderingCanBeAccelerated();
+    if (auto player = m_player.get()) {
+        m_renderingCanBeAccelerated = player->renderingCanBeAccelerated();
         connection().send(Messages::RemoteMediaPlayerProxy::AcceleratedRenderingStateChanged(m_renderingCanBeAccelerated), m_id);
     }
     renderingModeChanged();
@@ -485,8 +485,8 @@ void MediaPlayerPrivateRemote::acceleratedRenderingStateChanged()
 
 void MediaPlayerPrivateRemote::checkAcceleratedRenderingState()
 {
-    if (m_player) {
-        bool renderingCanBeAccelerated = m_player->renderingCanBeAccelerated();
+    if (auto player = m_player.get()) {
+        bool renderingCanBeAccelerated = player->renderingCanBeAccelerated();
         if (m_renderingCanBeAccelerated != renderingCanBeAccelerated)
             acceleratedRenderingStateChanged();
     }
@@ -603,8 +603,8 @@ void MediaPlayerPrivateRemote::addRemoteAudioTrack(TrackPrivateRemoteIdentifier 
         return;
 #endif
 
-    if (RefPtr player = m_player.get())
-        m_player->addAudioTrack(addResult.iterator->value);
+    if (auto player = m_player.get())
+        player->addAudioTrack(addResult.iterator->value);
 }
 
 void MediaPlayerPrivateRemote::removeRemoteAudioTrack(TrackPrivateRemoteIdentifier identifier)
@@ -612,7 +612,7 @@ void MediaPlayerPrivateRemote::removeRemoteAudioTrack(TrackPrivateRemoteIdentifi
     ASSERT(m_audioTracks.contains(identifier));
 
     if (auto* track = m_audioTracks.get(identifier)) {
-        if (RefPtr player = m_player.get())
+        if (auto player = m_player.get())
             player->removeAudioTrack(*track);
         m_audioTracks.remove(identifier);
     }
@@ -641,7 +641,7 @@ void MediaPlayerPrivateRemote::addRemoteTextTrack(TrackPrivateRemoteIdentifier i
         return;
 #endif
 
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->addTextTrack(addResult.iterator->value);
 }
 
@@ -650,7 +650,7 @@ void MediaPlayerPrivateRemote::removeRemoteTextTrack(TrackPrivateRemoteIdentifie
     ASSERT(m_textTracks.contains(identifier));
 
     if (auto* track = m_textTracks.get(identifier)) {
-        if (RefPtr player = m_player.get())
+        if (auto player = m_player.get())
             player->removeTextTrack(*track);
         m_textTracks.remove(identifier);
     }
@@ -761,7 +761,7 @@ void MediaPlayerPrivateRemote::addRemoteVideoTrack(TrackPrivateRemoteIdentifier 
         return;
 #endif
 
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->addVideoTrack(addResult.iterator->value);
 }
 
@@ -770,7 +770,7 @@ void MediaPlayerPrivateRemote::removeRemoteVideoTrack(TrackPrivateRemoteIdentifi
     ASSERT(m_videoTracks.contains(identifier));
 
     if (auto* track = m_videoTracks.get(identifier)) {
-        if (RefPtr player = m_player.get())
+        if (auto player = m_player.get())
             player->removeVideoTrack(*track);
         m_videoTracks.remove(identifier);
     }
@@ -794,7 +794,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
             if (!weakThis)
                 return;
 
-            RefPtr player = m_player.get();
+            auto player = m_player.get();
             if (!player)
                 return;
 
@@ -810,7 +810,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentTy
         if (!weakThis)
             return;
 
-        RefPtr player = m_player.get();
+        auto player = m_player.get();
         if (!player)
             return;
 
@@ -827,7 +827,7 @@ void MediaPlayerPrivateRemote::load(MediaStreamPrivate&)
         if (!weakThis)
             return;
 
-        RefPtr player = m_player.get();
+        auto player = m_player.get();
         if (!player)
             return;
 
@@ -887,7 +887,7 @@ void MediaPlayerPrivateRemote::setVideoFullscreenMode(MediaPlayer::VideoFullscre
 
 void MediaPlayerPrivateRemote::videoFullscreenStandbyChanged()
 {
-    RefPtr player = m_player.get();
+    auto player = m_player.get();
     if (!player)
         return;
 
@@ -1098,7 +1098,7 @@ void MediaPlayerPrivateRemote::setWirelessVideoPlaybackDisabled(bool disabled)
 void MediaPlayerPrivateRemote::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
 {
     m_isCurrentPlaybackTargetWireless = isCurrentPlaybackTargetWireless;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->currentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
 }
 
@@ -1225,7 +1225,7 @@ void MediaPlayerPrivateRemote::keyAdded()
 
 void MediaPlayerPrivateRemote::mediaPlayerKeyNeeded(IPC::DataReference&& message)
 {
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->keyNeeded(SharedBuffer::create(message));
 }
 #endif
@@ -1252,14 +1252,14 @@ void MediaPlayerPrivateRemote::attemptToDecryptWithInstance(CDMInstance& instanc
 void MediaPlayerPrivateRemote::waitingForKeyChanged(bool waitingForKey)
 {
     m_waitingForKey = waitingForKey;
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->waitingForKeyChanged();
 }
 
 void MediaPlayerPrivateRemote::initializationDataEncountered(const String& initDataType, IPC::DataReference&& initData)
 {
     auto initDataBuffer = ArrayBuffer::create(initData.data(), initData.size());
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->initializationDataEncountered(initDataType, WTFMove(initDataBuffer));
 }
 
@@ -1478,20 +1478,20 @@ void MediaPlayerPrivateRemote::removeResource(RemoteMediaResourceIdentifier remo
 
 void MediaPlayerPrivateRemote::resourceNotSupported()
 {
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->resourceNotSupported();
 }
 
 void MediaPlayerPrivateRemote::activeSourceBuffersChanged()
 {
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->activeSourceBuffersChanged();
 }
 
 #if PLATFORM(IOS_FAMILY)
 void MediaPlayerPrivateRemote::getRawCookies(const URL& url, WebCore::MediaPlayerClient::GetRawCookiesCallback&& completionHandler) const
 {
-    if (RefPtr player = m_player.get())
+    if (auto player = m_player.get())
         player->getRawCookies(url, WTFMove(completionHandler));
 }
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -44,7 +44,6 @@
 #include <WebCore/VideoFrameMetadata.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
-#include <wtf/WeakPtr.h>
 
 #if ENABLE(MEDIA_SOURCE)
 #include "MediaSourcePrivateRemote.h"
@@ -95,7 +94,7 @@ public:
     WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier() const { return m_remoteEngineIdentifier; }
     WebCore::MediaPlayerIdentifier identifier() const final { return m_id; }
     IPC::Connection& connection() const { return m_manager.gpuProcessConnection().connection(); }
-    WebCore::MediaPlayer* player() const { return m_player.get(); }
+    RefPtr<WebCore::MediaPlayer> player() const { return m_player.get(); }
 
     WebCore::MediaPlayer::ReadyState readyState() const final { return m_cachedState.readyState; }
     void setReadyState(WebCore::MediaPlayer::ReadyState);
@@ -430,7 +429,7 @@ private:
 #endif
     RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return m_manager.gpuProcessConnection().videoFrameObjectHeapProxy(); }
 
-    WeakPtr<WebCore::MediaPlayer> m_player;
+    ThreadSafeWeakPtr<WebCore::MediaPlayer> m_player;
     Ref<WebCore::PlatformMediaResourceLoader> m_mediaResourceLoader;
 #if PLATFORM(COCOA)
     mutable UniqueRef<WebCore::VideoLayerManager> m_videoLayerManager;


### PR DESCRIPTION
#### f9b1212d5dad101f393ea2d8da5b93327792922d
<pre>
MediaPlayer should inherit from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258261">https://bugs.webkit.org/show_bug.cgi?id=258261</a>
&lt;rdar://110955978&gt;

Reviewed by Alex Christensen.

Change MediaPlayer to inherit from
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt; since it currently
inherits from ThreadSafeRefCounted&lt;&gt; and CanMakeWeakPtr&lt;&gt; separately.

Most of the changes are to add local RefPtr&lt;&gt; variables for MediaPlayer
with nullptr checks, and change the type of m_player instance variables
to ThreadSafeWeakPtr&lt;&gt;.  Other changes noted below.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::ThreadSafeWeakPtrControlBlock):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::m_controlBlock):
- Make ThreadSafeWeakPtrControlBlock() constructor take a pointer
  instead of a reference to work around a compiler difference in MSVC.
- Use a C-style cast with MSVC to avoid a compiler error.

* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp:
(WebCore::CDMInstanceProxy::startedWaitingForKey):
(WebCore::CDMInstanceProxy::stoppedWaitingForKey):
- Pass ThreadSafeWeakPtr&lt;&gt; by value into lambda, then get
  RefPtr&lt;MediaPlayer&gt; inside the lambda.
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::CDMInstanceProxy::setPlayer):

* Source/WebCore/platform/graphics/MediaPlayer.h:
(class WebCore::MediaPlayer):
- Fix the bug by inheriting from
  ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt;.
(WebCore::MediaPlayer::~MediaPlayer):
- Destructor no longer needs to be virtual.

* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::preferredRenderingMode const):
(WebCore::MediaPlayerPrivateAVFoundation::renderingModeChanged):
(WebCore::MediaPlayerPrivateAVFoundation::setNaturalSize):
(WebCore::MediaPlayerPrivateAVFoundation::setNetworkState):
(WebCore::MediaPlayerPrivateAVFoundation::setReadyState):
(WebCore::MediaPlayerPrivateAVFoundation::characteristicsChanged):
(WebCore::MediaPlayerPrivateAVFoundation::updateStates):
(WebCore::MediaPlayerPrivateAVFoundation::rateChanged):
(WebCore::MediaPlayerPrivateAVFoundation::loadedTimeRangesChanged):
(WebCore::MediaPlayerPrivateAVFoundation::seekableTimeRangesChanged):
(WebCore::MediaPlayerPrivateAVFoundation::seekCompleted):
(WebCore::MediaPlayerPrivateAVFoundation::didEnd):
(WebCore::MediaPlayerPrivateAVFoundation::invalidateCachedDuration):
(WebCore::MediaPlayerPrivateAVFoundation::clearTextTracks):
(WebCore::MediaPlayerPrivateAVFoundation::processNewAndRemovedTextTracks):
(WebCore::MediaPlayerPrivateAVFoundation::playbackTargetIsWirelessChanged):
(WebCore::MediaPlayerPrivateAVFoundation::shouldEnableInheritURIQueryComponent const):
(WebCore::MediaPlayerPrivateAVFoundation::queueTaskOnEventLoop):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::player): Delete.
(WebCore::MediaPlayerPrivateAVFoundation::player const):
- Replace two player() methods with one that returns RefPtr&lt;&gt;.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::synchronizeTextTrackState):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPlayerRate):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPreservesPitch):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPitchCorrectionAlgorithm):
(WebCore::MediaPlayerPrivateAVFoundationObjC::trackIsPlayable const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processChapterTracks):
(WebCore::determineChangedTracksFromNewTracksAndOldItems):
- Use RefPtr&lt;&gt;&amp; to reduce ref churn.
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateAudioTracks):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateVideoTracks):
(WebCore::MediaPlayerPrivateAVFoundationObjC::keyAdded):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setWaitingForKey):
(WebCore::MediaPlayerPrivateAVFoundationObjC::processMetadataTrack):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateDisableExternalPlayback):
(WebCore::MediaPlayerPrivateAVFoundationObjC::timeControlStatusDidChange):
(WebCore::MediaPlayerPrivateAVFoundationObjC::audioOutputDeviceChanged):

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::waitForSeekCompleted):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::seekCompleted):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setRateDouble):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setPreservesPitch):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::notifyActiveSourceBuffersChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyLayer):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setNaturalSize):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::keyNeeded):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::waitingForKeyChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::initializationDataEncountered):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::mediaContentTypesRequiringHardwareSupport const):
- Can&apos;t add nullptr check here since the method returns a Vector&lt;&gt;
  reference.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldCheckHardwareSupport const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setReadyState):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setNetworkState):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeAudioTrack):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeVideoTrack):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::removeTextTrack):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::audioOutputDeviceChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::checkNewVideoFrameMetadata):

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::processNewVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::ensureLayers):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::activeVideoTrack const):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::play):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::pause):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::activeStatusChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::scheduleRenderingModeChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::characteristicsChanged):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateTracks):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateLayersAsNeeded):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setReadyState):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setNetworkState):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::audioOutputDeviceChanged):

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::load):
(WebCore::MediaPlayerPrivateWebM::seek):
(WebCore::MediaPlayerPrivateWebM::setRateDouble):
(WebCore::MediaPlayerPrivateWebM::setNaturalSize):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setNetworkState):
(WebCore::MediaPlayerPrivateWebM::setReadyState):
(WebCore::MediaPlayerPrivateWebM::characteristicsChanged):
(WebCore::MediaPlayerPrivateWebM::shouldEnsureLayer const):
(WebCore::MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::addAudioRenderer):
(WebCore::MediaPlayerPrivateWebM::destroyLayer):
(WebCore::MediaPlayerPrivateWebM::destroyAudioRenderers):
(WebCore::MediaPlayerPrivateWebM::clearTracks):
(WebCore::MediaPlayerPrivateWebM::checkNewVideoFrameMetadata):

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::load):
(WebCore::MediaPlayerPrivateGStreamer::play):
(WebCore::MediaPlayerPrivateGStreamer::doSeek):
(WebCore::MediaPlayerPrivateGStreamer::seek):
(WebCore::MediaPlayerPrivateGStreamer::updatePlaybackRate):
(WebCore::MediaPlayerPrivateGStreamer::setRate):
(WebCore::MediaPlayerPrivateGStreamer::durationChanged):
(WebCore::MediaPlayerPrivateGStreamer::sourceSetup):
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack):
(WebCore::MediaPlayerPrivateGStreamer::timeChanged):
(WebCore::MediaPlayerPrivateGStreamer::loadingFailed):
(WebCore::MediaPlayerPrivateGStreamer::createAudioSink):
(WebCore::MediaPlayerPrivateGStreamer::gstreamerPositionFromSinks const):
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const):
(WebCore::MediaPlayerPrivateGStreamer::updateTracks):
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfVolumeChange):
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfMute):
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
(WebCore::MediaPlayerPrivateGStreamer::processMpegTsSection):
(WebCore::MediaPlayerPrivateGStreamer::processTableOfContents):
(WebCore::MediaPlayerPrivateGStreamer::updateStates):
(WebCore::MediaPlayerPrivateGStreamer::loadNextLocation):
(WebCore::MediaPlayerPrivateGStreamer::didEnd):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
(WebCore::MediaPlayerPrivateGStreamer::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateGStreamer::isLoopingChanged):
(WebCore::MediaPlayerPrivateGStreamer::repaint):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoOrientation):
(WebCore::MediaPlayerPrivateGStreamer::updateVideoSizeAndOrientationFromCaps):
(WebCore::MediaPlayerPrivateGStreamer::ensureSeekFlags):
(WebCore::MediaPlayerPrivateGStreamer::triggerRepaint):
(WebCore::MediaPlayerPrivateGStreamer::setVisibleInViewport):
(WebCore::MediaPlayerPrivateGStreamer::createHolePunchVideoSink):
(WebCore::MediaPlayerPrivateGStreamer::createVideoSink):
(WebCore::MediaPlayerPrivateGStreamer::setStreamVolumeElement):
(WebCore::MediaPlayerPrivateGStreamer::initializationDataEncountered):
(WebCore::MediaPlayerPrivateGStreamer::cdmInstanceAttached):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::load):
(WebCore::MediaPlayerPrivateGStreamerMSE::setNetworkState):
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer):
(WebCore::MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone):
(WebCore::MediaPlayerPrivateGStreamerMSE::durationChanged):

* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::MediaPlayerPrivateHolePunch::notifyReadyState):
(WebCore::MediaPlayerPrivateHolePunch::setNetworkState):
(WebCore::MediaPlayerPrivateHolePunch::load):
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:

* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::load):
(WebCore::MediaPlayerPrivateMediaFoundation::hostWindow):
(WebCore::MediaPlayerPrivateMediaFoundation::invalidateVideoArea):
(WebCore::MediaPlayerPrivateMediaFoundation::updateReadyState):
(WebCore::MediaPlayerPrivateMediaFoundation::onNetworkStateChanged):
(WebCore::MediaPlayerPrivateMediaFoundation::onSessionStarted):
(WebCore::MediaPlayerPrivateMediaFoundation::onSessionEnded):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.h:
- Update m_player to be ThreadSafeWeakPtr&lt;MediaPlayer&gt; in other ports.

* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.cpp:
(WebCore::MockMediaPlayerMediaSource::seekWithTolerance):
(WebCore::MockMediaPlayerMediaSource::advanceCurrentTime):
(WebCore::MockMediaPlayerMediaSource::updateDuration):
(WebCore::MockMediaPlayerMediaSource::setReadyState):
(WebCore::MockMediaPlayerMediaSource::setNetworkState):
(WebCore::MockMediaPlayerMediaSource::seekCompleted):
* Source/WebCore/platform/mock/mediasource/MockMediaPlayerMediaSource.h:
(WebCore::MockMediaPlayerMediaSource::mediaPlayerLogIdentifier):
(WebCore::MockMediaPlayerMediaSource::mediaPlayerLogger):
- No nullptr check here for logging methods.

* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::prepareForPlayback):
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::networkStateChanged):
(WebKit::MediaPlayerPrivateRemote::setReadyState):
(WebKit::MediaPlayerPrivateRemote::readyStateChanged):
(WebKit::MediaPlayerPrivateRemote::volumeChanged):
(WebKit::MediaPlayerPrivateRemote::muteChanged):
(WebKit::MediaPlayerPrivateRemote::timeChanged):
(WebKit::MediaPlayerPrivateRemote::durationChanged):
(WebKit::MediaPlayerPrivateRemote::rateChanged):
(WebKit::MediaPlayerPrivateRemote::playbackStateChanged):
(WebKit::MediaPlayerPrivateRemote::engineFailedToLoad):
(WebKit::MediaPlayerPrivateRemote::characteristicChanged):
(WebKit::MediaPlayerPrivateRemote::sizeChanged):
(WebKit::MediaPlayerPrivateRemote::currentTimeChanged):
(WebKit::MediaPlayerPrivateRemote::firstVideoFrameAvailable):
(WebKit::MediaPlayerPrivateRemote::renderingModeChanged):
(WebKit::MediaPlayerPrivateRemote::acceleratedRenderingStateChanged):
(WebKit::MediaPlayerPrivateRemote::checkAcceleratedRenderingState):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::removeRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::videoFullscreenStandbyChanged):
(WebKit::MediaPlayerPrivateRemote::currentPlaybackTargetIsWirelessChanged):
(WebKit::MediaPlayerPrivateRemote::mediaPlayerKeyNeeded):
(WebKit::MediaPlayerPrivateRemote::waitingForKeyChanged):
(WebKit::MediaPlayerPrivateRemote::initializationDataEncountered):
(WebKit::MediaPlayerPrivateRemote::performTaskAtMediaTime):
(WebKit::MediaPlayerPrivateRemote::resourceNotSupported):
(WebKit::MediaPlayerPrivateRemote::activeSourceBuffersChanged):
(WebKit::MediaPlayerPrivateRemote::getRawCookies const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/265366@main">https://commits.webkit.org/265366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ac5ae256368b50181800a76cdcde5586efafb1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12314 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13260 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13147 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12717 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16886 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9027 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13029 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10121 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8337 "4 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10783 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9401 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2907 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13673 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11083 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1200 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10105 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2714 "Passed tests") | 
<!--EWS-Status-Bubble-End-->