### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at WebCore: WTF::Detail::CallableWrapper<WebCore::FullscreenManager::cancelFullscreen()::$_5, void>::call

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-iframe-cancel-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-iframe-cancel-expected.txt
@@ -1,0 +1,2 @@
+iframe closed with no crash
+

--- a/LayoutTests/fullscreen/fullscreen-iframe-cancel.html
+++ b/LayoutTests/fullscreen/fullscreen-iframe-cancel.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<head>
+<meta charset="UTF-8">
+</head>
+<body>
+<script src="full-screen-test.js"></script>
+<iframe id="iframe"></iframe>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    addEventListener("load", async () => {
+        function loadiframe() {
+            return new Promise(function(resolve) {
+                var frame = document.getElementById('iframe');
+                frame.srcdoc = '<button id="iframebutton" onclick="document.webkitCancelFullScreen();parent.iframe.remove();">Cancel fullscreen</button>';
+                frame.onload = () => {
+                    internals.withUserGesture(() => {
+                        frame.contentWindow.document.getElementById("iframebutton").click();
+                        resolve();
+                    });
+                };
+            });
+        }
+
+        function gofullscreen() {
+            return new Promise(function(resolve) {
+                internals.withUserGesture(async () => {
+                    await document.documentElement.requestFullscreen();
+                    await loadiframe();
+                    setTimeout(resolve, 100);
+                });
+            });
+        }
+        await gofullscreen();
+
+        consoleWrite("iframe closed with no crash");
+        if (window.testRunner)
+            testRunner.notifyDone();
+    });
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -296,7 +296,10 @@ void FullscreenManager::cancelFullscreen()
 
     m_pendingExitFullscreen = true;
 
-    m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, topDocument = WTFMove(topDocument), identifier = LOGIDENTIFIER] {
+    m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, topDocument = WTFMove(topDocument), identifier = LOGIDENTIFIER] {
+        if (!weakThis)
+            return;
+
         if (!topDocument->page()) {
             INFO_LOG(identifier, "Top document has no page.");
             return;
@@ -304,7 +307,7 @@ void FullscreenManager::cancelFullscreen()
 
         // This triggers finishExitFullscreen with ExitMode::Resize, which fully exits the document.
         if (auto* fullscreenElement = topDocument->fullscreenManager().fullscreenElement())
-            page()->chrome().client().exitFullScreenForElement(fullscreenElement);
+            topDocument->page()->chrome().client().exitFullScreenForElement(fullscreenElement);
         else
             INFO_LOG(identifier, "Top document has no fullscreen element");
     });


### PR DESCRIPTION
#### b51cb995ff77add785b859a434404dd75f7d5342
<pre>
CrashTracer: com.apple.WebKit.WebContent at WebCore: WTF::Detail::CallableWrapper&lt;WebCore::FullscreenManager::cancelFullscreen()::$_5, void&gt;::call
<a href="https://bugs.webkit.org/show_bug.cgi?id=258268">https://bugs.webkit.org/show_bug.cgi?id=258268</a>
rdar://107182009

Reviewed by Youenn Fablet and Tim Nguyen.

Exit early if either FullscreenManager has been deleted (not possible, but may as well check).
And use the topDocument&apos;s page to trigger exitFullscreen.

* LayoutTests/fullscreen/fullscreen-iframe-cancel-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-iframe-cancel.html: Added.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::cancelFullscreen): Use topDocument&apos;s page instead of page.

Canonical link: <a href="https://commits.webkit.org/265311@main">https://commits.webkit.org/265311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63eed54b69f51f8b08ca77572775d8b9c38aab59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/10591 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/10813 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/11093 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/12238 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10162 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/10606 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/13185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/10780 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/12238 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/10753 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/13185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/11093 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/12639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/13185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/11093 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/12639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/13185 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/11093 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/12639 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10181 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/10780 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9335 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/11093 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2529 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13599 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10037 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->