### PR TITLE
[webkitpy] Avoid autoinstalling libraries in init

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/setup.py
+++ b/Tools/Scripts/libraries/webkitbugspy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitbugspy',
-    version='0.10.0',
+    version='0.11.0',
     description='Library containing a shared API for various bug trackers.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(0, 10, 0)
+version = Version(0, 11, 0)
 
 from .user import User
 from .issue import Issue

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,7 +22,6 @@
 
 import calendar
 import re
-import requests
 import sys
 import time
 import webkitcorepy
@@ -33,6 +32,8 @@ from .radar import Tracker as RadarTracker
 
 from datetime import datetime
 from webkitbugspy import User, log
+
+requests = webkitcorepy.CallByNeed(lambda: __import__('requests'))
 
 
 class Tracker(GenericTracker):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py
@@ -22,7 +22,6 @@
 
 import calendar
 import re
-import requests
 import sys
 import time
 import webkitcorepy
@@ -31,8 +30,10 @@ from .issue import Issue
 from .tracker import Tracker as GenericTracker
 
 from datetime import datetime
-from requests.auth import HTTPBasicAuth
 from webkitbugspy import User
+
+requests = webkitcorepy.CallByNeed(lambda: __import__('requests'))
+HTTPBasicAuth = webkitcorepy.CallByNeed(lambda: __import__('requests.auth', fromlist=['HTTPBasicAuth']).HTTPBasicAuth)
 
 
 class Tracker(GenericTracker):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -20,11 +20,10 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import six
-
 from .tracker import Tracker
 from .user import User
 from datetime import datetime
+from webkitcorepy import string_utils
 
 
 class Issue(object):
@@ -35,13 +34,13 @@ class Issue(object):
             else:
                 self.user = user
 
-            if isinstance(timestamp, six.string_types) and timestamp.isdigit():
+            if isinstance(timestamp, string_utils.basestring) and timestamp.isdigit():
                 timestamp = int(timestamp)
             if timestamp and not isinstance(timestamp, int):
                 raise TypeError("Expected 'timestamp' to be of type int, got '{}'".format(timestamp))
             self.timestamp = timestamp
 
-            if content and not isinstance(content, six.string_types):
+            if content and not isinstance(content, string_utils.basestring):
                 raise ValueError("Expected 'content' to be a string, got '{}'".format(content))
             self.content = content
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/user.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/user.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,7 +21,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import six
 
 from collections import defaultdict
 from webkitcorepy import string_utils
@@ -107,7 +106,7 @@ class User(object):
     def name(self):
         if self._name:
             return self._name
-        if self.username and isinstance(self.username, six.string_types):
+        if self.username and isinstance(self.username, string_utils.basestring):
             return self.username
         if self.email:
             return self.email
@@ -133,7 +132,7 @@ class User(object):
     def __repr__(self):
         address = None
         for candidate in [self.username, self.email]:
-            if isinstance(candidate, six.string_types) and candidate != self.name:
+            if isinstance(candidate, string_utils.basestring) and candidate != self.name:
                 address = candidate
                 break
         if not address:

--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.14.6',
+    version='0.15.0',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -48,7 +48,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 14, 6)
+version = Version(0, 15, 0)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/call_by_need.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/call_by_need.py
@@ -31,11 +31,7 @@ class CallByNeed(object):
         if name in dir(type(self)) or name in {'_callback', '_value'}:
             return object.__getattribute__(self, name)
         typ = object.__getattribute__(self, 'type')
-        if not typ:
-            raise AttributeError(
-                "'{}' object has no attribute '{},' and doesn't define a target type".format(type(self).__name__, name),
-            )
-        if name in dir(typ):
+        if typ is None or name in dir(typ):
             return object.__getattribute__(self, 'value').__getattribute__(name)
         raise AttributeError("'{}' object has no attribute '{}'".format(typ.__name__, name))
 
@@ -46,7 +42,9 @@ class CallByNeed(object):
             self._callback = None
         return self._value
 
