### PR TITLE
[GTK][WPE] WebGL: add support for platforms where surfaceless context is not available

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsTypesGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypesGL.h
@@ -67,6 +67,7 @@ using GCGLDisplay = void*;
 using GCGLConfig = void*;
 using GCGLContext = void*;
 using GCEGLImage = void*;
+using GCEGLSuface = void*;
 using GCEGLSync = void*;
 
 #if !PLATFORM(COCOA)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -435,6 +435,9 @@ protected:
     GCGLDisplay m_displayObj { nullptr };
     GCGLContext m_contextObj { nullptr };
     GCGLConfig m_configObj { nullptr };
+#if USE(TEXTURE_MAPPER)
+    GCEGLSuface m_surfaceObj { nullptr };
+#endif
     GCGLint m_packAlignment { 4 };
     GCGLint m_packRowLength { 0 };
 };


### PR DESCRIPTION
#### 10ab3e37dd66d9bf8cbc500e17455a5d01c082f0
<pre>
[GTK][WPE] WebGL: add support for platforms where surfaceless context is not available
<a href="https://bugs.webkit.org/show_bug.cgi?id=258350">https://bugs.webkit.org/show_bug.cgi?id=258350</a>

Reviewed by Miguel Gomez.

Create a mock pbuffer surface when surfaceless is not supported.

* Source/WebCore/platform/graphics/GraphicsTypesGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::~GraphicsContextGLANGLE):
(WebCore::GraphicsContextGLANGLE::makeContextCurrent):
(WebCore::GraphicsContextGLTextureMapperANGLE::platformInitializeContext):

Canonical link: <a href="https://commits.webkit.org/265357@main">https://commits.webkit.org/265357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed9b20b5b6d042700263f6a4715b8f83a3f35686

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12765 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16924 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9444 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2555 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13717 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->