### PR TITLE
Make topOrigin optional in URLKeepingBlobAlive

### DIFF
--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -413,7 +413,7 @@ const char* Blob::activeDOMObjectName() const
 
 URLKeepingBlobAlive Blob::handle() const
 {
-    return { m_internalURL, m_topOrigin };
+    return { m_internalURL };
 }
 
 WebCoreOpaqueRoot root(Blob* blob)

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -27,10 +27,11 @@
 #include "URLKeepingBlobAlive.h"
 
 #include "ThreadableBlobRegistry.h"
+#include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {
 
-URLKeepingBlobAlive::URLKeepingBlobAlive(const URL& url, const SecurityOriginData& topOrigin)
+URLKeepingBlobAlive::URLKeepingBlobAlive(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
     : m_url(url)
     , m_topOrigin(topOrigin)
 {
@@ -46,7 +47,7 @@ void URLKeepingBlobAlive::clear()
 {
     unregisterBlobURLHandleIfNecessary();
     m_url = { };
-    m_topOrigin = { };
+    m_topOrigin = std::nullopt;
 }
 
 URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URLKeepingBlobAlive&& other)
@@ -74,7 +75,7 @@ void URLKeepingBlobAlive::unregisterBlobURLHandleIfNecessary()
 
 URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() const
 {
-    return { m_url.isolatedCopy(), m_topOrigin.isolatedCopy() };
+    return { m_url.isolatedCopy(), crossThreadCopy(m_topOrigin) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class URLKeepingBlobAlive {
 public:
     URLKeepingBlobAlive() = default;
-    URLKeepingBlobAlive(const URL&, const SecurityOriginData&);
+    URLKeepingBlobAlive(const URL&, const std::optional<SecurityOriginData>& = std::nullopt);
     WEBCORE_EXPORT ~URLKeepingBlobAlive();
 
     URLKeepingBlobAlive(URLKeepingBlobAlive&&) = default;
@@ -46,7 +46,7 @@ public:
     operator const URL&() const { return m_url; }
     const URL& url() const { return m_url; }
     bool isEmpty() const { return m_url.isEmpty(); }
-    const SecurityOriginData& topOrigin() const { return m_topOrigin; }
+    std::optional<SecurityOriginData> topOrigin() const { return m_topOrigin; }
 
     void clear();
 
@@ -58,7 +58,7 @@ private:
     void unregisterBlobURLHandleIfNecessary();
 
     URL m_url;
-    SecurityOriginData m_topOrigin;
+    Markable<SecurityOriginData, SecurityOriginDataMarkableTraits> m_topOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SecurityOriginData.h
+++ b/Source/WebCore/page/SecurityOriginData.h
@@ -188,6 +188,10 @@ struct SecurityOriginDataHash {
     static const bool safeToCompareToEmptyOrDeleted = false;
 };
 
+struct SecurityOriginDataMarkableTraits {
+    static bool isEmptyValue(const SecurityOriginData& value) { return value.isNull(); }
+    static SecurityOriginData emptyValue() { return { }; }
+};
 } // namespace WebCore
 
 namespace WTF {


### PR DESCRIPTION
#### 0e157e8e441ff79d3915536606872dd9054b559f
<pre>
Make topOrigin optional in URLKeepingBlobAlive
<a href="https://bugs.webkit.org/show_bug.cgi?id=256499">https://bugs.webkit.org/show_bug.cgi?id=256499</a>
rdar://problem/109067113

Reviewed by Chris Dumez.

The top origin SecurityOriginData is not always required for keeping a Blob
alive. In the case where the Blob URL is the Blob&apos;s internal URL, there is not
an associated top origin. Therefore, we only set the top origin for Blob URLs
that are created by script where the top origin is well defined.

* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::handle const):
* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
(WebCore::URLKeepingBlobAlive::URLKeepingBlobAlive):
(WebCore::URLKeepingBlobAlive::clear):
(WebCore::URLKeepingBlobAlive::isolatedCopy const):
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
(WebCore::URLKeepingBlobAlive::topOrigin const):
* Source/WebCore/page/SecurityOriginData.h:
(WebCore::SecurityOriginDataMarkableTraits::isEmptyValue):
(WebCore::SecurityOriginDataMarkableTraits::emptyValue):

Canonical link: <a href="https://commits.webkit.org/265788@main">https://commits.webkit.org/265788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c508a6b20fb7a04af47865552162572008ee431d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14197 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13972 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17945 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14143 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9410 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10554 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2868 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->