### PR TITLE
Allow multiple providers in a backing sharing sequence

### DIFF
--- a/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 8
+      (children 7
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,6 +21,7 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 385.00 832.00)
+                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -57,22 +58,6 @@
                       )
                     )
                   )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 24.00 106.00)
-          (bounds 385.00 350.00)
-          (clips 1)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
@@ -7,7 +7,7 @@
       (bounds 800.00 600.00)
       (contentsOpaque 1)
       (backingStoreAttached 1)
-      (children 10
+      (children 2
         (GraphicsLayer
           (position 9.00 14.00)
           (bounds 256.00 500.00)
@@ -17,7 +17,7 @@
             (GraphicsLayer
               (bounds 256.00 500.00)
               (backingStoreAttached 1)
-              (children 1
+              (children 2
                 (GraphicsLayer
                   (bounds 241.00 485.00)
                   (clips 1)
@@ -26,6 +26,32 @@
                     (GraphicsLayer
                       (anchor 0.00 0.00)
                       (bounds 241.00 1000.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                  )
+                )
+                (GraphicsLayer
+                  (bounds 256.00 500.00)
+                  (clips 1)
+                  (backingStoreAttached 1)
+                  (children 3
+                    (GraphicsLayer
+                      (position 0.00 485.00)
+                      (bounds 241.00 15.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                    (GraphicsLayer
+                      (position 241.00 0.00)
+                      (bounds 15.00 485.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                    (GraphicsLayer
+                      (position 241.00 485.00)
+                      (bounds 15.00 15.00)
+                      (drawsContent 1)
                       (backingStoreAttached 1)
                     )
                   )
@@ -43,7 +69,7 @@
             (GraphicsLayer
               (bounds 444.00 500.00)
               (backingStoreAttached 1)
-              (children 1
+              (children 2
                 (GraphicsLayer
                   (bounds origin 0.00 1000.00)
                   (bounds 429.00 485.00)
@@ -54,275 +80,35 @@
                       (scrollOffset (0,1000))
                       (anchor 0.00 0.00)
                       (bounds 429.00 2810.00)
+                      (drawsContent 1)
                       (backingStoreAttached 1)
                     )
                   )
                 )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 14.00)
-          (bounds 256.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 241.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
                 (GraphicsLayer
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 241.00 1000.00)
-                      (contentsOpaque 1)
-                      (backingStoreAttached 1)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 14.00)
-          (bounds 256.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 256.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 3
-                (GraphicsLayer
-                  (position 0.00 485.00)
-                  (bounds 241.00 15.00)
-                  (drawsContent 1)
+                  (bounds 444.00 500.00)
+                  (clips 1)
                   (backingStoreAttached 1)
-                )
-                (GraphicsLayer
-                  (position 241.00 0.00)
-                  (bounds 15.00 485.00)
-                  (drawsContent 1)
-                  (backingStoreAttached 1)
-                )
-                (GraphicsLayer
-                  (position 241.00 485.00)
-                  (bounds 15.00 15.00)
-                  (drawsContent 1)
-                  (backingStoreAttached 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
+                  (children 3
                     (GraphicsLayer
-                      (bounds 429.00 2810.00)
-                      (clips 1)
+                      (position 0.00 485.00)
+                      (bounds 429.00 15.00)
+                      (drawsContent 1)
                       (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 300.00)
-                          (bounds 409.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
+                    )
+                    (GraphicsLayer
+                      (position 429.00 0.00)
+                      (bounds 15.00 485.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
+                    )
+                    (GraphicsLayer
+                      (position 429.00 485.00)
+                      (bounds 15.00 15.00)
+                      (drawsContent 1)
+                      (backingStoreAttached 1)
                     )
                   )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 429.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 802.00)
-                          (bounds 409.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 1)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 429.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 1304.00)
-                          (bounds 409.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 1)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 429.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 1806.00)
-                          (bounds 409.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 429.00 485.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 429.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 2308.00)
-                          (bounds 409.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 3
-                (GraphicsLayer
-                  (position 0.00 485.00)
-                  (bounds 429.00 15.00)
-                  (drawsContent 1)
-                  (backingStoreAttached 1)
-                )
-                (GraphicsLayer
-                  (position 429.00 0.00)
-                  (bounds 15.00 485.00)
-                  (drawsContent 1)
-                  (backingStoreAttached 1)
-                )
-                (GraphicsLayer
-                  (position 429.00 485.00)
-                  (bounds 15.00 15.00)
-                  (drawsContent 1)
-                  (backingStoreAttached 1)
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 7
+      (children 6
         (GraphicsLayer
           (position 23.00 105.00)
           (bounds 402.00 352.00)
@@ -21,6 +21,7 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 400.00 832.00)
+                  (drawsContent 1)
                   (children 1
                     (GraphicsLayer
                       (position 20.00 110.00)
@@ -45,22 +46,6 @@
                       )
                     )
                   )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 24.00 106.00)
-          (bounds 400.00 350.00)
-          (clips 1)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 80.00)
-                  (contentsOpaque 1)
                 )
               )
             )

--- a/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
+++ b/LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt
@@ -7,7 +7,7 @@
       (bounds 800.00 600.00)
       (contentsOpaque 1)
       (backingStoreAttached 1)
-      (children 8
+      (children 2
         (GraphicsLayer
           (position 9.00 14.00)
           (bounds 256.00 500.00)
@@ -26,6 +26,7 @@
                     (GraphicsLayer
                       (anchor 0.00 0.00)
                       (bounds 256.00 1000.00)
+                      (drawsContent 1)
                       (backingStoreAttached 1)
                     )
                   )
@@ -54,207 +55,8 @@
                       (scrollOffset (0,1000))
                       (anchor 0.00 0.00)
                       (bounds 444.00 2810.00)
+                      (drawsContent 1)
                       (backingStoreAttached 1)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 14.00)
-          (bounds 256.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 256.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 256.00 1000.00)
-                      (contentsOpaque 1)
-                      (backingStoreAttached 1)
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 444.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 300.00)
-                          (bounds 424.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 444.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 802.00)
-                          (bounds 424.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 1)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 444.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 1304.00)
-                          (bounds 424.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 1)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 444.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 1806.00)
-                          (bounds 424.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 265.00 14.00)
-          (bounds 444.00 500.00)
-          (clips 1)
-          (backingStoreAttached 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 444.00 500.00)
-              (clips 1)
-              (backingStoreAttached 1)
-              (children 1
-                (GraphicsLayer
-                  (bounds origin 0.00 1000.00)
-                  (backingStoreAttached 0)
-                  (children 1
-                    (GraphicsLayer
-                      (bounds 444.00 2810.00)
-                      (clips 1)
-                      (backingStoreAttached 1)
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 2308.00)
-                          (bounds 424.00 202.00)
-                          (contentsOpaque 1)
-                          (drawsContent 1)
-                          (backingStoreAttached 0)
-                        )
-                      )
                     )
                   )
                 )

--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
@@ -11,7 +11,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,421))
   (behavior for fixed 1)
-  (children 2
+  (children 1
     (Overflow scrolling node
       (scrollable area size 310 310)
       (contents size 310 1112)
@@ -33,9 +33,6 @@
             (allows horizontal scrolling 1))
         )
       )
-    )
-    (Overflow scroll proxy node
-      (related overflow scrolling node scroll position (0,0))
     )
   )
 )

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
@@ -12,7 +12,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,421))
   (behavior for fixed 1)
