### PR TITLE
Treat performance.mark like console.timeStamp in Web Inspector's timeline

### DIFF
--- a/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
+++ b/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
@@ -52,4 +52,51 @@ TestPage.registerInitializer(() => {
 
         return promise.promise;
     }
+
+    InspectorTest.TimelineEvent.captureTimelineWithMarker = function({expression, markerType, timelineType}) {
+        let savePageDataPromise = InspectorTest.awaitEvent("SavePageData").then((event) => {
+            return event.data;
+        });
+
+        let promise = new WI.WrappedPromise;
+
+        let listener = WI.timelineManager.addEventListener(WI.TimelineManager.Event.CapturingStateChanged, (event) => {
+            if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Active) {
+                let recording = WI.timelineManager.activeRecording;
+                
+                let markerAddedListener = recording.addEventListener(WI.TimelineRecording.Event.MarkerAdded, (markerAddedEvent) => {
+                    let {marker} = markerAddedEvent.data;
+                    if (markerType && marker.type !== markerType)
+                        return;
+
+                    recording.removeEventListener(WI.TimelineRecording.Event.MarkerAdded, markerAddedListener);
+
+                    InspectorTest.log("Stopping Capture...");
+                    WI.timelineManager.stopCapturing();
+                });
+
+                InspectorTest.log("Evaluating...");
+                InspectorTest.evaluateInPage(expression)
+                .catch((error) => {
+                    promise.reject(error);
+                });
+                return;
+            }
+
+            if (WI.timelineManager.capturingState === WI.TimelineManager.CapturingState.Inactive) {
+                WI.timelineManager.removeEventListener(WI.TimelineManager.Event.CapturingStateChanged, listener);
+                InspectorTest.assert(savePageDataPromise, "savePageData should have been called in the page before capturing was stopped.");
+                savePageDataPromise.then((data) => {
+                    promise.resolve(data);
+                });
+                return;
+            }
+        });
+
+        InspectorTest.log("Starting Capture...");
+        const newRecording = true;
+        WI.timelineManager.startCapturing(newRecording);
+
+        return promise.promise;
+    }
 });

--- a/LayoutTests/inspector/timeline/timeline-event-performance-mark-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-event-performance-mark-expected.txt
@@ -1,0 +1,14 @@
+Tests 'performance.mark' Timeline event records.
+
+
+== Running test suite: TimelineEvent.PerformanceMark
+-- Running test case: TimelineEvent.PerformanceMark.performanceMark
+Starting Capture...
+Evaluating...
+Stopping Capture...
+PASS: expectEqual(2, 2)
+PASS: expectEqual("timestamp", "timestamp")
+PASS: expectEqual("foo", "foo")
+PASS: expectEqual("timestamp", "timestamp")
+PASS: expectEqual("bar", "bar")
+

--- a/LayoutTests/inspector/timeline/timeline-event-performance-mark.html
+++ b/LayoutTests/inspector/timeline/timeline-event-performance-mark.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="./resources/timeline-event-utilities.js"></script>
+<script>
+
+function testPerformanceMark() {
+    let startTime = performance.now();
+    while (startTime + 10 > performance.now());
+    performance.mark('foo');
+    performance.mark('bar', {startTime});
+    savePageData({});
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("TimelineEvent.PerformanceMark");
+
+    suite.addTestCase({
+        name: "TimelineEvent.PerformanceMark.performanceMark",
+        async test() {
+            let pageRecordingData = await InspectorTest.TimelineEvent.captureTimelineWithMarker({
+                expression: `testPerformanceMark()`,
+                markerType: WI.TimelineMarker.Type.TimeStamp,
+            });
+
+            let recording = WI.timelineManager.activeRecording;
+
+            InspectorTest.expectEqual(recording.markers.length, 2);
+            InspectorTest.expectEqual(recording.markers[0].type, "timestamp");
+            InspectorTest.expectEqual(recording.markers[0].details, "foo");
+            InspectorTest.expectEqual(recording.markers[1].type, "timestamp");
+            InspectorTest.expectEqual(recording.markers[1].details, "bar");
+            InspectorTest.assert(recording.markers[0].time > recording.markers[1].time);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests 'performance.mark' Timeline event records.</p>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1036,6 +1036,18 @@ void InspectorInstrumentation::stopProfilingImpl(InstrumentingAgents& instrument
         timelineAgent->stopFromConsole(exec, title);
 }
 
+void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, const String& label, std::optional<MonotonicTime> timestamp)
+{
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->didPerformanceMark(label, timestamp, &frame);
+}
+
+void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, const String& label, std::optional<MonotonicTime> timestamp)
+{
+    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
+        timelineAgent->didPerformanceMark(label, timestamp, nullptr);
+}
+
 void InspectorInstrumentation::consoleStartRecordingCanvasImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)
 {
     if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -269,6 +269,9 @@ public:
     static void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvas(CanvasRenderingContext&);
 
+    static void performanceMark(LocalFrame&, const String&, std::optional<MonotonicTime>);
+    static void performanceMark(WorkerOrWorkletGlobalScope&, const String&, std::optional<MonotonicTime>);
+
     static void didRequestAnimationFrame(Document&, int callbackId);
     static void didCancelAnimationFrame(Document&, int callbackId);
     static void willFireAnimationFrame(Document&, int callbackId);
@@ -475,6 +478,9 @@ private:
     static void stopProfilingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& title);
     static void consoleStartRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&);
