### PR TITLE
Make RenderSVGPath check if its path is created before calling RenderSVGShape::strokeShape()

### DIFF
--- a/Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.cpp
@@ -40,7 +40,6 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGEllipse);
 
 LegacyRenderSVGEllipse::LegacyRenderSVGEllipse(SVGGraphicsElement& element, RenderStyle&& style)
     : LegacyRenderSVGShape(element, WTFMove(style))
-    , m_usePathFallback(false)
 {
 }
 
@@ -54,6 +53,7 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
     m_strokeBoundingBox = FloatRect();
     m_center = FloatPoint();
     m_radii = FloatSize();
+    clearPath();
 
     calculateRadiiAndCenter();
 
@@ -64,11 +64,8 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
     if (hasNonScalingStroke()) {
         // Fallback to LegacyRenderSVGShape if shape has a non-scaling stroke.
         LegacyRenderSVGShape::updateShapeFromElement();
-        m_usePathFallback = true;
         return;
     }
-
-    m_usePathFallback = false;
 
     m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
     m_strokeBoundingBox = m_fillBoundingBox;
@@ -99,7 +96,7 @@ void LegacyRenderSVGEllipse::calculateRadiiAndCenter()
 
 void LegacyRenderSVGEllipse::fillShape(GraphicsContext& context) const
 {
-    if (m_usePathFallback) {
+    if (hasPath()) {
         LegacyRenderSVGShape::fillShape(context);
         return;
     }
@@ -110,7 +107,7 @@ void LegacyRenderSVGEllipse::strokeShape(GraphicsContext& context) const
 {
     if (!style().hasVisibleStroke())
         return;
-    if (m_usePathFallback) {
+    if (hasPath()) {
         LegacyRenderSVGShape::strokeShape(context);
         return;
     }
@@ -119,13 +116,13 @@ void LegacyRenderSVGEllipse::strokeShape(GraphicsContext& context) const
 
 bool LegacyRenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
 {
-    // The optimized contains code below does not support non-smooth strokes so we need
-    // to fall back to LegacyRenderSVGShape::shapeDependentStrokeContains in these cases.
-    if (m_usePathFallback || !hasSmoothStroke()) {
-        if (!hasPath())
-            LegacyRenderSVGShape::updateShapeFromElement();
+    // The optimized code below does not support non-smooth strokes so we need to
+    // fall back to LegacyRenderSVGShape::shapeDependentStrokeContains in these cases.
+    if (!hasSmoothStroke() && !hasPath())
+        LegacyRenderSVGShape::updateShapeFromElement();
+
+    if (hasPath())
         return LegacyRenderSVGShape::shapeDependentStrokeContains(point, pointCoordinateSpace);
-    }
 
     float halfStrokeWidth = strokeWidth() / 2;
     FloatPoint center = FloatPoint(m_center.x() - point.x(), m_center.y() - point.y());
@@ -144,7 +141,7 @@ bool LegacyRenderSVGEllipse::shapeDependentStrokeContains(const FloatPoint& poin
 
 bool LegacyRenderSVGEllipse::shapeDependentFillContains(const FloatPoint& point, const WindRule fillRule) const
 {
-    if (m_usePathFallback)
+    if (hasPath())
         return LegacyRenderSVGShape::shapeDependentFillContains(point, fillRule);
 
     FloatPoint center = FloatPoint(m_center.x() - point.x(), m_center.y() - point.y());

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.h
@@ -40,7 +40,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGEllipse"_s; }
 
     void updateShapeFromElement() override;
-    bool isEmpty() const override { return m_usePathFallback ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
+    bool isEmpty() const override { return hasPath() ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;
     void strokeShape(GraphicsContext&) const override;
@@ -51,7 +51,6 @@ private:
 private:
     FloatPoint m_center;
     FloatSize m_radii;
-    bool m_usePathFallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGPath.h
@@ -49,6 +49,7 @@ private:
     Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
+    void strokeZeroLengthSubpaths(GraphicsContext&) const;
 
     bool isRenderingDisabled() const override;
 

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRect.h
@@ -46,7 +46,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGRect"_s; }
 
     void updateShapeFromElement() override;
-    bool isEmpty() const override { return m_usePathFallback ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
+    bool isEmpty() const override { return hasPath() ? LegacyRenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;
     void strokeShape(GraphicsContext&) const override;
@@ -56,7 +56,6 @@ private:
 private:
     FloatRect m_innerStrokeRect;
     FloatRect m_outerStrokeRect;
-    bool m_usePathFallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp
@@ -233,7 +233,7 @@ void LegacyRenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& 
     }
 }
 
-void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& originalContext)
+void LegacyRenderSVGShape::strokeShapeInternal(const RenderStyle& style, GraphicsContext& originalContext)
 {
     GraphicsContext* context = &originalContext;
     Color fallbackColor;
@@ -249,9 +249,9 @@ void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext
     }
 }
 
-void LegacyRenderSVGShape::strokeShape(GraphicsContext& context)
+void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style().hasVisibleStroke())
+    if (!style.hasVisibleStroke())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
@@ -260,7 +260,7 @@ void LegacyRenderSVGShape::strokeShape(GraphicsContext& context)
         if (!setupNonScalingStrokeContext(nonScalingTransform, stateSaver))
             return;
     }
-    strokeShape(style(), context);
+    strokeShapeInternal(style, context);
 }
 
 void LegacyRenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
@@ -271,7 +271,7 @@ void LegacyRenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
             fillShape(style(), childPaintInfo.context());
             break;
         case PaintType::Stroke:
-            strokeShape(childPaintInfo.context());
+            strokeShape(style(), childPaintInfo.context());
             break;
         case PaintType::Markers:
             if (!m_markerPositions.isEmpty())

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGShape.h
@@ -124,8 +124,8 @@ private:
     void processMarkerPositions();
 
     void fillShape(const RenderStyle&, GraphicsContext&);
+    void strokeShapeInternal(const RenderStyle&, GraphicsContext&);
     void strokeShape(const RenderStyle&, GraphicsContext&);
-    void strokeShape(GraphicsContext&);
     void fillStrokeMarkers(PaintInfo&);
     void drawMarkers(PaintInfo&);
 

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.h
@@ -42,7 +42,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGEllipse"_s; }
 
     void updateShapeFromElement() override;
-    bool isEmpty() const override { return m_usePathFallback ? RenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
+    bool isEmpty() const override { return hasPath() ? RenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;
     void strokeShape(GraphicsContext&) const override;
@@ -53,7 +53,6 @@ private:
 private:
     FloatPoint m_center;
     FloatSize m_radii;
-    bool m_usePathFallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -86,25 +86,12 @@ void RenderSVGPath::strokeShape(GraphicsContext& context) const
     if (!style().hasVisibleStroke())
         return;
 
-    RenderSVGShape::strokeShape(context);
-
-    if (m_zeroLengthLinecapLocations.isEmpty())
+    // This happens only if the layout was never been called for this element.
+    if (!hasPath())
         return;
 
-    Path* usePath;
-    AffineTransform nonScalingTransform;
-
-    if (hasNonScalingStroke())
-        nonScalingTransform = nonScalingStrokeTransform();
-
-    GraphicsContextStateSaver stateSaver(context, true);
-    useStrokeStyleToFill(context);
-    for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
-        if (hasNonScalingStroke())
-            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
-        context.fillPath(*usePath);
-    }
+    RenderSVGShape::strokeShape(context);
+    strokeZeroLengthSubpaths(context);
 }
 
 bool RenderSVGPath::shapeDependentStrokeContains(const FloatPoint& point, PointCoordinateSpace pointCoordinateSpace)
@@ -165,6 +152,25 @@ void RenderSVGPath::updateZeroLengthSubpaths()
         SVGSubpathData::updateFromPathElement(subpathData, pathElement);
     });
     subpathData.pathIsDone();
+}
+
+void RenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) const
+{
+    if (m_zeroLengthLinecapLocations.isEmpty())
+        return;
+
+    AffineTransform nonScalingTransform;
+    if (hasNonScalingStroke())
+        nonScalingTransform = nonScalingStrokeTransform();
+
+    GraphicsContextStateSaver stateSaver(context, true);
+    useStrokeStyleToFill(context);
+    for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
+        auto usePath = zeroLengthLinecapPath(m_zeroLengthLinecapLocations[i]);
+        if (hasNonScalingStroke())
+            usePath = nonScalingStrokePath(usePath, nonScalingTransform);
+        context.fillPath(*usePath);
+    }
 }
 
 bool RenderSVGPath::isRenderingDisabled() const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -51,6 +51,7 @@ private:
     Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();
