### PR TITLE
Fix ignoring stringop-truncation warnings with clang

### DIFF
--- a/Source/JavaScriptCore/runtime/ConfigFile.cpp
+++ b/Source/JavaScriptCore/runtime/ConfigFile.cpp
@@ -243,9 +243,9 @@ ConfigFile::ConfigFile(const char* filename)
     if (!filename)
         m_filename[0] = '\0';
     else {
-        IGNORE_GCC_WARNINGS_BEGIN("stringop-truncation")
+        IGNORE_WARNINGS_BEGIN("stringop-truncation")
         strncpy(m_filename, filename, s_maxPathLength);
-        IGNORE_GCC_WARNINGS_END
+        IGNORE_WARNINGS_END
         m_filename[s_maxPathLength] = '\0';
     }
 
@@ -489,10 +489,10 @@ void ConfigFile::canonicalizePaths()
             if (sizeof(filenameBuffer) - 1  >= pathnameLength + shouldAddPathSeparator) {
                 if (shouldAddPathSeparator)
                     strncat(filenameBuffer, "/", 2); // Room for '/' plus NUL
-                IGNORE_GCC_WARNINGS_BEGIN("stringop-truncation")
+                IGNORE_WARNINGS_BEGIN("stringop-truncation")
                 strncat(filenameBuffer, m_filename, sizeof(filenameBuffer) - strlen(filenameBuffer) - 1);
-                IGNORE_GCC_WARNINGS_END
                 strncpy(m_filename, filenameBuffer, s_maxPathLength);
+                IGNORE_WARNINGS_END
                 m_filename[s_maxPathLength] = '\0';
             }
         }


### PR DESCRIPTION
#### 9f8cdbea8cd8ec9da2afa1f5839e7125b862c7e7
<pre>
Fix ignoring stringop-truncation warnings with clang
<a href="https://bugs.webkit.org/show_bug.cgi?id=258362">https://bugs.webkit.org/show_bug.cgi?id=258362</a>

Reviewed by Yusuke Suzuki.

IGNORE_GCC_WARNINGS_BEGIN only applies to gcc and
in this case clang supports the same stringop-truncation
warning.

* Source/JavaScriptCore/runtime/ConfigFile.cpp:
(JSC::ConfigFile::ConfigFile):
(JSC::ConfigFile::canonicalizePaths):

Canonical link: <a href="https://commits.webkit.org/265414@main">https://commits.webkit.org/265414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65993edacfe55e941ab5abebca8398e3116dce22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10295 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13208 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12788 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16946 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9092 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13092 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10308 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8403 "1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10850 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9467 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2945 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13740 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11154 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1219 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10170 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2727 "Passed tests") | 
<!--EWS-Status-Bubble-End-->