### PR TITLE
[GTK] Only swap front and display file descriptors when there's a pending frame

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -444,12 +444,13 @@ void AcceleratedBackingStoreDMABuf::frame()
 
 void AcceleratedBackingStoreDMABuf::willDisplayFrame()
 {
+    ASSERT(m_frameCompletionHandler);
     if (m_isSoftwareRast)
         std::swap(m_surface.frontBitmap, m_surface.displayBitmap);
     else
         std::swap(m_surface.frontFD, m_surface.displayFD);
 
-    if (m_committedSource && m_frameCompletionHandler)
+    if (m_committedSource)
         m_committedSource->willDisplayFrame();
 }
 
@@ -534,7 +535,9 @@ void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
 #if USE(GTK4)
 void AcceleratedBackingStoreDMABuf::snapshot(GtkSnapshot* gtkSnapshot)
 {
-    willDisplayFrame();
+    if (m_frameCompletionHandler)
+        willDisplayFrame();
+
     if (!m_committedSource)
         return;
 
@@ -547,7 +550,9 @@ void AcceleratedBackingStoreDMABuf::snapshot(GtkSnapshot* gtkSnapshot)
 #else
 bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& clipRect)
 {
-    willDisplayFrame();
+    if (m_frameCompletionHandler)
+        willDisplayFrame();
+
     if (!m_committedSource)
         return false;
 


### PR DESCRIPTION
#### 5f14903ba2e87fcce8e1b3572bc3253d948b7f8b
<pre>
[GTK] Only swap front and display file descriptors when there&apos;s a pending frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=258344">https://bugs.webkit.org/show_bug.cgi?id=258344</a>

Reviewed by Alejandro G. Castro.

In other cases it&apos;s just a web view redraw for the same display buffer.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::willDisplayFrame):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):

Canonical link: <a href="https://commits.webkit.org/265351@main">https://commits.webkit.org/265351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61894ecc07c6a60bea4417cf141a4128c8c66742

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12759 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9075 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16917 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13061 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10279 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13711 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->