### PR TITLE
[WPE] Crash in `WebKit.OnDeviceChangeCrash` API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
@@ -108,14 +108,15 @@ static void didCrashCallback(WKPageRef, const void*)
 
 TEST(WebKit, OnDeviceChangeCrash)
 {
-    auto configuration = adoptWK(WKPageConfigurationCreate());
-    auto preferences = adoptWK(WKPreferencesCreate());
-    WKPreferencesSetMediaDevicesEnabled(preferences.get(), true);
-    WKPreferencesSetFileAccessFromFileURLsAllowed(preferences.get(), true);
-    WKPreferencesSetMediaCaptureRequiresSecureConnection(preferences.get(), false);
-    WKPreferencesSetMockCaptureDevicesEnabled(preferences.get(), true);
-    WKPreferencesSetGetUserMediaRequiresFocus(preferences.get(), false);
-    WKPageConfigurationSetPreferences(configuration.get(), preferences.get());
+    auto context = adoptWK(WKContextCreateWithConfiguration(nullptr));
+
+    WKRetainPtr<WKPageGroupRef> pageGroup = adoptWK(WKPageGroupCreateWithIdentifier(Util::toWK("GetUserMedia").get()));
+    WKPreferencesRef preferences = WKPageGroupGetPreferences(pageGroup.get());
+    WKPreferencesSetMediaDevicesEnabled(preferences, true);
+    WKPreferencesSetFileAccessFromFileURLsAllowed(preferences, true);
+    WKPreferencesSetMediaCaptureRequiresSecureConnection(preferences, false);
+    WKPreferencesSetMockCaptureDevicesEnabled(preferences, true);
+    WKPreferencesSetGetUserMediaRequiresFocus(preferences, false);
 
     WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
@@ -123,7 +124,7 @@ TEST(WebKit, OnDeviceChangeCrash)
     uiClient.decidePolicyForUserMediaPermissionRequest = decidePolicyForUserMediaPermissionRequestCallBack;
     uiClient.checkUserMediaPermissionForOrigin = checkUserMediaPermissionCallback;
 
-    PlatformWebView webView(configuration.get());
+    PlatformWebView webView(context.get(), pageGroup.get());
     WKPageSetPageUIClient(webView.page(), &uiClient.base);
 
     // Load a page registering ondevicechange handler.

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -241,9 +241,6 @@
             "WebKit.FocusedFrameAfterCrash": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}
             },
-            "WebKit.OnDeviceChangeCrash": {
-                "expected": {"gtk": {"status": ["CRASH", "TIMEOUT", "PASS"], "bug": "webkit.org/b/214805"}}
-            },
             "WebKit.PrivateBrowsingPushStateNoHistoryCallback": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
             },


### PR DESCRIPTION
#### c8433592f6c2b3cdc476006f7693daa9c9be6b2f
<pre>
[WPE] Crash in `WebKit.OnDeviceChangeCrash` API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=258353">https://bugs.webkit.org/show_bug.cgi?id=258353</a>

Reviewed by Philippe Normand.

When we create `WPEView` we get a process pool from the page configuration
provided as an argument and then use this pool to create a web page.

```
auto* pool = configuration-&gt;processPool();
m_pageProxy = pool-&gt;createWebPage(*m_pageClient, WTFMove(configuration));
```

But default page configuration we use in the test doesn&apos;t automatically
create a process pool.

```
auto configuration = adoptWK(WKPageConfigurationCreate())
```

To fix that we can use `WKContextCreateWithConfiguration(nullptr)`
because it creates a default process pool configuration for us:
```
RefPtr&lt;API::ProcessPoolConfiguration&gt; apiConfiguration = WebKit::toImpl(configuration);
if (!apiConfiguration)
    apiConfiguration = API::ProcessPoolConfiguration::create();
```

This is how it&apos;s done in `WebKit.EnumerateDevicesCrash` test in the
same file.

* Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265365@main">https://commits.webkit.org/265365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68267703f4e1b67083197ccff09147d24e84fc4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13200 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11802 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12782 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9684 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16940 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10167 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13085 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10302 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9461 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2564 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->