### PR TITLE
fast/mediastream/microphone-change-while-capturing.html failing in ports not using GPUProcess

### DIFF
--- a/LayoutTests/fast/mediastream/microphone-change-while-capturing.html
+++ b/LayoutTests/fast/mediastream/microphone-change-while-capturing.html
@@ -58,6 +58,7 @@
         testRunner.addMockMicrophoneDevice("usbmic3", "my third USB microphone");
         await new Promise(resolve => setTimeout(resolve, 200));
         assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
+        video.srcObject.getAudioTracks()[0].stop();
     }, "Adding or removing a new device should not fail ongoing capture");
     </script>
 </body>


### PR DESCRIPTION
#### 9487d81df53daa05773cedc5241b6a3fa7cd2618
<pre>
fast/mediastream/microphone-change-while-capturing.html failing in ports not using GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=258355">https://bugs.webkit.org/show_bug.cgi?id=258355</a>

Reviewed by Youenn Fablet.

On ports using the GPUProcess the test runner might terminate the test execution before the
GPUProcess received the final `resetMockMediaDevices` message. OTOH on ports not using the
GPUProcess, the `resetMockMediaDevices` is received by the WebProcess while a mock capture device is
in use, triggering a console message, hence test failure. To prevent this console message we
explicitely stop the audio track before reseting the mock devices.

* LayoutTests/fast/mediastream/microphone-change-while-capturing.html:

Canonical link: <a href="https://commits.webkit.org/265363@main">https://commits.webkit.org/265363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd92d853aaa006dfbbe052379c93ae7416bd01bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10279 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10915 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13191 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12772 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9674 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13075 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9565 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2557 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->