### PR TITLE
[GStreamer][MediaStream] A muted microphone track should get ended if its device disappears

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1718,11 +1718,8 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 # This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
 fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
 
-# Tests should be rebased, mock infra might need some updates.
-fast/mediastream/MediaDevices-addEventListener.html [ Failure ]
-fast/mediastream/microphone-change-while-capturing.html [ Failure ]
-fast/mediastream/microphone-change-while-muted.html [ Failure ]
-fast/mediastream/device-change-event-2.html [ Failure ]
+# Missing/broken pageIsFocused notification.
+fast/mediastream/device-change-event-2.html [ Timeout Failure ]
 
 # Regressions introduced by https://commits.webkit.org/263750@main
 fast/mediastream/apply-constraints-advanced.html [ Failure ]

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -215,6 +215,14 @@ void RealtimeMediaSourceCenter::captureDevicesChanged()
 #endif
 }
 
+void RealtimeMediaSourceCenter::captureDeviceWillBeRemoved(const String& persistentId)
+{
+    Ref protectedThis { *this };
+    m_observers.forEach([&](auto& observer) {
+        observer.deviceWillBeRemoved(persistentId);
+    });
+}
+
 void RealtimeMediaSourceCenter::triggerDevicesChangedObservers()
 {
     Ref protectedThis { *this };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -65,6 +65,7 @@ public:
         virtual ~Observer();
 
         virtual void devicesChanged() = 0;
+        virtual void deviceWillBeRemoved(const String& persistentId) = 0;
     };
 
     ~RealtimeMediaSourceCenter();
@@ -101,6 +102,7 @@ public:
     WEBCORE_EXPORT void removeDevicesChangedObserver(Observer&);
 
     void captureDevicesChanged();
+    void captureDeviceWillBeRemoved(const String& persistentId);
 
     WEBCORE_EXPORT static bool shouldInterruptAudioOnPageVisibilityChange();
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class GStreamerAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource> {
+class GStreamerAudioCaptureSource : public RealtimeMediaSource, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>,  public GStreamerCapturer::Observer {
 public:
     static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*);
     WEBCORE_EXPORT static AudioCaptureFactory& factory();
@@ -45,6 +45,9 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::deref(); }
     ThreadSafeWeakPtrControlBlock& controlBlock() const final { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerAudioCaptureSource>::controlBlock(); }
     virtual ~GStreamerAudioCaptureSource();
+
+    // GStreamerCapturer::Observer
+    void captureEnded()final;
 
 protected:
     GStreamerAudioCaptureSource(GStreamerCaptureDevice&&, MediaDeviceHashSalts&&);
@@ -62,7 +65,7 @@ private:
     bool isCaptureSource() const final { return true; }
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
 
-    std::unique_ptr<GStreamerAudioCapturer> m_capturer;
+    RefPtr<GStreamerAudioCapturer> m_capturer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp
@@ -62,14 +62,6 @@ GStreamerAudioCapturer::GStreamerAudioCapturer()
     initializeAudioCapturerDebugCategory();
 }
 
-GStreamerAudioCapturer::~GStreamerAudioCapturer()
-{
-    auto* sink = this->sink();
-    if (!sink)
-        return;
-    g_signal_handlers_disconnect_by_data(sink, this);
-}
-
 void GStreamerAudioCapturer::setSinkAudioCallback(SinkAudioDataCallback&& callback)
 {
     if (m_sinkAudioDataCallback.first)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h
@@ -32,7 +32,7 @@ class GStreamerAudioCapturer final : public GStreamerCapturer {
 public:
     GStreamerAudioCapturer(GStreamerCaptureDevice&&);
     GStreamerAudioCapturer();
-    ~GStreamerAudioCapturer();
+    ~GStreamerAudioCapturer() = default;
 
     GstElement* createConverter() final;
     const char* name() final { return "Audio"; }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -66,6 +66,14 @@ GStreamerVideoCaptureDeviceManager& GStreamerVideoCaptureDeviceManager::singleto
 
 GStreamerCaptureDeviceManager::GStreamerCaptureDeviceManager()
 {
+    ensureGStreamerInitialized();
+
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkitGStreamerCaptureDeviceManagerDebugCategory, "webkitcapturedevicemanager", 0, "WebKit Capture Device Manager");
+        gst_device_provider_register(nullptr, "mock-device-provider", GST_RANK_PRIMARY, GST_TYPE_MOCK_DEVICE_PROVIDER);
+    });
+
     RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);
 }
 
