### PR TITLE
[CSS] Use Ref instead of RefPtr to store child rules

### DIFF
--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -155,9 +155,8 @@ void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilde
         if (!index) {
             // It's the first rule.
             auto childRule = childRules[index];
-            ASSERT(childRule);
             if (childRule->isStyleRuleWithNesting()) {
-                auto& nestedStyleRule = downcast<StyleRuleWithNesting>(*childRule);
+                auto& nestedStyleRule = downcast<StyleRuleWithNesting>(childRule);
                 if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
                     decls.append(nestedStyleRule.properties().asText());
                     continue;
@@ -176,9 +175,9 @@ RefPtr<StyleRuleWithNesting> CSSGroupingRule::prepareChildStyleRuleForNesting(St
     auto& rules = m_groupRule->m_childRules;
     for (size_t i = 0 ; i < rules.size() ; i++) {
         auto& rule = rules[i];
-        if (rule == &styleRule) {
+        if (rule.ptr() == &styleRule) {
             auto styleRuleWithNesting = StyleRuleWithNesting::create(WTFMove(styleRule));
-            rules[i] = styleRuleWithNesting.ptr();
+            rules[i] = styleRuleWithNesting;
             if (auto* styleSheet = parentStyleSheet())
                 styleSheet->contents().setHasNestingRules();
             return styleRuleWithNesting;
@@ -215,7 +214,7 @@ void CSSGroupingRule::reattach(StyleRuleBase& rule)
     m_groupRule = downcast<StyleRuleGroup>(rule);
     for (unsigned i = 0; i < m_childRuleCSSOMWrappers.size(); ++i) {
         if (m_childRuleCSSOMWrappers[i])
-            m_childRuleCSSOMWrappers[i]->reattach(*m_groupRule.get().childRules()[i]);
+            m_childRuleCSSOMWrappers[i]->reattach(m_groupRule->childRules()[i]);
     }
 }
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -182,9 +182,9 @@ RefPtr<StyleRuleWithNesting> CSSStyleSheet::prepareChildStyleRuleForNesting(Styl
     RuleMutationScope scope(this);
     auto& rules = m_contents->m_childRules;
     for (size_t i = 0 ; i < rules.size() ; i++) {
-        if (rules[i] == &styleRule) {
+        if (rules[i].ptr() == &styleRule) {
             auto styleRuleWithNesting = StyleRuleWithNesting::create(WTFMove(styleRule));
-            rules[i] = styleRuleWithNesting.ptr();
+            rules[i] = styleRuleWithNesting;
             m_contents->setHasNestingRules();
             return styleRuleWithNesting;
         }        

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -274,11 +274,11 @@ Ref<StyleRule> StyleRule::createForSplitting(const Vector<const CSSSelector*>& s
     return styleRule;
 }
 
-Vector<RefPtr<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorComponentCount(unsigned maxCount) const
+Vector<Ref<StyleRule>> StyleRule::splitIntoMultipleRulesWithMaximumSelectorComponentCount(unsigned maxCount) const
 {
     ASSERT(selectorList().componentCount() > maxCount);
 
-    Vector<RefPtr<StyleRule>> rules;
+    Vector<Ref<StyleRule>> rules;
     Vector<const CSSSelector*> componentsSinceLastSplit;
 
     for (const CSSSelector* selector = selectorList().first(); selector; selector = CSSSelectorList::next(selector)) {
@@ -424,7 +424,7 @@ StyleRuleFontPaletteValues::StyleRuleFontPaletteValues(const AtomString& name, c
 {
 }
     
-StyleRuleGroup::StyleRuleGroup(StyleRuleType type, Vector<RefPtr<StyleRuleBase>>&& rules)
+StyleRuleGroup::StyleRuleGroup(StyleRuleType type, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleBase(type)
     , m_childRules(WTFMove(rules))
 {
@@ -432,11 +432,11 @@ StyleRuleGroup::StyleRuleGroup(StyleRuleType type, Vector<RefPtr<StyleRuleBase>>
 
 StyleRuleGroup::StyleRuleGroup(const StyleRuleGroup& other)
     : StyleRuleBase(other)
-    , m_childRules(other.childRules().map([](auto& rule) -> RefPtr<StyleRuleBase> { return rule->copy(); }))
+    , m_childRules(other.childRules().map([](auto& rule) -> Ref<StyleRuleBase> { return rule->copy(); }))
 {
 }
 
-const Vector<RefPtr<StyleRuleBase>>& StyleRuleGroup::childRules() const
+const Vector<Ref<StyleRuleBase>>& StyleRuleGroup::childRules() const
 {
     return m_childRules;
 }
@@ -451,7 +451,7 @@ void StyleRuleGroup::wrapperRemoveRule(unsigned index)
     m_childRules.remove(index);
 }
 
-StyleRuleMedia::StyleRuleMedia(MQ::MediaQueryList&& mediaQueries, Vector<RefPtr<StyleRuleBase>>&& rules)
+StyleRuleMedia::StyleRuleMedia(MQ::MediaQueryList&& mediaQueries, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::Media, WTFMove(rules))
     , m_mediaQueries(WTFMove(mediaQueries))
 {
@@ -463,7 +463,7 @@ StyleRuleMedia::StyleRuleMedia(const StyleRuleMedia& other)
 {
 }
 
-Ref<StyleRuleMedia> StyleRuleMedia::create(MQ::MediaQueryList&& mediaQueries, Vector<RefPtr<StyleRuleBase>>&& rules)
+Ref<StyleRuleMedia> StyleRuleMedia::create(MQ::MediaQueryList&& mediaQueries, Vector<Ref<StyleRuleBase>>&& rules)
 {
     return adoptRef(*new StyleRuleMedia(WTFMove(mediaQueries), WTFMove(rules)));
 }
@@ -473,25 +473,25 @@ Ref<StyleRuleMedia> StyleRuleMedia::copy() const
     return adoptRef(*new StyleRuleMedia(*this));
 }
 
-StyleRuleSupports::StyleRuleSupports(const String& conditionText, bool conditionIsSupported, Vector<RefPtr<StyleRuleBase>>&& rules)
+StyleRuleSupports::StyleRuleSupports(const String& conditionText, bool conditionIsSupported, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::Supports, WTFMove(rules))
     , m_conditionText(conditionText)
     , m_conditionIsSupported(conditionIsSupported)
 {
 }
 
-Ref<StyleRuleSupports> StyleRuleSupports::create(const String& conditionText, bool conditionIsSupported, Vector<RefPtr<StyleRuleBase>>&& rules)
+Ref<StyleRuleSupports> StyleRuleSupports::create(const String& conditionText, bool conditionIsSupported, Vector<Ref<StyleRuleBase>>&& rules)
 {
     return adoptRef(*new StyleRuleSupports(conditionText, conditionIsSupported, WTFMove(rules)));
 }
 
 StyleRuleLayer::StyleRuleLayer(Vector<CascadeLayerName>&& nameList)
-    : StyleRuleGroup(StyleRuleType::LayerStatement, Vector<RefPtr<StyleRuleBase>> { })
+    : StyleRuleGroup(StyleRuleType::LayerStatement, Vector<Ref<StyleRuleBase>> { })
     , m_nameVariant(WTFMove(nameList))
 {
 }
 
-StyleRuleLayer::StyleRuleLayer(CascadeLayerName&& name, Vector<RefPtr<StyleRuleBase>>&& rules)
+StyleRuleLayer::StyleRuleLayer(CascadeLayerName&& name, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::LayerBlock, WTFMove(rules))
     , m_nameVariant(WTFMove(name))
 {
@@ -502,18 +502,18 @@ Ref<StyleRuleLayer> StyleRuleLayer::createStatement(Vector<CascadeLayerName>&& n
     return adoptRef(*new StyleRuleLayer(WTFMove(nameList)));
 }
 
-Ref<StyleRuleLayer> StyleRuleLayer::createBlock(CascadeLayerName&& name, Vector<RefPtr<StyleRuleBase>>&& rules)
+Ref<StyleRuleLayer> StyleRuleLayer::createBlock(CascadeLayerName&& name, Vector<Ref<StyleRuleBase>>&& rules)
 {
     return adoptRef(*new StyleRuleLayer(WTFMove(name), WTFMove(rules)));
 }
 
-StyleRuleContainer::StyleRuleContainer(CQ::ContainerQuery&& query, Vector<RefPtr<StyleRuleBase>>&& rules)
+StyleRuleContainer::StyleRuleContainer(CQ::ContainerQuery&& query, Vector<Ref<StyleRuleBase>>&& rules)
     : StyleRuleGroup(StyleRuleType::Container, WTFMove(rules))
     , m_containerQuery(WTFMove(query))
 {
 }
 
-Ref<StyleRuleContainer> StyleRuleContainer::create(CQ::ContainerQuery&& query, Vector<RefPtr<StyleRuleBase>>&& rules)
+Ref<StyleRuleContainer> StyleRuleContainer::create(CQ::ContainerQuery&& query, Vector<Ref<StyleRuleBase>>&& rules)
 {
     return adoptRef(*new StyleRuleContainer(WTFMove(query), WTFMove(rules)));
 }

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -31,6 +31,7 @@
 #include "StyleRuleType.h"
 #include <map>
 #include <variant>
+#include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/UniqueArray.h>
@@ -124,7 +125,7 @@ public:
 
     void wrapperAdoptSelectorList(CSSSelectorList&&);
 
-    Vector<RefPtr<StyleRule>> splitIntoMultipleRulesWithMaximumSelectorComponentCount(unsigned) const;
+    Vector<Ref<StyleRule>> splitIntoMultipleRulesWithMaximumSelectorComponentCount(unsigned) const;
 
 #if ENABLE(CSS_SELECTOR_JIT)
     CompiledSelector& compiledSelectorForListIndex(unsigned index) const;
@@ -280,7 +281,7 @@ private:
 
 class StyleRuleGroup : public StyleRuleBase {
 public:
-    const Vector<RefPtr<StyleRuleBase>>& childRules() const;
+    const Vector<Ref<StyleRuleBase>>& childRules() const;
 
     void wrapperInsertRule(unsigned, Ref<StyleRuleBase>&&);
     void wrapperRemoveRule(unsigned);
@@ -289,23 +290,23 @@ public:
     friend class CSSStyleSheet;
 
 protected:
-    StyleRuleGroup(StyleRuleType, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleGroup(StyleRuleType, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleGroup(const StyleRuleGroup&);
     
 private:
-    mutable Vector<RefPtr<StyleRuleBase>> m_childRules;
+    mutable Vector<Ref<StyleRuleBase>> m_childRules;
 };
 
 class StyleRuleMedia final : public StyleRuleGroup {
 public:
-    static Ref<StyleRuleMedia> create(MQ::MediaQueryList&&, Vector<RefPtr<StyleRuleBase>>&&);
+    static Ref<StyleRuleMedia> create(MQ::MediaQueryList&&, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleMedia> copy() const;
 
     const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&& queries) { m_mediaQueries = WTFMove(queries); }
 
 private:
-    StyleRuleMedia(MQ::MediaQueryList&&, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleMedia(MQ::MediaQueryList&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleMedia(const StyleRuleMedia&);
 
     MQ::MediaQueryList m_mediaQueries;
@@ -313,14 +314,14 @@ private:
 
 class StyleRuleSupports final : public StyleRuleGroup {
 public:
-    static Ref<StyleRuleSupports> create(const String& conditionText, bool conditionIsSupported, Vector<RefPtr<StyleRuleBase>>&&);
+    static Ref<StyleRuleSupports> create(const String& conditionText, bool conditionIsSupported, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleSupports> copy() const { return adoptRef(*new StyleRuleSupports(*this)); }
 
     String conditionText() const { return m_conditionText; }
     bool conditionIsSupported() const { return m_conditionIsSupported; }
 
 private:
-    StyleRuleSupports(const String& conditionText, bool conditionIsSupported, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleSupports(const String& conditionText, bool conditionIsSupported, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleSupports(const StyleRuleSupports&) = default;
 
     String m_conditionText;
@@ -330,7 +331,7 @@ private:
 class StyleRuleLayer final : public StyleRuleGroup {
 public:
     static Ref<StyleRuleLayer> createStatement(Vector<CascadeLayerName>&&);
-    static Ref<StyleRuleLayer> createBlock(CascadeLayerName&&, Vector<RefPtr<StyleRuleBase>>&&);
+    static Ref<StyleRuleLayer> createBlock(CascadeLayerName&&, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleLayer> copy() const { return adoptRef(*new StyleRuleLayer(*this)); }
 
     bool isStatement() const { return type() == StyleRuleType::LayerStatement; }
@@ -340,7 +341,7 @@ public:
 
 private:
     StyleRuleLayer(Vector<CascadeLayerName>&&);
-    StyleRuleLayer(CascadeLayerName&&, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleLayer(CascadeLayerName&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleLayer(const StyleRuleLayer&) = default;
 
     std::variant<CascadeLayerName, Vector<CascadeLayerName>> m_nameVariant;
@@ -348,13 +349,13 @@ private:
 
 class StyleRuleContainer final : public StyleRuleGroup {
 public:
-    static Ref<StyleRuleContainer> create(CQ::ContainerQuery&&, Vector<RefPtr<StyleRuleBase>>&&);
+    static Ref<StyleRuleContainer> create(CQ::ContainerQuery&&, Vector<Ref<StyleRuleBase>>&&);
     Ref<StyleRuleContainer> copy() const { return adoptRef(*new StyleRuleContainer(*this)); }
 
     const CQ::ContainerQuery& containerQuery() const { return m_containerQuery; }
 
 private:
-    StyleRuleContainer(CQ::ContainerQuery&&, Vector<RefPtr<StyleRuleBase>>&&);
+    StyleRuleContainer(CQ::ContainerQuery&&, Vector<Ref<StyleRuleBase>>&&);
     StyleRuleContainer(const StyleRuleContainer&) = default;
 
     CQ::ContainerQuery m_containerQuery;

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -103,10 +103,10 @@ public:
     void clearRules();
 
     String encodingFromCharsetRule() const { return m_encodingFromCharsetRule; }
-    const Vector<RefPtr<StyleRuleLayer>>& layerRulesBeforeImportRules() const { return m_layerRulesBeforeImportRules; }
-    const Vector<RefPtr<StyleRuleImport>>& importRules() const { return m_importRules; }
-    const Vector<RefPtr<StyleRuleNamespace>>& namespaceRules() const { return m_namespaceRules; }
-    const Vector<RefPtr<StyleRuleBase>>& childRules() const { return m_childRules; }
+    const Vector<Ref<StyleRuleLayer>>& layerRulesBeforeImportRules() const { return m_layerRulesBeforeImportRules; }
+    const Vector<Ref<StyleRuleImport>>& importRules() const { return m_importRules; }
+    const Vector<Ref<StyleRuleNamespace>>& namespaceRules() const { return m_namespaceRules; }
+    const Vector<Ref<StyleRuleBase>>& childRules() const { return m_childRules; }
 
     void notifyLoadedSheet(const CachedCSSStyleSheet*);
     
@@ -166,10 +166,10 @@ private:
     String m_originalURL;
 
     String m_encodingFromCharsetRule;
-    Vector<RefPtr<StyleRuleLayer>> m_layerRulesBeforeImportRules;
-    Vector<RefPtr<StyleRuleImport>> m_importRules;
-    Vector<RefPtr<StyleRuleNamespace>> m_namespaceRules;
-    Vector<RefPtr<StyleRuleBase>> m_childRules;
+    Vector<Ref<StyleRuleLayer>> m_layerRulesBeforeImportRules;
+    Vector<Ref<StyleRuleImport>> m_importRules;
+    Vector<Ref<StyleRuleNamespace>> m_namespaceRules;
+    Vector<Ref<StyleRuleBase>> m_childRules;
     typedef HashMap<AtomString, AtomString> PrefixNamespaceURIMap;
     PrefixNamespaceURIMap m_namespaces;
     AtomString m_defaultNamespace;

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -135,7 +135,7 @@ private:
     RefPtr<StyleRuleBase> consumeQualifiedRule(CSSParserTokenRange&, AllowedRulesType);
 
     // This function is used for all the nested group rules (@media, @supports,..etc)
-    Vector<RefPtr<StyleRuleBase>> consumeRegularRuleList(CSSParserTokenRange block);
+    Vector<Ref<StyleRuleBase>> consumeRegularRuleList(CSSParserTokenRange block);
 
     static RefPtr<StyleRuleCharset> consumeCharsetRule(CSSParserTokenRange prelude);
     RefPtr<StyleRuleImport> consumeImportRule(CSSParserTokenRange prelude);
@@ -172,7 +172,7 @@ private:
 
     static Vector<double> consumeKeyframeKeyList(CSSParserTokenRange);
 
-    RefPtr<StyleRuleBase> createNestingParentRule();
+    Ref<StyleRuleBase> createNestingParentRule();
     void runInNewNestingContext(auto&& run);
     NestingContext& topContext()
     {

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -391,7 +391,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
     for (const auto& rule : childRules) {
         if (!rule->isStyleRule())
             return true;
-        const auto& styleRule = downcast<StyleRule>(*rule);
+        const auto& styleRule = downcast<StyleRule>(rule);
 
         const auto& selectorList = styleRule.selectorList();
         if (selectorList.listSize() != 1)

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -95,7 +95,7 @@ void RuleSetBuilder::addRulesFromSheet(const StyleSheetContents& sheet, const MQ
     m_mediaQueryCollector.pop(sheetQuery);
 }
 
-void RuleSetBuilder::addChildRules(const Vector<RefPtr<StyleRuleBase>>& rules)
+void RuleSetBuilder::addChildRules(const Vector<Ref<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
         if (requiresStaticMediaQueryEvaluation)
@@ -104,26 +104,26 @@ void RuleSetBuilder::addChildRules(const Vector<RefPtr<StyleRuleBase>>& rules)
     }
 }
 
-void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
+void RuleSetBuilder::addChildRule(Ref<StyleRuleBase> rule)
 {
     switch (rule->type()) {
     case StyleRuleType::StyleWithNesting:
         if (m_ruleSet)
-            addStyleRule(downcast<StyleRuleWithNesting>(*rule));
+            addStyleRule(downcast<StyleRuleWithNesting>(rule));
         return;
 
     case StyleRuleType::Style:
         if (m_ruleSet)
-            addStyleRule(downcast<StyleRule>(*rule));
+            addStyleRule(downcast<StyleRule>(rule));
         return;
 
     case StyleRuleType::Page:
         if (m_ruleSet)
-            m_ruleSet->addPageRule(downcast<StyleRulePage>(*rule));
+            m_ruleSet->addPageRule(downcast<StyleRulePage>(rule));
         return;
 
     case StyleRuleType::Media: {
-        auto& mediaRule = downcast<StyleRuleMedia>(*rule);
+        auto& mediaRule = downcast<StyleRuleMedia>(rule);
         if (m_mediaQueryCollector.pushAndEvaluate(mediaRule.mediaQueries()))
             addChildRules(mediaRule.childRules());
         m_mediaQueryCollector.pop(mediaRule.mediaQueries());
@@ -131,7 +131,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
     }
 
     case StyleRuleType::Container: {
-        auto& containerRule = downcast<StyleRuleContainer>(*rule);
+        auto& containerRule = downcast<StyleRuleContainer>(rule);
         auto previousContainerQueryIdentifier = m_currentContainerQueryIdentifier;
         if (m_ruleSet) {
             m_ruleSet->m_containerQueries.append({ containerRule, previousContainerQueryIdentifier });
@@ -147,7 +147,7 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
     case StyleRuleType::LayerStatement: {
         disallowDynamicMediaQueryEvaluationIfNeeded();
 
-        auto& layerRule = downcast<StyleRuleLayer>(*rule);
+        auto& layerRule = downcast<StyleRuleLayer>(rule);
         if (layerRule.isStatement()) {
             // Statement syntax just registers the layers.
             registerLayers(layerRule.nameList());
@@ -167,12 +167,12 @@ void RuleSetBuilder::addChildRule(RefPtr<StyleRuleBase> rule)
     case StyleRuleType::Property:
         disallowDynamicMediaQueryEvaluationIfNeeded();
         if (m_resolver)
-            m_collectedResolverMutatingRules.append({ *rule, m_currentCascadeLayerIdentifier });
+            m_collectedResolverMutatingRules.append({ rule, m_currentCascadeLayerIdentifier });
         return;
 
     case StyleRuleType::Supports:
-        if (downcast<StyleRuleSupports>(*rule).conditionIsSupported())
-            addChildRules(downcast<StyleRuleSupports>(*rule).childRules());
+        if (downcast<StyleRuleSupports>(rule).conditionIsSupported())
+            addChildRules(downcast<StyleRuleSupports>(rule).childRules());
         return;
 
     case StyleRuleType::Import:
@@ -255,7 +255,7 @@ void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
     // Process nested rules
     m_styleRuleStack.append(&selectorList);
     for (auto& nestedRule : rule.nestedRules())
-        addChildRule(nestedRule.ptr());
+        addChildRule(nestedRule);
     m_styleRuleStack.removeLast();
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -42,8 +42,8 @@ private:
 
     void addStyleRule(StyleRuleWithNesting&);
     void addRulesFromSheetContents(const StyleSheetContents&);
-    void addChildRules(const Vector<RefPtr<StyleRuleBase>>&);
-    void addChildRule(RefPtr<StyleRuleBase>);
+    void addChildRules(const Vector<Ref<StyleRuleBase>>&);
+    void addChildRule(Ref<StyleRuleBase>);
     void disallowDynamicMediaQueryEvaluationIfNeeded();
     void addStyleRuleWithSelectorList(const CSSSelectorList&, const StyleRule&);
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -46,25 +46,21 @@
 namespace WebCore {
 namespace Style {
 
-static bool shouldDirtyAllStyle(const Vector<RefPtr<StyleRuleBase>>& rules)
+static bool shouldDirtyAllStyle(const Vector<Ref<StyleRuleBase>>& rules)
 {
     for (auto& rule : rules) {
-        if (is<StyleRuleMedia>(*rule)) {
-            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(*rule).childRules()))
+        if (is<StyleRuleMedia>(rule)) {
+            if (shouldDirtyAllStyle(downcast<StyleRuleMedia>(rule).childRules()))
                 return true;
             continue;
         }
-        if (is<StyleRuleWithNesting>(*rule)) {
-            auto childRules = downcast<StyleRuleWithNesting>(*rule).nestedRules().map(
-                [](auto& rule) {
-                    return RefPtr { rule.ptr() };
-                });
-            if (shouldDirtyAllStyle(childRules))
+        if (is<StyleRuleWithNesting>(rule)) {
+            if (shouldDirtyAllStyle(downcast<StyleRuleWithNesting>(rule).nestedRules()))
                 return true;
             continue;
         }
         // FIXME: At least font faces don't need full recalc in all cases.
-        if (!is<StyleRule>(*rule))
+        if (!is<StyleRule>(rule))
             return true;
     }
     return false;

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -141,9 +141,9 @@ void UserAgentStyle::addToDefaultStyle(StyleSheetContents& sheet)
     // Build a stylesheet consisting of non-trivial media queries seen in default style.
     // Rulesets for these can't be global and need to be built in document context.
     for (auto& rule : sheet.childRules()) {
-        if (!is<StyleRuleMedia>(*rule))
+        if (!is<StyleRuleMedia>(rule))
             continue;
-        auto& mediaRule = downcast<StyleRuleMedia>(*rule);
+        auto& mediaRule = downcast<StyleRuleMedia>(rule);
         auto& mediaQuery = mediaRule.mediaQueries();
         if (screenEval().evaluate(mediaQuery))
             continue;


### PR DESCRIPTION
#### b84670c51376b97ae8da0159656e720f793da5ee
<pre>
[CSS] Use Ref instead of RefPtr to store child rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=258295">https://bugs.webkit.org/show_bug.cgi?id=258295</a>
rdar://111030709

Reviewed by Brent Fulgham.

* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
(WebCore::CSSGroupingRule::prepareChildStyleRuleForNesting):
(WebCore::CSSGroupingRule::reattach):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::prepareChildStyleRuleForNesting):
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::splitIntoMultipleRulesWithMaximumSelectorComponentCount const):
(WebCore::StyleRuleGroup::StyleRuleGroup):
(WebCore::StyleRuleGroup::childRules const):
(WebCore::StyleRuleMedia::StyleRuleMedia):
(WebCore::StyleRuleMedia::create):
(WebCore::StyleRuleSupports::StyleRuleSupports):
(WebCore::StyleRuleSupports::create):
(WebCore::StyleRuleLayer::StyleRuleLayer):
(WebCore::StyleRuleLayer::createBlock):
(WebCore::StyleRuleContainer::StyleRuleContainer):
(WebCore::StyleRuleContainer::create):
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parserAppendRule):
(WebCore::StyleSheetContents::ruleAt const):
(WebCore::StyleSheetContents::wrapperInsertRule):
(WebCore::traverseRulesInVector):
(WebCore::StyleSheetContents::traverseRules const):
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parseStyleSheet):
(WebCore::CSSParserImpl::parseStyleSheetForInspector):
(WebCore::CSSParserImpl::consumeRuleList):
(WebCore::CSSParserImpl::createNestingParentRule):
(WebCore::CSSParserImpl::consumeRegularRuleList):
(WebCore::CSSParserImpl::consumeFontFeatureValuesRule):
(WebCore::CSSParserImpl::consumeKeyframesRule):
* Source/WebCore/css/parser/CSSParserImpl.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addChildRules):
(WebCore::Style::RuleSetBuilder::addChildRule):
(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::addToDefaultStyle):

Canonical link: <a href="https://commits.webkit.org/265350@main">https://commits.webkit.org/265350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c09f04683f0491002630e8e4ce671fd28927c9d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12268 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11705 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8930 "7 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12671 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16852 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9363 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->