### PR TITLE
_WKFrameTreeNode should not inherit from WKFrameInfo

### DIFF
--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
@@ -26,21 +26,8 @@
 #include "config.h"
 #include "APIFrameTreeNode.h"
 
-#include "APIFrameHandle.h"
-#include "WebPageProxy.h"
-
 namespace API {
 
 FrameTreeNode::~FrameTreeNode() = default;
-
-Ref<FrameHandle> FrameTreeNode::handle() const
-{
-    return FrameHandle::create(m_data.info.frameID ? *m_data.info.frameID : WebCore::FrameIdentifier { });
-}
-
-RefPtr<FrameHandle> FrameTreeNode::parentFrameHandle() const
-{
-    return m_data.info.parentFrameID ? RefPtr<FrameHandle>(FrameHandle::create(*m_data.info.parentFrameID)) : nullptr;
-}
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -43,21 +43,14 @@ public:
 
     WebKit::WebPageProxy& page() { return m_page.get(); }
     const WebKit::FrameInfoData& info() const { return m_data.info; }
-    bool isMainFrame() const { return m_data.info.isMainFrame; }
-    bool isLocalFrame() const { return m_data.info.frameType == WebKit::FrameType::Local; }
-    const WebCore::ResourceRequest& request() const { return m_data.info.request; }
-    const WebCore::SecurityOriginData& securityOrigin() const { return m_data.info.securityOrigin; }
     const Vector<WebKit::FrameTreeNodeData>& childFrames() const { return m_data.children; }
-    Ref<FrameHandle> handle() const;
-    RefPtr<FrameHandle> parentFrameHandle() const;
-    ProcessID processID() const { return m_data.info.processID; }
 
 private:
     FrameTreeNode(WebKit::FrameTreeNodeData&& data, WebKit::WebPageProxy& page)
         : m_data(WTFMove(data))
         , m_page(page) { }
 
-    WebKit::FrameTreeNodeData m_data;
+    const WebKit::FrameTreeNodeData m_data;
     Ref<WebKit::WebPageProxy> m_page;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h
@@ -26,13 +26,11 @@
 #import <WebKit/WKFrameInfo.h>
 
 WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
-@interface _WKFrameTreeNode : WKFrameInfo
+@interface _WKFrameTreeNode : NSObject
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
-// FIXME: Move Safari to use _WKFrameTreeNode.info and make _WKFrameTreeNode no longer inherit from WKFrameInfo
-// so we don't have to implement all the selectors of WKFrameInfo twice.
 @property (nonatomic, readonly, copy) WKFrameInfo *info WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly) NSArray<_WKFrameTreeNode *> *childFrames;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
@@ -49,58 +49,11 @@
     return wrapper(API::FrameInfo::create(WebKit::FrameInfoData(_node->info()), &_node->page()));
 }
 
-- (BOOL)isMainFrame
-{
-    return _node->isMainFrame();
-}
-
-- (NSURLRequest *)request
-{
-    return _node->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
-}
-
-- (WKSecurityOrigin *)securityOrigin
-{
-    auto& data = _node->securityOrigin();
-    auto apiOrigin = API::SecurityOrigin::create(data);
-    return retainPtr(wrapper(apiOrigin.get())).autorelease();
-}
-
-- (WKWebView *)webView
-{
-    return _node->page().cocoaView().autorelease();
-}
-
 - (NSArray<_WKFrameTreeNode *> *)childFrames
 {
     return createNSArray(_node->childFrames(), [&] (auto& child) {
         return wrapper(API::FrameTreeNode::create(WebKit::FrameTreeNodeData(child), _node->page()));
     }).autorelease();
-}
-
-- (id)copyWithZone:(NSZone *)zone
-{
-    return [self retain];
-}
-
-- (_WKFrameHandle *)_handle
-{
-    return retainPtr(wrapper(_node->handle())).autorelease();
-}
-
-- (_WKFrameHandle *)_parentFrameHandle
-{
-    return retainPtr(wrapper(_node->parentFrameHandle())).autorelease();
-}
-
-- (pid_t)_processIdentifier
-{
-    return _node->processID();
-}
-
-- (BOOL)_isLocalFrame
-{
-    return _node->isLocalFrame();
 }
 
 - (API::Object&)_apiObject

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -128,8 +128,8 @@ enum class FrameType : bool { Local, Remote };
 static pid_t findFramePID(NSSet<_WKFrameTreeNode *> *set, FrameType local)
 {
     for (_WKFrameTreeNode *node in set) {
-        if (node._isLocalFrame == (local == FrameType::Local))
-            return node._processIdentifier;
+        if (node.info._isLocalFrame == (local == FrameType::Local))
+            return node.info._processIdentifier;
     }
     ASSERT_NOT_REACHED();
     return 0;
@@ -382,8 +382,8 @@ TEST(SiteIsolation, PostMessageWithMessagePorts)
 
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = mainFrame.childFrames.firstObject._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = mainFrame.childFrames.firstObject.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
@@ -455,8 +455,8 @@ TEST(SiteIsolation, PostMessageWithNotAllowedTargetOrigin)
 
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = mainFrame.childFrames.firstObject._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = mainFrame.childFrames.firstObject.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
@@ -522,8 +522,8 @@ TEST(SiteIsolation, PostMessageToIFrameWithOpaqueOrigin)
 
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = mainFrame.childFrames.firstObject._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = mainFrame.childFrames.firstObject.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
@@ -582,13 +582,13 @@ TEST(SiteIsolation, NavigatingCrossOriginIframeToSameOrigin)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_EQ(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
         done = true;
     }];
     Util::run(&done);
