### PR TITLE
ThreadSafeWeakPtr should be able to be safely created during object destructor

### DIFF
--- a/Source/WTF/wtf/CompactRefPtrTuple.h
+++ b/Source/WTF/wtf/CompactRefPtrTuple.h
@@ -49,9 +49,8 @@ public:
 
     void setPointer(T* pointer)
     {
-        WTF::DefaultRefDerefTraits<T>::refIfNotNull(pointer);
         auto* old = m_data.pointer();
-        m_data.setPointer(pointer);
+        m_data.setPointer(WTF::DefaultRefDerefTraits<T>::refIfNotNull(pointer));
         WTF::DefaultRefDerefTraits<T>::derefIfNotNull(old);
     }
 

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -237,7 +237,7 @@ namespace WTF {
     // make PtrHash the default hash function for pointer types that don't specialize
 
     template<typename P> struct DefaultHash<P*> : PtrHash<P*> { };
-    template<typename P> struct DefaultHash<RefPtr<P>> : PtrHash<RefPtr<P>> { };
+    template<typename P, typename Q, typename R> struct DefaultHash<RefPtr<P, Q, R>> : PtrHash<RefPtr<P, Q, R>> { };
     template<typename P> struct DefaultHash<Ref<P>> : PtrHash<Ref<P>> { };
 
     template<typename P, typename Deleter> struct DefaultHash<std::unique_ptr<P, Deleter>> : PtrHash<std::unique_ptr<P, Deleter>> { };

--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -201,19 +201,20 @@ template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<Uni
     static TakeType take(std::nullptr_t) { return nullptr; }
 };
 
-template<typename P> struct HashTraits<RefPtr<P>> : SimpleClassHashTraits<RefPtr<P>> {
+template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> : SimpleClassHashTraits<RefPtr<P, Q, R>> {
     static P* emptyValue() { return nullptr; }
 
-    typedef P* PeekType;
-    static PeekType peek(const RefPtr<P>& value) { return value.get(); }
+    using PeekType = P*;
+    static PeekType peek(const RefPtr<P, Q, R>& value) { return value.get(); }
     static PeekType peek(P* value) { return value; }
 
-    static void customDeleteBucket(RefPtr<P>& value)
+    static void customDeleteBucket(RefPtr<P, Q, R>& value)
     {
         // See unique_ptr's customDeleteBucket() for an explanation.
-        ASSERT(!SimpleClassHashTraits<RefPtr<P>>::isDeletedValue(value));
+        bool isDeletedValue = SimpleClassHashTraits<RefPtr<P, Q, R>>::isDeletedValue(value);
+        ASSERT_UNUSED(isDeletedValue, !isDeletedValue);
         auto valueToBeDestroyed = WTFMove(value);
-        SimpleClassHashTraits<RefPtr<P>>::constructDeletedValue(value);
+        SimpleClassHashTraits<RefPtr<P, Q, R>>::constructDeletedValue(value);
     }
 };
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -30,15 +30,16 @@
 namespace WTF {
 
 template<typename T> struct DefaultRefDerefTraits {
-    static ALWAYS_INLINE void refIfNotNull(T* ptr)
+    static ALWAYS_INLINE T* refIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr != nullptr))
+        if (LIKELY(ptr))
             ptr->ref();
+        return ptr;
     }
 
     static ALWAYS_INLINE void derefIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr != nullptr))
+        if (LIKELY(ptr))
             ptr->deref();
     }
 };
@@ -59,9 +60,9 @@ public:
 
     ALWAYS_INLINE constexpr RefPtr() : m_ptr(nullptr) { }
     ALWAYS_INLINE constexpr RefPtr(std::nullptr_t) : m_ptr(nullptr) { }