+    void strokeZeroLengthSubpaths(GraphicsContext&) const;
 
     bool isRenderingDisabled() const override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.h
@@ -49,7 +49,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGRect"_s; }
 
     void updateShapeFromElement() override;
-    bool isEmpty() const override { return m_usePathFallback ? RenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
+    bool isEmpty() const override { return hasPath() ? RenderSVGShape::isEmpty() : m_fillBoundingBox.isEmpty(); }
     bool isRenderingDisabled() const override;
     void fillShape(GraphicsContext&) const override;
     void strokeShape(GraphicsContext&) const override;
@@ -59,7 +59,6 @@ private:
 private:
     FloatRect m_innerStrokeRect;
     FloatRect m_outerStrokeRect;
-    bool m_usePathFallback;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -222,7 +222,7 @@ void RenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& origin
     }
 }
 
-void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& originalContext)
+void RenderSVGShape::strokeShapeInternal(const RenderStyle& style, GraphicsContext& originalContext)
 {
     GraphicsContext* context = &originalContext;
     Color fallbackColor;
@@ -238,9 +238,9 @@ void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& orig
     }
 }
 
-void RenderSVGShape::strokeShape(GraphicsContext& context)
+void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style().hasVisibleStroke())
+    if (!style.hasVisibleStroke())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
@@ -249,7 +249,7 @@ void RenderSVGShape::strokeShape(GraphicsContext& context)
         if (!setupNonScalingStrokeContext(nonScalingTransform, stateSaver))
             return;
     }
