### PR TITLE
New broken test: http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1013,8 +1013,6 @@ http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Skip ]
 # Reenable it when having a custom gc exposed in service workers.
 [ Debug ] http/wpt/service-workers/fetchEvent.https.html [ Skip ]
 
-webkit.org/b/248735 http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html [ Pass Failure ]
-webkit.org/b/248735 http/wpt/service-workers/fetch-service-worker-preload.https.html [ Pass Failure ]
 webkit.org/b/248743 http/wpt/service-workers/fetch-service-worker-preload-download.https.html [ Pass Failure ]
 webkit.org/b/248743 http/wpt/service-workers/file-upload.html [ Pass Failure ]
 

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt
@@ -1,5 +1,5 @@
 
 
 PASS Setup activating worker
-PASS Service worker load uses preload through calling fetch on the fetch event request
+PASS Service worker load does not use preload when using an updated fetch request
 

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
@@ -57,11 +57,7 @@ promise_test(async (test) => {
 
     const frame = await promise;
     assert_equals(frame.contentWindow.value, "my-custom-header");
-
-    // We should have only one GET fetch to url: the service worker preload
-    const response = await fetch(url + "&count=True");
-    assert_equals(await response.text(), "1");
-}, "Service worker load uses preload through calling fetch on the fetch event request");
+}, "Service worker load does not use preload when using an updated fetch request");
 </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -245,8 +245,11 @@ ExceptionOr<void> FetchRequest::initializeWith(FetchRequest& input, Init&& init)
         auto fillResult = init.headers ? m_headers->fill(*init.headers) : m_headers->fill(input.headers());
         if (fillResult.hasException())
             return fillResult;
-    } else
+        m_navigationPreloadIdentifier = { };
+    } else {
         m_headers->setInternalHeaders(HTTPHeaderMap { input.headers().internalHeaders() });
+        m_navigationPreloadIdentifier = input.m_navigationPreloadIdentifier;
+    }
 
     auto setBodyResult = init.body ? setBody(WTFMove(*init.body)) : setBody(input);
     if (setBodyResult.hasException())


### PR DESCRIPTION
#### 41c888f493fe21f4a759e4dee01532181f629833
<pre>
New broken test: http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=248735">https://bugs.webkit.org/show_bug.cgi?id=248735</a>
rdar://problem/103220705

Reviewed by Alex Christensen.

When calling fetch(event.request), we are creating a new FetchRequest.
To be able to reuse the preload, we need to set the navigation preload identifier in the new FetchRequest.
We make sure to not set it when the request is changed, in particular its headers.

Covered by tests no longer failing.
CoveWe update LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html since it must not reuse preload in that case.
Cove
Cove* LayoutTests/TestExpectations:
Cove* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https-expected.txt:
* LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html:
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeWith):

Canonical link: <a href="https://commits.webkit.org/265705@main">https://commits.webkit.org/265705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d83b0abedec71dd720157e45c8226acf0325921

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12372 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10281 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12774 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16934 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10163 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9826 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13079 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8386 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9453 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2803 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->