-    def __call__(self):
+    def __call__(self, *args, **kwargs):
+        if callable(self.value):
+            return self.value(*args, **kwargs)
         return self.value
 
     def __repr__(self):

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.4.9',
+    version='6.5.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 4, 9)
+version = Version(6, 5, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -21,12 +21,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import six
 import re
 
 from datetime import datetime
 from webkitbugspy import Tracker
 from webkitscmpy import Contributor
+from webkitcorepy import string_utils
 
 
 class Commit(object):
@@ -67,7 +67,7 @@ class Commit(object):
         if hash is None:
             return None
 
-        if not isinstance(hash, six.string_types):
+        if not isinstance(hash, string_utils.basestring):
             if do_assert:
                 raise ValueError("Expected string type for hash, got '{}'".format(type(hash)))
             return None
@@ -84,7 +84,7 @@ class Commit(object):
         if revision is None:
             return None
 
-        if isinstance(revision, six.string_types):
+        if isinstance(revision, string_utils.basestring):
             match = cls.REVISION_RE.match(revision)
             if match:
                 revision = int(match.group('revision'))
@@ -113,7 +113,7 @@ class Commit(object):
             return None
 
         branch = None
-        if isinstance(identifier, six.string_types):
+        if isinstance(identifier, string_utils.basestring):
             match = cls.IDENTIFIER_RE.match(identifier)
             if match:
                 identifier = match.group('branch_point'), int(match.group('identifier'))
@@ -193,7 +193,7 @@ class Commit(object):
             self.branch_point = branch_point
             self.branch = branch
 
-        if branch and not isinstance(branch, six.string_types):
+        if branch and not isinstance(branch, string_utils.basestring):
             raise ValueError("Expected 'branch' to be a string")
         if branch and branch != self.branch:
             raise ValueError(
@@ -211,13 +211,13 @@ class Commit(object):
                 ),
             )
 
-        if isinstance(timestamp, six.string_types) and timestamp.isdigit():
+        if isinstance(timestamp, string_utils.basestring) and timestamp.isdigit():
             timestamp = int(timestamp)
         if timestamp and not isinstance(timestamp, int):
             raise TypeError("Expected 'timestamp' to be of type int, got '{}'".format(timestamp))
         self.timestamp = timestamp
 
-        if isinstance(order, six.string_types) and order.isdigit():
+        if isinstance(order, string_utils.basestring) and order.isdigit():
             order = int(order)
         if order and not isinstance(order, int):
             raise TypeError("Expected 'order' to be of type int, got '{}'".format(order))
@@ -225,18 +225,18 @@ class Commit(object):
 
         if author and isinstance(author, dict) and author.get('name'):
             self.author = Contributor(author.get('name'), author.get('emails'))
-        elif author and isinstance(author, six.string_types) and '@' in author:
+        elif author and isinstance(author, string_utils.basestring) and '@' in author:
             self.author = Contributor(author, [author])
         elif author and not isinstance(author, Contributor):
             raise TypeError("Expected 'author' to be of type {}, got '{}'".format(Contributor, author))
         else:
             self.author = author
 
-        if message and not isinstance(message, six.string_types):
+        if message and not isinstance(message, string_utils.basestring):
             raise ValueError("Expected 'message' to be a string, got '{}'".format(message))
         self.message = message
 
-        if repository_id and not isinstance(repository_id, six.string_types):
+        if repository_id and not isinstance(repository_id, string_utils.basestring):
             raise ValueError("Expected 'repository_id' to be a string, got '{}'".format(repository_id))
         self.repository_id = repository_id
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -27,14 +27,6 @@ import re
 
 from webkitcorepy import CallByNeed, string_utils
 
-fuzz = None
-
-if sys.version_info > (3, 6):
-    try:
-        from rapidfuzz import fuzz
-    except ModuleNotFoundError:
-        pass
-
 
 class CommitClassifier(object):
     class LineFilter(object):
@@ -42,7 +34,11 @@ class CommitClassifier(object):
 
         @classmethod
         def fuzzy(cls, string, ratio=None):
-            if not fuzz:
+            if sys.version_info <= (3, 6):
+                return re.compile(string)
+            try:
+                from rapidfuzz import fuzz
+            except ModuleNotFoundError:
                 return re.compile(string)
 
             ratio = cls.DEFAULT_FUZZ_RATIO if not ratio else ratio

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -25,7 +25,6 @@ import logging
 import os
 import json
 import re
-import six
 import subprocess
 import sys
 import time
@@ -923,7 +922,7 @@ class Git(Scm):
                 log.kill()
 
     def find(self, argument, include_log=True, include_identifier=True):
-        if not isinstance(argument, six.string_types):
+        if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))
 
         # Map any candidate default branch to the one used by this repository
@@ -957,7 +956,7 @@ class Git(Scm):
     def _to_git_ref(self, argument):
         if not argument:
             return None