@@ -615,13 +615,13 @@ TEST(SiteIsolation, ParentNavigatingCrossOriginIframeToSameOrigin)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_EQ(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
         done = true;
     }];
     Util::run(&done);
@@ -654,13 +654,13 @@ TEST(SiteIsolation, IframeNavigatesSelfWithoutChangingOrigin)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -685,13 +685,13 @@ TEST(SiteIsolation, IframeWithConfirm)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -716,13 +716,13 @@ TEST(SiteIsolation, IframeWithPrompt)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -770,13 +770,13 @@ TEST(SiteIsolation, ChildNavigatingToNewDomain)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "foo.com");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "foo.com");
         done = true;
     }];
     Util::run(&done);
@@ -803,13 +803,13 @@ TEST(SiteIsolation, ChildNavigatingToMainFrameDomain)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_EQ(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
         done = true;
     }];
     Util::run(&done);
@@ -836,13 +836,13 @@ TEST(SiteIsolation, ChildNavigatingToSameDomain)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -874,10 +874,10 @@ TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)
     __block pid_t firstFramePID = 0;
     __block bool done { false };
     [firstWebView _frames:^(_WKFrameTreeNode *mainFrame) {
-        pid_t mainFramePid = mainFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         firstFramePID = mainFramePid;
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -885,14 +885,14 @@ TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)
     done = false;
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
         EXPECT_NE(firstFramePID, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -928,17 +928,17 @@ TEST(SiteIsolation, MainFrameWithTwoIFramesInTheSameProcess)
         EXPECT_EQ(mainFrame.childFrames.count, 2u);
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
         _WKFrameTreeNode *otherChildFrame = mainFrame.childFrames[1];
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
-        pid_t otherChildFramePid = otherChildFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
+        pid_t otherChildFramePid = otherChildFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(otherChildFramePid, 0);
         EXPECT_EQ(childFramePid, otherChildFramePid);
-        EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
-        EXPECT_WK_STREQ(otherChildFrame.securityOrigin.host, "webkit.org");
+        EXPECT_EQ(mainFramePid, childFramePid);
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(otherChildFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);
@@ -965,13 +965,13 @@ TEST(SiteIsolation, ChildBeingNavigatedToMainFrameDomainByParent)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_EQ(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "example.com");
         done = true;
     }];
     Util::run(&done);
@@ -1004,13 +1004,13 @@ TEST(SiteIsolation, ChildBeingNavigatedToSameDomainByParent)
     __block bool done { false };
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
         _WKFrameTreeNode *childFrame = mainFrame.childFrames.firstObject;