@@ -88,9 +96,40 @@ void GStreamerCaptureDeviceManager::stopMonitor()
 
 void GStreamerCaptureDeviceManager::devicesChanged()
 {
-    GST_INFO("RealtimeMediaSourceCenter notified devices list update, clearing our internal cache");
+    GST_INFO_OBJECT(m_deviceMonitor.get(), "RealtimeMediaSourceCenter notified devices list update, clearing our internal cache");
     stopMonitor();
+    m_gstreamerDevices.clear();
     m_devices.clear();
+}
+
+void GStreamerCaptureDeviceManager::deviceWillBeRemoved(const String& persistentId)
+{
+    stopCapturing(persistentId);
+}
+
+void GStreamerCaptureDeviceManager::registerCapturer(const RefPtr<GStreamerCapturer>& capturer)
+{
+    m_capturers.append(capturer);
+}
+
+void GStreamerCaptureDeviceManager::unregisterCapturer(const GStreamerCapturer& capturer)
+{
+    m_capturers.removeAllMatching([&](auto& item) -> bool {
+        return item.get() == &capturer;
+    });
+}
+
+void GStreamerCaptureDeviceManager::stopCapturing(const String& persistentId)
+{
+    GST_DEBUG("Stopping capturer for device with persistent ID: %s", persistentId.ascii().data());
+    m_capturers.removeAllMatching([&persistentId](auto& capturer) -> bool {
+        GST_DEBUG("Checking capturer with device persistent ID: %s", capturer->devicePersistentId().ascii().data());
+        if (capturer->devicePersistentId() != persistentId)
+            return false;
+
+        capturer->stopDevice();
+        return true;
+    });
 }
 
 std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::gstreamerDeviceWithUID(const String& deviceID)
@@ -109,13 +148,6 @@ std::optional<GStreamerCaptureDevice> GStreamerCaptureDeviceManager::gstreamerDe
 
 const Vector<CaptureDevice>& GStreamerCaptureDeviceManager::captureDevices()
 {
-    ensureGStreamerInitialized();
-
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        GST_DEBUG_CATEGORY_INIT(webkitGStreamerCaptureDeviceManagerDebugCategory, "webkitcapturedevicemanager", 0, "WebKit Capture Device Manager");
-        gst_device_provider_register(nullptr, "mock-device-provider", GST_RANK_PRIMARY, GST_TYPE_MOCK_DEVICE_PROVIDER);
-    });
     if (m_devices.isEmpty())
         refreshCaptureDevices();
 
@@ -144,19 +176,34 @@ void GStreamerCaptureDeviceManager::addDevice(GRefPtr<GstDevice>&& device)
     GST_INFO("Registering device %s", deviceName.get());
     gboolean isDefault = FALSE;
     gst_structure_get_boolean(properties.get(), "is-default", &isDefault);
-
     auto label = makeString(isDefault ? "default: "_s : ""_s, deviceName.get());
+
     auto identifier = label;
-    if (const char* persistentId = gst_structure_get_string(properties.get(), "persistent-id"))
+    bool isMock = false;
+    if (const char* persistentId = gst_structure_get_string(properties.get(), "persistent-id")) {
         identifier = String::fromLatin1(persistentId);
+        isMock = true;
+    }
 
     auto gstCaptureDevice = GStreamerCaptureDevice(WTFMove(device), identifier, type, label);
     gstCaptureDevice.setEnabled(true);
+    gstCaptureDevice.setIsMockDevice(isMock);
+
     m_gstreamerDevices.append(WTFMove(gstCaptureDevice));