-    ALWAYS_INLINE RefPtr(T* ptr) : m_ptr(ptr) { RefDerefTraits::refIfNotNull(ptr); }
-    ALWAYS_INLINE RefPtr(const RefPtr& o) : m_ptr(o.m_ptr) { RefDerefTraits::refIfNotNull(PtrTraits::unwrap(m_ptr)); }
-    template<typename X, typename Y, typename Z> RefPtr(const RefPtr<X, Y, Z>& o) : m_ptr(o.get()) { RefDerefTraits::refIfNotNull(PtrTraits::unwrap(m_ptr)); }
+    ALWAYS_INLINE RefPtr(T* ptr) : m_ptr(RefDerefTraits::refIfNotNull(ptr)) { }
+    ALWAYS_INLINE RefPtr(const RefPtr& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.m_ptr))) { }
+    template<typename X, typename Y, typename Z> RefPtr(const RefPtr<X, Y, Z>& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.get()))) { }
 
     ALWAYS_INLINE RefPtr(RefPtr&& o) : m_ptr(o.leakRef()) { }
     template<typename X, typename Y, typename Z> RefPtr(RefPtr<X, Y, Z>&& o) : m_ptr(o.leakRef()) { }

--- a/Source/WTF/wtf/ThreadSafeWeakHashSet.h
+++ b/Source/WTF/wtf/ThreadSafeWeakHashSet.h
@@ -92,22 +92,26 @@ public:
     const_iterator end() const { return { { } }; }
 
     template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
-    typename HashSet<std::pair<RefPtr<ThreadSafeWeakPtrControlBlock>, const T*>>::AddResult add(const U& value)
+    void add(const U& value)
     {
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!value.controlBlock().objectHasStartedDeletion());
         Locker locker { m_lock };
-        RefPtr retainedControlBlock { &value.controlBlock() };
+        ControlBlockRefPtr retainedControlBlock { &value.controlBlock() };
+        if (!retainedControlBlock)
+            return;
         amortizedCleanupIfNeeded();
-        return m_set.add({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
+        m_set.add({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
     }
 
     template<typename U, std::enable_if_t<std::is_convertible_v<U*, T*>>* = nullptr>
     bool remove(const U& value)
     {
         Locker locker { m_lock };
-        RefPtr retainedControlBlock { &value.controlBlock() };
+        ControlBlockRefPtr retainedControlBlock { &value.controlBlock() };
+        if (!retainedControlBlock)
+            return false;
         amortizedCleanupIfNeeded();
-        return m_set.remove({ &value.controlBlock(), static_cast<const T*>(&value) });
+        return m_set.remove({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
     }
 
     void clear()
@@ -121,7 +125,9 @@ public:
     bool contains(const U& value) const
     {
         Locker locker { m_lock };
-        RefPtr retainedControlBlock { &value.controlBlock() };
+        ControlBlockRefPtr retainedControlBlock { &value.controlBlock() };
+        if (!retainedControlBlock)
+            return false;
         amortizedCleanupIfNeeded();
         return m_set.contains({ WTFMove(retainedControlBlock), static_cast<const T*>(&value) });
     }
@@ -184,9 +190,7 @@ private:
         }
     }
 
-    // FIXME: Make PairHashTraits and RefHashTraits work together and change this back to a Ref<ThreadSafeWeakPtrControlBlock>.
-    // We only add non-null pointers.
-    mutable HashSet<std::pair<RefPtr<ThreadSafeWeakPtrControlBlock>, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
+    mutable HashSet<std::pair<ControlBlockRefPtr, const T*>> m_set WTF_GUARDED_BY_LOCK(m_lock);
     mutable unsigned m_operationCountSinceLastCleanup WTF_GUARDED_BY_LOCK(m_lock) { 0 };
     mutable Lock m_lock;
 };

--- a/Source/WebCore/Modules/webaudio/AudioNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioNode.h
@@ -282,15 +282,16 @@ private:
 };
 
 template<typename T> struct AudioNodeConnectionRefDerefTraits {
-    static ALWAYS_INLINE void refIfNotNull(T* ptr)
+    static ALWAYS_INLINE T* refIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr != nullptr))
+        if (LIKELY(ptr))
             ptr->incrementConnectionCount();
