### PR TITLE
[JHBuild] Add libjxl to moduleset

### DIFF
--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -7,30 +7,31 @@
 
   <metamodule id="webkitgtk-testing-dependencies">
     <dependencies>
+      <dep package="adwaita-icon-theme"/>
+      <dep package="atk"/>
       <dep package="avif"/>
       <dep package="cairo"/>
       <dep package="dicts"/>
       <dep package="fontconfig"/>
       <dep package="freetype6"/>
-      <dep package="harfbuzz"/>
-      <dep package="libxml2"/>
       <dep package="gdk-pixbuf"/>
-      <dep package="gtk+"/>
       <dep package="glib"/>
       <dep package="glib-networking"/>
-      <dep package="adwaita-icon-theme"/>
+      <dep package="gtk+"/>
+      <dep package="harfbuzz"/>
       <dep package="icu"/>
-      <dep package="atk"/>
-      <dep package="webkit-gstreamer-testing-dependencies"/>
-      <dep package="pango"/>
-      <dep package="llvm"/>
-      <dep package="shared-mime-info"/>
-      <dep package="libsecret"/>
-      <dep package="libgpg-error"/>
       <dep package="libgcrypt"/>
+      <dep package="libgpg-error"/>
+      <dep package="libjxl"/>
+      <dep package="libsecret"/>
+      <dep package="libxml2"/>
+      <dep package="llvm"/>
       <dep package="manette"/>
       <dep package="openjpeg"/>
+      <dep package="pango"/>
+      <dep package="shared-mime-info"/>
       <dep package="wpebackend-fdo"/>
+      <dep package="webkit-gstreamer-testing-dependencies"/>
       <if condition-set="linux">
           <dep package="xdg-dbus-proxy"/>
           <dep package="xserver"/>
@@ -576,5 +577,34 @@
       <dep package="glib"/>
     </dependencies>
   </autotools>
+
+  <!-- libjxl required for JPEGXL support -->
+  <cmake id="libjxl"
+         cmakeargs="-DBUILD_TESTING=OFF
+                    -DPROVISION_DEPENDENCIES=ON
+                    -DJPEGXL_ENABLE_FUZZERS=OFF
+                    -DJPEGXL_ENABLE_DEVTOOLS=OFF
+                    -DJPEGXL_ENABLE_TOOLS=OFF
+                    -DJPEGXL_ENABLE_MANPAGES=OFF
+                    -DJPEGXL_ENABLE_BENCHMARK=OFF
+                    -DJPEGXL_ENABLE_EXAMPLES=OFF
+                    -DJPEGXL_ENABLE_JNI=OFF
+                    -DJPEGXL_ENABLE_VIEWERS=OFF
+                    -DJPEGXL_ENABLE_TCMALLOC=OFF
+                    -DJPEGXL_ENABLE_PLUGINS=OFF
+                    -DJPEGXL_ENABLE_COVERAGE=OFF
+                    -DJPEGXL_ENABLE_TRANSCODE_JPEG=OFF
+                    -DJPEGXL_ENABLE_SJPEG=OFF
+                    -DJPEGXL_STATIC=OFF
+                    -DJPEGXL_WARNINGS_AS_ERRORS=OFF
+                    -DJPEGXL_ENABLE_SKCMS=ON">
+    <pkg-config>libjxl.pc</pkg-config>
+    <branch module="libjxl/libjxl.git"
+            tag="v0.6.1"
+            checkoutdir="libjxl-0.6.1"
+            repo="github.com">
+      <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
+    </branch>
+  </cmake>
 
 </moduleset>

