### PR TITLE
[JSC] Support ArrayWithInt32.concat(ArrayWithDouble) fast path

### DIFF
--- a/JSTests/microbenchmarks/array-concat-double-and-int32.js
+++ b/JSTests/microbenchmarks/array-concat-double-and-int32.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1, array2) {
+    return array1.concat(array2);
+}
+noInline(test);
+
+var array1 = [2.1, 2.2, 2.3, 2.4];
+var array2 = [0, 1, 2, 3, 4]
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1, array2);
+    shouldBe(result[0], 2.1);
+    shouldBe(result[1], 2.2);
+    shouldBe(result[2], 2.3);
+    shouldBe(result[3], 2.4);
+    shouldBe(result[4], 0);
+    shouldBe(result[5], 1);
+    shouldBe(result[6], 2);
+    shouldBe(result[7], 3);
+    shouldBe(result[8], 4);
+    shouldBe(result.length, 9);
+}

--- a/JSTests/microbenchmarks/array-concat-int32-and-double.js
+++ b/JSTests/microbenchmarks/array-concat-int32-and-double.js
@@ -1,0 +1,25 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array1, array2) {
+    return array1.concat(array2);
+}
+noInline(test);
+
+var array1 = [0, 1, 2, 3, 4]
+var array2 = [2.1, 2.2, 2.3, 2.4];
+for (var i = 0; i < 1e4; ++i) {
+    var result = test(array1, array2);
+    shouldBe(result[0], 0);
+    shouldBe(result[1], 1);
+    shouldBe(result[2], 2);
+    shouldBe(result[3], 3);
+    shouldBe(result[4], 4);
+    shouldBe(result[5], 2.1);
+    shouldBe(result[6], 2.2);
+    shouldBe(result[7], 2.3);
+    shouldBe(result[8], 2.4);
+    shouldBe(result.length, 9);
+}

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -488,7 +488,8 @@ bool JSArray::appendMemcpy(JSGlobalObject* globalObject, VM& vm, unsigned startI
 
     IndexingType type = indexingType();
     IndexingType otherType = otherArray->indexingType();
-    IndexingType copyType = mergeIndexingTypeForCopying(otherType);
+    bool allowPromotion = false;
+    IndexingType copyType = mergeIndexingTypeForCopying(otherType, allowPromotion);
     if (type == ArrayWithUndecided && copyType != NonArray) {
         if (copyType == ArrayWithInt32)
             convertUndecidedToInt32(vm);

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -111,7 +111,7 @@ public:
     bool canFastAppend(JSArray* otherArray) const;
     bool canDoFastIndexedAccess() const;
     // This function returns NonArray if the indexing types are not compatable for copying.
-    IndexingType mergeIndexingTypeForCopying(IndexingType other);
+    IndexingType mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion);
     bool appendMemcpy(JSGlobalObject*, VM&, unsigned startIndex, JSArray* otherArray);
 
     enum ShiftCountMode {

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other)
+inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other, bool allowPromotion)
 {
     IndexingType type = indexingType();
     if (!(type & IsArray && other & IsArray))
@@ -53,6 +53,14 @@ inline IndexingType JSArray::mergeIndexingTypeForCopying(IndexingType other)
         if (other == ArrayWithContiguous)
             return other;
         return type;
+    }
+
+    if (allowPromotion) {
+        if ((type == ArrayWithInt32 || type == ArrayWithDouble) && (other == ArrayWithInt32 || other == ArrayWithDouble)) {
+            if (type == other)
+                return type;
+            return ArrayWithDouble;
+        }
     }
 
     if (type != other)


### PR DESCRIPTION
#### 0ac3e5f3c4d0c91cfc3548c1a41b82cbb8735707
<pre>
[JSC] Support ArrayWithInt32.concat(ArrayWithDouble) fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=258340">https://bugs.webkit.org/show_bug.cgi?id=258340</a>
rdar://111085265

Reviewed by Michael Saboff.

This patch adds ArrayWithInt32.concat(ArrayWithDouble) fast path by promoting from Int32 to Double array.

                                              ToT                     Patched

    array-concat-int32-and-double        1.6732+-0.0203     ^      1.2596+-0.0190        ^ definitely 1.3283x faster
    array-concat-double-and-int32        1.5538+-0.0151     ^      1.2633+-0.0136        ^ definitely 1.2299x faster

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendOne):
(JSC::copyElements):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::appendMemcpy):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::mergeIndexingTypeForCopying):

Canonical link: <a href="https://commits.webkit.org/265386@main">https://commits.webkit.org/265386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc07f851fefb30de9be2662938bd83d7b8576f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11839 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12818 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16969 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13114 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8426 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10879 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9494 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2956 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13767 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11183 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1211 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10197 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2731 "Passed tests") | 
<!--EWS-Status-Bubble-End-->