### PR TITLE
[CoordinatedGraphics] WebGL: the intermediate texture is no longer needed

### DIFF
--- a/LayoutTests/platform/glib/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/platform/glib/inspector/canvas/recording-webgl-full-expected.txt
@@ -56,7 +56,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 4)
+    0: bindTexture(1, 3)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -275,7 +275,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(4)
+    0: deleteTexture(3)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -127,10 +127,6 @@ GraphicsContextGLTextureMapperANGLE::~GraphicsContextGLTextureMapperANGLE()
 
     if (m_compositorTexture)
         GL_DeleteTextures(1, &m_compositorTexture);
-#if USE(COORDINATED_GRAPHICS)
-    if (m_intermediateTexture)
-        GL_DeleteTextures(1, &m_intermediateTexture);
-#endif
 }
 
 RefPtr<GraphicsLayerContentsDisplayDelegate> GraphicsContextGLTextureMapperANGLE::layerContentsDisplayDelegate()
@@ -300,18 +296,6 @@ bool GraphicsContextGLTextureMapperANGLE::platformInitialize()
     m_compositorTextureID = setupCurrentTexture();
 #endif
 
-#if USE(COORDINATED_GRAPHICS)
-    GL_GenTextures(1, &m_intermediateTexture);
-    GL_BindTexture(textureTarget, m_intermediateTexture);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    GL_TexParameteri(textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-#if USE(NICOSIA)
-    m_intermediateTextureID = setupCurrentTexture();
-#endif
-#endif
-
     GL_BindTexture(textureTarget, 0);
 
     // Create an FBO.
@@ -347,12 +331,8 @@ void GraphicsContextGLTextureMapperANGLE::prepareTexture()
         resolveMultisamplingIfNecessary();
 
     std::swap(m_texture, m_compositorTexture);
-#if USE(COORDINATED_GRAPHICS)
-    std::swap(m_texture, m_intermediateTexture);
 #if USE(NICOSIA)
     std::swap(m_textureID, m_compositorTextureID);
-    std::swap(m_textureID, m_intermediateTextureID);
-#endif
 #endif
 
     GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
@@ -380,10 +360,6 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
 
     GL_BindTexture(textureTarget, m_compositorTexture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);
-#if USE(COORDINATED_GRAPHICS)
-    GL_BindTexture(textureTarget, m_intermediateTexture);
-    GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);
-#endif
     GL_BindTexture(textureTarget, m_texture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);
     GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, textureTarget, m_texture, 0);

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -73,14 +73,10 @@ private:
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 
     GCGLuint m_compositorTexture { 0 };
-#if USE(COORDINATED_GRAPHICS)
-    GCGLuint m_intermediateTexture { 0 };
-#endif
 
 #if USE(NICOSIA)
     GCGLuint m_textureID { 0 };
     GCGLuint m_compositorTextureID { 0 };
-    GCGLuint m_intermediateTextureID { 0 };
 
     std::unique_ptr<Nicosia::GCGLANGLELayer> m_nicosiaLayer;
 


### PR DESCRIPTION
#### 241e71855ab5c54f4a46804b0e5000df9cac0961
<pre>
[CoordinatedGraphics] WebGL: the intermediate texture is no longer needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=258348">https://bugs.webkit.org/show_bug.cgi?id=258348</a>

Reviewed by Miguel Gomez.

It was introduced to fix flickering when we didn&apos;t wait for previous
frame to be displayed to render the next one. Now, two textures should
be enough.

* LayoutTests/platform/glib/inspector/canvas/recording-webgl-full-expected.txt:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::~GraphicsContextGLTextureMapperANGLE):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitialize):
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareTexture):
(WebCore::GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:

Canonical link: <a href="https://commits.webkit.org/265352@main">https://commits.webkit.org/265352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88bddb4ed958c04d07dca71bad97a348c7b6a7f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12359 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13180 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12761 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9076 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16919 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13063 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10281 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8374 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9440 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13713 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1197 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->