-    strokeShape(style(), context);
+    strokeShapeInternal(style, context);
 }
 
 void RenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
@@ -260,7 +260,7 @@ void RenderSVGShape::fillStrokeMarkers(PaintInfo& childPaintInfo)
             fillShape(style(), childPaintInfo.context());
             break;
         case PaintType::Stroke:
-            strokeShape(childPaintInfo.context());
+            strokeShape(style(), childPaintInfo.context());
             break;
         case PaintType::Markers:
             if (!m_markerPositions.isEmpty())

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -128,8 +128,8 @@ private:
     void processMarkerPositions();
 
     void fillShape(const RenderStyle&, GraphicsContext&);
+    void strokeShapeInternal(const RenderStyle&, GraphicsContext&);
     void strokeShape(const RenderStyle&, GraphicsContext&);
-    void strokeShape(GraphicsContext&);
     void fillStrokeMarkers(PaintInfo&);
     void drawMarkers(PaintInfo&);
 


### PR DESCRIPTION
#### 76697a3fe448ca55326e8b18e0ee20d44494509d
<pre>
Make RenderSVGPath check if its path is created before calling RenderSVGShape::strokeShape()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258333">https://bugs.webkit.org/show_bug.cgi?id=258333</a>
rdar://110382674

Reviewed by Cameron McCormack.

1) Remove the flag `m_usePathFallback` from the SVG renderers. It is always set
to false when the fallback Path is cleared. It is set to true when the base class
method updateShapeFromElement() is called. So replace `m_usePathFallback` with
`hasPath()`.

2) RenderSVGShape has two strokeShape() functions. Both take a GraphicsContext as
an argument. One of them is marked as const and the other is  not. They have two
different behaviors. To remove this confusion, add a RenderStyle as an argument
to the non const one and rename the similar one strokeShapeInternal().

* Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.cpp:
(WebCore::LegacyRenderSVGEllipse::LegacyRenderSVGEllipse):
(WebCore::LegacyRenderSVGEllipse::updateShapeFromElement):
(WebCore::LegacyRenderSVGEllipse::fillShape const):
(WebCore::LegacyRenderSVGEllipse::strokeShape const):
(WebCore::LegacyRenderSVGEllipse::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGEllipse::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/LegacyRenderSVGEllipse.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::strokeShape const):
(WebCore::LegacyRenderSVGPath::strokeZeroLengthSubpaths const):
* Source/WebCore/rendering/svg/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGRect.cpp:
(WebCore::LegacyRenderSVGRect::LegacyRenderSVGRect):
(WebCore::LegacyRenderSVGRect::updateShapeFromElement):
(WebCore::LegacyRenderSVGRect::fillShape const):
(WebCore::LegacyRenderSVGRect::strokeShape const):
(WebCore::LegacyRenderSVGRect::shapeDependentStrokeContains):
(WebCore::LegacyRenderSVGRect::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/LegacyRenderSVGRect.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeShapeInternal):
(WebCore::LegacyRenderSVGShape::strokeShape):
(WebCore::LegacyRenderSVGShape::fillStrokeMarkers):
* Source/WebCore/rendering/svg/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::RenderSVGEllipse):
(WebCore::RenderSVGEllipse::updateShapeFromElement):
(WebCore::RenderSVGEllipse::fillShape const):
(WebCore::RenderSVGEllipse::strokeShape const):
(WebCore::RenderSVGEllipse::shapeDependentStrokeContains):
(WebCore::RenderSVGEllipse::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/RenderSVGEllipse.h:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::strokeShape const):
(WebCore::RenderSVGPath::strokeZeroLengthSubpaths const):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::RenderSVGRect):
(WebCore::RenderSVGRect::updateShapeFromElement):
(WebCore::RenderSVGRect::fillShape const):
(WebCore::RenderSVGRect::strokeShape const):
(WebCore::RenderSVGRect::shapeDependentStrokeContains):
(WebCore::RenderSVGRect::shapeDependentFillContains const):
* Source/WebCore/rendering/svg/RenderSVGRect.h:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeShapeInternal):
(WebCore::RenderSVGShape::strokeShape):
(WebCore::RenderSVGShape::fillStrokeMarkers):
* Source/WebCore/rendering/svg/RenderSVGShape.h:

Canonical link: <a href="https://commits.webkit.org/265374@main">https://commits.webkit.org/265374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a84b7ebe9de9ee1b2d148ac5bb9fd56c4212eb87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11248 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10292 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11805 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12785 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9687 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13089 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9464 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2569 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13737 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->