+        return ptr;
     }
 
     static ALWAYS_INLINE void derefIfNotNull(T* ptr)
     {
-        if (LIKELY(ptr != nullptr))
+        if (LIKELY(ptr))
             ptr->decrementConnectionCount();
     }
 };

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPtr.h
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPtr.h
@@ -49,15 +49,16 @@ struct WebGPUPtrTraits {
 };
 
 template <typename T, void (*reference)(T), void(*release)(T)> struct BaseWebGPURefDerefTraits {
-    static ALWAYS_INLINE void refIfNotNull(T t)
+    static ALWAYS_INLINE T refIfNotNull(T t)
     {
-        if (LIKELY(t != nullptr))
+        if (LIKELY(t))
             reference(t);
+        return t;
     }
 
     static ALWAYS_INLINE void derefIfNotNull(T t)
     {
-        if (LIKELY(t != nullptr))
+        if (LIKELY(t))
             release(t);
     }
 };

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.cpp
@@ -25,10 +25,11 @@
 
 namespace WTF {
 
-void DefaultRefDerefTraits<cairo_t>::refIfNotNull(cairo_t* ptr)
+cairo_t* DefaultRefDerefTraits<cairo_t>::refIfNotNull(cairo_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_t>::derefIfNotNull(cairo_t* ptr)
@@ -37,10 +38,11 @@ void DefaultRefDerefTraits<cairo_t>::derefIfNotNull(cairo_t* ptr)
         cairo_destroy(ptr);
 }
 
-void DefaultRefDerefTraits<cairo_surface_t>::refIfNotNull(cairo_surface_t* ptr)
+cairo_surface_t* DefaultRefDerefTraits<cairo_surface_t>::refIfNotNull(cairo_surface_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_surface_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_surface_t>::derefIfNotNull(cairo_surface_t* ptr)
@@ -49,10 +51,11 @@ void DefaultRefDerefTraits<cairo_surface_t>::derefIfNotNull(cairo_surface_t* ptr
         cairo_surface_destroy(ptr);
 }
 
-void DefaultRefDerefTraits<cairo_font_face_t>::refIfNotNull(cairo_font_face_t* ptr)
+cairo_font_face_t* DefaultRefDerefTraits<cairo_font_face_t>::refIfNotNull(cairo_font_face_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_font_face_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_font_face_t>::derefIfNotNull(cairo_font_face_t* ptr)
@@ -61,10 +64,11 @@ void DefaultRefDerefTraits<cairo_font_face_t>::derefIfNotNull(cairo_font_face_t*
         cairo_font_face_destroy(ptr);
 }
 
-void DefaultRefDerefTraits<cairo_scaled_font_t>::refIfNotNull(cairo_scaled_font_t* ptr)
+cairo_scaled_font_t* DefaultRefDerefTraits<cairo_scaled_font_t>::refIfNotNull(cairo_scaled_font_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_scaled_font_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_scaled_font_t>::derefIfNotNull(cairo_scaled_font_t* ptr)
@@ -73,10 +77,11 @@ void DefaultRefDerefTraits<cairo_scaled_font_t>::derefIfNotNull(cairo_scaled_fon
         cairo_scaled_font_destroy(ptr);
 }
 
-void DefaultRefDerefTraits<cairo_pattern_t>::refIfNotNull(cairo_pattern_t* ptr)
+cairo_pattern_t* DefaultRefDerefTraits<cairo_pattern_t>::refIfNotNull(cairo_pattern_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_pattern_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_pattern_t>::derefIfNotNull(cairo_pattern_t* ptr)
@@ -85,10 +90,11 @@ void DefaultRefDerefTraits<cairo_pattern_t>::derefIfNotNull(cairo_pattern_t* ptr
         cairo_pattern_destroy(ptr);
 }
 
-void DefaultRefDerefTraits<cairo_region_t>::refIfNotNull(cairo_region_t* ptr)
+cairo_region_t* DefaultRefDerefTraits<cairo_region_t>::refIfNotNull(cairo_region_t* ptr)
 {
     if (LIKELY(ptr))
         cairo_region_reference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<cairo_region_t>::derefIfNotNull(cairo_region_t* ptr)

--- a/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/RefPtrCairo.h
@@ -17,8 +17,7 @@
  *  Boston, MA 02110-1301, USA.
  */
 
-#ifndef RefPtrCairo_h
-#define RefPtrCairo_h
+#pragma once
 
 #if USE(CAIRO)
 
@@ -35,42 +34,40 @@ namespace WTF {
 
 template<>
 struct DefaultRefDerefTraits<cairo_t> {
-    WEBCORE_EXPORT static void refIfNotNull(cairo_t* ptr);
-    WEBCORE_EXPORT static void derefIfNotNull(cairo_t* ptr);
+    WEBCORE_EXPORT static cairo_t* refIfNotNull(cairo_t*);
+    WEBCORE_EXPORT static void derefIfNotNull(cairo_t*);
 };
 
 template<>
 struct DefaultRefDerefTraits<cairo_surface_t> {
-    WEBCORE_EXPORT static void refIfNotNull(cairo_surface_t* ptr);
-    WEBCORE_EXPORT static void derefIfNotNull(cairo_surface_t* ptr);
+    WEBCORE_EXPORT static cairo_surface_t* refIfNotNull(cairo_surface_t*);
+    WEBCORE_EXPORT static void derefIfNotNull(cairo_surface_t*);
 };
 
 template<>
 struct DefaultRefDerefTraits<cairo_font_face_t> {
-    static void refIfNotNull(cairo_font_face_t* ptr);
-    static void derefIfNotNull(cairo_font_face_t* ptr);
+    static cairo_font_face_t* refIfNotNull(cairo_font_face_t*);
+    static void derefIfNotNull(cairo_font_face_t*);
 };
 
 template<>
 struct DefaultRefDerefTraits<cairo_scaled_font_t> {
-    static void refIfNotNull(cairo_scaled_font_t* ptr);
-    WEBCORE_EXPORT static void derefIfNotNull(cairo_scaled_font_t* ptr);
+    static cairo_scaled_font_t* refIfNotNull(cairo_scaled_font_t*);
+    WEBCORE_EXPORT static void derefIfNotNull(cairo_scaled_font_t*);
 };
 
 template<>
 struct DefaultRefDerefTraits<cairo_pattern_t> {
-    static void refIfNotNull(cairo_pattern_t*);
+    static cairo_pattern_t* refIfNotNull(cairo_pattern_t*);
     static void derefIfNotNull(cairo_pattern_t*);
 };
 
 template<>
 struct DefaultRefDerefTraits<cairo_region_t> {
-    static void refIfNotNull(cairo_region_t*);
+    static cairo_region_t* refIfNotNull(cairo_region_t*);
     static void derefIfNotNull(cairo_region_t*);
 };
 
 } // namespace WTF
 
 #endif // USE(CAIRO)
-
-#endif // RefPtrCairo_h

--- a/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.cpp
+++ b/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.cpp
@@ -25,10 +25,11 @@
 
 namespace WTF {
 
-void DefaultRefDerefTraits<FcPattern>::refIfNotNull(FcPattern* ptr)
+FcPattern* DefaultRefDerefTraits<FcPattern>::refIfNotNull(FcPattern* ptr)
 {
     if (LIKELY(ptr))
         FcPatternReference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<FcPattern>::derefIfNotNull(FcPattern* ptr)
@@ -37,10 +38,11 @@ void DefaultRefDerefTraits<FcPattern>::derefIfNotNull(FcPattern* ptr)
         FcPatternDestroy(ptr);
 }
 
-void DefaultRefDerefTraits<FcConfig>::refIfNotNull(FcConfig* ptr)
+FcConfig* DefaultRefDerefTraits<FcConfig>::refIfNotNull(FcConfig* ptr)
 {
     if (LIKELY(ptr))
         FcConfigReference(ptr);
+    return ptr;
 }
 
 void DefaultRefDerefTraits<FcConfig>::derefIfNotNull(FcConfig* ptr)

--- a/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.h
+++ b/Source/WebCore/platform/graphics/freetype/RefPtrFontconfig.h
@@ -30,14 +30,14 @@ namespace WTF {
 
 template<>
 struct DefaultRefDerefTraits<FcPattern> {
-    static void refIfNotNull(FcPattern* ptr);
-    static void derefIfNotNull(FcPattern* ptr);
+    static FcPattern* refIfNotNull(FcPattern*);
+    static void derefIfNotNull(FcPattern*);
 };
 
 template<>
 struct DefaultRefDerefTraits<FcConfig> {
-    static void refIfNotNull(FcConfig* ptr);
-    static void derefIfNotNull(FcConfig* ptr);
+    static FcConfig* refIfNotNull(FcConfig*);
+    static void derefIfNotNull(FcConfig*);
 };
 
 } // namespace WTF

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -3007,4 +3007,19 @@ TEST(WTF_ThreadSafeWeakPtr, RemoveInDestructor)
     }
 }
 
+TEST(WTF_ThreadSafeWeakPtr, WeakRefInDestructor)
+{
+    struct S;
+    static ThreadSafeWeakPtr<S> weakPtr;
+    struct S : ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<S> {
+        ~S() { weakPtr = { *this }; }
+    };
+
+    {
+        auto s = adoptRef(*new S);
+    }
+    auto shouldBeNull = weakPtr.get();
+    EXPECT_NULL(shouldBeNull.get());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 522fb3fb9f3b48d6d23181470190a899dd2cf1d0
<pre>
ThreadSafeWeakPtr should be able to be safely created during object destructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=258324">https://bugs.webkit.org/show_bug.cgi?id=258324</a>

Reviewed by Chris Dumez.

This requires a RefPtr to use traits to make it null if weakRef is called after the object&apos;s destructor
has been scheduled.  Otherwise, we get a non-null RefPtr to the control block.

* Source/WTF/wtf/CompactRefPtrTuple.h:
* Source/WTF/wtf/HashFunctions.h:
* Source/WTF/wtf/HashTraits.h:
(WTF::HashTraits&lt;RefPtr&lt;P&gt;&gt;::emptyValue): Deleted.
(WTF::HashTraits&lt;RefPtr&lt;P&gt;&gt;::peek): Deleted.
(WTF::HashTraits&lt;RefPtr&lt;P&gt;&gt;::customDeleteBucket): Deleted.
* Source/WTF/wtf/RefPtr.h:
(WTF::DefaultRefDerefTraits::refIfNotNull):
(WTF::DefaultRefDerefTraits::derefIfNotNull):
(WTF::RefPtr::RefPtr):
* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::weakRef):
(WTF::ThreadSafeWeakPtrControlBlock::weakDeref):
(WTF::ThreadSafeWeakPtrControlBlockRefDerefTraits::refIfNotNull):
(WTF::ThreadSafeWeakPtrControlBlockRefDerefTraits::derefIfNotNull):
(WTF::ThreadSafeWeakPtrControlBlock::ref const): Deleted.
(WTF::ThreadSafeWeakPtrControlBlock::deref const): Deleted.
* Source/WebCore/Modules/webaudio/AudioNode.h:
(WebCore::AudioNodeConnectionRefDerefTraits::refIfNotNull):
(WebCore::AudioNodeConnectionRefDerefTraits::derefIfNotNull):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUPtr.h:
(PAL::WebGPU::release):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265344@main">https://commits.webkit.org/265344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/011a3d751ca125b42cacdef60ad91bc6c032133f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13153 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16892 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9032 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13035 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10248 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10791 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9408 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2912 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13680 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11092 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1193 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10110 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2717 "Passed tests") | 
<!--EWS-Status-Bubble-End-->