-        if not isinstance(argument, six.string_types):
+        if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))
         parsed_commit = Commit.parse(argument, do_assert=False)
         try:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,10 +23,9 @@
 import json
 import os
 import re
-import six
 
 from webkitbugspy import Tracker, bugzilla, github, radar
-from webkitcorepy import decorators
+from webkitcorepy import decorators, string_utils
 from webkitscmpy import ScmBase, Contributor, CommitClassifier
 
 
@@ -56,7 +55,7 @@ class Scm(ScmBase):
         raise OSError("'{}' is not a known SCM type".format(path))
 
     def __init__(self, path, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
-        if not isinstance(path, six.string_types):
+        if not isinstance(path, string_utils.basestring):
             raise ValueError("Expected 'path' to be a string type, not '{}'".format(type(path)))
         self.path = path
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -27,7 +27,6 @@ import re
 import time
 
 from datetime import datetime
-from mock import patch
 from collections import OrderedDict
 
 from webkitcorepy import decorators, mocks, string_utils, OutputCapture, StringIO
@@ -735,6 +734,8 @@ nothing to commit, working tree clean
         )
 
     def __enter__(self):
+        from mock import patch
+
         # TODO: Use shutil directly when Python 2.7 is removed
         from whichcraft import which
         self.patches.append(patch('whichcraft.which', lambda cmd: dict(git=self.executable).get(cmd, which(cmd))))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,7 +25,6 @@ import os
 import re
 
 from datetime import datetime
-from mock import patch
 
 from webkitcorepy import mocks
 from webkitscmpy import local
@@ -170,6 +169,8 @@ class Svn(mocks.Subprocess):
         )
 
     def __enter__(self):
+        from mock import patch
+
         # TODO: Use shutil directly when Python 2.7 is removed
         from whichcraft import which
         self.patches.append(patch('whichcraft.which', lambda cmd: dict(svn=self.executable).get(cmd, which(cmd))))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -23,7 +23,6 @@
 import json
 import os
 import re
-import xmltodict
 
 from collections import OrderedDict
 from webkitcorepy import mocks
@@ -119,6 +118,7 @@ class Svn(mocks.Requests):
                 yield candidate
 
     def request(self, method, url, data=None, **kwargs):
+        import xmltodict
         from datetime import datetime, timedelta
 
         if not url.startswith('http://') and not url.startswith('https://'):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,16 +24,17 @@ import logging
 import os
 import platform
 import re
-import requests
 import shutil
 import subprocess
 import sys
 import tempfile
 import zipfile
 
-from webkitcorepy import Version, arguments, run
+from webkitcorepy import CallByNeed, Version, arguments, run
 from webkitscmpy import local, log
 from .command import Command
+
+requests = CallByNeed(lambda: __import__('requests'))
 
 
 class InstallGitLFS(Command):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py
@@ -32,14 +32,6 @@ from datetime import datetime
 from webkitcorepy import arguments, run, string_utils
 from webkitscmpy import Commit, local, CommitClassifier
 
-fuzz = None
-
-if sys.version_info > (3, 6):
-    try:
-        from rapidfuzz import fuzz
-    except ModuleNotFoundError:
-        pass
-
 
 class Pickable(Command):
     class Filters(object):
@@ -47,7 +39,12 @@ class Pickable(Command):
 
         @classmethod
         def fuzzy(cls, string, ratio=None):
-            if not fuzz:
+            if sys.version_info <= (3, 6):
+                return re.compile(string)
+
+            try:
+                from rapidfuzz import fuzz
+            except ModuleNotFoundError:
                 return re.compile(string)
 
             ratio = cls.DEFAULT_FUZZ_RATIO if not ratio else ratio

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -22,15 +22,16 @@
 
 import getpass
 import os
-import requests
 import sys
 import time
 
 from .command import Command
 from .install_hooks import InstallHooks
-from requests.auth import HTTPBasicAuth
-from webkitcorepy import arguments, run, Editor, OutputCapture, Terminal
+from webkitcorepy import arguments, run, CallByNeed, Editor, OutputCapture, Terminal
 from webkitscmpy import log, local, remote
+
+requests = CallByNeed(lambda: __import__('requests'))
+HTTPBasicAuth = CallByNeed(lambda: __import__('requests.auth', fromlist=['HTTPBasicAuth']).HTTPBasicAuth)
 
 
 class Setup(Command):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -21,11 +21,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-import six
 
 from .commit import Commit
 from datetime import datetime
 from webkitscmpy import Contributor