+
+    static void performanceMarkImpl(InstrumentingAgents&, LocalFrame&, const String& label, std::optional<MonotonicTime> timestamp);
+    static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime> timestamp);
 
     static void didRequestAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
     static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
@@ -1675,6 +1681,18 @@ inline void InspectorInstrumentation::consoleStopRecordingCanvas(CanvasRendering
 {
     if (auto* agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))
         consoleStopRecordingCanvasImpl(*agents, context);
+}
+
+inline void InspectorInstrumentation::performanceMark(LocalFrame& frame, const String& label, std::optional<MonotonicTime> startTime)
+{
+    FAST_RETURN_IF_NO_FRONTENDS(void());
+    if (auto* agents = instrumentingAgents(frame))
+        performanceMarkImpl(*agents, frame, label, WTFMove(startTime));
+}
+
+inline void InspectorInstrumentation::performanceMark(WorkerOrWorkletGlobalScope& globalScope, const String& label, std::optional<MonotonicTime> startTime)
+{
+    performanceMarkImpl(instrumentingAgents(globalScope), label, WTFMove(startTime));
 }
 
 inline void InspectorInstrumentation::didRequestAnimationFrame(Document& document, int callbackId)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -127,6 +127,7 @@ public:
     void didRecalculateStyle();
     void didScheduleStyleRecalculation(LocalFrame*);
     void didTimeStamp(LocalFrame&, const String&);
+    void didPerformanceMark(const String&, std::optional<MonotonicTime>, LocalFrame*);
     void didRequestAnimationFrame(int callbackId, LocalFrame*);
     void didCancelAnimationFrame(int callbackId, LocalFrame*);
     void willFireAnimationFrame(int callbackId, LocalFrame*);
@@ -180,9 +181,10 @@ private:
     void internalStart(std::optional<int>&& maxCallStackDepth);
     void internalStop();
     double timestamp();
+    std::optional<double> timestampFromMonotonicTime(MonotonicTime);
 
     void sendEvent(Ref<JSON::Object>&&);
-    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, LocalFrame*);
+    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(const TimelineRecordEntry& record) { m_recordStack.append(record); }
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -110,6 +110,11 @@ DOMHighResTimeStamp Performance::relativeTimeFromTimeOriginInReducedResolution(M
     return reduceTimeResolution(seconds).milliseconds();
 }
 
