### PR TITLE
Regression(260713@main) https://www.theverge.com/2023/5/17/23686294/montana-tiktok-ban-signed-governor-gianforte-court load never completes

### DIFF
--- a/LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt
+++ b/LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt
@@ -3,9 +3,9 @@ Tests that a lazy loaded iframe gets a contentWindow / contentDocument as soon a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-document.body.append(iframe)
 PASS iframe.contentDocument.URL is "about:blank"
 PASS iframe.contentWindow.location.href is "about:blank"
+PASS The load event fired for the main frame
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/lazyload/synchronous-frame-creation.html
+++ b/LayoutTests/http/tests/lazyload/synchronous-frame-creation.html
@@ -2,16 +2,21 @@
 <html>
 <body>
 <script src="/js-test-resources/js-test.js"></script>
+<div style="height:10000px;"></div>
+<iframe id="testFrame" src="../dom/resources/dummy.html" loading="lazy"></iframe>
 <script>
 description("Tests that a lazy loaded iframe gets a contentWindow / contentDocument as soon as it gets inserted in the document.");
+jsTestIsAsync = true;
 
-let iframe = document.createElement("iframe");
-iframe.src = "../dom/resources/dummy.html";
-iframe.loading = "lazy";
+let iframe = document.getElementById("testFrame");
 
-evalAndLog("document.body.append(iframe)");
 shouldBeEqualToString("iframe.contentDocument.URL", "about:blank");
 shouldBeEqualToString("iframe.contentWindow.location.href", "about:blank");
+
+onload = () => {
+    testPassed("The load event fired for the main frame");
+    finishJSTest();
+};
 </script>
 </body>
 </html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -350,6 +350,7 @@ void FrameLoader::init()
     setPolicyDocumentLoader(m_client->createDocumentLoader(ResourceRequest(URL({ }, emptyString())), SubstituteData()).ptr());
     setProvisionalDocumentLoader(m_policyDocumentLoader.get());
     m_provisionalDocumentLoader->startLoadingMainResource();
+    setPolicyDocumentLoader(nullptr);
 
     Ref protectedFrame { m_frame };
     Ref document { *m_frame.document() };


### PR DESCRIPTION
#### 409eb08416e5072a678a4d7dbb9c7f6febdeeabe
<pre>
Regression(260713@main) <a href="https://www.theverge.com/2023/5/17/23686294/montana-tiktok-ban-signed-governor-gianforte-court">https://www.theverge.com/2023/5/17/23686294/montana-tiktok-ban-signed-governor-gianforte-court</a> load never completes
<a href="https://bugs.webkit.org/show_bug.cgi?id=258361">https://bugs.webkit.org/show_bug.cgi?id=258361</a>
rdar://109517889

Reviewed by Ryosuke Niwa.

In 260713@main, I made it so that lazily loaded iframes synchronously get an
initial empty document until they get closed to the viewport and actually get
loaded. This was to align with the specification and Chrome.

However, there was an unintentional side effect from this change. The load event
of the parent frame would no longer fire until the lazy iframe actually gets
loaded, which is incorrect. After investigation, I figured out that the lazy
iframes delay the load event of its parent because FrameLoader::subframeIsLoading()
returns true, because the lazy iframe has a policy DocumentLoader.

This policy DocumentLoader gets set by FrameLoader::init() before setting the
provisional DocumentLoader and it doesn&apos;t actually get cleared until a load
occurs in the frame.

To address the issue, I am updating FrameLoader::init() to clear the policy
DocumentLoader after setting the provisional one. No policy decision occurs
for the initial empty document so this policy DocumentLoder is not needed
and would not get cleared otherwise since it is supposed to happen after
the policy decision has been made.

* LayoutTests/http/tests/lazyload/synchronous-frame-creation-expected.txt:
* LayoutTests/http/tests/lazyload/synchronous-frame-creation.html:
Update test added in 260713@main to verify that the load event actually
fires and to move the lazy iframe out of the viewport in order to reproduce
the bug.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::init):

Canonical link: <a href="https://commits.webkit.org/265391@main">https://commits.webkit.org/265391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d48799456d906b323a0e8032e2ecc94284bed2f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10294 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13205 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12787 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16945 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10307 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8400 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9592 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2580 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->