-    // FIXME: We need a CaptureDevice copy in other vector just for captureDevices API.
-    auto captureDevice = CaptureDevice(identifier, type, label);
-    captureDevice.setEnabled(true);
-    m_devices.append(WTFMove(captureDevice));
+    m_devices.append(m_gstreamerDevices.last());
+}
+
+void GStreamerCaptureDeviceManager::removeDevice(GRefPtr<GstDevice>&& gstDevice)
+{
+    m_gstreamerDevices.removeFirstMatching([&](auto& captureDevice) -> bool {
+        if (captureDevice.device() != gstDevice.get())
+            return false;
+
+        m_devices.removeFirstMatching([&](auto& device) -> bool {
+            return device.persistentId() == captureDevice.persistentId();
+        });
+        return true;
+    });
 }
 
 void GStreamerCaptureDeviceManager::refreshCaptureDevices()
@@ -186,35 +233,6 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
             return;
         }
 
-        auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
-        gst_bus_add_watch(bus.get(), reinterpret_cast<GstBusFunc>(+[](GstBus*, GstMessage* message, GStreamerCaptureDeviceManager* manager) -> gboolean {
-#ifndef GST_DISABLE_GST_DEBUG
-            GRefPtr<GstDevice> device;
-            GUniquePtr<char> name;
-#endif
-            switch (GST_MESSAGE_TYPE(message)) {
-            case GST_MESSAGE_DEVICE_ADDED:
-#ifndef GST_DISABLE_GST_DEBUG
-                gst_message_parse_device_added(message, &device.outPtr());
-                name.reset(gst_device_get_display_name(device.get()));
-                GST_INFO("Device added: %s", name.get());
-#endif
-                manager->deviceChanged();
-                break;
-            case GST_MESSAGE_DEVICE_REMOVED:
-#ifndef GST_DISABLE_GST_DEBUG
-                gst_message_parse_device_removed(message, &device.outPtr());
-                name.reset(gst_device_get_display_name(device.get()));
-                GST_INFO("Device removed: %s", name.get());
-#endif
-                manager->deviceChanged();
-                break;
-            default:
-                break;
-            }
-            return G_SOURCE_CONTINUE;
-        }), this);
-
         if (!gst_device_monitor_start(m_deviceMonitor.get())) {
             GST_WARNING_OBJECT(m_deviceMonitor.get(), "Could not start device monitor");
             m_deviceMonitor = nullptr;
@@ -227,6 +245,41 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
         addDevice(adoptGRef(GST_DEVICE_CAST(devices->data)));
         devices = g_list_delete_link(devices, devices);
     }
+
+    auto bus = adoptGRef(gst_device_monitor_get_bus(m_deviceMonitor.get()));
+
+    // Flush out device-added messages queued during initial probe of the device providers.
+    gst_bus_set_flushing(bus.get(), TRUE);
+    gst_bus_set_flushing(bus.get(), FALSE);
+
+    // Monitor the bus for future device-added and device-removed messages.
+    gst_bus_add_watch(bus.get(), reinterpret_cast<GstBusFunc>(+[](GstBus*, GstMessage* message, GStreamerCaptureDeviceManager* manager) -> gboolean {
+        GRefPtr<GstDevice> device;
+#ifndef GST_DISABLE_GST_DEBUG
+        GUniquePtr<char> name;
+#endif
+        switch (GST_MESSAGE_TYPE(message)) {
+        case GST_MESSAGE_DEVICE_ADDED:
+            gst_message_parse_device_added(message, &device.outPtr());
+#ifndef GST_DISABLE_GST_DEBUG
+            name.reset(gst_device_get_display_name(device.get()));
+            GST_INFO("Device added: %s", name.get());
+#endif
+            manager->addDevice(WTFMove(device));
+            break;
+        case GST_MESSAGE_DEVICE_REMOVED:
+            gst_message_parse_device_removed(message, &device.outPtr());
+#ifndef GST_DISABLE_GST_DEBUG
+            name.reset(gst_device_get_display_name(device.get()));
+            GST_INFO("Device removed: %s", name.get());
+#endif
+            manager->removeDevice(WTFMove(device));
+            break;
+        default:
+            break;
+        }
+        return G_SOURCE_CONTINUE;
+    }),  this);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -26,6 +26,7 @@
 #include "DisplayCaptureManager.h"
 #include "GRefPtrGStreamer.h"
 #include "GStreamerCaptureDevice.h"
