### PR TITLE
Web Inspector: Node sidebar panel: long attribute name is cut off without visual hint

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -365,6 +365,7 @@ body[dir=rtl] .data-grid .resizer {
     background: none;
     border: none;
     outline: none;
+    text-overflow: ellipsis;
 }
 
 body:not(.window-inactive, .window-docked-inactive) .data-grid:focus tr.editable.selected .cell-content > input {


### PR DESCRIPTION
#### 4629f05354c3b380207e2fd5875bc995b295e09a
<pre>
Web Inspector: Node sidebar panel: long attribute name is cut off without visual hint
<a href="https://bugs.webkit.org/show_bug.cgi?id=258274">https://bugs.webkit.org/show_bug.cgi?id=258274</a>
<a href="https://rdar.apple.com/110999382">rdar://110999382</a>

Reviewed by Patrick Angle and Devin Rousso.

Use `text-overflow: ellipsis` to indicate when DataGrid input content is visually cut off.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(.data-grid tr.editable .cell-content &gt; input):

Canonical link: <a href="https://commits.webkit.org/272135@main">https://commits.webkit.org/272135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31d96cba80cb53c317811b3c7466cc3a7f12ae86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12204 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13065 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10719 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8879 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12605 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16799 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10149 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8231 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12942 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9304 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7261 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13567 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->