### PR TITLE
[JPEGXL] [Cocoa] Hook up color conversion to downlevel JPEG XL infrastructure

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AppleJPEGXL/AppleJPEGXLSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AppleJPEGXL/AppleJPEGXLSPI.h
@@ -50,6 +50,7 @@ typedef enum {
     JXL_DEC_ERROR = 1,
     JXL_DEC_NEED_MORE_INPUT = 2,
     JXL_DEC_BASIC_INFO = 0x40,
+    JXL_DEC_COLOR_ENCODING = 0x100,
     JXL_DEC_FRAME = 0x400,
     JXL_DEC_FULL_IMAGE = 0x1000,
 } JxlDecoderStatus;
@@ -137,6 +138,10 @@ typedef struct {
     JxlLayerInfo layer_info;
 } JxlFrameHeader;
 
+typedef enum {
+    JXL_COLOR_PROFILE_TARGET_DATA = 1,
+} JxlColorProfileTarget;
+
 typedef struct JxlDecoderStruct JxlDecoder;
 
 typedef void* (*jpegxl_alloc_func)(void* opaque, size_t size);
@@ -162,6 +167,8 @@ JxlDecoderStatus JxlDecoderGetFrameHeader(const JxlDecoder*, JxlFrameHeader*);
 JxlDecoderStatus JxlDecoderSetImageOutCallback(JxlDecoder*, const JxlPixelFormat*, JxlImageOutCallback, void* opaque);
 void JxlDecoderDestroy(JxlDecoder*);
 JxlSignature JxlSignatureCheck(const uint8_t* buf, size_t len);
+JxlDecoderStatus JxlDecoderGetICCProfileSize(const JxlDecoder*, const JxlPixelFormat*, JxlColorProfileTarget, size_t*);
+JxlDecoderStatus JxlDecoderGetColorAsICCProfile(const JxlDecoder*, const JxlPixelFormat*, JxlColorProfileTarget, uint8_t* icc_profile, size_t);
 
 #if defined(__cplusplus) || defined(c_plusplus)
 }

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -242,7 +242,7 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
     ASSERT(destination.format.pixelFormat == PixelFormat::RGBA8 || destination.format.pixelFormat == PixelFormat::BGRA8);
 
 #if USE(ACCELERATE) && USE(CG)