+#include "GStreamerCapturer.h"
 #include "GStreamerVideoCapturer.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "RealtimeMediaSourceFactory.h"
@@ -45,15 +46,22 @@ public:
 
     // RealtimeMediaSourceCenter::Observer interface.
     void devicesChanged() final;
+    void deviceWillBeRemoved(const String& persistentId) final;
+
+    void registerCapturer(const RefPtr<GStreamerCapturer>&);
+    void unregisterCapturer(const GStreamerCapturer&);
+    void stopCapturing(const String& persistentId);
 
 private:
     void addDevice(GRefPtr<GstDevice>&&);
+    void removeDevice(GRefPtr<GstDevice>&&);
     void stopMonitor();
     void refreshCaptureDevices();
 
     GRefPtr<GstDeviceMonitor> m_deviceMonitor;
     Vector<GStreamerCaptureDevice> m_gstreamerDevices;
     Vector<CaptureDevice> m_devices;
+    Vector<RefPtr<GStreamerCapturer>> m_capturers;
 };
 
 class GStreamerAudioCaptureDeviceManager final : public GStreamerCaptureDeviceManager {
@@ -67,7 +75,6 @@ class GStreamerVideoCaptureDeviceManager final : public GStreamerCaptureDeviceMa
     friend class NeverDestroyed<GStreamerVideoCaptureDeviceManager>;
 public:
     static GStreamerVideoCaptureDeviceManager& singleton();
-    static VideoCaptureFactory& videoFactory();
     CaptureDevice::DeviceType deviceType() final { return CaptureDevice::DeviceType::Camera; }
 };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -27,14 +27,12 @@
 #include "GStreamerCaptureDevice.h"
 #include "GStreamerCommon.h"
 
-#include <gst/gst.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
-class GStreamerCapturer
-    : public ThreadSafeRefCounted<GStreamerCapturer, WTF::DestructionThread::MainRunLoop> {
+class GStreamerCapturer : public ThreadSafeRefCounted<GStreamerCapturer> {
 
 public:
     class Observer : public CanMakeWeakPtr<Observer> {
@@ -42,6 +40,7 @@ public:
         virtual ~Observer();
 
         virtual void sourceCapsChanged(const GstCaps*) { }
+        virtual void captureEnded() { }
     };
 
     GStreamerCapturer(GStreamerCaptureDevice&&, GRefPtr<GstCaps>&&);
@@ -63,7 +62,6 @@ public:
     virtual const char* name() = 0;
 
     GstElement* sink() const { return m_sink.get(); }
-    void setSink(GstElement* sink) { m_sink = adoptGRef(sink); };
 
     GstElement* pipeline() const { return m_pipeline.get(); }
     virtual GstElement* createConverter() = 0;
@@ -72,6 +70,9 @@ public:
     void setInterrupted(bool);
 
     CaptureDevice::DeviceType deviceType() const { return m_deviceType; }
+    const String& devicePersistentId() const { return m_device ? m_device->persistentId() : emptyString(); }
+
+    void stopDevice();
 
 protected:
     GRefPtr<GstElement> m_sink;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -48,6 +48,7 @@ public:
 
     // GStreamerCapturer::Observer
     void sourceCapsChanged(const GstCaps*) final;
+    void captureEnded() final;
 
 protected:
     GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const gchar* source_factory, CaptureDevice::DeviceType, const NodeAndFD&);
@@ -67,7 +68,7 @@ private:
     bool isCaptureSource() const final { return true; }
     void settingsDidChange(OptionSet<RealtimeMediaSourceSettings::Flag>) final;
 
-    std::unique_ptr<GStreamerVideoCapturer> m_capturer;
+    RefPtr<GStreamerVideoCapturer> m_capturer;
     CaptureDevice::DeviceType m_deviceType;
 };
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -55,14 +55,6 @@ GStreamerVideoCapturer::GStreamerVideoCapturer(const char* sourceFactory, Captur
     initializeVideoCapturerDebugCategory();
 }
 