+from webkitcorepy import string_utils
 
 
 class PullRequest(object):
@@ -36,20 +36,20 @@ class PullRequest(object):
         def __init__(self, author, timestamp, content):
             if author and isinstance(author, dict) and author.get('name'):
                 self.author = Contributor(author.get('name'), author.get('emails'))
-            elif author and isinstance(author, six.string_types) and '@' in author:
+            elif author and isinstance(author, string_utils.basestring) and '@' in author:
                 self.author = Contributor(author, [author])
             elif author and not isinstance(author, Contributor):
                 raise TypeError("Expected 'author' to be of type {}, got '{}'".format(Contributor, author))
             else:
                 self.author = author
 
-            if isinstance(timestamp, six.string_types) and timestamp.isdigit():
+            if isinstance(timestamp, string_utils.basestring) and timestamp.isdigit():
                 timestamp = int(timestamp)
             if timestamp and not isinstance(timestamp, int):
                 raise TypeError("Expected 'timestamp' to be of type int, got '{}'".format(timestamp))
             self.timestamp = timestamp
 
-            if content and not isinstance(content, six.string_types):
+            if content and not isinstance(content, string_utils.basestring):
                 raise ValueError("Expected 'content' to be a string, got '{}'".format(content))
             self.content = content
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -21,13 +21,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-import requests
-import six
 import sys
 
-from webkitcorepy import decorators
+from webkitcorepy import decorators, string_utils, CallByNeed
 from webkitscmpy import Commit, Contributor, PullRequest
 from webkitscmpy.remote.scm import Scm
+
+requests = CallByNeed(lambda: __import__('requests'))
 
 
 class BitBucket(Scm):
@@ -564,7 +564,7 @@ class BitBucket(Scm):
         )
 
     def find(self, argument, include_log=True, include_identifier=True):
-        if not isinstance(argument, six.string_types):
+        if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))
 
         if argument in self.DEFAULT_BRANCHES:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -23,18 +23,18 @@
 import calendar
 import os
 import re
-import requests
-import six
 import sys
 
 from datetime import datetime
-from requests.auth import HTTPBasicAuth
 from webkitbugspy import User
 from webkitbugspy.github import Tracker
-from webkitcorepy import decorators
+from webkitcorepy import decorators, string_utils, CallByNeed
 from webkitscmpy import Commit, Contributor, PullRequest
 from webkitscmpy.remote.scm import Scm
 from xml.dom import minidom
+
+requests = CallByNeed(lambda: __import__('requests'))
+HTTPBasicAuth = CallByNeed(lambda: __import__('requests.auth', fromlist=['HTTPBasicAuth']).HTTPBasicAuth)
 
 
 class GitHub(Scm):
@@ -737,7 +737,7 @@ class GitHub(Scm):
 
 
     def find(self, argument, include_log=True, include_identifier=True):
-        if not isinstance(argument, six.string_types):
+        if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))
 
         if argument in self.DEFAULT_BRANCHES:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -21,9 +21,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-import six
 
 from webkitscmpy.scm_base import ScmBase
+from webkitcorepy import string_utils
 
 
 class Scm(ScmBase):
@@ -86,7 +86,7 @@ class Scm(ScmBase):
             classifier=classifier,
         )
 
-        if not isinstance(url, six.string_types):
+        if not isinstance(url, string_utils.basestring):
             raise ValueError("Expected 'url' to be a string type, not '{}'".format(type(url)))
         self.url = url
         self.pull_requests = None

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
@@ -25,14 +25,16 @@ import calendar
 import json
 import os
 import re
-import requests
 import tempfile
 
 from datetime import datetime
 
-from webkitcorepy import decorators, string_utils
+from webkitcorepy import decorators, string_utils, CallByNeed
 from webkitscmpy.remote.scm import Scm
 from webkitscmpy import Commit, Version
+
+requests = CallByNeed(lambda: __import__('requests'))
+xmltodict = CallByNeed(lambda: __import__('xmltodict'))
 
 
 class Svn(Scm):
@@ -104,8 +106,6 @@ class Svn(Scm):
 
     @decorators.Memoize(cached=False)
     def info(self, branch=None, revision=None, tag=None):
-        import xmltodict
-
         if tag and branch:
             raise ValueError('Cannot specify both branch and tag')
         if tag and revision:
