### PR TITLE
Crash in RemoteLayerTreeEventDispatcherDisplayLinkClient teardown

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -143,6 +143,7 @@ public:
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
 
+    virtual void windowScreenWillChange() { }
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
 
     float topContentInset() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -49,7 +49,8 @@ public:
     void didRefreshDisplay() override;
 
     DisplayLink& displayLink();
-    
+    DisplayLink* existingDisplayLink();
+
     void updateZoomTransactionID();
     WebCore::PlatformLayerIdentifier pageScalingLayerID() { return m_pageScalingLayerID; }
 private:
@@ -80,8 +81,6 @@ private:
     void setDisplayLinkWantsFullSpeedUpdates(bool) override;
 
     void removeObserver(std::optional<DisplayLinkObserverID>&);
-
-    DisplayLink* exisingDisplayLink();
 
     WTF::MachSendRight createFence() override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -90,7 +90,7 @@ RemoteLayerTreeDrawingAreaProxyMac::RemoteLayerTreeDrawingAreaProxyMac(WebPagePr
 
 RemoteLayerTreeDrawingAreaProxyMac::~RemoteLayerTreeDrawingAreaProxyMac()
 {
-    if (auto* displayLink = exisingDisplayLink()) {
+    if (auto* displayLink = existingDisplayLink()) {
         if (m_fullSpeedUpdateObserverID)
             displayLink->removeObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID);
         if (m_displayRefreshObserverID)
@@ -108,7 +108,7 @@ std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxy
     return makeUnique<RemoteScrollingCoordinatorProxyMac>(m_webPageProxy);
 }
 
-DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink()
+DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink()
 {
     if (!m_displayID)
         return nullptr;
@@ -129,7 +129,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::removeObserver(std::optional<DisplayLin
     if (!observerID)
         return;
 
-    if (auto* displayLink = exisingDisplayLink())
+    if (auto* displayLink = existingDisplayLink())
         displayLink->removeObserver(*m_displayLinkClient, *observerID);
 
     observerID = { };
@@ -354,7 +354,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::setPreferredFramesPerSecond(WebCore::Fr
         return;
     }
 
-    auto* displayLink = exisingDisplayLink();
+    auto* displayLink = existingDisplayLink();
     if (m_displayRefreshObserverID && displayLink)
         displayLink->setObserverPreferredFramesPerSecond(*m_displayLinkClient, *m_displayRefreshObserverID, preferredFramesPerSecond);
 }
@@ -388,6 +388,9 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
 
     pauseDisplayRefreshCallbacks();
 
+    if (m_displayID)
+        m_webPageProxy.scrollingCoordinatorProxy()->windowScreenWillChange();
+
     m_displayID = displayID;
     m_displayNominalFramesPerSecond = displayNominalFramesPerSecond();
 
@@ -396,7 +399,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     scheduleDisplayRefreshCallbacks();
     if (hadFullSpeedOberver) {
         m_fullSpeedUpdateObserverID = DisplayLinkObserverID::generate();
-        if (auto* displayLink = exisingDisplayLink())
+        if (auto* displayLink = existingDisplayLink())
             displayLink->addObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID, displayLink->nominalFramesPerSecond());
     }
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -51,6 +51,7 @@ namespace WebKit {
 class DisplayLink;
 class NativeWebWheelEvent;
 class RemoteScrollingCoordinatorProxyMac;
+class RemoteLayerTreeDrawingAreaProxyMac;
 class RemoteScrollingTree;
 class RemoteLayerTreeEventDispatcherDisplayLinkClient;
 
@@ -79,6 +80,7 @@ public:
 
     void hasNodeWithAnimatedScrollChanged(bool hasAnimatedScrolls);
 
+    void windowScreenWillChange();
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>);
 
     void renderingUpdateComplete();
@@ -100,12 +102,15 @@ private:
     void wheelEventWasHandledByScrollingThread(WheelEventHandlingResult);
 
     DisplayLink* displayLink() const;
+    DisplayLink* existingDisplayLink() const;
+    RemoteLayerTreeDrawingAreaProxyMac& drawingAreaMac() const;
 
     void startDisplayLinkObserver();
     void stopDisplayLinkObserver();
 
     void startOrStopDisplayLink();
     void startOrStopDisplayLinkOnMainThread();
+    void removeDisplayLinkClient();
 
     void scheduleDelayedRenderingUpdateDetectionTimer(Seconds delay);
     void delayedRenderingUpdateDetectionTimerFired();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -60,6 +60,7 @@ private:
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
 
     void displayDidRefresh(WebCore::PlatformDisplayID) override;
+    void windowScreenWillChange() override;
     void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
 
     void willCommitLayerAndScrollingTrees() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -228,6 +228,13 @@ void RemoteScrollingCoordinatorProxyMac::windowScreenDidChange(PlatformDisplayID
 #endif
 }
 
+void RemoteScrollingCoordinatorProxyMac::windowScreenWillChange()
+{
+#if ENABLE(SCROLLING_THREAD)
+    m_wheelEventDispatcher->windowScreenWillChange();
+#endif
+}
+
 void RemoteScrollingCoordinatorProxyMac::willCommitLayerAndScrollingTrees()
 {
     scrollingTree()->lockLayersForHitTesting();


### PR DESCRIPTION
#### ab4981648cdb3f161ae8fcbd4cee84918ea94e16
<pre>
Crash in RemoteLayerTreeEventDispatcherDisplayLinkClient teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=258133">https://bugs.webkit.org/show_bug.cgi?id=258133</a>
rdar://109463023

Reviewed by Simon Fraser.

RemoteLayerTreeEventDispatcherDisplayLinkClient inherits indirectly from
CanMakeCheckedPtrBase. This means that for deleting a object of this type
we should first delete any CheckRef objects pointing to it.

At RemoteLayerTreeEventDispatcher::invalidate we currently call
stopDisplayLinkObserver() to remove the associated observer of
DisplayLink::Client. If that Client has no more observers, we remove
the CheckRef for this client from DisplayLink&apos;s m_client&apos;s map (See removeInfoForClientIfUnused()).

The problem is, since we want to delete m_displayClient at the end of
invalidate() we have to make sure that the associated CheckRef gets removed
from the map, independently of how many observers it still has.
Therefore, instead of removing just the single associated observer,
we can remove the reference for the client from DisplayLink.

The problem is: When RemoteLayerTreeDrawingAreaProxyMac::windowsCreenDidChange()
is called, we will end up having 2 DisplayLink objects and
both of them, hold a CheckedRef pointing to the same DisplayLink::Client.
So in teardown, when we invalidate the RemoteLayerTreeEventDispatcher,
even if we remove the DisplayLink::Client from the DisplayLink for that
dispatcher, the other DisplayLink will still have a CheckedRef for the
same client. Therefore, the m_count won&apos;t be zero when we are deleting
DisplayLink::Client.

Solution: When, for some reason, a DisplayLink::Client is associated
with another DisplayLink, we should remove its CheckedRef from the
original DisplayLink referencing it. We do that by creating a new function
windowScreenWillChange() to be called before the displayID is updated.
On the dispatcher, this function will remove the DisplayLink::Client reference
from the old DisplayLink object m_client&apos;s map.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::windowScreenWillChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::~RemoteLayerTreeDrawingAreaProxyMac):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::removeObserver):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::setPreferredFramesPerSecond):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::exisingDisplayLink): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::drawingAreaMac const):
(WebKit::RemoteLayerTreeEventDispatcher::displayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::existingDisplayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::removeDisplayLinkClient):
(WebKit::RemoteLayerTreeEventDispatcher::windowScreenWillChange):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::windowScreenWillChange):

Canonical link: <a href="https://commits.webkit.org/265566@main">https://commits.webkit.org/265566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7eec7856eb8fe5ff94ae033928c1225adb51ac17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12895 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10724 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13640 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13305 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9580 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17374 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13550 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8849 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9934 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2694 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->