+MonotonicTime Performance::monotonicTimeFromRelativeTime(DOMHighResTimeStamp relativeTime) const
+{
+    return m_timeOrigin + Seconds::fromMilliseconds(relativeTime);
+}
+
 PerformanceNavigation* Performance::navigation()
 {
     if (!is<Document>(scriptExecutionContext()))

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -110,6 +110,7 @@ public:
     static Seconds reduceTimeResolution(Seconds);
 
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;
+    MonotonicTime monotonicTimeFromRelativeTime(DOMHighResTimeStamp) const;
 
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 

--- a/Source/WebCore/page/PerformanceMarkOptions.h
+++ b/Source/WebCore/page/PerformanceMarkOptions.h
@@ -25,13 +25,14 @@
 
 #pragma once
 
+#include "DOMHighResTimeStamp.h"
 #include <JavaScriptCore/JSCJSValue.h>
 
 namespace WebCore {
 
 struct PerformanceMarkOptions {
     JSC::JSValue detail;
-    std::optional<double> startTime;
+    std::optional<DOMHighResTimeStamp> startTime;
 };
 
 }

--- a/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
@@ -44,8 +44,8 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
         this._discontinuities = null;
         this._firstRecordOfTypeAfterDiscontinuity = new Set;
 
+        this._markers = null;
         this._exportDataRecords = null;
-        this._exportDataMarkers = null;
         this._exportDataMemoryPressureEvents = null;
         this._exportDataSampleStackTraces = null;
         this._exportDataSampleDurations = null;
@@ -135,7 +135,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
             discontinuities: this._discontinuities,
             instrumentTypes: this._instruments.map((instrument) => instrument.timelineRecordType),
             records: this._exportDataRecords,
-            markers: this._exportDataMarkers,
+            markers: this._markers,
             memoryPressureEvents: this._exportDataMemoryPressureEvents,
             sampleStackTraces: this._exportDataSampleStackTraces,
             sampleDurations: this._exportDataSampleDurations,
@@ -153,6 +153,8 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
     get imported() { return this._imported; }
     get startTime() { return this._startTime; }
     get endTime() { return this._endTime; }
+
+    get markers() { return this._markers; }
 
     get topDownCallingContextTree() { return this._topDownCallingContextTree; }
     get bottomUpCallingContextTree() { return this._bottomUpCallingContextTree; }
@@ -243,8 +245,8 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
         this._discontinuities = [];
         this._firstRecordOfTypeAfterDiscontinuity.clear();
 
+        this._markers = [];
         this._exportDataRecords = [];
-        this._exportDataMarkers = [];
         this._exportDataMemoryPressureEvents = [];
         this._exportDataSampleStackTraces = [];
         this._exportDataSampleDurations = [];
@@ -310,7 +312,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
 
     addEventMarker(marker)
     {
-        this._exportDataMarkers.push(marker);
+        this._markers.push(marker);
 
         if (!this._capturing && !this.__importing)
             return;


### PR DESCRIPTION
#### 4d52235be538b0fb8ab33a0d80f1d7b18799f8df
<pre>
Treat performance.mark like console.timeStamp in Web Inspector&apos;s timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=258385">https://bugs.webkit.org/show_bug.cgi?id=258385</a>

Reviewed by Patrick Angle.

Treat performance.mark like console.timeStamp and generate a timeline marker (vertical line).
This will help investigate various aspects of the Speedometer 3 benchmark.

Since performance.now can be called at anytime even when inspector&apos;s stopwatch is paused,
this patch also introduces Stopwatch::fromMonotonicTime to convert monotonic time to time
used by the stopwatch.

Also expose markers via a public accessor in TimelineRecording.

* LayoutTests/inspector/timeline/resources/timeline-event-utilities.js:
(TestPage.registerInitializer.InspectorTest.TimelineEvent.captureTimelineWithMarker): Added.
* LayoutTests/inspector/timeline/timeline-event-performance-mark-expected.txt: Added.
* LayoutTests/inspector/timeline/timeline-event-performance-mark.html: Added.

* Source/WTF/wtf/Stopwatch.h:
(WTF::Stopwatch::stop):
(WTF::Stopwatch::fromMonotonicTime): Added.

* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::performanceMarkImpl): Added.

* Source/WebCore/inspector/InspectorInstrumentation.h: Added.
(WebCore::InspectorInstrumentation::performanceMark):

* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::timestampFromMonotonicTime): Added.
(WebCore::InspectorTimelineAgent::didPerformanceMark): Added.
(WebCore::InspectorTimelineAgent::appendRecord): Now optionally takes startTime.

* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:

* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::monotonicTimeFromRelativeTime const): Added.

* Source/WebCore/page/Performance.h:

* Source/WebCore/page/PerformanceMarkOptions.h:

* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):

* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording):
(WI.TimelineRecording.prototype.exportData):
(WI.TimelineRecording.prototype.get markers):
(WI.TimelineRecording.prototype.reset):
(WI.TimelineRecording.prototype.addEventMarker):

Canonical link: <a href="https://commits.webkit.org/265491@main">https://commits.webkit.org/265491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9339dba4262de4896c112fa72d6f6d7675917aad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13255 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11866 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12849 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16997 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9147 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13143 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10245 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10366 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8451 "14 flakes 2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10909 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9524 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9632 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2975 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13797 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11214 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10226 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2739 "Passed tests") | 
<!--EWS-Status-Bubble-End-->