-GStreamerVideoCapturer::~GStreamerVideoCapturer()
-{
-    auto* sink = this->sink();
-    if (!sink)
-        return;
-    g_signal_handlers_disconnect_by_data(sink, this);
-}
-
 void GStreamerVideoCapturer::setSinkVideoFrameCallback(SinkVideoFrameCallback&& callback)
 {
     if (m_sinkVideoFrameCallback.first)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h
@@ -36,7 +36,7 @@ class GStreamerVideoCapturer final : public GStreamerCapturer {
 public:
     GStreamerVideoCapturer(GStreamerCaptureDevice&&);
     GStreamerVideoCapturer(const char* sourceFactory, CaptureDevice::DeviceType);
-    ~GStreamerVideoCapturer();
+    ~GStreamerVideoCapturer() = default;
 
     GstElement* createSource() final;
     GstElement* createConverter() final;

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
@@ -31,13 +31,16 @@
 
 namespace WebCore {
 
-class MockRealtimeAudioSourceGStreamer final : public MockRealtimeAudioSource {
+class MockRealtimeAudioSourceGStreamer final : public MockRealtimeAudioSource, GStreamerCapturer::Observer {
 public:
     static Ref<MockRealtimeAudioSource> createForMockAudioCapturer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&);
 
     static const HashSet<MockRealtimeAudioSource*>& allMockRealtimeAudioSources();
 
     ~MockRealtimeAudioSourceGStreamer();
+
+    // GStreamerCapturer::Observer
+    void captureEnded() final;
 
 protected:
     void render(Seconds) final;
@@ -61,7 +64,7 @@ private:
     uint64_t m_samplesEmitted { 0 };
     uint64_t m_samplesRendered { 0 };
     bool m_isInterrupted { false };
-    std::unique_ptr<GStreamerAudioCapturer> m_capturer;
+    RefPtr<GStreamerAudioCapturer> m_capturer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h
@@ -29,10 +29,13 @@
 
 namespace WebCore {
 
-class MockRealtimeVideoSourceGStreamer final : public MockRealtimeVideoSource {
+class MockRealtimeVideoSourceGStreamer final : public MockRealtimeVideoSource, GStreamerCapturer::Observer {
 public:
     MockRealtimeVideoSourceGStreamer(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&);
-    ~MockRealtimeVideoSourceGStreamer() = default;
+    ~MockRealtimeVideoSourceGStreamer();
+
+    // GStreamerCapturer::Observer
+    void captureEnded() final;
 
 private:
     friend class MockRealtimeVideoSource;
@@ -41,7 +44,7 @@ private:
     void stopProducingData() final;
     void updateSampleBuffer() final;
     bool canResizeVideoFrames() const final { return true; }
-    std::unique_ptr<GStreamerVideoCapturer> m_capturer;
+    RefPtr<GStreamerVideoCapturer> m_capturer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -121,6 +121,7 @@ private:
 
     // RealtimeMediaSourceCenter::Observer
     void devicesChanged() final;
+    void deviceWillBeRemoved(const String&) final { }
 
     bool m_enableEchoCancellation { true };
     double m_volume { 1 };

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -343,6 +343,13 @@ void MockRealtimeMediaSourceCenter::setDevices(Vector<MockMediaDevice>&& newMock
     displayDevices().clear();
 
     auto& mockDevices = devices();
+    for (auto& device : mockDevices) {
+        auto& persistentId = device.persistentId;
+        if (!newMockDevices.containsIf([&persistentId](auto& newDevice) -> bool {
+            return newDevice.persistentId == persistentId;
+        }))
+            RealtimeMediaSourceCenter::singleton().captureDeviceWillBeRemoved(persistentId);
+    }
     mockDevices = WTFMove(newMockDevices);
 
     auto& map = deviceMap();
@@ -380,6 +387,7 @@ void MockRealtimeMediaSourceCenter::removeDevice(const String& persistentId)
     if (iterator == map.end())
         return;
 
+    RealtimeMediaSourceCenter::singleton().captureDeviceWillBeRemoved(persistentId);
     devices().removeFirstMatching([&persistentId](const auto& device) {
         return device.persistentId == persistentId;
     });

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.h
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.h
@@ -57,6 +57,7 @@ private:
 
     // RealtimeMediaSourceCenter::Observer
     void devicesChanged() final;
+    void deviceWillBeRemoved(const String& persistentId) final { }
 
     Vector<WebCore::CaptureDevice> m_captureDevices;
     bool m_captureEnabled { true };

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -66,6 +66,7 @@ private:
 #if USE(GSTREAMER)
     // WebCore::RealtimeMediaSourceCenter::Observer
     void devicesChanged() final;
+    void deviceWillBeRemoved(const String& persistentId) final { }
 #endif
 
     void sendUserMediaRequest(WebCore::UserMediaRequest&);


### PR DESCRIPTION
#### d377f55ddfb4213b0897152a263dc71e0423fb19
<pre>
[GStreamer][MediaStream] A muted microphone track should get ended if its device disappears
<a href="https://bugs.webkit.org/show_bug.cgi?id=258347">https://bugs.webkit.org/show_bug.cgi?id=258347</a>

Reviewed by Xabier Rodriguez-Calvar.

When a microphone device disappears the GStreamer capture device manager is now notified. Because it
now tracks each capturer pipeline it is able to interrupt the corresponding pipeline and that will
trigger a notification in the corresponding RealtimeMediaSource, which then signals the related
MediaStreamTrack ended, using `captureFailed()`.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::captureDeviceWillBeRemoved):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::GStreamerAudioCaptureSource):
(WebCore::GStreamerAudioCaptureSource::~GStreamerAudioCaptureSource):
(WebCore::GStreamerAudioCaptureSource::captureEnded):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.cpp:
(WebCore::GStreamerAudioCapturer::~GStreamerAudioCapturer): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::GStreamerCaptureDeviceManager):
(WebCore::GStreamerCaptureDeviceManager::devicesChanged):
(WebCore::GStreamerCaptureDeviceManager::deviceWillBeRemoved):
(WebCore::GStreamerCaptureDeviceManager::registerCapturer):
(WebCore::GStreamerCaptureDeviceManager::unregisterCapturer):
(WebCore::GStreamerCaptureDeviceManager::stopCapturing):
(WebCore::GStreamerCaptureDeviceManager::captureDevices):
(WebCore::GStreamerCaptureDeviceManager::addDevice):
(WebCore::GStreamerCaptureDeviceManager::removeDevice):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::~GStreamerCapturer):
(WebCore::GStreamerCapturer::stopDevice):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
(WebCore::GStreamerCapturer::Observer::captureEnded):
(WebCore::GStreamerCapturer::sink const):
(WebCore::GStreamerCapturer::devicePersistentId const):
(WebCore::GStreamerCapturer::setSink): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::m_deviceType):
(WebCore::GStreamerVideoCaptureSource::~GStreamerVideoCaptureSource):
(WebCore::GStreamerVideoCaptureSource::captureEnded):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::~GStreamerVideoCapturer): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::~MockRealtimeAudioSourceGStreamer):
(WebCore::MockRealtimeAudioSourceGStreamer::stopProducingData):
(WebCore::MockRealtimeAudioSourceGStreamer::captureEnded):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.cpp:
(WebCore::MockRealtimeVideoSourceGStreamer::~MockRealtimeVideoSourceGStreamer):
(WebCore::MockRealtimeVideoSourceGStreamer::captureEnded):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeVideoSourceGStreamer.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::MockRealtimeMediaSourceCenter::setDevices):
(WebCore::MockRealtimeMediaSourceCenter::removeDevice):
* Source/WebKit/UIProcess/UserMediaProcessManager.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:

Canonical link: <a href="https://commits.webkit.org/265401@main">https://commits.webkit.org/265401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c130c5be976c4514bea8989787afa4f97b0008f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10888 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11799 "1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9093 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16936 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10164 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13081 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8392 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9458 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2584 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->