--- a/Tools/gtk/patches/libjxl-add-cmake-flag-provision-dependencies.patch
+++ b/Tools/gtk/patches/libjxl-add-cmake-flag-provision-dependencies.patch
@@ -1,0 +1,36 @@
+From 4f433922a741268e0dbf4da432ca4c9e4317c6b6 Mon Sep 17 00:00:00 2001
+From: Diego Pino Garcia <dpino@igalia.com>
+Date: Tue, 20 Jun 2023 20:38:55 +0800
+Subject: [PATCH] add-cmake-flag-provision-dependencies
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c2790ab..2382603 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,6 +47,19 @@ if(CHECK_PIE_SUPPORTED)
+   endif()
+ endif()
+ 
++if(PROVISION_DEPENDENCIES)
++  # Run script to provision dependencies.
++  find_program (BASH_PROGRAM bash)
++  if(BASH_PROGRAM)
++    execute_process(
++      COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/deps.sh
++      RESULT_VARIABLE PROVISION_DEPENDENCIES_RESULT)
++  endif()
++  if(NOT PROVISION_DEPENDENCIES_RESULT EQUAL "0")
++    message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/deps.sh failed with ${PROVISION_DEPENDENCIES_RESULT}")
++  endif()
++endif()
++
+ ### Project build options:
+ if(${CXX_FUZZERS_SUPPORTED})
+   # Enabled by default except on arm64, Windows and Apple builds.
+-- 
+2.40.0
+

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -10,6 +10,7 @@
       <dep package="wpebackend-fdo"/>
       <dep package="icu"/>
       <dep package="manette"/>
+      <dep package="libjxl"/>
       <dep package="libvpx"/>
       <dep package="glib"/>
       <dep package="glib-networking"/>
@@ -26,6 +27,7 @@
       <dep package="wpebackend-fdo"/>
       <dep package="icu"/>
       <dep package="openxr"/>
+      <dep package="libjxl"/>
       <dep package="libvpx"/>
       <dep package="glib"/>
       <dep package="glib-networking"/>
@@ -222,5 +224,34 @@
       <dep package="at-spi2-core"/>
     </dependencies>
   </meson>
+
+  <!-- libjxl required for JPEGXL support -->
+  <cmake id="libjxl"
+         cmakeargs="-DBUILD_TESTING=OFF
+                    -DPROVISION_DEPENDENCIES=ON
+                    -DJPEGXL_ENABLE_FUZZERS=OFF
+                    -DJPEGXL_ENABLE_DEVTOOLS=OFF
+                    -DJPEGXL_ENABLE_TOOLS=OFF
+                    -DJPEGXL_ENABLE_MANPAGES=OFF
+                    -DJPEGXL_ENABLE_BENCHMARK=OFF
+                    -DJPEGXL_ENABLE_EXAMPLES=OFF
+                    -DJPEGXL_ENABLE_JNI=OFF
+                    -DJPEGXL_ENABLE_VIEWERS=OFF
+                    -DJPEGXL_ENABLE_TCMALLOC=OFF
+                    -DJPEGXL_ENABLE_PLUGINS=OFF
+                    -DJPEGXL_ENABLE_COVERAGE=OFF
+                    -DJPEGXL_ENABLE_TRANSCODE_JPEG=OFF
+                    -DJPEGXL_ENABLE_SJPEG=OFF
+                    -DJPEGXL_STATIC=OFF
+                    -DJPEGXL_WARNINGS_AS_ERRORS=OFF
+                    -DJPEGXL_ENABLE_SKCMS=ON">
+    <pkg-config>libjxl.pc</pkg-config>
+    <branch module="libjxl/libjxl.git"
+            tag="v0.6.1"
+            checkoutdir="libjxl-0.6.1"
+            repo="github.com">
+      <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
+    </branch>
+  </cmake>
 
 </moduleset>

