### PR TITLE
[Xcode] migrate-headers.py matches path filters too permissively

### DIFF
--- a/Source/WebKitLegacy/scripts/migrate-headers.py
+++ b/Source/WebKitLegacy/scripts/migrate-headers.py
@@ -3,35 +3,45 @@ import os
 import subprocess
 import sys
 from fnmatch import fnmatch
+from pathlib import Path
 
 postprocess_rule_env = os.environ.copy()
 postprocess_rule_env["SCRIPT_OUTPUT_FILE_COUNT"] = "1"
 postprocess_rule_env["SCRIPT_OUTPUT_FILE_LIST_COUNT"] = "0"
 
-excluded_patterns = os.environ.get("EXCLUDED_SOURCE_FILE_NAMES", "").split()
-included_patterns = os.environ.get("INCLUDED_SOURCE_FILE_NAMES", "").split()
+excluded_patterns = list(map(Path, os.environ.get("EXCLUDED_SOURCE_FILE_NAMES", "").split()))
+included_patterns = list(map(Path, os.environ.get("INCLUDED_SOURCE_FILE_NAMES", "").split()))
 
 migrate_rule = os.environ["SCRIPT_INPUT_FILE_1"]
+
+
+def pattern_match(path, pattern):
+    # Using the number of path components in `pattern`, only match that many
+    # trailing components in `path`. This is an imitation of Xcode's path
+    # filtering behavior.
+    components_to_match = zip(reversed(path.parts), reversed(pattern.parts))
+    return all(fnmatch(path_component, pattern_component) for path_component, pattern_component in components_to_match)
+
 
 for file_number in range(int(os.environ["SCRIPT_OUTPUT_FILE_LIST_COUNT"])):
     input_file_list = open(os.environ[f"SCRIPT_INPUT_FILE_LIST_{file_number}"])
     output_file_list = open(os.environ[f"SCRIPT_OUTPUT_FILE_LIST_{file_number}"])
     for input_file, output_file in zip(input_file_list, output_file_list):
-        input_file = input_file.rstrip()
-        output_file = output_file.rstrip()
+        input_file = Path(input_file.rstrip())
+        output_file = Path(output_file.rstrip())
 
-        input_name = os.path.basename(input_file)
-        if input_name != os.path.basename(output_file):
+        if input_file.name != output_file.name:
             sys.exit(f"error: Trying to migrate {input_file} to {output_file}, but the file names don't match. "
                      "Headers should always have the same name when migrated. "
                      "Ensure that the paths in MigrateHeaders-input.xcfilelist match the order in MigrateHeaders-output.xcfilelist.")
-        if any(fnmatch(input_name, pattern) or fnmatch(input_file, pattern) for pattern in excluded_patterns) \
-                and not any(fnmatch(input_name, pattern) or fnmatch(input_file, pattern) for pattern in included_patterns):
+
+        if any(pattern_match(input_file, pattern) for pattern in excluded_patterns) \
+                and not any(pattern_match(input_file, pattern) for pattern in included_patterns):
             continue
 
         postprocess_rule_env["INPUT_FILE_PATH"] = input_file
-        postprocess_rule_env["INPUT_FILE_NAME"] = input_name
+        postprocess_rule_env["INPUT_FILE_NAME"] = input_file.name
         postprocess_rule_env["SCRIPT_OUTPUT_FILE_0"] = output_file
-        postprocess_rule_env["SCRIPT_HEADER_VISIBILITY"] = "private" if "PrivateHeaders/" in output_file else "public"
+        postprocess_rule_env["SCRIPT_HEADER_VISIBILITY"] = "private" if "PrivateHeaders" in output_file.parts else "public"
         print("RuleScriptExecution", output_file, input_file, file=sys.stderr)
         subprocess.check_call((migrate_rule), env=postprocess_rule_env)


### PR DESCRIPTION
#### 862e1af4e3a7d177839475e9e2de9ee3fddab164
<pre>
[Xcode] migrate-headers.py matches path filters too permissively
<a href="https://bugs.webkit.org/show_bug.cgi?id=258381">https://bugs.webkit.org/show_bug.cgi?id=258381</a>
rdar://110926809

Reviewed by Alexey Proskuryakov.

Xcode does path filtering by checking each path component in a pattern
separately. e.g., the pattern &quot;foo*&quot; matches the path &quot;bar/foo.c&quot; but
not &quot;foo/bar.c&quot;. Replicate this behavior in migrate-headers.py, where we
read path filtering environment variables.

* Source/WebKitLegacy/scripts/migrate-headers.py:
(pattern_match):

Canonical link: <a href="https://commits.webkit.org/265412@main">https://commits.webkit.org/265412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c16b59ca45f5440fe63b449c30f6cb4a111b779

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10330 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13232 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9055 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16975 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13120 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10343 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8431 "16 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9501 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->