### PR TITLE
REGRESSION(263809@main): [UNIX] SharedMemory::map is leaking the file descriptor

### DIFF
--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -147,7 +147,6 @@ RefPtr<SharedMemory> SharedMemory::map(Handle&& handle, Protection protection)
     RefPtr<SharedMemory> instance = adoptRef(new SharedMemory());
     instance->m_data = data;
     instance->m_size = handle.size();
-    instance->m_fileDescriptor = handle.releaseHandle();
     return instance;
 }
 


### PR DESCRIPTION
#### 901d1f8cc477679f97b4cb50685cfec2e1bfa9b3
<pre>
REGRESSION(263809@main): [UNIX] SharedMemory::map is leaking the file descriptor
<a href="https://bugs.webkit.org/show_bug.cgi?id=258275">https://bugs.webkit.org/show_bug.cgi?id=258275</a>

Reviewed by Michael Catanzaro.

Once mapped, we don&apos;t need to keep the file descriptor open. Before
263809@main, we cleared the file descriptor after the mmap call, then
created an instance with -1 as fd. Now we are creating the new instance
with the handle fd moved.

* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemory::map):

Canonical link: <a href="https://commits.webkit.org/265326@main">https://commits.webkit.org/265326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c14dea208e9e021e4d710679e42c9e1ac972968

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10132 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12607 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8943 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16800 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12943 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10151 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8232 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13569 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1184 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->