--- a/Tools/jhbuild/patches/libjxl-add-cmake-flag-provision-dependencies.patch
+++ b/Tools/jhbuild/patches/libjxl-add-cmake-flag-provision-dependencies.patch
@@ -1,0 +1,36 @@
+From 4f433922a741268e0dbf4da432ca4c9e4317c6b6 Mon Sep 17 00:00:00 2001
+From: Diego Pino Garcia <dpino@igalia.com>
+Date: Tue, 20 Jun 2023 20:38:55 +0800
+Subject: [PATCH] add-cmake-flag-provision-dependencies
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c2790ab..2382603 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,6 +47,19 @@ if(CHECK_PIE_SUPPORTED)
+   endif()
+ endif()
+ 
++if(PROVISION_DEPENDENCIES)
++  # Run script to provision dependencies.
++  find_program (BASH_PROGRAM bash)
++  if(BASH_PROGRAM)
++    execute_process(
++      COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/deps.sh
++      RESULT_VARIABLE PROVISION_DEPENDENCIES_RESULT)
++  endif()
++  if(NOT PROVISION_DEPENDENCIES_RESULT EQUAL "0")
++    message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/deps.sh failed with ${PROVISION_DEPENDENCIES_RESULT}")
++  endif()
++endif()
++
+ ### Project build options:
+ if(${CXX_FUZZERS_SUPPORTED})
+   # Enabled by default except on arm64, Windows and Apple builds.
+-- 
+2.40.0
+

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -7,26 +7,27 @@
 
   <metamodule id="webkitwpe-testing-dependencies">
     <dependencies>
-      <dep package="glib"/>
+      <dep package="atk"/>
+      <dep package="at-spi2-atk"/>
       <dep package="cairo"/>
       <dep package="dicts"/>
       <dep package="fontconfig"/>
       <dep package="freetype6"/>
+      <dep package="glib"/>
       <dep package="harfbuzz"/>
       <dep package="icu"/>
-      <dep package="webkit-gstreamer-testing-dependencies"/>
-      <dep package="libwpe"/>
-      <dep package="wpebackend-fdo"/>
-      <dep package="libgpg-error"/>
-      <dep package="libgcrypt"/>
       <dep package="libepoxy"/>
-      <dep package="wayland-protocols"/>
-      <dep package="openjpeg"/>
-      <dep package="xdg-dbus-proxy"/>
-      <dep package="atk"/>
-      <dep package="at-spi2-atk"/>
+      <dep package="libgcrypt"/>
+      <dep package="libgpg-error"/>
+      <dep package="libjxl"/>
+      <dep package="libwpe"/>
       <dep package="libxml2"/>
+      <dep package="openjpeg"/>
       <dep package="shared-mime-info"/>
+      <dep package="wayland-protocols"/>
+      <dep package="wpebackend-fdo"/>
+      <dep package="xdg-dbus-proxy"/>
+      <dep package="webkit-gstreamer-testing-dependencies"/>
       <if condition-unset="USE_SOUP2">
         <dep package="libsoup3"/>
       </if>
@@ -324,5 +325,34 @@
             repo="freedesktop.org"
             hash="sha256:c625a83b4838befc8cafcd54e3619946515d9e44d63d61c4adf7f5513ddfbebf"/>
   </autotools>
+
+  <!-- libjxl required for JPEGXL support -->
+  <cmake id="libjxl"
+         cmakeargs="-DBUILD_TESTING=OFF
+                    -DPROVISION_DEPENDENCIES=ON
+                    -DJPEGXL_ENABLE_FUZZERS=OFF
+                    -DJPEGXL_ENABLE_DEVTOOLS=OFF
+                    -DJPEGXL_ENABLE_TOOLS=OFF
+                    -DJPEGXL_ENABLE_MANPAGES=OFF
+                    -DJPEGXL_ENABLE_BENCHMARK=OFF
+                    -DJPEGXL_ENABLE_EXAMPLES=OFF
+                    -DJPEGXL_ENABLE_JNI=OFF
+                    -DJPEGXL_ENABLE_VIEWERS=OFF
+                    -DJPEGXL_ENABLE_TCMALLOC=OFF
+                    -DJPEGXL_ENABLE_PLUGINS=OFF
+                    -DJPEGXL_ENABLE_COVERAGE=OFF
+                    -DJPEGXL_ENABLE_TRANSCODE_JPEG=OFF
+                    -DJPEGXL_ENABLE_SJPEG=OFF
+                    -DJPEGXL_STATIC=OFF
+                    -DJPEGXL_WARNINGS_AS_ERRORS=OFF
+                    -DJPEGXL_ENABLE_SKCMS=ON">
+    <pkg-config>libjxl.pc</pkg-config>
+    <branch module="libjxl/libjxl.git"
+            tag="v0.6.1"
+            checkoutdir="libjxl-0.6.1"
+            repo="github.com">
+      <patch file="libjxl-add-cmake-flag-provision-dependencies.patch" strip="1"/>
+    </branch>
+  </cmake>
 
 </moduleset>

