### PR TITLE
[GStreamer][WebRTC] Remove iSAC codec support

### DIFF
--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -62,20 +62,20 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
 a=sendrecv
 a=fingerprint:sha-256 {fingerprint:OK}
-m=video 9 UDP/TLS/RTP/SAVPF 99
+m=video 9 UDP/TLS/RTP/SAVPF 97
 c=IN IP4 0.0.0.0
 a=ice-ufrag:{ice-ufrag:OK}
 a=ice-pwd:{ice-password:OK}
 a=rtcp-mux
 a=mid:{mid:OK}
 a=setup:active
-a=rtpmap:99 H264/90000
-a=rtcp-fb:99 nack pli
-a=rtcp-fb:99 ccm fir
-a=rtcp-fb:99 transport-cc
+a=rtpmap:97 H264/90000
+a=rtcp-fb:97 nack pli
+a=rtcp-fb:97 ccm fir
+a=rtcp-fb:97 transport-cc
 a=rtcp-mux
 a=rtcp-rsize
-a=rtcp-fb:110 transport-cc
+a=rtcp-fb:108 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=ssrc-group:{semantics:OK} {ssrc-id:OK}
 a=fingerprint:sha-256 {fingerprint:OK}
@@ -85,7 +85,7 @@ a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/color-space
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
-a=fmtp:99 packetization-mode=1;level-asymmetry-allowed=1
+a=fmtp:97 packetization-mode=1;level-asymmetry-allowed=1
 a=sendrecv
 a=fingerprint:sha-256 {fingerprint:OK}
 ===

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
@@ -11,7 +11,7 @@ o=- {session-id:OK} 0 IN IP4 0.0.0.0
 s=-
 t=0 0
 a=ice-options:trickle
-m=audio 9 UDP/TLS/RTP/SAVPF 96 97 98 9 0 8 97 98
+m=audio 9 UDP/TLS/RTP/SAVPF 96 9 0 8 97 98
 c=IN IP4 0.0.0.0
 a=setup:actpass
 a=ice-ufrag:{ice-ufrag:OK}
@@ -26,12 +26,6 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
-a=rtpmap:97 ISAC/16000
-a=rtcp-fb:97 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=rtpmap:98 ISAC/32000
-a=rtcp-fb:98 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
@@ -43,10 +37,6 @@ a=rtcp-fb:8 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=rtpmap:97 red/48000
 a=rtpmap:98 ulpfec/48000
-a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
-a=ssrc:{ssrc:OK} cname:{cname:OK}
-a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
-a=ssrc:{ssrc:OK} cname:{cname:OK}
 a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
 a=ssrc:{ssrc:OK} cname:{cname:OK}
 a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
@@ -68,7 +58,7 @@ o=- {session-id:OK} 1 IN IP4 0.0.0.0
 s=-
 t=0 0
 a=ice-options:trickle
-m=audio 9 UDP/TLS/RTP/SAVPF 96 97 98 9 0 8 97 98
+m=audio 9 UDP/TLS/RTP/SAVPF 96 9 0 8 97 98
 c=IN IP4 0.0.0.0
 a=setup:actpass
 a=ice-ufrag:{ice-ufrag:OK}
@@ -83,12 +73,6 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=fmtp:96 minptime=10;useinbandfec=1
-a=rtpmap:97 ISAC/16000
-a=rtcp-fb:97 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=rtpmap:98 ISAC/32000
-a=rtcp-fb:98 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
@@ -108,13 +92,9 @@ a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
 a=ssrc:{ssrc:OK} cname:{cname:OK}
 a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
 a=ssrc:{ssrc:OK} cname:{cname:OK}
-a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
-a=ssrc:{ssrc:OK} cname:{cname:OK}
-a={ssrc:OK}msid:{media-stream-id:OK} {media-stream-track-id:FAILED}
-a=ssrc:{ssrc:OK} cname:{cname:OK}
 a=mid:{mid:OK}
 a=fingerprint:sha-256 {fingerprint:OK}
