### PR TITLE
Fix crash: deleting RemoteLayerTreeEventDispatcherDisplayLinkClient

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -118,7 +118,7 @@ void RemoteLayerTreeEventDispatcher::invalidate()
 {
     m_displayLinkClient->invalidate();
 
-    stopDisplayLinkObserver();
+    displayLink()->removeClient(*m_displayLinkClient);
 
     {
         Locker locker { m_scrollingTreeLock };


### PR DESCRIPTION
#### 7badad9c6f475813cd253f101cc37c8637d7f6d3
<pre>
Fix crash: deleting RemoteLayerTreeEventDispatcherDisplayLinkClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=258133">https://bugs.webkit.org/show_bug.cgi?id=258133</a>
rdar://109463023

Reviewed by Simon Fraser.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):

RemoteLayerTreeEventDispatcherDisplayLinkClient inherits indirectly from
CanMakeCheckedPtrBase. This means that for deleting a object of this type
we should first delete any CheckRef objects pointing to it.

At RemoteLayerTreeEventDispatcher::invalidate we currently call
stopDisplayLinkObserver() to remove the associated observer of
DisplayLink::Client. If that Client has no more observers, we remove
the CheckRef for this client from DisplayLink&apos;s m_client&apos;s map (See removeInfoForClientIfUnused()).

The problem is, since we want to delete m_displayClient at the end of
invalidate() we have to make sure that the associated CheckRef gets removed
from the map, independently of how many observers it still has.
Therefore, instead of removing just the single associated observer,
we can remove the reference for the client from DisplayLink.

Canonical link: <a href="https://commits.webkit.org/265322@main">https://commits.webkit.org/265322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ce03bb6d9008e11a13b23c64dff5ff72c13c54f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13078 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12622 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8956 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16812 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10166 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8246 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9321 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2537 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->