### PR TITLE
When waitingForBackingStoreSwap and an updateRendering is pending, don't CommitLayerTreeNotTriggered but set m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap

### DIFF
--- a/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm
@@ -37,12 +37,7 @@
 
 namespace TestWebKitAPI {
 
-// FIXME when rdar://110536156 is resolved.
-#if PLATFORM(IOS)
-TEST(ApplicationStateTracking, DISABLED_WindowDeallocDoesNotPermanentlyFreezeLayerTree)
-#else
 TEST(ApplicationStateTracking, WindowDeallocDoesNotPermanentlyFreezeLayerTree)
-#endif
 {
     auto configuration = adoptNS([WKWebViewConfiguration new]);
 


### PR DESCRIPTION
#### dcb5bdf28a06089bd20da9444effac52e88384f8
<pre>
When waitingForBackingStoreSwap and an updateRendering is pending, don&apos;t CommitLayerTreeNotTriggered but set m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap
<a href="https://bugs.webkit.org/show_bug.cgi?id=258391">https://bugs.webkit.org/show_bug.cgi?id=258391</a>
rdar://110536156

Reviewed by Simon Fraser.

In some situations there may be a race between `displayDidRefresh` and `updateRendering`, such that `displayDidRefresh` runs first, sees no updates, and sends `commitLayerTreeNotTriggered` to the UI process, which will pause further refresh callbacks; in the test at fault, this meant `synchronouslyLoadHTMLString` would never return.
In contrast, the test would succeed when `updateRendering` happened first, which would notice that something was waiting for an update (`m_waitingForBackingStoreSwap` being true), and setting `m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap` to prevent the subsequent `displayDidRefresh` from pausing refresh callbacks.

So to remedy the bad situation, when `displayDidRefresh` would normally send `commitLayerTreeNotTriggered`, it first checks if `m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap` is true AND if there is a pending `updateRendering`, in which case instead it mimics what an race-winning `updateRendering` would have done, and sets `m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap`.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
* Tools/TestWebKitAPI/Tests/ios/ApplicationStateTracking.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265611@main">https://commits.webkit.org/265611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3b73613c28583d619db048a7d33b8f44be6a48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10827 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13269 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10972 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12865 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9174 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17010 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13158 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10381 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8467 "13 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9540 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2732 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->