-m=video 9 UDP/TLS/RTP/SAVPF 99 100 101 102 103 104 105 106 107 108 109 110 96 97 98 100
+m=video 9 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102 103 104 105 106 107 108 96 98 99 100
 c=IN IP4 0.0.0.0
 a=setup:actpass
 a=ice-ufrag:{ice-ufrag:OK}
@@ -122,97 +102,97 @@ a=ice-pwd:{ice-password:OK}
 a=rtcp-mux
 a=rtcp-rsize
 a=sendrecv
-a=rtpmap:99 H264/90000
-a=rtcp-fb:99 nack
-a=rtcp-fb:99 nack pli
-a=rtcp-fb:99 ccm fir
-a=rtcp-fb:99 transport-cc
+a=rtpmap:97 H264/90000
+a=rtcp-fb:97 nack
+a=rtcp-fb:97 nack pli
+a=rtcp-fb:97 ccm fir
+a=rtcp-fb:97 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
 a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/color-space
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
-a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=fmtp:97 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtpmap:98 H264/90000
+a=rtcp-fb:98 nack
+a=rtcp-fb:98 nack pli
+a=rtcp-fb:98 ccm fir
+a=rtcp-fb:98 transport-cc
+a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
+a=fmtp:98 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f
+a=rtpmap:99 H264/90000
+a=rtcp-fb:99 nack
+a=rtcp-fb:99 nack pli
+a=rtcp-fb:99 ccm fir
+a=rtcp-fb:99 transport-cc
+a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
+a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f
 a=rtpmap:100 H264/90000
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f
+a=fmtp:100 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f
 a=rtpmap:101 H264/90000
 a=rtcp-fb:101 nack
 a=rtcp-fb:101 nack pli
 a=rtcp-fb:101 ccm fir
 a=rtcp-fb:101 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:101 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640c1f
+a=fmtp:101 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
 a=rtpmap:102 H264/90000
 a=rtcp-fb:102 nack
 a=rtcp-fb:102 nack pli
 a=rtcp-fb:102 ccm fir
 a=rtcp-fb:102 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=640c1f
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f
 a=rtpmap:103 H264/90000
 a=rtcp-fb:103 nack
 a=rtcp-fb:103 nack pli
 a=rtcp-fb:103 ccm fir
 a=rtcp-fb:103 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
+a=fmtp:103 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f
 a=rtpmap:104 H264/90000
 a=rtcp-fb:104 nack
 a=rtcp-fb:104 nack pli
 a=rtcp-fb:104 ccm fir
 a=rtcp-fb:104 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:104 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f
-a=rtpmap:105 H264/90000
+a=fmtp:104 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f
+a=rtpmap:105 AV1/90000
 a=rtcp-fb:105 nack
 a=rtcp-fb:105 nack pli
 a=rtcp-fb:105 ccm fir
 a=rtcp-fb:105 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:105 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f
-a=rtpmap:106 H264/90000
+a=rtpmap:106 VP8/90000
 a=rtcp-fb:106 nack
 a=rtcp-fb:106 nack pli
 a=rtcp-fb:106 ccm fir
 a=rtcp-fb:106 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:106 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=4d001f
-a=rtpmap:107 AV1/90000
+a=rtpmap:107 VP9/90000
 a=rtcp-fb:107 nack
 a=rtcp-fb:107 nack pli
 a=rtcp-fb:107 ccm fir
 a=rtcp-fb:107 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=rtpmap:108 VP8/90000
+a=fmtp:107 profile-id=0
+a=rtpmap:108 VP9/90000
 a=rtcp-fb:108 nack
 a=rtcp-fb:108 nack pli
 a=rtcp-fb:108 ccm fir
 a=rtcp-fb:108 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=rtpmap:109 VP9/90000
-a=rtcp-fb:109 nack
-a=rtcp-fb:109 nack pli
-a=rtcp-fb:109 ccm fir
-a=rtcp-fb:109 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:109 profile-id=0
-a=rtpmap:110 VP9/90000
-a=rtcp-fb:110 nack
-a=rtcp-fb:110 nack pli
-a=rtcp-fb:110 ccm fir
-a=rtcp-fb:110 transport-cc
-a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
-a=fmtp:110 profile-id=2
+a=fmtp:108 profile-id=2
 a=rtpmap:96 red/90000