-        pid_t mainFramePid = mainFrame._processIdentifier;
-        pid_t childFramePid = childFrame._processIdentifier;
+        pid_t mainFramePid = mainFrame.info._processIdentifier;
+        pid_t childFramePid = childFrame.info._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
         EXPECT_NE(mainFramePid, childFramePid);
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
-        EXPECT_WK_STREQ(childFrame.securityOrigin.host, "webkit.org");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "example.com");
+        EXPECT_WK_STREQ(childFrame.info.securityOrigin.host, "webkit.org");
         done = true;
     }];
     Util::run(&done);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -983,7 +983,7 @@ TEST(WKUserContentController, AddUserScriptInWorldWithGlobalObjectAvailableInIfr
 
     __block bool done = false;
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        [webView _evaluateJavaScript:@"window.worldName" inFrame:mainFrame.childFrames[0] inContentWorld:testWorld.get() completionHandler:^(id result, NSError *error) {
+        [webView _evaluateJavaScript:@"window.worldName" inFrame:mainFrame.childFrames[0].info inContentWorld:testWorld.get() completionHandler:^(id result, NSError *error) {
             EXPECT_WK_STREQ(result, "testWorld");
             done = true;
         }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm
@@ -1495,43 +1495,43 @@ TEST(URLSchemeHandler, Frames)
         TestWebKitAPI::Util::spinRunLoop();
     
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "host1");
-        EXPECT_WK_STREQ(mainFrame.request.URL.host, "host1");
+        EXPECT_WK_STREQ(mainFrame.info.securityOrigin.host, "host1");
+        EXPECT_WK_STREQ(mainFrame.info.request.URL.host, "host1");
         EXPECT_EQ(mainFrame.childFrames.count, 1u);
-        EXPECT_TRUE(mainFrame.isMainFrame);
+        EXPECT_TRUE(mainFrame.info.isMainFrame);
 
         _WKFrameTreeNode *child = mainFrame.childFrames[0];
-        EXPECT_WK_STREQ(child.request.URL.host, "host2");
-        EXPECT_WK_STREQ(child.securityOrigin.host, "host2");
+        EXPECT_WK_STREQ(child.info.request.URL.host, "host2");
+        EXPECT_WK_STREQ(child.info.securityOrigin.host, "host2");
         EXPECT_EQ(child.childFrames.count, 2u);
-        EXPECT_FALSE(child.isMainFrame);
+        EXPECT_FALSE(child.info.isMainFrame);
 
         _WKFrameTreeNode *grandchild1 = child.childFrames[0];
-        EXPECT_WK_STREQ(grandchild1.request.URL.host, "host3");
-        EXPECT_WK_STREQ(grandchild1.securityOrigin.host, "host3");
+        EXPECT_WK_STREQ(grandchild1.info.request.URL.host, "host3");
+        EXPECT_WK_STREQ(grandchild1.info.securityOrigin.host, "host3");
         EXPECT_EQ(grandchild1.childFrames.count, 0u);
-        EXPECT_FALSE(grandchild1.isMainFrame);
+        EXPECT_FALSE(grandchild1.info.isMainFrame);
 
         _WKFrameTreeNode *grandchild2 = child.childFrames[1];
-        EXPECT_WK_STREQ(grandchild2.request.URL.host, "host4");
-        EXPECT_WK_STREQ(grandchild2.securityOrigin.host, "host4");
+        EXPECT_WK_STREQ(grandchild2.info.request.URL.host, "host4");
+        EXPECT_WK_STREQ(grandchild2.info.securityOrigin.host, "host4");
         EXPECT_EQ(grandchild2.childFrames.count, 0u);
-        EXPECT_FALSE(grandchild2.isMainFrame);
+        EXPECT_FALSE(grandchild2.info.isMainFrame);
 
-        EXPECT_NE(mainFrame._handle.frameID, child._handle.frameID);
-        EXPECT_NE(mainFrame._handle.frameID, grandchild1._handle.frameID);
-        EXPECT_NE(mainFrame._handle.frameID, grandchild2._handle.frameID);
-        EXPECT_NE(child._handle.frameID, grandchild1._handle.frameID);
-        EXPECT_NE(child._handle.frameID, grandchild2._handle.frameID);
-        EXPECT_NE(grandchild1._handle.frameID, grandchild2._handle.frameID);
+        EXPECT_NE(mainFrame.info._handle.frameID, child.info._handle.frameID);
+        EXPECT_NE(mainFrame.info._handle.frameID, grandchild1.info._handle.frameID);
+        EXPECT_NE(mainFrame.info._handle.frameID, grandchild2.info._handle.frameID);
+        EXPECT_NE(child.info._handle.frameID, grandchild1.info._handle.frameID);
+        EXPECT_NE(child.info._handle.frameID, grandchild2.info._handle.frameID);
+        EXPECT_NE(grandchild1.info._handle.frameID, grandchild2.info._handle.frameID);
 
-        EXPECT_NULL(mainFrame._parentFrameHandle);
-        EXPECT_EQ(mainFrame._handle.frameID, child._parentFrameHandle.frameID);
-        EXPECT_EQ(child._handle.frameID, grandchild1._parentFrameHandle.frameID);
-        EXPECT_EQ(child._handle.frameID, grandchild2._parentFrameHandle.frameID);
+        EXPECT_NULL(mainFrame.info._parentFrameHandle);
+        EXPECT_EQ(mainFrame.info._handle.frameID, child.info._parentFrameHandle.frameID);
+        EXPECT_EQ(child.info._handle.frameID, grandchild1.info._parentFrameHandle.frameID);
+        EXPECT_EQ(child.info._handle.frameID, grandchild2.info._parentFrameHandle.frameID);
 
-        [webView _callAsyncJavaScript:@"window.customProperty = 'customValue'" arguments:nil inFrame:grandchild1 inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id, NSError *error) {
-            [webView _evaluateJavaScript:@"window.location.href + window.customProperty" inFrame:grandchild1 inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id result, NSError *error) {
+        [webView _callAsyncJavaScript:@"window.customProperty = 'customValue'" arguments:nil inFrame:grandchild1.info inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id, NSError *error) {
+            [webView _evaluateJavaScript:@"window.location.href + window.customProperty" inFrame:grandchild1.info inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id result, NSError *error) {
                 EXPECT_WK_STREQ(result, "frame://host3/customValue");
                 done = true;
             }];
@@ -1542,11 +1542,11 @@ TEST(URLSchemeHandler, Frames)
     done = false;
     auto emptyWebView = adoptNS([WKWebView new]);
     [emptyWebView _frames:^(_WKFrameTreeNode *mainFrame) {
-        EXPECT_NOT_NULL(mainFrame._handle);
+        EXPECT_NOT_NULL(mainFrame.info._handle);
 #if PLATFORM(MAC)
-        EXPECT_EQ(mainFrame._handle.frameID, 0u);
+        EXPECT_EQ(mainFrame.info._handle.frameID, 0u);
 #endif
-        [emptyWebView _evaluateJavaScript:@"window.location.href" inFrame:mainFrame inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id result, NSError *error) {
+        [emptyWebView _evaluateJavaScript:@"window.location.href" inFrame:mainFrame.info inContentWorld:[WKContentWorld defaultClientWorld] completionHandler:^(id result, NSError *error) {
             EXPECT_WK_STREQ(result, "about:blank");
             done = true;
         }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -322,7 +322,7 @@ TEST(WKWebView, EvaluateJavaScriptInWorldsWithGlobalObjectAvailableInCrossOrigin
     
     __block bool done = false;
     [webView _frames:^(_WKFrameTreeNode *mainFrame) {
-        [webView _evaluateJavaScript:@"window.worldName" inFrame:mainFrame.childFrames[0] inContentWorld:[WKContentWorld worldWithName:@"testName"] completionHandler:^(id result, NSError *error) {
+        [webView _evaluateJavaScript:@"window.worldName" inFrame:mainFrame.childFrames[0].info inContentWorld:[WKContentWorld worldWithName:@"testName"] completionHandler:^(id result, NSError *error) {
             EXPECT_WK_STREQ(result, "testName");
             done = true;
         }];


### PR DESCRIPTION
#### 7f823a2dc8db56e8e7c837d9aa08a395f0063f19
<pre>
_WKFrameTreeNode should not inherit from WKFrameInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=258370">https://bugs.webkit.org/show_bug.cgi?id=258370</a>
rdar://111125379

Reviewed by Tim Horton.

rdar://problem/111125090 makes it so there are no more users expecting the inheritance.
This reduces duplicate code and makes it so that adding a new selector won&apos;t cause crashes
when it&apos;s not implemented in two places.

* Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp:
(API::FrameTreeNode::handle const): Deleted.
(API::FrameTreeNode::parentFrameHandle const): Deleted.
* Source/WebKit/UIProcess/API/APIFrameTreeNode.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm:
(-[_WKFrameTreeNode isMainFrame]): Deleted.
(-[_WKFrameTreeNode request]): Deleted.
(-[_WKFrameTreeNode securityOrigin]): Deleted.
(-[_WKFrameTreeNode webView]): Deleted.
(-[_WKFrameTreeNode copyWithZone:]): Deleted.
(-[_WKFrameTreeNode _handle]): Deleted.
(-[_WKFrameTreeNode _parentFrameHandle]): Deleted.
(-[_WKFrameTreeNode _processIdentifier]): Deleted.
(-[_WKFrameTreeNode _isLocalFrame]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::findFramePID):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/265971@main">https://commits.webkit.org/265971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/900b0408c362486767878be697154358779dba05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12449 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/12780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14190 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12798 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12613 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14614 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/11269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/11922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/11159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1388 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->