### PR TITLE
[ Ventura Debug ] TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation is a flaky timeout.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -941,13 +941,20 @@ window.webkit.messageHandlers.regularPage.postMessage("PASS");
 </script>
 )SWRESOURCE"_s;
 
-// fix me when rdar://110012082 is resolved
-#if PLATFORM(MAC)
-TEST(ServiceWorkers, DISABLED_SWProcessConnectionCreation)
-#else
-TEST(ServiceWorkers, SWProcessConnectionCreation)
-#endif
+static bool isSWProcessConnectionCreationTestSlow()
 {
+#if (!defined(NDEBUG) && PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 140000)
+    return true;
+#else
+    return false;
+#endif
+}
+
+TEST(ServiceWorkers, SWProcessConnectionCreation)
+{
+    if (isSWProcessConnectionCreationTestSlow())
+        return;
+
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 428d036c6d5fd654b80514cfad7662fe64012d0a
<pre>
[ Ventura Debug ] TestWebKitAPI.ServiceWorkers.SWProcessConnectionCreation is a flaky timeout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257498">https://bugs.webkit.org/show_bug.cgi?id=257498</a>
rdar://110012082

Reviewed by Chris Dumez.

On macOS Ventura and below, the test is taking roughly 25 seconds in debug, sometimes a bit more sometimes a bit less.
When going above 30 seconds, it times out.
To prevent this, we are now skipping most of the test in Ventura and below debug configurations.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:

Canonical link: <a href="https://commits.webkit.org/265402@main">https://commits.webkit.org/265402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d308f25c1ca11521b31e6e2d52e02b715d32fb77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10815 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12465 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13273 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11884 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12868 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9757 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13162 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10384 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9543 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2585 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->