### PR TITLE
[WGSL] Type checker crashes when calling a non-existing function

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -681,7 +681,10 @@ void TypeChecker::visit(AST::CallExpression& call)
             return;
         }
 
-        typeError(target.span(), "cannot call value of type '", *targetBinding->type, "'");
+        if (targetBinding)
+            typeError(target.span(), "cannot call value of type '", *targetBinding->type, "'");
+        else
+            typeError(target.span(), "unresolved call target '", targetName, "'");
         return;
     }
 
@@ -745,9 +748,7 @@ void TypeChecker::visit(AST::CallExpression& call)
         return;
     }
 
-    // FIXME: Ensure we can remove this workaround
-    auto* result = resolve(target);
-    inferred(result);
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void TypeChecker::visit(AST::UnaryExpression& unary)

--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -3,6 +3,9 @@
 fn f1(x: f32) -> f32 { return x; }
 
 fn f2() {
+    // CHECK-L: unresolved call target 'f0'
+    _ = f0();
+
     // CHECK-L: type in function call does not match parameter type: expected 'f32', found 'i32'
     _ = f1(0i);
 


### PR DESCRIPTION
#### d552f3bf1512e47a070057df999049e537cd8350
<pre>
[WGSL] Type checker crashes when calling a non-existing function
<a href="https://bugs.webkit.org/show_bug.cgi?id=258280">https://bugs.webkit.org/show_bug.cgi?id=258280</a>
rdar://111003956

Reviewed by Dan Glastonbury.

When type checking a call we try to identify what is the type bound to the target,
e.g. for `f()`, first we look up the typing context to see if there&apos;s a type or
value bound to `f`. If there is none, we try to look up overloaded declarations
for `f`. If `f` isn&apos;t overloaded either, we have to emit an error, but at this
point we were unconditionally using the binding to construct the error message
(the first lookup just mentioned), which will be null if `f` doesn&apos;t exist. To
fix that we check if the binding exists to decide which error message we should
emit: either that the target doesn&apos;t exist or that it&apos;s an invalid target for a
call (i.e. it exists, but isn&apos;t a function).

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl:

Canonical link: <a href="https://commits.webkit.org/265312@main">https://commits.webkit.org/265312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0586ff047eca87e9abc5c4565be67fc90f3ffff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13075 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12617 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8951 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16809 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10022 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9696 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12952 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10161 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8240 "5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9316 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13579 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->