### PR TITLE
[JSC] Add Air OptimizePairedLoadStore phase

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1965,6 +1965,7 @@
 		E3F23A801ECF13F500978D99 /* SnippetReg.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7D1ECF13E500978D99 /* SnippetReg.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3F23A811ECF13FA00978D99 /* SnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7C1ECF13E500978D99 /* SnippetParams.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3F23A821ECF13FE00978D99 /* Snippet.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7B1ECF13E500978D99 /* Snippet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3F429BD2A41742F00C5FEFF /* AirOptimizePairedLoadStore.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F429BB2A41742700C5FEFF /* AirOptimizePairedLoadStore.h */; };
 		E3FB853A22F3667B008F90ED /* WasmCalleeRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FB853822F36674008F90ED /* WasmCalleeRegistry.h */; };
 		E3FCCB642310A90D00238E72 /* ConstructorKind.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FCCB632310A90D00238E72 /* ConstructorKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FF752F1D9CEA1200C7E16D /* DOMJITGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5516,6 +5517,8 @@
 		E3F23A7C1ECF13E500978D99 /* SnippetParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnippetParams.h; sourceTree = "<group>"; };
 		E3F23A7D1ECF13E500978D99 /* SnippetReg.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnippetReg.h; sourceTree = "<group>"; };
 		E3F23A7E1ECF13E500978D99 /* SnippetSlowPathCalls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnippetSlowPathCalls.h; sourceTree = "<group>"; };
+		E3F429BB2A41742700C5FEFF /* AirOptimizePairedLoadStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AirOptimizePairedLoadStore.h; path = b3/air/AirOptimizePairedLoadStore.h; sourceTree = "<group>"; };
+		E3F429BC2A41742700C5FEFF /* AirOptimizePairedLoadStore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AirOptimizePairedLoadStore.cpp; path = b3/air/AirOptimizePairedLoadStore.cpp; sourceTree = "<group>"; };
 		E3FB853822F36674008F90ED /* WasmCalleeRegistry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmCalleeRegistry.h; sourceTree = "<group>"; };
 		E3FB853922F36674008F90ED /* WasmCalleeRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCalleeRegistry.cpp; sourceTree = "<group>"; };
 		E3FC25102256ECF400583518 /* DoublePredictionFuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DoublePredictionFuzzerAgent.cpp; sourceTree = "<group>"; };
@@ -6368,6 +6371,8 @@
 				264091FA1BE2FD4100684DB2 /* AirOpcode.opcodes */,
 				0FB3878C1BFBC44D00E3AB1E /* AirOptimizeBlockOrder.cpp */,
 				0FB3878D1BFBC44D00E3AB1E /* AirOptimizeBlockOrder.h */,
+				E3F429BC2A41742700C5FEFF /* AirOptimizePairedLoadStore.cpp */,
+				E3F429BB2A41742700C5FEFF /* AirOptimizePairedLoadStore.h */,
 				0F9CABC61DB54A760008E83B /* AirPadInterference.cpp */,
 				0F9CABC71DB54A760008E83B /* AirPadInterference.h */,
 				0F2AC56C1E8D7AFF0001EE3F /* AirPhaseInsertionSet.cpp */,
@@ -9734,6 +9739,7 @@
 				0F40E4A81C497F7400A577FA /* AirOpcodeGenerated.h in Headers */,
 				0F40E4A91C497F7400A577FA /* AirOpcodeUtils.h in Headers */,
 				0FB387901BFBC44D00E3AB1E /* AirOptimizeBlockOrder.h in Headers */,