-  (children 2
+  (children 1
     (Overflow scrolling node
       (scrollable area size 295 295)
       (contents size 295 1112)
@@ -34,9 +34,6 @@
             (allows horizontal scrolling 1))
         )
       )
-    )
-    (Overflow scroll proxy node
-      (related overflow scrolling node scroll position (0,0))
     )
   )
 )

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -379,8 +379,9 @@ public:
     void startTrackingCompositingUpdates() { m_compositingUpdateCount = 0; }
     unsigned compositingUpdateCount() const { return m_compositingUpdateCount; }
 
-private:
     class BackingSharingState;
+
+private:
     struct CompositingState;
     struct OverlapExtent;
     struct UpdateBackingTraversalState;


### PR DESCRIPTION
#### 0a80aee13182b2feee32d8519e716edf3e876e18
<pre>
Allow multiple providers in a backing sharing sequence
<a href="https://bugs.webkit.org/show_bug.cgi?id=258071">https://bugs.webkit.org/show_bug.cgi?id=258071</a>
rdar://84376322

Reviewed by Simon Fraser.

Currently there can be exactly one backing provider layer within a stacking context.
With this patch we allow multiple providers for overflow scroll layers as long as
they don&apos;t overlap. This helps layer explosion on walmart.com.

Compared to the previous reverted version this patch limits the scope by only allowing scroll layers
as providers in the multi-provider case. This avoids large provider pile-ups in normal layer case.
Scroll layers also have overflow clip making their overlap testing simple.

* LayoutTests/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/layer-creation/clipping-scope/nested-scroller-overlap-expected.txt:
* LayoutTests/platform/ios-wk2/compositing/scrolling/async-overflow-scrolling/nested-scrollers-backing-attachment-expected.txt:
* LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt:
* LayoutTests/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt:

Various test results change because more backing sharing. Visually the results are identical.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidates const):

Sharing layers are now tracked per-provider.

(WebCore::RenderLayerCompositor::BackingSharingState::startBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::continueBackingSharingSequence):

Append a new provider.

(WebCore::RenderLayerCompositor::BackingSharingState::endBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderForLayer):
(WebCore::RenderLayerCompositor::BackingSharingState::canUseMultipleProviders const):

Limit to overflow scrollers for now. These have overflow clip and are cheap to overlap test.

(WebCore::RenderLayerCompositor::BackingSharingState::updateBeforeDescendantTraversal):

Allow the sequence to continue if we find another non-overlapping scrolling layer.
If applicable it will become an additional provider later.

(WebCore::RenderLayerCompositor::BackingSharingState::updateAfterDescendantTraversal):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::traverseUnchangedSubtree):
(WebCore::RenderLayerCompositor::layerRepaintTargetsBackingSharingLayer const):
(WebCore::operator&lt;&lt;):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidate const): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::appendSharingLayer): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::isPotentialBackingSharingLayer const): Deleted.
(WebCore::RenderLayerCompositor::BackingSharingState::canIncludeLayer const): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/265576@main">https://commits.webkit.org/265576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c860bd55576bf8db691959a0aba22e1d5712d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11303 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13684 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13373 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10242 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8896 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9988 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->