### PR TITLE
Upstream visionOS-specific AVKit usage

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -401,3 +401,17 @@ NS_ASSUME_NONNULL_END
 
 #endif // HAVE(PIP_CONTROLLER)
 
+#if PLATFORM(VISION)
+
+// FIXME: rdar://111125392 – import SPI using a header, following rdar://111123290.
+
+typedef NS_OPTIONS(NSUInteger, AVPlayerViewControllerFullScreenBehaviors) {
+    AVPlayerViewControllerFullScreenBehaviorHostContentInline = 1 << 3,
+};
+
+@interface AVPlayerViewController ()
+@property (nonatomic) BOOL prefersRoomDimming;
+@property (nonatomic) AVPlayerViewControllerFullScreenBehaviors fullScreenBehaviors;
+@end
+
+#endif // PLATFORM(VISION)

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -52,10 +52,6 @@
 #import <AVKit/AVPictureInPictureController.h>
 #endif
 
-#if PLATFORM(VISION)
-#import <WebKitAdditions/VideoFullscreenInterfaceAVKitAdditions.h>
-#endif
-
 using namespace WebCore;
 
 #import <pal/cf/CoreMediaSoftLink.h>
@@ -408,8 +404,9 @@ NS_ASSUME_NONNULL_END
     _avPlayerViewController.get().delegate = self;
 #endif
 
-#if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
-    setupAVPlayerViewControllerForFullscreenWindowEffects(_avPlayerViewController.get());
+#if PLATFORM(VISION)
+    [_avPlayerViewController setPrefersRoomDimming:NO];
+    [_avPlayerViewController setFullScreenBehaviors:AVPlayerViewControllerFullScreenBehaviorHostContentInline];
 #endif
 
 #if HAVE(PIP_CONTROLLER)


### PR DESCRIPTION
#### 0e11706c9cf73b368cd06d4ff7fc39d710abaf27
<pre>
Upstream visionOS-specific AVKit usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=258371">https://bugs.webkit.org/show_bug.cgi?id=258371</a>
rdar://111125631

Reviewed by Tim Horton.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(-[WebAVPlayerViewController initWithFullscreenInterface:]):

Canonical link: <a href="https://commits.webkit.org/265384@main">https://commits.webkit.org/265384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ee5518466214d846a7858b70f4071a66da1aba6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13214 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11823 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12809 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9699 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13107 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10321 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13752 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1209 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->