-a=rtpmap:97 ulpfec/90000
-a=rtpmap:98 rtx/90000
-a=fmtp:98 apt=99
+a=rtpmap:98 ulpfec/90000
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=97
 a=rtpmap:100 rtx/90000
 a=fmtp:100 apt=96
 a=ssrc-group:{semantics:OK} {ssrc-id:OK}

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt
@@ -11,7 +11,6 @@ PASS Test that decodingInfo returns a valid MediaCapabilitiesInfo objects
 PASS Test that decodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc video content type.
 PASS Test that decodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc audio content type.
 PASS Test that decodingInfo returns supported true for the codec audio/opus returned by RTCRtpReceiver.getCapabilities()
-PASS Test that decodingInfo returns supported true for the codec audio/ISAC returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/G722 returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpReceiver.getCapabilities()
 PASS Test that decodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpReceiver.getCapabilities()

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt
@@ -11,7 +11,6 @@ PASS Test that encodingInfo returns a valid MediaCapabilitiesInfo objects
 PASS Test that encodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc video content type.
 PASS Test that encodingInfo returns supported, smooth, and powerEfficient set to false for non-webrtc audio content type.
 PASS Test that encodingInfo returns supported true for the codec audio/opus returned by RTCRtpSender.getCapabilities()
-PASS Test that encodingInfo returns supported true for the codec audio/ISAC returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/G722 returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMU returned by RTCRtpSender.getCapabilities()
 PASS Test that encodingInfo returns supported true for the codec audio/PCMA returned by RTCRtpSender.getCapabilities()

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -988,11 +988,6 @@ void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configurat
     if (factories.hasElementForMediaType(codecElement, "audio/x-opus") && factories.hasElementForMediaType(rtpElement, "audio/x-opus"))
         capabilities.codecs.append({ .mimeType = "audio/opus"_s, .clockRate = 48000, .channels = 2, .sdpFmtpLine = "minptime=10;useinbandfec=1"_s });
 
-    if (factories.hasElementForMediaType(codecElement, "audio/isac") && factories.hasElementForMediaType(rtpElement, "audio/isac")) {
-        capabilities.codecs.append({ .mimeType = "audio/ISAC"_s, .clockRate = 16000, .channels = 1, .sdpFmtpLine = emptyString() });
-        capabilities.codecs.append({ .mimeType = "audio/ISAC"_s, .clockRate = 32000, .channels = 1, .sdpFmtpLine = emptyString() });
-    }
-
     if (factories.hasElementForMediaType(codecElement, "audio/G722") && factories.hasElementForMediaType(rtpElement, "audio/G722"))
         capabilities.codecs.append({ .mimeType = "audio/G722"_s, .clockRate = 8000, .channels = 1, .sdpFmtpLine = emptyString() });
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -88,8 +88,6 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
         m_encoder = makeGStreamerElement("alawenc", nullptr);
     else if (encoding == "pcmu"_s)
         m_encoder = makeGStreamerElement("mulawenc", nullptr);
-    else if (encoding == "isac"_s)
-        m_encoder = makeGStreamerElement("isacenc", nullptr);
     else {
         GST_ERROR_OBJECT(m_bin.get(), "Unsupported outgoing audio encoding: %s", encodingName);
         return false;


### PR DESCRIPTION
#### 093e1078e7b60bb5388404e0f4651c97cbaf9113
<pre>
[GStreamer][WebRTC] Remove iSAC codec support
<a href="https://bugs.webkit.org/show_bug.cgi?id=258345">https://bugs.webkit.org/show_bug.cgi?id=258345</a>

Reviewed by Xabier Rodriguez-Calvar.

This codec was removed from libwebrtc and for a long time already opus is the recommended alternative.

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/decodingInfo.webrtc-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-capabilities/encodingInfo.webrtc-expected.txt:
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillAudioRtpCapabilities):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/265396@main">https://commits.webkit.org/265396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7915f893663621a932550772965a8169f496082e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13186 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10876 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12767 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16925 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13069 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8378 "13 flakes 5 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9446 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2581 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13719 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->