### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.22.4

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -15,7 +15,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 config:

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch
@@ -1,7 +1,7 @@
 From d22c9daefbd330d00af0359004b16073ac0eab37 Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
 Date: Fri, 28 Apr 2023 13:18:24 +0100
-Subject: [PATCH] GStreamer: Bump to 1.22.2
+Subject: [PATCH] GStreamer: Bump to 1.22.4
 
 ---
  elements/components/gstreamer-plugins-good.bst       |  2 ++
@@ -49,7 +49,7 @@ index e73a056ab..ee16131c9 100644
    match:
    - 1.*[02468].*
 -  ref: 1.20.6-0-gb7d3037cca2fe72c5b7daab5e0617e61ae013dcc
-+  ref: 1.22.3-0-gecd471f5ea4645102b206a43d863f0f0fe7d04ec
++  ref: 1.22.4-0-g064711d8b382c106afffe75cefbabe8f7bac8532
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/gst-libav-no-cache-generator.patch b/patches/gstreamer/gst-libav-no-cache-generator.patch


### PR DESCRIPTION
#### 9c0f7c43098dd7d16406911d6559822292878b1d
<pre>
[Buildstream SDK] Bump to GStreamer 1.22.4
<a href="https://bugs.webkit.org/show_bug.cgi?id=258357">https://bugs.webkit.org/show_bug.cgi?id=258357</a>

Reviewed by Carlos Alberto Lopez Perez.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch.

Canonical link: <a href="https://commits.webkit.org/265684@main">https://commits.webkit.org/265684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f4516c3795cccba28672f02c431272770dc465

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10284 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12777 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16933 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13087 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10297 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8390 "12 flakes 6 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13729 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->