### PR TITLE
Rename StringView::empty() to emptyStringView()

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -73,8 +73,6 @@ public:
 
     ALWAYS_INLINE static StringView fromLatin1(const char* characters) { return StringView { characters }; }
 
-    static StringView empty();
-
     unsigned length() const;
     bool isEmpty() const;
 
@@ -267,7 +265,10 @@ WTF_EXPORT_PRIVATE StringViewWithUnderlyingString normalizedNFC(StringView);
 
 WTF_EXPORT_PRIVATE String normalizedNFC(const String&);
 
-}
+inline StringView nullStringView() { return { }; }
+inline StringView emptyStringView() { return StringView("", 0); }
+
+} // namespace WTF
 
 #include <wtf/text/AtomString.h>
 #include <wtf/text/WTFString.h>
@@ -445,11 +446,6 @@ inline void StringView::clear()
     m_is8Bit = true;
 }
 
-inline StringView StringView::empty()
-{
-    return StringView("", 0);
-}
-
 inline const LChar* StringView::characters8() const
 {
     ASSERT(is8Bit());
@@ -532,7 +528,7 @@ inline bool StringView::is8Bit() const
 inline StringView StringView::substring(unsigned start, unsigned length) const
 {
     if (start >= this->length())
-        return empty();
+        return emptyStringView();
     unsigned maxLength = this->length() - start;
 
     if (length >= maxLength) {
@@ -1115,7 +1111,7 @@ inline StringView StringView::trim(const CharacterType* characters, const Matche
         ++start;
 
     if (start > end)
-        return StringView::empty();
+        return emptyStringView();
 
     while (end && predicate(characters[end]))
         --end;
@@ -1466,3 +1462,5 @@ using WTF::makeStringBySimplifyingNewLines;
 using WTF::StringView;
 using WTF::StringViewWithUnderlyingString;
 using WTF::hasUnpairedSurrogate;
+using WTF::nullStringView;
+using WTF::emptyStringView;

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -44,7 +44,7 @@ StringView stringViewFromUTF8(String& ref, const char* characters)
 TEST(WTF, StringViewStartsWithEmptyVsNull)
 {
     StringView nullView;
-    StringView emptyView = StringView::empty();
+    StringView emptyView = emptyStringView();
     String stringWithCharacters("hello"_s);
     StringView viewWithCharacters(stringWithCharacters);
 
@@ -69,7 +69,7 @@ TEST(WTF, StringViewEmptyVsNull)
     else
         FAIL();
 
-    StringView emptyView = StringView::empty();
+    StringView emptyView = emptyStringView();
     EXPECT_FALSE(emptyView.isNull());
     EXPECT_TRUE(emptyView.isEmpty());
 
@@ -137,9 +137,9 @@ TEST(WTF, StringViewIterators)
     EXPECT_TRUE(compareLoopIterations(StringView().codeUnits(), { }));
     EXPECT_TRUE(compareLoopIterations(StringView().graphemeClusters(), { }));
 
-    EXPECT_TRUE(compareLoopIterations(StringView::empty().codePoints(), { }));
-    EXPECT_TRUE(compareLoopIterations(StringView::empty().codeUnits(), { }));
-    EXPECT_TRUE(compareLoopIterations(StringView::empty().graphemeClusters(), { }));
+    EXPECT_TRUE(compareLoopIterations(emptyStringView().codePoints(), { }));
+    EXPECT_TRUE(compareLoopIterations(emptyStringView().codeUnits(), { }));
+    EXPECT_TRUE(compareLoopIterations(emptyStringView().graphemeClusters(), { }));
 
     String helo("helo"_s);
     StringView heloView(helo);
@@ -892,7 +892,7 @@ TEST(WTF, StringViewEndsWithIgnoringASCIICaseWithLatin1Characters)
 TEST(WTF, StringView8Bit)
 {
     EXPECT_TRUE(StringView().is8Bit());
-    EXPECT_TRUE(StringView::empty().is8Bit());
+    EXPECT_TRUE(emptyStringView().is8Bit());
 
     LChar* lcharPtr = nullptr;
     UChar* ucharPtr = nullptr;
@@ -967,9 +967,9 @@ TEST(WTF, StringViewTrim)
     EXPECT_TRUE(stringViewFromLiteral("AAAAAACCC").trim(isA) == stringViewFromLiteral("CCC"));
     EXPECT_TRUE(stringViewFromLiteral("BBBAAAAAA").trim(isA) == stringViewFromLiteral("BBB"));
     EXPECT_TRUE(stringViewFromLiteral("CCCAAABBB").trim(isA) == stringViewFromLiteral("CCCAAABBB"));
-    EXPECT_TRUE(stringViewFromLiteral("AAAAAAAAA").trim(isA) == StringView::empty());
+    EXPECT_TRUE(stringViewFromLiteral("AAAAAAAAA").trim(isA) == emptyStringView());
 
-    StringView emptyView = StringView::empty();
+    StringView emptyView = emptyStringView();
     EXPECT_TRUE(emptyView.trim(isA) == emptyView);
 
     StringView nullView;


### PR DESCRIPTION
#### c6ae14a037dce326312ed56920059895f06040d1
<pre>
Rename StringView::empty() to emptyStringView()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258383">https://bugs.webkit.org/show_bug.cgi?id=258383</a>
rdar://111135973

Reviewed by Andy Estes.

There are 4 reasons for this:
1. It&apos;s too easy to write empty() when you mean isEmpty(). This is particularly
       bad because StringViews have an operator bool, so it&apos;s totally legal to
       write if (myStringView.empty()) but it doesn&apos;t mean what it looks like it
       means
2. empty() is a verb! But the function doesn&apos;t empty out the contents of the
       string.
3. It matches emptyString()
4. No one is using it.

This patch doesn&apos;t apply the same treatment to StringImpl::empty(), because that&apos;s
more complicated and used much more often.

* Source/WTF/wtf/text/StringView.h:
(WTF::nullStringView):
(WTF::emptyStringView):
(WTF::StringView::substring const):
(WTF::StringView::trim const):
(WTF::StringView::empty): Deleted.
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265521@main">https://commits.webkit.org/265521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc6d8f5f65f99f93740f47c50be398b4b605c36a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13070 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17173 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9325 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13342 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10443 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10546 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8631 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11124 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9717 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2662 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13988 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11435 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10400 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2804 "Passed tests") | 
<!--EWS-Status-Bubble-End-->