### PR TITLE
[CSS] Use "enum class" for CSSSelector Match and RelationType

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -157,7 +157,7 @@ class SelectorNeedsNamespaceResolutionFunctor {
 public:
     bool operator()(const CSSSelector* selector)
     {
-        if (selector->match() == CSSSelector::Tag && !selector->tagQName().prefix().isEmpty() && selector->tagQName().prefix() != starAtom())
+        if (selector->match() == CSSSelector::Match::Tag && !selector->tagQName().prefix().isEmpty() && selector->tagQName().prefix() != starAtom())
             return true;
         if (selector->isAttributeSelector() && !selector->attribute().prefix().isEmpty() && selector->attribute().prefix() != starAtom())
             return true;

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -131,7 +131,7 @@ private:
 
 inline bool SelectorChecker::isCommonPseudoClassSelector(const CSSSelector* selector)
 {
-    if (selector->match() != CSSSelector::PseudoClass)
+    if (selector->match() != CSSSelector::Match::PseudoClass)
         return false;
     CSSSelector::PseudoClassType pseudoType = selector->pseudoClassType();
     return pseudoType == CSSSelector::PseudoClassLink

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -138,33 +138,33 @@ void SelectorFilter::popParentsUntil(Element* parent)
 void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collectedHashes, const CSSSelector& selector)
 {
     switch (selector.match()) {
-    case CSSSelector::Id:
+    case CSSSelector::Match::Id:
         if (!selector.value().isEmpty())
             collectedHashes.ids.append(selector.value().impl()->existingHash() * IdSalt);
         break;
-    case CSSSelector::Class:
+    case CSSSelector::Match::Class:
         if (!selector.value().isEmpty())
             collectedHashes.classes.append(selector.value().impl()->existingHash() * ClassSalt);
         break;
-    case CSSSelector::Tag: {
+    case CSSSelector::Match::Tag: {
         auto& tagLowercaseLocalName = selector.tagLowercaseLocalName();
         if (tagLowercaseLocalName != starAtom())
             collectedHashes.tags.append(tagLowercaseLocalName.impl()->existingHash() * TagNameSalt);
         break;
     }
-    case CSSSelector::Exact:
-    case CSSSelector::Set:
-    case CSSSelector::List:
-    case CSSSelector::Hyphen:
-    case CSSSelector::Contain:
-    case CSSSelector::Begin:
-    case CSSSelector::End: {
+    case CSSSelector::Match::Exact:
+    case CSSSelector::Match::Set:
+    case CSSSelector::Match::List:
+    case CSSSelector::Match::Hyphen:
+    case CSSSelector::Match::Contain:
+    case CSSSelector::Match::Begin:
+    case CSSSelector::Match::End: {
         auto attributeName = selector.attribute().localNameLowercase();
         if (!isExcludedAttribute(attributeName))
             collectedHashes.attributes.append(attributeName.impl()->existingHash() * AttributeSalt);
         break;
     }
-    case CSSSelector::PseudoClass:
+    case CSSSelector::Match::PseudoClass:
         switch (selector.pseudoClassType()) {
         case CSSSelector::PseudoClassIs:
         case CSSSelector::PseudoClassWhere:
@@ -188,25 +188,25 @@ void SelectorFilter::collectSelectorHashes(CollectedSelectorHashes& collectedHas
         if (includeRightmost == IncludeRightmost::No)
             return std::tuple { rightmostSelector.tagHistory(), rightmostSelector.relation(), true };
 
-        return std::tuple { &rightmostSelector, CSSSelector::Subselector, false };
+        return std::tuple { &rightmostSelector, CSSSelector::RelationType::Subselector, false };
     }();
 
     for (; selector; selector = selector->tagHistory()) {
         // Only collect identifiers that match ancestors.
         switch (relation) {
-        case CSSSelector::Subselector:
+        case CSSSelector::RelationType::Subselector:
             if (!skipOverSubselectors)
                 collectSimpleSelectorHash(collectedHashes, *selector);
             break;
-        case CSSSelector::DirectAdjacent:
-        case CSSSelector::IndirectAdjacent:
-        case CSSSelector::ShadowDescendant:
-        case CSSSelector::ShadowPartDescendant:
-        case CSSSelector::ShadowSlotted:
+        case CSSSelector::RelationType::DirectAdjacent:
+        case CSSSelector::RelationType::IndirectAdjacent:
+        case CSSSelector::RelationType::ShadowDescendant:
+        case CSSSelector::RelationType::ShadowPartDescendant:
+        case CSSSelector::RelationType::ShadowSlotted:
             skipOverSubselectors = true;
             break;
-        case CSSSelector::DescendantSpace:
-        case CSSSelector::Child:
+        case CSSSelector::RelationType::DescendantSpace:
+        case CSSSelector::RelationType::Child:
             skipOverSubselectors = false;
             collectSimpleSelectorHash(collectedHashes, *selector);
             break;

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -229,7 +229,7 @@ CSSSelectorList CSSParserImpl::parsePageSelector(CSSParserTokenRange range, Styl
         selector = makeUnique<CSSParserSelector>();
         if (!pseudo.isNull()) {
             selector = std::unique_ptr<CSSParserSelector>(CSSParserSelector::parsePagePseudoSelector(pseudo));
-            if (!selector || selector->match() != CSSSelector::PagePseudoClass)
+            if (!selector || selector->match() != CSSSelector::Match::PagePseudoClass)
                 return CSSSelectorList();
         }
         if (!typeSelector.isNull())

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePagePseudoSelector(St
         return nullptr;
 
     auto selector = makeUnique<CSSParserSelector>();
-    selector->m_selector->setMatch(CSSSelector::PagePseudoClass);
+    selector->m_selector->setMatch(CSSSelector::Match::PagePseudoClass);
     selector->m_selector->setPagePseudoType(pseudoType);
     return selector;
 }
@@ -57,7 +57,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector
         return nullptr;
 
     auto selector = makeUnique<CSSParserSelector>();
-    selector->m_selector->setMatch(CSSSelector::PseudoElement);
+    selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
     selector->m_selector->setPseudoElementType(pseudoType);
     AtomString name;
     if (pseudoType != CSSSelector::PseudoElementWebKitCustomLegacyPrefixed)
@@ -81,13 +81,13 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoClassSelector(S
     auto pseudoType = parsePseudoClassAndCompatibilityElementString(pseudoTypeString);
     if (pseudoType.pseudoClass != CSSSelector::PseudoClassUnknown) {
         auto selector = makeUnique<CSSParserSelector>();
-        selector->m_selector->setMatch(CSSSelector::PseudoClass);
+        selector->m_selector->setMatch(CSSSelector::Match::PseudoClass);
         selector->m_selector->setPseudoClassType(pseudoType.pseudoClass);
         return selector;
     }
     if (pseudoType.compatibilityPseudoElement != CSSSelector::PseudoElementUnknown) {
         auto selector = makeUnique<CSSParserSelector>();
-        selector->m_selector->setMatch(CSSSelector::PseudoElement);
+        selector->m_selector->setMatch(CSSSelector::Match::PseudoElement);
         selector->m_selector->setPseudoElementType(pseudoType.compatibilityPseudoElement);
         selector->m_selector->setValue(pseudoTypeString.convertToASCIILowercaseAtom());
         return selector;
@@ -203,16 +203,16 @@ void CSSParserSelector::appendTagHistory(CSSParserSelectorCombinator relation, s
     CSSSelector::RelationType selectorRelation;
     switch (relation) {
     case CSSParserSelectorCombinator::Child:
-        selectorRelation = CSSSelector::Child;
+        selectorRelation = CSSSelector::RelationType::Child;
         break;
     case CSSParserSelectorCombinator::DescendantSpace:
-        selectorRelation = CSSSelector::DescendantSpace;
+        selectorRelation = CSSSelector::RelationType::DescendantSpace;
         break;
     case CSSParserSelectorCombinator::DirectAdjacent:
-        selectorRelation = CSSSelector::DirectAdjacent;
+        selectorRelation = CSSSelector::RelationType::DirectAdjacent;
         break;
     case CSSParserSelectorCombinator::IndirectAdjacent:
-        selectorRelation = CSSSelector::IndirectAdjacent;
+        selectorRelation = CSSSelector::RelationType::IndirectAdjacent;
         break;
     }
     end->setRelation(selectorRelation);
@@ -227,19 +227,19 @@ void CSSParserSelector::prependTagSelector(const QualifiedName& tagQName, bool t
     m_tagHistory = WTFMove(second);
 
     m_selector = makeUnique<CSSSelector>(tagQName, tagIsForNamespaceRule);
-    m_selector->setRelation(CSSSelector::Subselector);
+    m_selector->setRelation(CSSSelector::RelationType::Subselector);
 }
 
 std::unique_ptr<CSSParserSelector> CSSParserSelector::releaseTagHistory()
 {
-    setRelation(CSSSelector::Subselector);
+    setRelation(CSSSelector::RelationType::Subselector);
     return WTFMove(m_tagHistory);
 }
 
 // FIXME-NEWPARSER: Add support for :host-context
 bool CSSParserSelector::isHostPseudoSelector() const
 {
-    return match() == CSSSelector::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassHost;
+    return match() == CSSSelector::Match::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassHost;
 }
 
 }

--- a/Source/WebCore/css/parser/CSSParserSelector.h
+++ b/Source/WebCore/css/parser/CSSParserSelector.h
@@ -104,7 +104,7 @@ private:
 
 inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
 {
-    return match() == CSSSelector::PseudoElement
+    return match() == CSSSelector::Match::PseudoElement
         && (pseudoElementType() == CSSSelector::PseudoElementWebKitCustom
 #if ENABLE(VIDEO)
             || pseudoElementType() == CSSSelector::PseudoElementCue
@@ -117,7 +117,7 @@ inline bool CSSParserSelector::needsImplicitShadowCombinatorForMatching() const
 inline bool CSSParserSelector::isPseudoElementCueFunction() const
 {
 #if ENABLE(VIDEO)
-    return m_selector->match() == CSSSelector::PseudoElement && m_selector->pseudoElementType() == CSSSelector::PseudoElementCue;
+    return m_selector->match() == CSSSelector::Match::PseudoElement && m_selector->pseudoElementType() == CSSSelector::PseudoElementCue;
 #else
     return false;
 #endif

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -42,12 +42,12 @@ namespace WebCore {
 #if ASSERT_ENABLED
 static bool isSingleTagNameSelector(const CSSSelector& selector)
 {
-    return selector.isLastInTagHistory() && selector.match() == CSSSelector::Tag;
+    return selector.isLastInTagHistory() && selector.match() == CSSSelector::Match::Tag;
 }
 
 static bool isSingleClassNameSelector(const CSSSelector& selector)
 {
-    return selector.isLastInTagHistory() && selector.match() == CSSSelector::Class;
+    return selector.isLastInTagHistory() && selector.match() == CSSSelector::Match::Class;
 }
 #endif // ASSERT_ENABLED
 
@@ -68,8 +68,8 @@ template<typename Output> static ALWAYS_INLINE void appendOutputForElement(Outpu
 
 static bool canBeUsedForIdFastPath(const CSSSelector& selector)
 {
-    return selector.match() == CSSSelector::Id
-        || (selector.match() == CSSSelector::Exact && selector.attribute() == HTMLNames::idAttr && !selector.attributeValueMatchingIsCaseInsensitive());
+    return selector.match() == CSSSelector::Match::Id
+        || (selector.match() == CSSSelector::Match::Exact && selector.attribute() == HTMLNames::idAttr && !selector.attributeValueMatchingIsCaseInsensitive());
 }
 
 static IdMatchingType findIdMatchingType(const CSSSelector& firstSelector)
@@ -81,7 +81,7 @@ static IdMatchingType findIdMatchingType(const CSSSelector& firstSelector)
                 return IdMatchingType::Rightmost;
             return IdMatchingType::Filter;
         }
-        if (selector->relation() != CSSSelector::Subselector)
+        if (selector->relation() != CSSSelector::RelationType::Subselector)
             inRightmost = false;
     }
     return IdMatchingType::None;
@@ -101,10 +101,10 @@ SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
         const CSSSelector& selector = *m_selectors.first().selector;
         if (selector.isLastInTagHistory()) {
             switch (selector.match()) {
-            case CSSSelector::Tag:
+            case CSSSelector::Match::Tag:
                 m_matchType = TagNameMatch;
                 break;
-            case CSSSelector::Class:
+            case CSSSelector::Match::Class:
                 m_matchType = ClassNameMatch;
                 break;
             default:
@@ -193,7 +193,7 @@ static const CSSSelector* selectorForIdLookup(const ContainerNode& rootNode, con
     for (const CSSSelector* selector = &firstSelector; selector; selector = selector->tagHistory()) {
         if (canBeUsedForIdFastPath(*selector))
             return selector;
-        if (selector->relation() != CSSSelector::Subselector)
+        if (selector->relation() != CSSSelector::RelationType::Subselector)
             break;
     }
 
@@ -240,7 +240,7 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
     const CSSSelector* selector = &firstSelector;
     do {
         ASSERT(!canBeUsedForIdFastPath(*selector));
-        if (selector->relation() != CSSSelector::Subselector)
+        if (selector->relation() != CSSSelector::RelationType::Subselector)
             break;
         selector = selector->tagHistory();
     } while (selector);
@@ -258,9 +258,9 @@ static ContainerNode& filterRootById(ContainerNode& rootNode, const CSSSelector&
                 }
             }
         }
-        if (selector->relation() == CSSSelector::Subselector)
+        if (selector->relation() == CSSSelector::RelationType::Subselector)
             continue;
-        inAdjacentChain = selector->relation() == CSSSelector::DirectAdjacent || selector->relation() == CSSSelector::IndirectAdjacent;
+        inAdjacentChain = selector->relation() == CSSSelector::RelationType::DirectAdjacent || selector->relation() == CSSSelector::RelationType::IndirectAdjacent;
     }
     return rootNode;
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1477,7 +1477,7 @@ Protocol::ErrorStringOr<void> InspectorDOMAgent::highlightSelector(const String&
         auto& pseudo = descendantElement.pseudo();
 
         for (const auto* selector = selectorList->first(); selector; selector = CSSSelectorList::next(selector)) {
-            if (isInUserAgentShadowTree && (selector->match() != CSSSelector::PseudoElement || selector->value() != pseudo))
+            if (isInUserAgentShadowTree && (selector->match() != CSSSelector::Match::PseudoElement || selector->value() != pseudo))
                 continue;
 
             SelectorChecker::CheckingContext context(SelectorChecker::Mode::ResolvingStyle);

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -68,12 +68,12 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
     SelectorFilter::CollectedSelectorHashes hashes;
     bool hasHoverInCompound = false;
     for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
-        if (simpleSelector->match() == CSSSelector::PseudoClass && simpleSelector->pseudoClassType() == CSSSelector::PseudoClassHover)
+        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClassType() == CSSSelector::PseudoClassHover)
             hasHoverInCompound = true;
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);
         if (!hashes.ids.isEmpty())
             break;
-        if (simpleSelector->relation() != CSSSelector::Subselector)
+        if (simpleSelector->relation() != CSSSelector::RelationType::Subselector)
             break;
     }
 

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -93,11 +93,11 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
 static bool checkPageSelectorComponents(const CSSSelector* selector, bool isLeftPage, bool isFirstPage, const String& pageName)
 {
     for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
-        if (component->match() == CSSSelector::Tag) {
+        if (component->match() == CSSSelector::Match::Tag) {
             const AtomString& localName = component->tagQName().localName();
             if (localName != starAtom() && localName != pageName)
                 return false;
-        } else if (component->match() == CSSSelector::PagePseudoClass) {
+        } else if (component->match() == CSSSelector::Match::PagePseudoClass) {
             CSSSelector::PagePseudoClassType pseudoType = component->pagePseudoClassType();
             if ((pseudoType == CSSSelector::PagePseudoClassLeft && !isLeftPage)
                 || (pseudoType == CSSSelector::PagePseudoClassRight && isLeftPage)

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -64,7 +64,7 @@ static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector
     if (selector.tagHistory())
         return MatchBasedOnRuleHash::None;
 
-    if (selector.match() == CSSSelector::Tag) {
+    if (selector.match() == CSSSelector::Match::Tag) {
         const QualifiedName& tagQualifiedName = selector.tagQName();
         const AtomString& selectorNamespace = tagQualifiedName.namespaceURI();
         if (selectorNamespace == starAtom() || selectorNamespace == xhtmlNamespaceURI) {
@@ -76,9 +76,9 @@ static inline MatchBasedOnRuleHash computeMatchBasedOnRuleHash(const CSSSelector
     }
     if (SelectorChecker::isCommonPseudoClassSelector(&selector))
         return MatchBasedOnRuleHash::ClassB;
-    if (selector.match() == CSSSelector::Id)
+    if (selector.match() == CSSSelector::Match::Id)
         return MatchBasedOnRuleHash::ClassA;
-    if (selector.match() == CSSSelector::Class)
+    if (selector.match() == CSSSelector::Match::Class)
         return MatchBasedOnRuleHash::ClassB;
     // FIXME: Valueless [attribute] case can be handled here too.
 
@@ -129,7 +129,7 @@ static bool computeContainsUncommonAttributeSelector(const CSSSelector& rootSele
             }
         }
 
-        if (selector->relation() != CSSSelector::Subselector)
+        if (selector->relation() != CSSSelector::RelationType::Subselector)
             matchesRightmostElement = false;
 
         selector = selector->tagHistory();
@@ -141,10 +141,10 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
 {
     for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
 #if ENABLE(VIDEO)
-        if (component->match() == CSSSelector::PseudoElement && (component->pseudoElementType() == CSSSelector::PseudoElementCue || component->value() == ShadowPseudoIds::cue()))
+        if (component->match() == CSSSelector::Match::PseudoElement && (component->pseudoElementType() == CSSSelector::PseudoElementCue || component->value() == ShadowPseudoIds::cue()))
             return PropertyAllowlist::Cue;
 #endif
-        if (component->match() == CSSSelector::PseudoElement && component->pseudoElementType() == CSSSelector::PseudoElementMarker)
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElementType() == CSSSelector::PseudoElementMarker)
             return propertyAllowlistForPseudoId(PseudoId::Marker);
 
         if (const auto* selectorList = selector->selectorList()) {

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -103,41 +103,41 @@ static MatchElement computeNextMatchElement(MatchElement matchElement, CSSSelect
 
     if (isSiblingOrSubject(matchElement)) {
         switch (relation) {
-        case CSSSelector::Subselector:
+        case CSSSelector::RelationType::Subselector:
             return matchElement;
-        case CSSSelector::DescendantSpace:
+        case CSSSelector::RelationType::DescendantSpace:
             return MatchElement::Ancestor;
-        case CSSSelector::Child:
+        case CSSSelector::RelationType::Child:
             return MatchElement::Parent;
-        case CSSSelector::IndirectAdjacent:
+        case CSSSelector::RelationType::IndirectAdjacent:
             if (matchElement == MatchElement::AnySibling)
                 return MatchElement::AnySibling;
             return MatchElement::IndirectSibling;
-        case CSSSelector::DirectAdjacent:
+        case CSSSelector::RelationType::DirectAdjacent:
             if (matchElement == MatchElement::AnySibling)
                 return MatchElement::AnySibling;
             return matchElement == MatchElement::Subject ? MatchElement::DirectSibling : MatchElement::IndirectSibling;
-        case CSSSelector::ShadowDescendant:
-        case CSSSelector::ShadowPartDescendant:
+        case CSSSelector::RelationType::ShadowDescendant:
+        case CSSSelector::RelationType::ShadowPartDescendant:
             return MatchElement::Host;
-        case CSSSelector::ShadowSlotted:
+        case CSSSelector::RelationType::ShadowSlotted:
             // FIXME: Implement accurate invalidation.
             return matchElement;
         };
     }
     switch (relation) {
-    case CSSSelector::Subselector:
+    case CSSSelector::RelationType::Subselector:
         return matchElement;
-    case CSSSelector::DescendantSpace:
-    case CSSSelector::Child:
+    case CSSSelector::RelationType::DescendantSpace:
+    case CSSSelector::RelationType::Child:
         return MatchElement::Ancestor;
-    case CSSSelector::IndirectAdjacent:
-    case CSSSelector::DirectAdjacent:
+    case CSSSelector::RelationType::IndirectAdjacent:
+    case CSSSelector::RelationType::DirectAdjacent:
         return matchElement == MatchElement::Parent ? MatchElement::ParentSibling : MatchElement::AncestorSibling;
-    case CSSSelector::ShadowDescendant:
-    case CSSSelector::ShadowPartDescendant:
+    case CSSSelector::RelationType::ShadowDescendant:
+    case CSSSelector::RelationType::ShadowPartDescendant:
         return MatchElement::Host;
-    case CSSSelector::ShadowSlotted:
+    case CSSSelector::RelationType::ShadowSlotted:
         // FIXME: Implement accurate invalidation.
         return matchElement;
     };
@@ -151,7 +151,7 @@ static MatchElement computeNextHasPseudoClassMatchElement(MatchElement matchElem
 
     // :has(:is(foo bar)) can be affected by changes outside the :has scope.
     if (canBreakScope == CanBreakScope::Yes) {
-        if (relation == CSSSelector::DescendantSpace || relation == CSSSelector::Child)
+        if (relation == CSSSelector::RelationType::DescendantSpace || relation == CSSSelector::RelationType::Child)
             return MatchElement::HasNonSubjectOrScopeBreaking;
     }
     return matchElement;
@@ -190,7 +190,7 @@ MatchElement computeHasPseudoClassMatchElement(const CSSSelector& hasSelector)
 
 static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, const CSSSelector& selector, const CSSSelector& childSelector)
 {
-    if (selector.match() == CSSSelector::PseudoClass) {
+    if (selector.match() == CSSSelector::Match::PseudoClass) {
         auto type = selector.pseudoClassType();
         // For :nth-child(n of .some-subselector) where an element change may affect other elements similar to sibling combinators.
         if (type == CSSSelector::PseudoClassNthChild || type == CSSSelector::PseudoClassNthLastChild)
@@ -207,7 +207,7 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
         }
 
     }
-    if (selector.match() == CSSSelector::PseudoElement) {
+    if (selector.match() == CSSSelector::Match::PseudoElement) {
         // Similarly for ::slotted().
         if (selector.pseudoElementType() == CSSSelector::PseudoElementSlotted)
             return MatchElement::Host;
@@ -220,19 +220,19 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
 {
     const CSSSelector* selector = &firstSelector;
     do {
-        if (selector->match() == CSSSelector::Id) {
+        if (selector->match() == CSSSelector::Match::Id) {
             idsInRules.add(selector->value());
             if (matchElement == MatchElement::Parent || matchElement == MatchElement::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
             else if (isHasPseudoClassMatchElement(matchElement) || matchElement == MatchElement::AnySibling)
                 selectorFeatures.ids.append({ selector, matchElement, isNegation });
-        } else if (selector->match() == CSSSelector::Class)
+        } else if (selector->match() == CSSSelector::Match::Class)
             selectorFeatures.classes.append({ selector, matchElement, isNegation });
         else if (selector->isAttributeSelector()) {
             attributeLowercaseLocalNamesInRules.add(selector->attribute().localNameLowercase());
             attributeLocalNamesInRules.add(selector->attribute().localName());
             selectorFeatures.attributes.append({ selector, matchElement, isNegation });
-        } else if (selector->match() == CSSSelector::PseudoElement) {
+        } else if (selector->match() == CSSSelector::Match::PseudoElement) {
             switch (selector->pseudoElementType()) {
             case CSSSelector::PseudoElementFirstLine:
                 usesFirstLineRules = true;
@@ -243,7 +243,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             default:
                 break;
             }
-        } else if (selector->match() == CSSSelector::PseudoClass) {
+        } else if (selector->match() == CSSSelector::Match::PseudoClass) {
             bool isLogicalCombination = isLogicalCombinationPseudoClass(selector->pseudoClassType());
             if (!isLogicalCombination)
                 selectorFeatures.pseudoClasses.append({ selector, matchElement, isNegation });
@@ -255,7 +255,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
 
         if (const CSSSelectorList* selectorList = selector->selectorList()) {
             auto subSelectorIsNegation = isNegation;
-            if (selector->match() == CSSSelector::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassNot)
+            if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassNot)
                 subSelectorIsNegation = isNegation == IsNegation::No ? IsNegation::Yes : IsNegation::No;
 
             for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
@@ -264,7 +264,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
                     selectorFeatures.hasSiblingSelector = true;
                 recursivelyCollectFeaturesFromSelector(selectorFeatures, *subSelector, subSelectorMatchElement, subSelectorIsNegation, canBreakScope);
 
-                if (selector->match() == CSSSelector::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassHas)
+                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassHas)
                     selectorFeatures.hasPseudoClasses.append({ subSelector, subSelectorMatchElement, isNegation });
             }
         }
@@ -294,16 +294,16 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
     AtomString className;
     AtomString tagName;
     for (auto* simpleSelector = selector.firstInCompound(); simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
-        if (simpleSelector->match() == CSSSelector::Id)
+        if (simpleSelector->match() == CSSSelector::Match::Id)
             return makePseudoClassInvalidationKey(pseudoClassType, InvalidationKeyType::Id, simpleSelector->value());
 
-        if (simpleSelector->match() == CSSSelector::Class && className.isNull())
+        if (simpleSelector->match() == CSSSelector::Match::Class && className.isNull())
             className = simpleSelector->value();
 
-        if (simpleSelector->match() == CSSSelector::Tag)
+        if (simpleSelector->match() == CSSSelector::Match::Tag)
             tagName = simpleSelector->tagLowercaseLocalName();
 
-        if (simpleSelector->relation() != CSSSelector::Subselector)
+        if (simpleSelector->relation() != CSSSelector::RelationType::Subselector)
             break;
     }
     if (!className.isEmpty())

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -78,9 +78,9 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
     bool hasOnlyOneCompound = true;
     bool hasHostInLastCompound = false;
     for (auto* selector = &startSelector; selector; selector = selector->tagHistory()) {
-        if (selector->match() == CSSSelector::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassHost)
+        if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassHost)
             hasHostInLastCompound = true;
-        if (selector->tagHistory() && selector->relation() != CSSSelector::Subselector) {
+        if (selector->tagHistory() && selector->relation() != CSSSelector::RelationType::Subselector) {
             hasOnlyOneCompound = false;
             hasHostInLastCompound = false;
         }
@@ -143,10 +143,10 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     const CSSSelector* selector = ruleData.selector();
     do {
         switch (selector->match()) {
-        case CSSSelector::Id:
+        case CSSSelector::Match::Id:
             idSelector = selector;
             break;
-        case CSSSelector::Class: {
+        case CSSSelector::Match::Class: {
             auto& className = selector->value();
             if (!classSelector) {
                 classSelector = selector;
@@ -160,21 +160,21 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             }
             break;
         }
-        case CSSSelector::Exact:
-        case CSSSelector::Set:
-        case CSSSelector::List:
-        case CSSSelector::Hyphen:
-        case CSSSelector::Contain:
-        case CSSSelector::Begin:
-        case CSSSelector::End:
+        case CSSSelector::Match::Exact:
+        case CSSSelector::Match::Set:
+        case CSSSelector::Match::List:
+        case CSSSelector::Match::Hyphen:
+        case CSSSelector::Match::Contain:
+        case CSSSelector::Match::Begin:
+        case CSSSelector::Match::End:
             if (shouldHaveBucketForAttributeName(*selector))
                 attributeSelector = selector;
             break;
-        case CSSSelector::Tag:
+        case CSSSelector::Match::Tag:
             if (selector->tagQName().localName() != starAtom())
                 tagSelector = selector;
             break;
-        case CSSSelector::PseudoElement:
+        case CSSSelector::Match::PseudoElement:
             switch (selector->pseudoElementType()) {
             case CSSSelector::PseudoElementWebKitCustom:
             case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
@@ -195,7 +195,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
                 break;
             }
             break;
-        case CSSSelector::PseudoClass:
+        case CSSSelector::Match::PseudoClass:
             switch (selector->pseudoClassType()) {
             case CSSSelector::PseudoClassLink:
             case CSSSelector::PseudoClassVisited:
@@ -214,11 +214,11 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
                 break;
             }
             break;
-        case CSSSelector::Unknown:
-        case CSSSelector::PagePseudoClass:
+        case CSSSelector::Match::Unknown:
+        case CSSSelector::Match::PagePseudoClass:
             break;
         }
-        if (selector->relation() != CSSSelector::Subselector)
+        if (selector->relation() != CSSSelector::RelationType::Subselector)
             break;
         selector = selector->tagHistory();
     } while (selector);
@@ -252,7 +252,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         ruleData.disableSelectorFiltering();
 
         auto* nextSelector = customPseudoElementSelector->tagHistory();
-        if (nextSelector && nextSelector->match() == CSSSelector::PseudoElement && nextSelector->pseudoElementType() == CSSSelector::PseudoElementPart) {
+        if (nextSelector && nextSelector->match() == CSSSelector::Match::PseudoElement && nextSelector->pseudoElementType() == CSSSelector::PseudoElementPart) {
             // Handle selectors like ::part(foo)::placeholder with the part codepath.
             m_partPseudoElementRules.append(ruleData);
             return;


### PR DESCRIPTION
#### 923265e5941bc1687fb511685061d831a92189b5
<pre>
[CSS] Use &quot;enum class&quot; for CSSSelector Match and RelationType
<a href="https://bugs.webkit.org/show_bug.cgi?id=258358">https://bugs.webkit.org/show_bug.cgi?id=258358</a>
rdar://111104973

Reviewed by Brent Fulgham.

It&apos;s a pure refactoring without any functional change.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::createRareData):
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::specificityForPage const):
(WebCore::CSSSelector::firstInCompound const):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::resolveNestingParentSelectors):
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):
(WebCore::CSSSelector::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::hasDescendantRelation const):
(WebCore::CSSSelector::hasDescendantOrChildRelation const):
(WebCore::CSSSelector::matchesPseudoElement const):
(WebCore::CSSSelector::isUnknownPseudoElement const):
(WebCore::CSSSelector::isCustomPseudoElement const):
(WebCore::CSSSelector::isSiblingSelector const):
(WebCore::CSSSelector::isAttributeSelector const):
(WebCore::CSSSelector::setValue):
(WebCore::CSSSelector::~CSSSelector):
(WebCore::CSSSelector::value const):
(WebCore::CSSSelector::serializingValue const):
(WebCore::CSSSelector::pseudoClassType const):
(WebCore::CSSSelector::pseudoElementType const):
(WebCore::CSSSelector::pagePseudoClassType const):
(WebCore::CSSSelector::setPagePseudoType):
(WebCore::CSSSelector::setRelation):
(WebCore::CSSSelector::setMatch):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::SelectorNeedsNamespaceResolutionFunctor::operator()):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::localContextForParent):
(WebCore::SelectorChecker::matchRecursively const):
(WebCore::attributeValueMatches):
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::checkScrollbarPseudoClass const):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorChecker.h:
(WebCore::SelectorChecker::isCommonPseudoClassSelector):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):
(WebCore::SelectorFilter::collectSelectorHashes):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::parsePageSelector):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePagePseudoSelector):
(WebCore::CSSParserSelector::parsePseudoElementSelector):
(WebCore::CSSParserSelector::parsePseudoClassSelector):
(WebCore::CSSParserSelector::appendTagHistory):
(WebCore::CSSParserSelector::prependTagSelector):
(WebCore::CSSParserSelector::releaseTagHistory):
(WebCore::CSSParserSelector::isHostPseudoSelector const):
* Source/WebCore/css/parser/CSSParserSelector.h:
(WebCore::CSSParserSelector::needsImplicitShadowCombinatorForMatching const):
(WebCore::CSSParserSelector::isPseudoElementCueFunction const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::extractCompoundFlags):
(WebCore::isDescendantCombinator):
(WebCore::CSSSelectorParser::consumeComplexSelector):
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::CSSSelectorParser::consumeRelativeNestedSelector):
(WebCore::isSimpleSelectorValidAfterPseudoElement):
(WebCore::CSSSelectorParser::consumeCompoundSelector):
(WebCore::CSSSelectorParser::consumeId):
(WebCore::CSSSelectorParser::consumeClass):
(WebCore::CSSSelectorParser::consumeNesting):
(WebCore::CSSSelectorParser::consumeAttribute):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::consumeCombinator):
(WebCore::CSSSelectorParser::consumeAttributeMatch):
(WebCore::CSSSelectorParser::consumeAttributeFlags):
(WebCore::CSSSelectorParser::splitCompoundAtImplicitShadowCrossingCombinator):
(WebCore::CSSSelectorParser::containsUnknownWebKitPseudoElements):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::attributeSelectorCaseSensitivity):
(WebCore::SelectorCompiler::AttributeMatchingInfo::AttributeMatchingInfo):
(WebCore::SelectorCompiler::fragmentRelationForSelectorRelation):
(WebCore::SelectorCompiler::constructFragmentsInternal):
(WebCore::SelectorCompiler::attributeValueTestingRequiresExtraRegister):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAttributeMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementAttributeValueMatching):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::isSingleTagNameSelector):
(WebCore::isSingleClassNameSelector):
(WebCore::canBeUsedForIdFastPath):
(WebCore::findIdMatchingType):
(WebCore::SelectorDataList::SelectorDataList):
(WebCore::selectorForIdLookup):
(WebCore::filterRootById):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::highlightSelector):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::checkPageSelectorComponents):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::computeMatchBasedOnRuleHash):
(WebCore::Style::computeContainsUncommonAttributeSelector):
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeNextMatchElement):
(WebCore::Style::computeNextHasPseudoClassMatchElement):
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::makePseudoClassInvalidationKey):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/265457@main">https://commits.webkit.org/265457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6558f86850e49b62adaf7facd60e4e17d53e4682

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13298 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12897 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10409 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8495 "10 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9569 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2628 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->