### PR TITLE
fast/editing/document-leak-altered-text-field.html is a flaky crash

### DIFF
--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -85,9 +85,10 @@ static bool markersHaveIdenticalDescription(const Vector<RenderedDocumentMarker*
 }
 
 AlternativeTextController::AlternativeTextController(Document& document)
-    : m_timer(*this, &AlternativeTextController::timerFired)
+    : m_timer(&document, *this, &AlternativeTextController::timerFired)
     , m_document(document)
 {
+    m_timer.suspendIfNeeded();
 }
 
 AlternativeTextController::~AlternativeTextController()
@@ -118,7 +119,7 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
 
 void AlternativeTextController::stopAlternativeTextUITimer()
 {
-    m_timer.stop();
+    m_timer.cancel();
     m_rangeWithAlternative = std::nullopt;
 }
 

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -28,7 +28,7 @@
 #include "AlternativeTextClient.h"
 #include "DocumentMarker.h"
 #include "Position.h"
-#include "Timer.h"
+#include "SuspendableTimer.h"
 #include <variant>
 #include <wtf/Noncopyable.h>
 
@@ -119,7 +119,7 @@ private:
     FloatRect rootViewRectForRange(const SimpleRange&) const;
     void markPrecedingWhitespaceForDeletedAutocorrectionAfterCommand(EditCommand*);
 
-    Timer m_timer;
+    SuspendableTimer m_timer;
     std::optional<SimpleRange> m_rangeWithAlternative;
     bool m_isActive { };
     bool m_isDismissedByEditing { };


### PR DESCRIPTION
#### d3bab4fdb4dc4cc8da0167cd9c1f141e6b3cf7ea
<pre>
fast/editing/document-leak-altered-text-field.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=258356">https://bugs.webkit.org/show_bug.cgi?id=258356</a>

Reviewed by Wenson Hsieh.

We would hit an assertion in Editor::markAllMisspellingsAndBadGrammarInRanges()
indicating that unifiedTextCheckerEnabled() is not true. The reason this function
returns false is that the Document no longer has a frame.

Normally, the AlternativeTextController::stopAlternativeTextUITimer() gets called
to stop the timer when the document gets detached from its frame
(via Editor::clear()). However, here the document is only temporarily detached
from its frame because it is in the back/forward cache and we fail to stop the
timer in this case.

To address the issue, I updated AlternativeTextController&apos;s timer to use a
SuspendableTimer instead of a Timer. As a result, the timer will be aware
of the back/forward cache and will suspend as needed so that it doesn&apos;t fire
while in the cache (and thus while having no frame).

* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::AlternativeTextController):
(WebCore::AlternativeTextController::stopAlternativeTextUITimer):
* Source/WebCore/editing/AlternativeTextController.h:

Canonical link: <a href="https://commits.webkit.org/265380@main">https://commits.webkit.org/265380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb11d01772fe066044ea1fad0ce1f5ed624a70f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10902 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11812 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12793 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9695 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9472 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2574 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->