### PR TITLE
[CSS] Nesting '&' selector is not a pseudo class

### DIFF
--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -81,7 +81,8 @@ struct PossiblyQuotedIdentifier {
             Contain, // css3: E[foo*="bar"]
             Begin, // css3: E[foo^="bar"]
             End, // css3: E[foo$="bar"]
-            PagePseudoClass
+            PagePseudoClass,
+            NestingParent // &
         };
 
         enum class RelationType : uint8_t {
@@ -191,8 +192,7 @@ struct PossiblyQuotedIdentifier {
             PseudoClassModal,
             PseudoClassPopoverOpen,
             PseudoClassUserInvalid,
-            PseudoClassUserValid,
-            PseudoClassNestingParent,
+            PseudoClassUserValid
         };
 
         enum PseudoElementType {

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -208,7 +208,7 @@ bool CSSSelectorList::hasOnlyNestingSelector() const
     if (singleSelector->tagHistory())
         return false;
 
-    return singleSelector->match() == CSSSelector::Match::PseudoClass && singleSelector->pseudoClassType() == CSSSelector::PseudoClassType::PseudoClassNestingParent;
+    return singleSelector->match() == CSSSelector::Match::NestingParent;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -627,6 +627,7 @@ static bool canMatchHoverOrActiveInQuirksMode(const SelectorChecker::LocalContex
         case CSSSelector::Match::PagePseudoClass:
         case CSSSelector::Match::PseudoElement:
             return true;
+        case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::Unknown:
             ASSERT_NOT_REACHED();
             break;
@@ -724,8 +725,6 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
         // Normal element pseudo class checking.
         switch (selector.pseudoClassType()) {
             // Pseudo classes:
-        case CSSSelector::PseudoClassNestingParent:
-            // This pseudo selector should have been replaced earlier.
         case CSSSelector::PseudoClassNot:
             ASSERT_NOT_REACHED();
             break; // Already handled up above.

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -569,8 +569,7 @@ void CSSParserImpl::runInNewNestingContext(auto&& run)
 Ref<StyleRuleBase> CSSParserImpl::createNestingParentRule()
 {
     CSSSelector nestingParentSelector;
-    nestingParentSelector.setMatch(CSSSelector::Match::PseudoClass);
-    nestingParentSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassNestingParent);
+    nestingParentSelector.setMatch(CSSSelector::Match::NestingParent);
     auto parserSelector = makeUnique<CSSParserSelector>(nestingParentSelector);
     Vector<std::unique_ptr<CSSParserSelector>> selectorList;
     selectorList.append(WTFMove(parserSelector));

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -663,8 +663,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeNesting(CSSParserTo
     range.consume();
 
     auto selector = makeUnique<CSSParserSelector>();
-    selector->setMatch(CSSSelector::Match::PseudoClass);
-    selector->setPseudoClassType(CSSSelector::PseudoClassNestingParent);
+    selector->setMatch(CSSSelector::Match::NestingParent);
     
     return selector;
 }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1386,7 +1386,6 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         }
     case CSSSelector::PseudoClassHost:
         return FunctionType::CannotCompile;
-    case CSSSelector::PseudoClassNestingParent: // Should have already been replaced by the actual parent selector at this point.
     case CSSSelector::PseudoClassUnknown:
         ASSERT_NOT_REACHED();
         return FunctionType::CannotMatchAnything;
@@ -1540,6 +1539,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             fragment->onlyMatchesLinksInQuirksMode = false;
             // Pseudo page class are only relevant for style resolution, they are ignored for matching.
             break;
+        case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::Unknown:
             ASSERT_NOT_REACHED();
             return FunctionType::CannotMatchAnything;

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -215,6 +215,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             }
             break;
         case CSSSelector::Match::Unknown:
+        case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::PagePseudoClass:
             break;
         }


### PR DESCRIPTION
#### c6b7717a83e78c6d5c850610338fb2644bdf2fbd
<pre>
[CSS] Nesting &apos;&amp;&apos; selector is not a pseudo class
<a href="https://bugs.webkit.org/show_bug.cgi?id=252188">https://bugs.webkit.org/show_bug.cgi?id=252188</a>
rdar://107328044

Reviewed by Tim Nguyen.

<a href="https://drafts.csswg.org/css-nesting/#nest-selector">https://drafts.csswg.org/css-nesting/#nest-selector</a>

The nesting selector, written as &apos;&amp;&apos;, is a new selector
and not a pseudo class.
This a pure refactoring without any functional change.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::resolveNestingParentSelectors):
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):
(WebCore::CSSSelector::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::hasOnlyNestingSelector const):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::createNestingParentRule):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeNesting):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/265509@main">https://commits.webkit.org/265509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27d27094741c2e5ee8b5e9bde901c14f87f3c94f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10564 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13122 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17219 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10484 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10596 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8681 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9767 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2657 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14040 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->