### PR TITLE
[JSC] Add fast path for TypedArray::setArrayLike

### DIFF
--- a/JSTests/microbenchmarks/typed-array-new-from-double-array.js
+++ b/JSTests/microbenchmarks/typed-array-new-from-double-array.js
@@ -1,0 +1,11 @@
+var array = [];
+for (var i = 0; i < 1024; ++i)
+    array.push(i + 0.5);
+
+function test(array) {
+    return new Uint32Array(array);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test(array);

--- a/JSTests/microbenchmarks/typed-array-new-from-int32-array.js
+++ b/JSTests/microbenchmarks/typed-array-new-from-int32-array.js
@@ -1,0 +1,11 @@
+var array = [];
+for (var i = 0; i < 1024; ++i)
+    array.push(i);
+
+function test(array) {
+    return new Uint32Array(array);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test(array);


### PR DESCRIPTION
#### a586f85207e80977e49deccbdb80f09cd1930f7c
<pre>
[JSC] Add fast path for TypedArray::setArrayLike
<a href="https://bugs.webkit.org/show_bug.cgi?id=258337">https://bugs.webkit.org/show_bug.cgi?id=258337</a>
rdar://111080722

Reviewed by Alexey Shvayka.

We should make `new TypedArray([0, 1, 2, 3, ...])` faster. This patch adds a fast path converting Int32 / Double arrays to TypedArray.

                                              ToT                     Patched

typed-array-new-from-double-array       61.5644+-0.2921     ^     14.6969+-0.2090        ^ definitely 4.1889x faster
typed-array-new-from-int32-array        54.1675+-0.2508     ^     15.0343+-0.2724        ^ definitely 3.6029x faster

* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):

Canonical link: <a href="https://commits.webkit.org/265346@main">https://commits.webkit.org/265346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319199a50df733d86141b3577ff4157166084643

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10886 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10854 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12745 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9062 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9646 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9049 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13048 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10265 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10807 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9424 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2918 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13697 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11111 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1194 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10127 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2720 "Passed tests") | 
<!--EWS-Status-Bubble-End-->