@@ -169,8 +169,6 @@ class Svn(Scm):
         return 'trunk'
 
     def list(self, category):
-        import xmltodict
-
         revision = self._latest()
         if not revision:
             return []
@@ -290,8 +288,6 @@ class Svn(Scm):
         return self._metadata_cache[branch]
 
     def _branch_for(self, revision):
-        import xmltodict
-
         response = requests.request(
             method='REPORT',
             url='{}!svn/rvr/{}'.format(self.url, revision),
@@ -342,8 +338,6 @@ class Svn(Scm):
         return self._commit_count(revision=self._metadata_cache[branch][0], branch=self.default_branch)
 
     def commit(self, hash=None, revision=None, identifier=None, branch=None, tag=None, include_log=True, include_identifier=True):
-        import xmltodict
-
         if hash:
             raise ValueError('SVN does not support Git hashes')
 
@@ -468,8 +462,6 @@ class Svn(Scm):
         )
 
     def _args_from_content(self, content, include_log=True):
-        import xmltodict
-
         xml = xmltodict.parse(content)
         date = datetime.strptime(string_utils.decode(xml['S:log-item']['S:date']).split('.')[0], '%Y-%m-%dT%H:%M:%S')
         name = string_utils.decode(xml['S:log-item']['D:creator-displayname'])

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -22,13 +22,13 @@
 
 import logging
 import re
-import six
 import sys
 import time
 
 from datetime import datetime
 from logging import NullHandler
 from webkitscmpy import Commit, Contributor, CommitClassifier, log
+from webkitcorepy import string_utils
 
 
 class ScmBase(object):
@@ -57,7 +57,7 @@ class ScmBase(object):
         self.contributors = Contributor.Mapping() if contributors is None else contributors
         self.classifier = CommitClassifier() if classifier is None else classifier
 
-        if id and not isinstance(id, six.string_types):
+        if id and not isinstance(id, string_utils.basestring):
             raise ValueError("Expected 'id' to be a string type, not '{}'".format(type(id)))
         self.id = id
 
@@ -140,7 +140,7 @@ class ScmBase(object):
         return sorted(filtered_candidates)[0]
 
     def find(self, argument, include_log=True, include_identifier=True):
-        if not isinstance(argument, six.string_types):
+        if not isinstance(argument, string_utils.basestring):
             raise ValueError("Expected 'argument' to be a string, not '{}'".format(type(argument)))
 
         offset = 0


### PR DESCRIPTION
#### 5f9e420cedb1ad9e41602f43e9423e10c9a1b71a
<pre>
[webkitpy] Avoid autoinstalling libraries in init
<a href="https://bugs.webkit.org/show_bug.cgi?id=258366">https://bugs.webkit.org/show_bug.cgi?id=258366</a>
rdar://111120365

Reviewed by Elliott Williams.

Re-organize webkitscmpy and webkitbugspy to avoid invoking the autoinstaller
in webkitpy&apos;s __init__.py.

* Tools/Scripts/libraries/webkitbugspy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
Lazy-evaluate requests import.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/github.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py: Ditto.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/user.py:
Use webkitcorepy instead of six.
* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/call_by_need.py:
(CallByNeed.__getattribute__): Attempt to use underlying object&apos;s attributes
when no type is defined.
(CallByNeed.__call__): If the value is callable, call it.
* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py:
Use webkitcorepy instead of six.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
(CommitClassifier.LineFilter.fuzzy): Move rapidfuzz import into function call.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
Use webkitcorepy instead of six.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/scm.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
Move mock import into function call.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py:
Move xmldict import into function call.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_git_lfs.py:
Lazy import requests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pickable.py:
(Pickable.Filters.fuzzy): Move rapidfuzz import into function call.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
Lazy import requests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py:
Use webkitcorepy instead of six.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
Use webkitcorepy instead of six, lazy import requests.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
Use webkitcorepy instead of six.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py:
Lazy import requests and xmltodict.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py:
Use webkitcorepy instead of six.

Canonical link: <a href="https://commits.webkit.org/265377@main">https://commits.webkit.org/265377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fc6dc6fc1d368e84ca597941a3bf6cee03249f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/10759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10979 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/12408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10774 "Failed to checkout and rebase branch from PR 15157") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13353 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/10955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/10919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12811 "Failed to checkout and rebase branch from PR 15157") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/10863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13106 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/10664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/11279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1205 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->