+				E3F429BD2A41742F00C5FEFF /* AirOptimizePairedLoadStore.h in Headers */,
 				0F9CABC91DB54A7A0008E83B /* AirPadInterference.h in Headers */,
 				0F2AC56F1E8D7B030001EE3F /* AirPhaseInsertionSet.h in Headers */,
 				0FEC85841BDACDC70080FF74 /* AirPhaseScope.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -95,6 +95,7 @@ b3/air/AirLowerEntrySwitch.cpp
 b3/air/AirLowerMacros.cpp
 b3/air/AirLowerStackArgs.cpp
 b3/air/AirOptimizeBlockOrder.cpp
+b3/air/AirOptimizePairedLoadStore.cpp
 b3/air/AirPadInterference.cpp
 b3/air/AirPhaseInsertionSet.cpp
 b3/air/AirPhaseScope.cpp

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1656,6 +1656,27 @@ public:
         m_assembler.ldp<32>(dest1, dest2, src.base, PairPostIndex(src.index));
     }
 
+    void loadPair32(Address address, RegisterID dest1, RegisterID dest2)
+    {
+        loadPair32(address.base, TrustedImm32(address.offset), dest1, dest2);
+    }
+
+    void loadPair32(RegisterID src, TrustedImm32 offset, FPRegisterID dest1, FPRegisterID dest2)
+    {
+        ASSERT(dest1 != dest2); // If it is the same, ldp becomes illegal instruction.
+        if (ARM64Assembler::isValidLDPFPImm<32>(offset.m_value)) {
+            m_assembler.ldp<32>(dest1, dest2, src, offset.m_value);
+            return;
+        }
+        loadFloat(Address(src, offset.m_value), dest1);
+        loadFloat(Address(src, offset.m_value + 8), dest2);
+    }
+
+    void loadPairFloat(Address src, FPRegisterID dest1, FPRegisterID dest2)
+    {
+        loadPair32(src.base, TrustedImm32(src.offset), dest1, dest2);
+    }
+
     void loadPair64(RegisterID src, RegisterID dest1, RegisterID dest2)
     {
         loadPair64(src, TrustedImm32(0), dest1, dest2);
@@ -1685,6 +1706,11 @@ public:
     void loadPair64(PostIndexAddress src, RegisterID dest1, RegisterID dest2)
     {
         m_assembler.ldp<64>(dest1, dest2, src.base, PairPostIndex(src.index));
+    }
+
+    void loadPair64(Address address, RegisterID dest1, RegisterID dest2)
+    {
+        loadPair64(address.base, TrustedImm32(address.offset), dest1, dest2);
     }
 
     void loadPair64WithNonTemporalAccess(RegisterID src, RegisterID dest1, RegisterID dest2)
@@ -1722,6 +1748,11 @@ public:
         }
         loadDouble(Address(src, offset.m_value), dest1);
         loadDouble(Address(src, offset.m_value + 8), dest2);
+    }
+
+    void loadPairDouble(Address src, FPRegisterID dest1, FPRegisterID dest2)
+    {
+        loadPair64(src.base, TrustedImm32(src.offset), dest1, dest2);
     }
 
     void abortWithReason(AbortReason reason)
@@ -2110,6 +2141,26 @@ public:
         m_assembler.stp<32>(src1, src2, dest.base, PairPostIndex(dest.index));
     }
 
+    void storePair32(RegisterID src1, RegisterID src2, Address dest)
+    {
+        storePair32(src1, src2, dest.base, TrustedImm32(dest.offset));
+    }
+
+    void storePair32(FPRegisterID src1, FPRegisterID src2, RegisterID dest, TrustedImm32 offset)
+    {
+        if (ARM64Assembler::isValidSTPFPImm<32>(offset.m_value)) {
+            m_assembler.stp<32>(src1, src2, dest, offset.m_value);
+            return;
+        }
+        storeFloat(src1, Address(dest, offset.m_value));
+        storeFloat(src2, Address(dest, offset.m_value + 8));
+    }
+
+    void storePairFloat(FPRegisterID src1, FPRegisterID src2, Address dest)
+    {
+        storePair32(src1, src2, dest.base, TrustedImm32(dest.offset));
+    }
+
     void storePair64(RegisterID src1, RegisterID src2, RegisterID dest)
     {
         storePair64(src1, src2, dest, TrustedImm32(0));
@@ -2150,6 +2201,11 @@ public:
         store64(src2, Address(dest, offset.m_value + 8));
     }
 
+    void storePair64(RegisterID src1, RegisterID src2, Address dest)
+    {
+        storePair64(src1, src2, dest.base, TrustedImm32(dest.offset));
+    }
+
     void storePair64(FPRegisterID src1, FPRegisterID src2, RegisterID dest)
     {
         storePair64(src1, src2, dest, TrustedImm32(0));
@@ -2163,6 +2219,11 @@ public:
         }
         storeDouble(src1, Address(dest, offset.m_value));
         storeDouble(src2, Address(dest, offset.m_value + 8));
+    }
+
+    void storePairDouble(FPRegisterID src1, FPRegisterID src2, Address dest)
+    {
+        storePair64(src1, src2, dest.base, TrustedImm32(dest.offset));
     }
 
     void store32(RegisterID src, Address address)

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1227,20 +1227,20 @@ private:
                 default:
                     break;
                 case Air::Store8:
-                    if (isValidForm(Air::Store8, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width8))
-                        return Inst(Air::Store8, m_value, zeroReg(), dest);
+                    if (isValidForm(move.opcode, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width8))
+                        return Inst(move, m_value, zeroReg(), dest);
                     break;
                 case Air::Store16:
-                    if (isValidForm(Air::Store16, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width16))
-                        return Inst(Air::Store16, m_value, zeroReg(), dest);
+                    if (isValidForm(move.opcode, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width16))
+                        return Inst(move, m_value, zeroReg(), dest);
                     break;
                 case Air::Move32:
-                    if (isValidForm(Store32, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width32))
-                        return Inst(Store32, m_value, zeroReg(), dest);
+                    if (isValidForm(move.opcode, Arg::ZeroReg, dest.kind()) && dest.isValidForm(move.opcode, Width32))
+                        return Inst(move, m_value, zeroReg(), dest);
                     break;
                 case Air::Move:
-                    if (isValidForm(Store64, Arg::ZeroReg, dest.kind()) && dest.isValidForm(Move, Width64))
-                        return Inst(Store64, m_value, zeroReg(), dest);
+                    if (isValidForm(move.opcode, Arg::ZeroReg, dest.kind()) && dest.isValidForm(move.opcode, Width64))
+                        return Inst(move, m_value, zeroReg(), dest);
                     break;
                 }
             }

--- a/Source/JavaScriptCore/b3/air/AirInst.h
+++ b/Source/JavaScriptCore/b3/air/AirInst.h
@@ -143,7 +143,10 @@ struct Inst {
     // registers. Note that Thing can only be Arg or Tmp when you use this functor.
     template<typename Thing, typename Functor>
     static void forEachDefWithExtraClobberedRegs(Inst* prevInst, Inst* nextInst, const Functor&);
-    
+
+    template<typename Thing, typename Functor>
+    static void forEachUse(Inst* prevInst, Inst* nextInst, const Functor&);
+
     // Some summaries about all arguments. These are useful for needsPadding().
     bool hasEarlyDef();
     bool hasLateUseOrDef();

--- a/Source/JavaScriptCore/b3/air/AirInstInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirInstInlines.h
@@ -57,6 +57,26 @@ inline RegisterSetBuilder Inst::extraEarlyClobberedRegs()
 }
 
 template<typename Thing, typename Functor>
+inline void Inst::forEachUse(Inst* prevInst, Inst* nextInst, const Functor& functor)
+{
+    if (prevInst) {
+        prevInst->forEach<Thing>(
+            [&] (Thing& thing, Arg::Role role, Bank argBank, Width argWidth) {
+                if (Arg::isLateUse(role))
+                    functor(thing, role, argBank, argWidth);
+            });
+    }
+
+    if (nextInst) {
+        nextInst->forEach<Thing>(
+            [&] (Thing& thing, Arg::Role role, Bank argBank, Width argWidth) {
+                if (Arg::isEarlyUse(role))
+                    functor(thing, role, argBank, argWidth);
+            });
+    }
+}
+
+template<typename Thing, typename Functor>
 inline void Inst::forEachDef(Inst* prevInst, Inst* nextInst, const Functor& functor)
 {
     if (prevInst) {

--- a/Source/JavaScriptCore/b3/air/AirKind.h
+++ b/Source/JavaScriptCore/b3/air/AirKind.h
@@ -42,7 +42,6 @@ namespace JSC { namespace B3 { namespace Air {
 struct Kind {
     Kind(Opcode opcode)
         : opcode(opcode)
-        , effects(false)
     {
     }
     
@@ -54,12 +53,13 @@ struct Kind {
     bool operator==(const Kind& other) const
     {
         return opcode == other.opcode
-            && effects == other.effects;
+            && effects == other.effects
+            && spill == other.spill;
     }
     
     unsigned hash() const
     {
-        return static_cast<unsigned>(opcode) + (static_cast<unsigned>(effects) << 16);
+        return static_cast<unsigned>(opcode) + (static_cast<unsigned>(effects) << 16) + (static_cast<unsigned>(spill) << 17);
     }
     
     explicit operator bool() const
@@ -75,7 +75,10 @@ struct Kind {
     // any of the following:
     // - Trap.
     // - Perform some non-arg non-control effect.
-    bool effects : 1;
+    bool effects : 1 { false };
+
+    // This marks whether this instruction was generated for stack spilling.
+    bool spill : 1 { false };
 };
 
 } } } // namespace JSC::B3::Air

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -154,6 +154,8 @@ void lowerStackArgs(Code& code)
                     switch (arg.kind()) {
                     case Arg::Stack: {
                         StackSlot* slot = arg.stackSlot();
+                        if (inst.kind.opcode == Move && slot->kind() == StackSlotKind::Spill)
+                            inst.kind.spill = true;
                         if (Arg::isZDef(role)
                             && slot->kind() == StackSlotKind::Spill
                             && slot->byteSize() > bytesForWidth(width)) {
@@ -165,7 +167,7 @@ void lowerStackArgs(Code& code)
                             RELEASE_ASSERT(width == Width32);
 
 #if CPU(ARM64) || CPU(RISCV64)
-                            Air::Opcode storeOpcode = Store32;
+                            Air::Opcode storeOpcode = Move32;
                             Air::Arg::Kind operandKind = Arg::ZeroReg;
                             Air::Arg operand = Arg::zeroReg();
 #elif CPU(X86_64) || CPU(ARM)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -721,13 +721,23 @@ arm64: MoveWithIncrement32 UD:G:32, ZD:G:32
 Move32 U:G:32, ZD:G:32, S:G:32
     Addr, Addr, Tmp
 
-arm64: Store32 U:G:32, ZD:G:32
-    ZeroReg, Addr
-    ZeroReg, Index
+arm64: LoadPair32 U:G:64, D:G:32, D:G:32
+    Addr, Tmp, Tmp
 
-arm64: Store64 U:G:64, D:G:64
-    ZeroReg, Addr
-    ZeroReg, Index
+arm64: LoadPair64 U:G:128, D:G:64, D:G:64
+    Addr, Tmp, Tmp
+
+arm64: StorePair32 U:G:32, U:G:32, D:G:64
+    Tmp, Tmp, Addr
+    ZeroReg, Tmp, Addr
+    Tmp, ZeroReg, Addr
+    ZeroReg, ZeroReg, Addr
+
+arm64: StorePair64 U:G:64, U:G:64, D:G:128
+    Tmp, Tmp, Addr
+    ZeroReg, Tmp, Addr
+    Tmp, ZeroReg, Addr
+    ZeroReg, ZeroReg, Addr
 
 64: SignExtend8To64 U:G:8, D:G:64
     Tmp, Tmp
@@ -777,7 +787,19 @@ MoveDouble U:F:64, D:F:64
 
 MoveDouble U:F:64, D:F:64, S:F:64
     Addr, Addr, Tmp
-    
+
+arm64: LoadPairFloat U:F:64, D:F:32, D:F:32
+    Addr, Tmp, Tmp
+
+arm64: LoadPairDouble U:F:128, D:F:64, D:F:64
+    Addr, Tmp, Tmp
+
+arm64: StorePairFloat U:F:32, U:F:32, D:F:64
+    Tmp, Tmp, Addr
+
+arm64: StorePairDouble U:F:64, U:F:64, D:F:128
+    Tmp, Tmp, Addr
+
 64: MoveVector U:F:128, D:F:128
     Tmp, Tmp
     Addr, Tmp as loadVector

--- a/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
+++ b/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AirOptimizePairedLoadStore.h"
+
+#if ENABLE(B3_JIT)
+#if CPU(ARM64)
+
+#include "AirArgInlines.h"
+#include "AirCode.h"
+#include "AirInst.h"
+#include "AirPhaseScope.h"
+#include <wtf/Range.h>
+
+namespace JSC { namespace B3 { namespace Air {
+namespace AirOptimizePairedLoadStoreInternal {
+static constexpr bool verbose = false;
+static constexpr unsigned scanInstructions = 16;
+}
+
+static inline Width accessWidth(Opcode opcode)
+{
+    switch (opcode) {
+    case Move:
+        return pointerWidth();
+    case Move32:
+        return Width32;
+    case MoveFloat:
+        return Width32;
+    case MoveDouble:
+        return Width64;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return Width8;
+    }
+}
+
+static bool tryStorePair(Code& code, BasicBlock* block, unsigned current, Inst& inst)
+{
+    Width instWidth = accessWidth(inst.kind.opcode);
+    int64_t instOffset = static_cast<int64_t>(inst.args[1].offset());
+    unsigned limit = std::min(current, AirOptimizePairedLoadStoreInternal::scanInstructions);
+    RegisterSet clobbered;
+    for (unsigned count = 1; count <= limit; ++count) {
+        unsigned index = current - count;
+        Inst& target = block->at(index);
+
+        auto logFound = [&](const Inst& newInst) {
+            if (AirOptimizePairedLoadStoreInternal::verbose) {
+                dataLogLn("FOUND  ", inst, " ", target, " => ", newInst);
+                for (unsigned i = 1; i < count; ++i)
+                    dataLogLn("    ", block->at(current - i));
+            }
+        };
+
+        auto logFailed = [&]() {
+            if (AirOptimizePairedLoadStoreInternal::verbose) {
+                dataLogLn("FAILED ", inst, " ", target);
+                for (unsigned i = 1; i < count; ++i)
+                    dataLogLn("    ", block->at(current - i));
+            }
+        };
+
+        // If the instruction has some special effect (including Patchpoint), we give up since we cannot model the effect of this.
+        if (target.hasNonArgEffects()) {
+            logFailed();
+            return false;
+        }
+
+        // If some instructions between the current and target clobbers registers used for current / target,
+        // then we cannot merge them since the current instruction's registers are changed.
+        //
+        //     stur %x1, [%fp]
+        //     movz %x2, #0
+        //     stur %x2, [%fp, #8]
+        //
+        // Then we cannot make it to
+        //
+        //     stp %x1, %x2, [%fp]
+        //     movz %x2, #0
+        Inst::forEachDefWithExtraClobberedRegs<Tmp>(
+            &block->at(index), &block->at(index + 1),
+            [&] (const Tmp& arg, Arg::Role, Bank, Width, PreservedWidth) {
+                clobbered.add(arg.reg(), IgnoreVectors);
+            });
+        if (clobbered.contains(inst.args[1].base().reg(), IgnoreVectors) || (inst.args[0].isTmp() && clobbered.contains(inst.args[0].reg(), IgnoreVectors))) {
+            logFailed();
+            return false;
+        }
+
+        {
+            // If some instructions between the current and target have memory-load or memory-store,
+            // then we cannot merge them since reordering can change the results.
+            // But this is really pessimistic: if the base is the same to the current instruction, and if the offset
+            // is different from the current instruction, it is OK actually.
+
+            bool interfere = false;
+
+            auto clobberMemory = [&](const Tmp& argBase, int64_t argOffset, Width argWidth) {
+                if (argBase == inst.args[1].base()) {
+                    Range<int64_t> argRange(argOffset, argOffset + bytesForWidth(argWidth));
+                    Range<int64_t> instRange(instOffset, instOffset + bytesForWidth(instWidth));
+                    return argRange.overlaps(instRange);
+                }
+
+                if ((argBase == Tmp(CCallHelpers::stackPointerRegister) || argBase == Tmp(GPRInfo::callFrameRegister)) && (inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args[1].base() == Tmp(GPRInfo::callFrameRegister))) {
+                    int64_t instOffsetFromFP = instOffset;
+                    if (inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister))
+                        instOffsetFromFP = instOffset - code.frameSize();
+
+                    int64_t argOffsetFromFP = argOffset;
+                    if (argBase == Tmp(CCallHelpers::stackPointerRegister))
+                        argOffsetFromFP = argOffset - code.frameSize();
+
+                    Range<int64_t> argRange(argOffsetFromFP, argOffsetFromFP + bytesForWidth(argWidth));
+                    Range<int64_t> instRange(instOffsetFromFP, instOffsetFromFP + bytesForWidth(instWidth));
+                    return argRange.overlaps(instRange);
+                }
+
+                return true;
+            };
+
+            auto checkInterfere = [&](const Arg& arg, Arg::Role, Bank, Width width) {
+                if (!arg.isMemory())
+                    return;
+                if (arg.isAddr()) {
+                    if (!clobberMemory(arg.base(), static_cast<int64_t>(arg.offset()), width))
+                        return;
+                }
+                if (arg.isSimpleAddr()) {
+                    if (!clobberMemory(arg.base(), 0, width))
+                        return;
+                }
+                interfere = true;
+            };
+
+            Inst::forEachUse<Arg>(&block->at(index), &block->at(index + 1), checkInterfere);
+            if (interfere) {
+                logFailed();
+                return false;
+            }
+            Inst::forEachDef<Arg>(&block->at(index), &block->at(index + 1), checkInterfere);
+            if (interfere) {
+                logFailed();
+                return false;
+            }
+        }
+
+        if (target.kind != inst.kind)
+            continue;
+
+        if (target.args.size() != 2)
+            continue;
+
+        if ((!target.args[0].isTmp() && !target.args[0].isZeroReg()) || !target.args[1].isAddr())
+            continue;
+
+        if (target.args[1].base() != inst.args[1].base())
+            continue;
+
+        Opcode pairOpcode = StorePair32;
+        switch (inst.kind.opcode) {
+        case Move32:
+            pairOpcode = StorePair32;
+            break;
+        case Move:
+            pairOpcode = StorePair64;
+            break;
+        case MoveDouble:
+            pairOpcode = StorePairDouble;
+            break;
+        case MoveFloat:
+            pairOpcode = StorePairFloat;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        auto isValidOffset = [&](auto offset) {
+            switch (inst.kind.opcode) {
+            case Move32:
+                return ARM64Assembler::isValidSTPImm<32>(offset);
+            case Move:
+                return ARM64Assembler::isValidSTPImm<64>(offset);
+            case MoveDouble:
+                return ARM64Assembler::isValidSTPFPImm<64>(offset);
+            case MoveFloat:
+                return ARM64Assembler::isValidSTPFPImm<32>(offset);
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                return false;
+            }
+        };
+
+        int64_t targetOffset = static_cast<int64_t>(target.args[1].offset());
+
+        if (isValidOffset(instOffset) && targetOffset == (instOffset + bytesForWidth(instWidth))) {
+            Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], inst.args[1]);
+            logFound(newInst);
+            target = newInst;
+            return true;
+        }
+
+        if (isValidOffset(targetOffset) && (targetOffset + bytesForWidth(instWidth)) == instOffset) {
+            Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], target.args[1]);
+            logFound(newInst);
+            target = newInst;
+            return true;
+        }
+
+        // Because str pimm only takes unsigned offset, we tend to pick stackPointerRegister based offsetting.
+        // But it is possible that framePointerRegister based offsetting can offer a benefit here.
+        if (target.args[1].base() == Tmp(CCallHelpers::stackPointerRegister)) {
+            int64_t instOffsetFromFP = instOffset - code.frameSize();
+            int64_t targetOffsetFromFP = targetOffset - code.frameSize();
+
+            if (isValidOffset(instOffsetFromFP) && targetOffsetFromFP == (instOffsetFromFP + bytesForWidth(instWidth))) {
+                Inst newInst(pairOpcode, target.origin, inst.args[0], target.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), instOffsetFromFP));
+                logFound(newInst);
+                target = newInst;
+                return true;
+            }
+
+            if (isValidOffset(targetOffsetFromFP) && (targetOffsetFromFP + bytesForWidth(instWidth)) == instOffsetFromFP) {
+                Inst newInst(pairOpcode, target.origin, target.args[0], inst.args[0], Arg::addr(Air::Tmp(GPRInfo::callFrameRegister), targetOffsetFromFP));
+                logFound(newInst);
+                target = newInst;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool optimizePairedLoadStore(Code& code)
+{
+    constexpr bool verbose = false;
+
+    PhaseScope phaseScope(code, "optimizePairedLoadStore");
+
+    if (verbose) {
+        dataLog("Air before an iteration of optimizePairedLoadStore:\n");
+        dataLog(code);
+    }
+
+    bool changed = false;
+    for (BasicBlock* block : code) {
+        unsigned index = block->size();
+        while (index--) {
+            Inst& inst = block->at(index);
+            if (inst.hasNonArgEffects())
+                continue;
+
+            switch (inst.kind.opcode) {
+            case Move:
+            case Move32: {
+                if (inst.args.size() != 2)
+                    continue;
+
+                if ((inst.args[0].isGPTmp() || inst.args[0].isZeroReg()) && inst.args[1].isAddr()) {
+                    // sp & fp slot usage is, in particular, different for call args and spills.
+                    // We would like to do stp merging only for spills.
+                    if ((inst.args[1].base() == Tmp(CCallHelpers::stackPointerRegister) || inst.args[1].base() == Tmp(CCallHelpers::framePointerRegister)) && !inst.kind.spill)
+                        continue;
+                    if (tryStorePair(code, block, index, inst)) {
+                        block->insts().remove(index);
+                        changed = true;
+                    }
+                    continue;
+                }
+                break;
+            }
+
+            default:
+                continue;
+            }
+        }
+    }
+
+    return changed;
+}
+
+} } } // namespace JSC::B3::Air
+
+#endif // CPU(ARM64)
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.h
+++ b/Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CPU.h"
+
+#if ENABLE(B3_JIT)
+#if CPU(ARM64)
+
+namespace JSC { namespace B3 { namespace Air {
+
+class Code;
+
+// Optimize
+
+bool optimizePairedLoadStore(Code&);
+
+} } } // namespace JSC::B3::Air
+
+#endif // CPU(ARM64)
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -454,6 +454,7 @@ bool canUseWebAssemblyFastMemory();
     v(Unsigned, maxB3TailDupBlockSuccessors, 3, Normal, nullptr) \
     v(Bool, useB3HoistLoopInvariantValues, false, Normal, nullptr) \
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
+    v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \
     v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects") \
     v(OptionString, functionOverrides, nullptr, Restricted, "file with debugging overrides for function bodies") \


### PR DESCRIPTION
#### 3632268ff8926089279b8c844d3d92a2cee78e69
<pre>
[JSC] Add Air OptimizePairedLoadStore phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=258293">https://bugs.webkit.org/show_bug.cgi?id=258293</a>
rdar://111026259

Reviewed by Keith Miller.

This patch attempts to fuse multiple stores into StorePair when possible.
We do this optimization very lately: one of the major target of this optimization is stack spills with %fp base.
We would like to perform this optimization *after* register allocation is done. Also since this is block-local analysis,
we would like to perform it after Air SimplifyCFG phase is done.

We currently do not attempt to merge multiple loads into LoadPair. The reason is that we observed 20% regression
in particular tests (JetStream3/async-fs / JetStream3/sync-fs) because it is repeatedly performing `ldp`
against recently `stur`-ed address, which causes much longer latency than just doing `ldur`. Until we find a good way to
determine when we merge multiple loads into LoadPair, we only do StorePair merging.

For StorePair merging, we observed very specific regression in JetStream2/crypto-md5-SP only when perfoming stp ongoing call-args.
As a conservative first step, we do not perform merging when the base is %sp or %fp and when they are not spills. To make it work,
we annotate `spill` infomration in AirKind.

This offers 2~% progression in JetStream2/tsf-wasm&apos;s Runtime.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::loadPair32):
(JSC::MacroAssemblerARM64::loadPair64):
(JSC::MacroAssemblerARM64::storePair32):
(JSC::MacroAssemblerARM64::storePair64):
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp:
(JSC::B3::Air::lowerStackArgs):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.cpp: Added.
(JSC::B3::Air::tryLoadPair):
(JSC::B3::Air::optimizePairedLoadStore):
* Source/JavaScriptCore/b3/air/AirOptimizePairedLoadStore.h: Added.

Canonical link: <a href="https://commits.webkit.org/265591@main">https://commits.webkit.org/265591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2132c8c87be6b1146500f878c3ea5bd56eb18709

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11263 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12914 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10741 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13650 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13326 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17395 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9565 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10675 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13571 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10687 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8866 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11363 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9952 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3080 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14227 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11682 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10635 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2851 "Passed tests") | 
<!--EWS-Status-Bubble-End-->