-    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat) {
+    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace) {
         // FIXME: Can thes both just use per-row memcpy?
         if (source.format.alphaFormat == AlphaPremultiplication::Premultiplied)
             convertImagePixelsUnaccelerated<convertSinglePixelPremultipliedToPremultiplied<PixelFormatConversion::None>>(source, destination, destinationSize);

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp
@@ -29,6 +29,8 @@
 
 #if USE(JPEGXL)
 
+#include "PixelBufferConversion.h"
+
 #if USE(LCMS)
 #include "PlatformDisplay.h"
 #endif
@@ -43,7 +45,7 @@ namespace WebCore {
 
 static const JxlPixelFormat s_pixelFormat { 4, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0 };
 
-#if USE(LCMS)
+#if USE(LCMS) || USE(CG)
 static constexpr int s_eventsWanted = JXL_DEC_BASIC_INFO | JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE | JXL_DEC_COLOR_ENCODING;
 #else
 static constexpr int s_eventsWanted = JXL_DEC_BASIC_INFO | JXL_DEC_FRAME | JXL_DEC_FULL_IMAGE;
@@ -71,7 +73,7 @@ JPEGXLImageDecoder::~JPEGXLImageDecoder()
 void JPEGXLImageDecoder::clear()
 {
     m_decoder.reset();
-#if USE(LCMS)
+#if USE(LCMS) || USE(CG)
     clearColorTransform();
 #endif
 }
@@ -302,7 +304,7 @@ JxlDecoderStatus JPEGXLImageDecoder::processInput(Query query)
             continue;
         }
 
-#if USE(LCMS)
+#if USE(LCMS) || USE(CG)
         if (status == JXL_DEC_COLOR_ENCODING && !m_ignoreGammaAndColorProfile) {
             prepareColorTransform();
             continue;
@@ -393,13 +395,11 @@ void JPEGXLImageDecoder::imageOut(size_t x, size_t y, size_t numPixels, const ui
         buffer.backingStore()->setPixel(currentAddress++, r, g, b, a);
     }
 
-#if USE(LCMS)
-    if (m_iccTransform)
-        cmsDoTransform(m_iccTransform.get(), row, row, numPixels);
-#endif
+    maybePerformColorSpaceConversion(row, row, numPixels);
 }
 
 #if USE(LCMS)
+
 void JPEGXLImageDecoder::clearColorTransform()
 {
     m_iccTransform.reset();
@@ -426,7 +426,7 @@ void JPEGXLImageDecoder::prepareColorTransform()
 
 LCMSProfilePtr JPEGXLImageDecoder::tryDecodeICCColorProfile()
 {
-    size_t profileSize;
+    size_t profileSize = 0;
     if (JxlDecoderGetICCProfileSize(m_decoder.get(), &s_pixelFormat, JXL_COLOR_PROFILE_TARGET_DATA, &profileSize) != JXL_DEC_SUCCESS)
         return nullptr;
 
@@ -437,7 +437,85 @@ LCMSProfilePtr JPEGXLImageDecoder::tryDecodeICCColorProfile()
     return LCMSProfilePtr(cmsOpenProfileFromMem(profileData.data(), profileData.size()));
 }
 
-#endif // USE(LCMS)
+void JPEGXLImageDecoder::maybePerformColorSpaceConversion(void* inputBuffer, void* outputBuffer, unsigned numberOfPixels)
+{
+    if (!m_iccTransform)
+        return;
+
+    cmsDoTransform(m_iccTransform.get(), inputBuffer, outputBuffer, numberOfPixels);
+}
+
+#elif USE(CG)
+
+void JPEGXLImageDecoder::clearColorTransform()
+{
+    m_profile = nullptr;
+}
+
+void JPEGXLImageDecoder::prepareColorTransform()
+{
+    if (m_profile || !m_basicInfo || m_basicInfo->num_extra_channels > 1 || m_basicInfo->exponent_bits_per_sample || m_basicInfo->alpha_exponent_bits)
+        return;
+
+    m_profile = tryDecodeICCColorProfile();
+    // TODO(bugs.webkit.org/show_bug.cgi?id=234222): We should try to use encoded color profile if ICC profile is not available.
+}
+
+RetainPtr<CGColorSpaceRef> JPEGXLImageDecoder::tryDecodeICCColorProfile()
+{
+
+    size_t profileSize = 0;
+    if (JxlDecoderGetICCProfileSize(m_decoder.get(), &s_pixelFormat, JXL_COLOR_PROFILE_TARGET_DATA, &profileSize) != JXL_DEC_SUCCESS)
+        return nullptr;
+
+    auto data = adoptCF(CFDataCreateMutable(kCFAllocatorDefault, profileSize));
+    CFDataIncreaseLength(data.get(), profileSize);
+
+    if (JxlDecoderGetColorAsICCProfile(m_decoder.get(), &s_pixelFormat, JXL_COLOR_PROFILE_TARGET_DATA, CFDataGetMutableBytePtr(data.get()), profileSize) != JXL_DEC_SUCCESS)
+        return nullptr;
+
+    return adoptCF(CGColorSpaceCreateWithICCData(data.get()));
+}
+
+void JPEGXLImageDecoder::maybePerformColorSpaceConversion(void* inputBuffer, void* outputBuffer, unsigned numberOfPixels)
+{
+    if (!m_profile)
+        return;
+
+    // https://developer.apple.com/documentation/accelerate/1399134-vimageconvert_anytoany?language=objc
+    // "The destination buffer may only alias the srcs buffers if vImageConverter_MustOperateOutOfPlace returns 0 and the respective scanlines of the aliasing buffers start at the same address."
+    // convertImagePixels() doesn't have any logic for this, so we can just pessimize here and assume aliasing is illegal.
+    std::unique_ptr<uint8_t[]> intermediateBuffer(new uint8_t[4 * numberOfPixels]);
+    auto alphaFormat = m_premultiplyAlpha ? AlphaPremultiplication::Premultiplied : AlphaPremultiplication::Unpremultiplied;
+    ConstPixelBufferConversionView source {
+        .format = {
+            .alphaFormat = alphaFormat,
+            .pixelFormat = PixelFormat::BGRA8,
+            .colorSpace = DestinationColorSpace(m_profile.get()),
+        },
+        .bytesPerRow = static_cast<unsigned>(4 * size().width()),
+        .rows = static_cast<const uint8_t*>(inputBuffer),
+    };
+    PixelBufferConversionView destination {
+        .format = {
+            .alphaFormat = alphaFormat,
+            .pixelFormat = PixelFormat::BGRA8,
+            .colorSpace = DestinationColorSpace::SRGB(),
+        },
+        .bytesPerRow = static_cast<unsigned>(4 * size().width()),
+        .rows = intermediateBuffer.get(),
+    };
+    convertImagePixels(source, destination, { static_cast<int>(numberOfPixels), 1 });
+    memcpy(outputBuffer, intermediateBuffer.get(), numberOfPixels * 4);
+}
+
+#else
+
+void JPEGXLImageDecoder::maybePerformColorSpaceConversion(void*, void*, unsigned)
+{
+}
+
+#endif // USE(LCMS), USE(CG)
 
 }
 #endif // USE(JPEGXL)

--- a/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
+++ b/Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h
@@ -34,6 +34,9 @@
 
 #if USE(LCMS)
 #include "LCMSUniquePtr.h"
+#elif USE(CG)
+#include <CoreGraphics/CoreGraphics.h>
+#include <wtf/RetainPtr.h>
 #endif
 
 namespace WebCore {
@@ -85,10 +88,13 @@ private:
     static void imageOutCallback(void*, size_t x, size_t y, size_t numPixels, const void* pixels);
     void imageOut(size_t x, size_t y, size_t numPixels, const uint8_t* pixels) WTF_REQUIRES_LOCK(m_lock);
 
-#if USE(LCMS)
     void clearColorTransform();
     void prepareColorTransform();
+    void maybePerformColorSpaceConversion(void* inputBuffer, void* outputBuffer, unsigned numberOfPixels);
+#if USE(LCMS)
     LCMSProfilePtr tryDecodeICCColorProfile();
+#elif USE(CG)
+    RetainPtr<CGColorSpaceRef> tryDecodeICCColorProfile();
 #endif
 
     JxlDecoderPtr m_decoder;
@@ -103,6 +109,8 @@ private:
 
 #if USE(LCMS)
     LCMSTransformPtr m_iccTransform;
+#elif USE(CG)
+    RetainPtr<CGColorSpaceRef> m_profile;
 #endif
 };
 

--- a/WebKitLibraries/DownlevelFrameworkStubs/120000/AppleJPEGXL.framework/AppleJPEGXL.tbd
+++ b/WebKitLibraries/DownlevelFrameworkStubs/120000/AppleJPEGXL.framework/AppleJPEGXL.tbd
@@ -4,5 +4,5 @@ targets:         [ x86_64-macos, arm64-macos, arm64e-macos ]
 install-name:    '/System/Library/PrivateFrameworks/AppleJPEGXL.framework/Versions/A/AppleJPEGXL'
 exports:
   - targets:         [ x86_64-macos, arm64-macos, arm64e-macos ]
-    symbols:         [ _JxlDecoderCreate, _JxlDecoderSubscribeEvents, _JxlDecoderRewind, _JxlDecoderSkipFrames, _JxlDecoderSetInput, _JxlDecoderReleaseInput, _JxlDecoderProcessInput, _JxlDecoderGetBasicInfo, _JxlDecoderGetFrameHeader, _JxlDecoderSetImageOutCallback, _JxlDecoderDestroy, _JxlSignatureCheck ]
+    symbols:         [ _JxlDecoderCreate, _JxlDecoderSubscribeEvents, _JxlDecoderRewind, _JxlDecoderSkipFrames, _JxlDecoderSetInput, _JxlDecoderReleaseInput, _JxlDecoderProcessInput, _JxlDecoderGetBasicInfo, _JxlDecoderGetFrameHeader, _JxlDecoderSetImageOutCallback, _JxlDecoderDestroy, _JxlSignatureCheck, _JxlDecoderGetColorAsICCProfile, _JxlDecoderGetICCProfileSize ]
 ...

--- a/WebKitLibraries/DownlevelFrameworkStubs/130000/AppleJPEGXL.framework/AppleJPEGXL.tbd
+++ b/WebKitLibraries/DownlevelFrameworkStubs/130000/AppleJPEGXL.framework/AppleJPEGXL.tbd
@@ -4,5 +4,5 @@ targets:         [ x86_64-macos, arm64-macos, arm64e-macos ]
 install-name:    '/System/Library/PrivateFrameworks/AppleJPEGXL.framework/Versions/A/AppleJPEGXL'
 exports:
   - targets:         [ x86_64-macos, arm64-macos, arm64e-macos ]
-    symbols:         [ _JxlDecoderCreate, _JxlDecoderSubscribeEvents, _JxlDecoderRewind, _JxlDecoderSkipFrames, _JxlDecoderSetInput, _JxlDecoderReleaseInput, _JxlDecoderProcessInput, _JxlDecoderGetBasicInfo, _JxlDecoderGetFrameHeader, _JxlDecoderSetImageOutCallback, _JxlDecoderDestroy, _JxlSignatureCheck ]
+    symbols:         [ _JxlDecoderCreate, _JxlDecoderSubscribeEvents, _JxlDecoderRewind, _JxlDecoderSkipFrames, _JxlDecoderSetInput, _JxlDecoderReleaseInput, _JxlDecoderProcessInput, _JxlDecoderGetBasicInfo, _JxlDecoderGetFrameHeader, _JxlDecoderSetImageOutCallback, _JxlDecoderDestroy, _JxlSignatureCheck, _JxlDecoderGetColorAsICCProfile, _JxlDecoderGetICCProfileSize ]
 ...


### PR DESCRIPTION
#### 19b823079b6db3f9210dcc7e4034e0c2d317b92a
<pre>
[JPEGXL] [Cocoa] Hook up color conversion to downlevel JPEG XL infrastructure
<a href="https://bugs.webkit.org/show_bug.cgi?id=258267">https://bugs.webkit.org/show_bug.cgi?id=258267</a>
rdar://111012276

Reviewed by Cameron McCormack and Don Olmstead.

The existing JPEG XL infrastructure on downlevel builds uses the &quot;little cms&quot; library
from <a href="https://github.com/LuaDist/lcms/tree/master">https://github.com/LuaDist/lcms/tree/master</a> to perform color conversions. However,
on Cocoa platforms, we already have color conversion support in the platform. This
patch hooks up the existing colorspace conversion functionality in
PixelBufferConversion.cpp instead of the little cms library.

The existing infrastructure only works with RGBA8 sRGB images, so configuring all
the converters is actually pretty straightforward.

This patch isn&apos;t testable, because AppleJPEGXL will only be present in builds produced
by Apple&apos;s internal build system, but our testers use local builds to test with. I had
to verify manually that this patch is working correctly.

* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/VImageConverterPtr.h: Added.
(VImageConverterRefDerefTraits::refIfNotNull):
(VImageConverterRefDerefTraits::derefIfNotNull):
(adoptVImageConverter):
* Source/WebCore/PAL/pal/spi/cocoa/AppleJPEGXL/AppleJPEGXLSPI.h:
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.cpp:
(WebCore::JPEGXLImageDecoder::clear):
(WebCore::JPEGXLImageDecoder::processInput):
(WebCore::JPEGXLImageDecoder::imageOut):
(WebCore::JPEGXLImageDecoder::maybePerformColorSpaceConversion):
(WebCore::JPEGXLImageDecoder::clearColorTransform):
(WebCore::JPEGXLImageDecoder::prepareColorTransform):
(WebCore::JPEGXLImageDecoder::tryDecodeICCColorProfile):
* Source/WebCore/platform/image-decoders/jpegxl/JPEGXLImageDecoder.h:
* WebKitLibraries/DownlevelFrameworkStubs/120000/AppleJPEGXL.framework/AppleJPEGXL.tbd:
* WebKitLibraries/DownlevelFrameworkStubs/130000/AppleJPEGXL.framework/AppleJPEGXL.tbd:

Canonical link: <a href="https://commits.webkit.org/265440@main">https://commits.webkit.org/265440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec3972bf7093ed4d8ccd1c24d5923ff8ab1d1e51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12546 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12950 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9843 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13232 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9613 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2616 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13883 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->