--- a/Tools/wpe/patches/libjxl-add-cmake-flag-provision-dependencies.patch
+++ b/Tools/wpe/patches/libjxl-add-cmake-flag-provision-dependencies.patch
@@ -1,0 +1,36 @@
+From 4f433922a741268e0dbf4da432ca4c9e4317c6b6 Mon Sep 17 00:00:00 2001
+From: Diego Pino Garcia <dpino@igalia.com>
+Date: Tue, 20 Jun 2023 20:38:55 +0800
+Subject: [PATCH] add-cmake-flag-provision-dependencies
+
+---
+ CMakeLists.txt | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c2790ab..2382603 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,6 +47,19 @@ if(CHECK_PIE_SUPPORTED)
+   endif()
+ endif()
+ 
++if(PROVISION_DEPENDENCIES)
++  # Run script to provision dependencies.
++  find_program (BASH_PROGRAM bash)
++  if(BASH_PROGRAM)
++    execute_process(
++      COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/deps.sh
++      RESULT_VARIABLE PROVISION_DEPENDENCIES_RESULT)
++  endif()
++  if(NOT PROVISION_DEPENDENCIES_RESULT EQUAL "0")
++    message(FATAL_ERROR "${CMAKE_CURRENT_SOURCE_DIR}/deps.sh failed with ${PROVISION_DEPENDENCIES_RESULT}")
++  endif()
++endif()
++
+ ### Project build options:
+ if(${CXX_FUZZERS_SUPPORTED})
+   # Enabled by default except on arm64, Windows and Apple builds.
+-- 
+2.40.0
+


### PR DESCRIPTION
#### e45a46fae1a59709b4d5dd5c043352129364d150
<pre>
[JHBuild] Add libjxl to moduleset
<a href="https://bugs.webkit.org/show_bug.cgi?id=258341">https://bugs.webkit.org/show_bug.cgi?id=258341</a>

Reviewed by Carlos Alberto Lopez Perez.

Changeset &apos;265024@main&apos; enabled JPEGXL by default in WebKitGTK and WPE.
This caused a build failure in systems such as Ubuntu 20.04, Ubuntu
22.04 and Debian 11, which do not provide &apos;libjxl&apos; as a system library.

To work around the issue, the failing build bots disabled USE_JPEGXL. By
adding &apos;libjxl&apos; to the JHBuild moduleset, USE_JPEGXL can be enabled
again.

* Tools/gtk/jhbuild.modules:
* Tools/gtk/patches/libjxl-add-cmake-flag-provision-dependencies.patch: Added.
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/jhbuild/patches/libjxl-add-cmake-flag-provision-dependencies.patch: Added.
* Tools/wpe/jhbuild.modules:
* Tools/wpe/patches/libjxl-add-cmake-flag-provision-dependencies.patch: Added.

Canonical link: <a href="https://commits.webkit.org/265394@main">https://commits.webkit.org/265394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0193cf95ba87014c8de0d99cd469505528564dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10335 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13237 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11846 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12830 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9721 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10211 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13123 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9506 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2577 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->