### PR TITLE
Revert [265280@main] REGRESSION(264714@main) 5% regression in Speedometer 3's Editor-TipTap suite

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
@@ -57,10 +57,7 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        if (priorContext.empty())
-            m_string = string.createCFStringWithoutCopying();
-        else
-            m_string = createContextualizedCFString(string, priorContext);
+        m_string = createContextualizedCFString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
     }

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -57,7 +57,7 @@ public:
             }
         }();
 
-        auto stringObject = createString(string, priorContext);
+        auto stringObject = createContextualizedCFString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
@@ -72,7 +72,7 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        auto stringObject = createString(string, priorContext);
+        auto stringObject = createContextualizedCFString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength));
@@ -114,13 +114,6 @@ public:
     }
 
 private:
-    RetainPtr<CFStringRef> createString(StringView string, StringView priorContext)
-    {
-        if (priorContext.empty())
-            return string.createCFStringWithoutCopying();
-        return createContextualizedCFString(string, priorContext);
-    }
-
     RetainPtr<CFStringTokenizerRef> m_stringTokenizer;
     unsigned long m_stringLength { 0 };
     unsigned long m_priorContextLength { 0 };


### PR DESCRIPTION
#### 0b5f8c1635d920574dd7934785c0b812a728630d
<pre>
Revert [265280@main] REGRESSION(264714@main) 5% regression in Speedometer 3&apos;s Editor-TipTap suite
<a href="https://bugs.webkit.org/show_bug.cgi?id=258259">https://bugs.webkit.org/show_bug.cgi?id=258259</a>
rdar://110926113

Unreviewed revert
This reverts because it caused six API tests to constantly fail.

* Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h:
(WTF::TextBreakIteratorCFCharacterCluster::setText):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
(WTF::TextBreakIteratorCFStringTokenizer::setText):
(WTF::TextBreakIteratorCFStringTokenizer::createString): Deleted.

Canonical link: <a href="https://commits.webkit.org/265364@main">https://commits.webkit.org/265364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2891aa1ebde82e1be746f8a9d8a8a7595c460e1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10924 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10890 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12781 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9085 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13083 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10843 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9460 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13733 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11147 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1199 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10163 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->