### PR TITLE
REGRESSION(264714@main) 5% regression in Speedometer 3's Editor-TipTap suite

### DIFF
--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h
@@ -57,7 +57,10 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        m_string = createContextualizedCFString(string, priorContext);
+        if (priorContext.isEmpty())
+            m_string = string.createCFStringWithoutCopying();
+        else
+            m_string = createContextualizedCFString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
     }

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -57,7 +57,7 @@ public:
             }
         }();
 
-        auto stringObject = createContextualizedCFString(string, priorContext);
+        auto stringObject = createString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
@@ -72,7 +72,7 @@ public:
 
     void setText(StringView string, StringView priorContext)
     {
-        auto stringObject = createContextualizedCFString(string, priorContext);
+        auto stringObject = createString(string, priorContext);
         m_stringLength = string.length();
         m_priorContextLength = priorContext.length();
         CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength));
@@ -114,6 +114,13 @@ public:
     }
 
 private:
+    RetainPtr<CFStringRef> createString(StringView string, StringView priorContext)
+    {
+        if (priorContext.isEmpty())
+            return string.createCFStringWithoutCopying();
+        return createContextualizedCFString(string, priorContext);
+    }
+
     RetainPtr<CFStringTokenizerRef> m_stringTokenizer;
     unsigned long m_stringLength { 0 };
     unsigned long m_priorContextLength { 0 };


### PR DESCRIPTION
#### cef67a15794121ce2c8b17671619eb5cb2f7e983
<pre>
REGRESSION(264714@main) 5% regression in Speedometer 3&apos;s Editor-TipTap suite
<a href="https://bugs.webkit.org/show_bug.cgi?id=258259">https://bugs.webkit.org/show_bug.cgi?id=258259</a>
rdar://110926113

Reviewed by Ryosuke Niwa.

There&apos;s no need to use the fancy NSString subclass if there is no prior context.
The whole reason the NSString subclass exists is to deal with the prior context.
If we can use CFString directly, that&apos;s faster.

* Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h:
(WTF::TextBreakIteratorCFCharacterCluster::setText):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
(WTF::TextBreakIteratorCFStringTokenizer::setText):
(WTF::TextBreakIteratorCFStringTokenizer::createString):

Canonical link: <a href="https://commits.webkit.org/265389@main">https://commits.webkit.org/265389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638eb0e78dcce9d84ace8f06ea60e5ac96b15d4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13235 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11836 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12821 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16971 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9123 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10201 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13116 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10339 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10882 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9497 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2575 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13770 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11186 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10200 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2733 "Passed tests") | 
<!--EWS-Status-Bubble-End-->