### PR TITLE
Safari not rendering some PDFs correctly

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "PluginDocument.h"
 
+#include "CSSValuePool.h"
 #include "DocumentLoader.h"
 #include "FrameLoader.h"
 #include "HTMLBodyElement.h"
@@ -87,10 +88,17 @@ void PluginDocumentParser::createDocumentStructure()
     body->setAttributeWithoutSynchronization(marginwidthAttr, "0"_s);
     body->setAttributeWithoutSynchronization(marginheightAttr, "0"_s);
 #if PLATFORM(IOS_FAMILY)
-    body->setAttribute(styleAttr, "background-color: rgb(217,224,233); height: 100%; width: 100%; overflow:hidden; margin: 0"_s);
+    constexpr auto bodyBackgroundColor = SRGBA<uint8_t> { 217, 224, 233 };
 #else
-    body->setAttribute(styleAttr, "background-color: rgb(38,38,38); height: 100%; width: 100%; overflow:hidden; margin: 0"_s);
+    constexpr auto bodyBackgroundColor = SRGBA<uint8_t> { 38, 38, 38 };
 #endif
+
+    // If the plugin is a PDF, the background color is overriden in `PDFPlugin::PDFPlugin`.
+    body->setInlineStyleProperty(CSSPropertyBackgroundColor, CSSValuePool::singleton().createColorValue(bodyBackgroundColor));
+    body->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::CSS_PERCENTAGE);
+    body->setInlineStyleProperty(CSSPropertyWidth, 100, CSSUnitType::CSS_PERCENTAGE);
+    body->setInlineStyleProperty(CSSPropertyOverflow, CSSValueHidden);
+    body->setInlineStyleProperty(CSSPropertyMargin, 0, CSSUnitType::CSS_PERCENTAGE);
 
     rootElement->appendChild(body);
         


### PR DESCRIPTION
#### 9dfcb542a351d1fc7fff821dfb025427fdd2b77b
<pre>
Safari not rendering some PDFs correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=258377">https://bugs.webkit.org/show_bug.cgi?id=258377</a>
rdar://110632076

Reviewed by Tim Horton.

254526@main made `PluginDocument` use &quot;no-quirks&quot; mode. PDFs were relying on the &quot;body element fills the html element&quot;
quirk to ensure their height matches the root HTML element&apos;s height, because the body element had no CSS `height` value
specified. Because `PluginDocument` is now in no-quirks mode, the body element&apos;s height can sometimes be less than the
height of the web view, which is incorrect.

254526@main tried to ensure this would not happen by using `setAttribute` on the body element to set the relevant CSS
attributes, including the height. However, `setAttribute` is lazy, so for some PDFS, none of these attributes were
actually being applied.

To fix, use `setInlineStyleProperty` instead of `setAttribute` to ensure the attributes are properly set immediately.

Also added a comment to clarify where the body background color actually comes from in the case of PDFs, to avoid future
confusion.

* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createDocumentStructure):

Canonical link: <a href="https://commits.webkit.org/265409@main">https://commits.webkit.org/265409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa6d6e5f6213fca672cb9862e5e0449b5cee643

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13236 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12829 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13122 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8436 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9505 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2590 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->