### PR TITLE
Stop squaring GameController haptics intensity values on macOS 14+

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -608,6 +608,11 @@
 #define HAVE_GCCONTROLLER_HID_DEVICE_CHECK 1
 #endif
 
+// Newer versions no longer square continuous haptics (rdar://110338126).
+#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED < 140000)
+#define HAVE_GCCONTROLLER_REQUIRING_HAPTICS_SQUARING 1
+#endif
+
 #if PLATFORM(MAC)
 #define HAVE_INCREMENTAL_PDF_APIS 1
 #endif

--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm
@@ -40,10 +40,13 @@ namespace WebCore {
 
 static double magnitudeToIntensity(double magnitude)
 {
-    // GameController doesn't use the intensity as-is and values below 0.1 would end up
-    // not triggering any gamepad vibration. Per GameController developers, we should
-    // pass sqrt(magnitude) to address this issue.
-    return std::sqrt(std::clamp<double>(magnitude, 0, 1));
+    auto intensity = std::clamp<double>(magnitude, 0, 1);
+#if HAVE(GCCONTROLLER_REQUIRING_HAPTICS_SQUARING)
+    // Older versions of GameController didn't use the intensity as-is and required the values to
+    // be squared. Without this, values below 0.1 would end up not triggering any gamepad vibration.
+    intensity = std::sqrt(intensity);
+#endif
+    return intensity;
 }
 
 std::unique_ptr<GameControllerHapticEffect> GameControllerHapticEffect::create(GameControllerHapticEngines& engines, GamepadHapticEffectType type, const GamepadEffectParameters& parameters)


### PR DESCRIPTION
#### eb8b06f8fc5c12e029469f06b19650760c3ae2f5
<pre>
Stop squaring GameController haptics intensity values on macOS 14+
<a href="https://bugs.webkit.org/show_bug.cgi?id=258368">https://bugs.webkit.org/show_bug.cgi?id=258368</a>
rdar://111120352

Reviewed by Brent Fulgham.

When we implemented Gamepad vibration using GameController, we had to get the
square roots of haptics intensity values before passing them to the framework.

GameController was updated in macOS 14+ (rdar://110338126) so that this is no
longer needed. To maintain the behavior, we now need to pass values as-is to
the framework, without computing their square root first.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/platform/gamepad/cocoa/GameControllerHapticEffect.mm:
(WebCore::magnitudeToIntensity):

Canonical link: <a href="https://commits.webkit.org/265381@main">https://commits.webkit.org/265381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae9e2fb256faf807884795a10f544409d7b7a7e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13212 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11816 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9041 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12796 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9700 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16951 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9100 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10181 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13096 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10195 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10317 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10858 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9475 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2571 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13748 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11162 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10178 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2728 "Passed tests") | 
<!--EWS-Status-Bubble-End-->