### PR TITLE
[iOS] Avoid incrementing the WebItemProviderPasteboard change count upon handling a drop

### DIFF
--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.h
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.h
@@ -31,6 +31,8 @@
 
 #if TARGET_OS_IOS
 
+@protocol UIDropSession;
+
 typedef NS_ENUM(NSInteger, WebPreferredPresentationStyle) {
     WebPreferredPresentationStyleUnspecified,
     WebPreferredPresentationStyleInline,
@@ -103,6 +105,8 @@ WEBCORE_EXPORT @interface WebItemProviderPasteboard : NSObject<AbstractPasteboar
 @property (readonly, nonatomic) BOOL hasPendingOperation;
 - (void)incrementPendingOperationCount;
 - (void)decrementPendingOperationCount;
+
+- (void)setItemProviders:(NSArray<__kindof NSItemProvider *> *)itemProviders dropSession:(nullable id<UIDropSession>)dropSession;
 
 - (void)enumerateItemProvidersWithBlock:(void (^)(__kindof NSItemProvider *itemProvider, NSUInteger index, BOOL *stop))block;
 

--- a/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
+++ b/Source/WebCore/platform/ios/WebItemProviderPasteboard.mm
@@ -473,6 +473,7 @@ static UIPreferredPresentationStyle uiPreferredPresentationStyle(WebPreferredPre
     RetainPtr<NSArray<WebItemProviderRegistrationInfoList *>> _stagedRegistrationInfoLists;
 
     Vector<RetainPtr<WebItemProviderLoadResult>> _loadResults;
+    __weak id<UIDropSession> _dropSession;
 }
 
 + (instancetype)sharedInstance
@@ -524,17 +525,25 @@ static UIPreferredPresentationStyle uiPreferredPresentationStyle(WebPreferredPre
     return _itemProviders.get();
 }
 
-- (void)setItemProviders:(NSArray<__kindof NSItemProvider *> *)itemProviders
+- (void)setItemProviders:(NSArray<__kindof NSItemProvider *> *)itemProviders dropSession:(id<UIDropSession>)dropSession
 {
     itemProviders = itemProviders ?: @[ ];
     if (_itemProviders == itemProviders || [_itemProviders isEqualToArray:itemProviders])
         return;
 
-    _itemProviders = itemProviders;
-    _changeCount++;
+    if (dropSession != _dropSession || !dropSession)
+        _changeCount++;
+
+    _dropSession = dropSession;
+    _itemProviders = adoptNS(itemProviders.copy);
 
     if (!itemProviders.count)
         _loadResults = { };
+}
+
+- (void)setItemProviders:(NSArray<__kindof NSItemProvider *> *)itemProviders
+{
+    [self setItemProviders:itemProviders dropSession:nil];
 }
 
 - (NSInteger)numberOfItems

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9953,13 +9953,13 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 
     _dragDropInteractionState.dropSessionDidEnterOrUpdate(session, dragData);
 
-    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session)];
+    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session) dropSession:session];
     _page->dragEntered(dragData, WebCore::Pasteboard::nameOfDragPasteboard());
 }
 
 - (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction sessionDidUpdate:(id <UIDropSession>)session
 {
-    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session)];
+    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session) dropSession:session];
 
     auto dragData = [self dragDataForDropSession:session dragDestinationAction:[self _dragDestinationActionForDropSession:session]];
     _page->dragUpdated(dragData, WebCore::Pasteboard::nameOfDragPasteboard());
@@ -9991,7 +9991,7 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 - (void)dropInteraction:(UIDropInteraction *)interaction sessionDidExit:(id <UIDropSession>)session
 {
     RELEASE_LOG(DragAndDrop, "Drop session exited: %p with %tu items", session, session.items.count);
-    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session)];
+    [[WebItemProviderPasteboard sharedInstance] setItemProviders:extractItemProvidersFromDropSession(session) dropSession:session];
 
     auto dragData = [self dragDataForDropSession:session dragDestinationAction:WKDragDestinationActionAny];
     _page->dragExited(dragData, WebCore::Pasteboard::nameOfDragPasteboard());
@@ -10017,7 +10017,7 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
 
     _dragDropInteractionState.dropSessionWillPerformDrop();
 
-    [[WebItemProviderPasteboard sharedInstance] setItemProviders:itemProviders];
+    [[WebItemProviderPasteboard sharedInstance] setItemProviders:itemProviders dropSession:session];
     [[WebItemProviderPasteboard sharedInstance] incrementPendingOperationCount];
     auto dragData = [self dragDataForDropSession:session dragDestinationAction:WKDragDestinationActionAny];
     BOOL shouldSnapshotView = ![self _handleDropByInsertingImagePlaceholders:itemProviders session:session];

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -1097,6 +1097,7 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropFileUpload)
     NSString *outputValue = [webView stringByEvaluatingJavaScript:@"output.value"];
     EXPECT_WK_STREQ("text/html", outputValue.UTF8String);
     EXPECT_FALSE([simulator lastKnownDropProposal].precise);
+    EXPECT_EQ(2, WebItemProviderPasteboard.sharedInstance.changeCount);
 }
 
 static RetainPtr<NSItemProvider> createMapItemForTesting()
@@ -1276,6 +1277,7 @@ TEST(DragAndDropTests, ExternalSourceOverrideDropInsertURL)
     [simulator runFrom:CGPointMake(300, 400) to:CGPointMake(100, 300)];
 
     EXPECT_WK_STREQ("https://webkit.org/", [webView stringByEvaluatingJavaScript:@"editor.textContent"]);
+    EXPECT_EQ(2, WebItemProviderPasteboard.sharedInstance.changeCount);
 }
 
 TEST(DragAndDropTests, OverrideDrop)


### PR DESCRIPTION
#### 7a9e0cf4d1795b7ef6a49ea7becba561416a6f23
<pre>
[iOS] Avoid incrementing the WebItemProviderPasteboard change count upon handling a drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=258374">https://bugs.webkit.org/show_bug.cgi?id=258374</a>
rdar://111130159

Reviewed by Aditya Keerthi.

This is a speculative fix for rdar://107712399, wherein the `changeCount` of the drag and drop
pasteboard (`WebItemProviderPasteboard`) may be incremented while performing a drop if the dropped
items are overwritten upon drop, thus bumping the pasteboard&apos;s `_changeCount`.

To mitigate this possibility, instead of incrementing the `_changeCount` whenever the backing item
provider array changes, we instead keep it stable across the lifetime of a given drop session
(`UIDropSession`), even in the case where a WebKit client overrides dropped items at the last
minute when performing the drop.

* Source/WebCore/platform/ios/WebItemProviderPasteboard.h:
* Source/WebCore/platform/ios/WebItemProviderPasteboard.mm:
(-[WebItemProviderPasteboard setItemProviders:dropSession:]):
(-[WebItemProviderPasteboard setItemProviders:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView dropInteraction:sessionDidEnter:]):
(-[WKContentView dropInteraction:sessionDidUpdate:]):
(-[WKContentView dropInteraction:sessionDidExit:]):
(-[WKContentView dropInteraction:performDrop:]):
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:

Adjust a couple of API tests to exercise the fix, by checking that the final `changeCount` ends up
at 2 after concluding a simulated drop (+1 for when we first begin the drop session, and +1 again
after we clean up the pasteboard, after the webpage is done handling the drop).

Canonical link: <a href="https://commits.webkit.org/265392@main">https://commits.webkit.org/265392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a54c7d5dea5f8a2c624f770f840da0b14642cfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10315 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13222 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12814 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16967 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10328 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8420 "15 flakes 6 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9486 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->