### PR TITLE
[UI-side compositing] NSScrollerImps are still created in the web process (triggering CATransactions)

### DIFF
--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -528,4 +528,9 @@ float Scrollbar::deviceScaleFactor() const
     return m_scrollableArea.deviceScaleFactor();
 }
 
+bool Scrollbar::shouldRegisterScrollbar() const
+{
+    return m_scrollableArea.scrollbarsController().shouldRegisterScrollbars();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -141,6 +141,8 @@ public:
 
     float deviceScaleFactor() const;
 
+    bool shouldRegisterScrollbar() const;
+
 protected:
     Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);
 

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -94,6 +94,7 @@ public:
     WEBCORE_EXPORT virtual void setScrollbarVisibilityState(ScrollbarOrientation, bool) { }
 
     WEBCORE_EXPORT virtual bool shouldDrawIntoScrollbarLayer(Scrollbar&) const { return true; }
+    WEBCORE_EXPORT virtual bool shouldRegisterScrollbars() const { return true; }
 
 private:
     ScrollableArea& m_scrollableArea;

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -156,7 +156,7 @@ void ScrollbarThemeMac::didCreateScrollerImp(Scrollbar& scrollbar)
 
 void ScrollbarThemeMac::registerScrollbar(Scrollbar& scrollbar)
 {
-    if (scrollbar.isCustomScrollbar())
+    if (scrollbar.isCustomScrollbar() || !scrollbar.shouldRegisterScrollbar())
         return;
 
     bool isHorizontal = scrollbar.orientation() == ScrollbarOrientation::Horizontal;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -51,6 +51,7 @@ public:
 
     void setScrollbarVisibilityState(WebCore::ScrollbarOrientation, bool) final;
     bool shouldDrawIntoScrollbarLayer(WebCore::Scrollbar&) const final;
+    bool shouldRegisterScrollbars() const final { return scrollableArea().isListBox(); }
 
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };


### PR DESCRIPTION
#### 1b57a2e0de6aad8821281cd336b13ab56f57d19e
<pre>
[UI-side compositing] NSScrollerImps are still created in the web process (triggering CATransactions)
<a href="https://bugs.webkit.org/show_bug.cgi?id=258369">https://bugs.webkit.org/show_bug.cgi?id=258369</a>
rdar://109689491

Reviewed by Simon Fraser.

With UI-side compositing, NSScrollerImps are now kept in the UI-process for all scrollbars
except for RenderListBox scrollbars. To prevent the unnecessary creation of NSScrollerImps
in the web process in ScrollbarThemeMac::registerScrollbar, check if the scrollbar is one
of a RenderListBox and if we have a RemoteScrollbarsController.

* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::shouldRegisterScrollbars const):
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::shouldRegisterScrollbar const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::shouldRegisterScrollbars const):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::registerScrollbar):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:

Canonical link: <a href="https://commits.webkit.org/265731@main">https://commits.webkit.org/265731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09198cb7763d0b94dd4bb96bc1c50234041a50fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11257 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13645 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9515 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13320 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17390 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10665 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13566 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9946 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14221 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1314 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->