### PR TITLE
Refactor various parts of caret animation code post-upstreaming

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7064,8 +7064,7 @@ void Document::serviceRequestAnimationFrameCallbacks()
 
 void Document::serviceCaretAnimation()
 {
-    if (auto* window = domWindow())
-        selection().caretAnimator().serviceCaretAnimation(window->frozenNowTimestamp());
+    selection().caretAnimator().serviceCaretAnimation();
 }
 
 void Document::serviceRequestVideoFrameCallbacks()

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -58,7 +58,7 @@ class CaretBase {
     WTF_MAKE_NONCOPYABLE(CaretBase);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*);
+    WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*, const std::optional<VisibleSelection>&);
 protected:
     enum class CaretVisibility : bool { Visible, Hidden };
     explicit CaretBase(CaretVisibility = CaretVisibility::Hidden);

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -47,12 +47,12 @@ void CaretAnimator::stop(CaretAnimatorStopReason)
     didEnd();
 }
 
-void CaretAnimator::serviceCaretAnimation(ReducedResolutionSeconds timestamp)
+void CaretAnimator::serviceCaretAnimation()
 {
     if (!isActive())
         return;
 
-    updateAnimationProperties(timestamp);
+    updateAnimationProperties();
 }
 
 void CaretAnimator::scheduleAnimation()
@@ -61,7 +61,7 @@ void CaretAnimator::scheduleAnimation()
         page->scheduleRenderingUpdate(RenderingUpdateStep::CaretAnimation);
 }
 
-void CaretAnimator::paint(const Node&, GraphicsContext& context, const FloatRect& caret, const Color& color, const LayoutPoint&, const std::optional<VisibleSelection>&) const
+void CaretAnimator::paint(GraphicsContext& context, const FloatRect& caret, const Color& color, const LayoutPoint&) const
 {
     context.fillRect(caret, color);
 }

--- a/Source/WebCore/platform/DictationCaretAnimator.h
+++ b/Source/WebCore/platform/DictationCaretAnimator.h
@@ -38,8 +38,8 @@ public:
     explicit DictationCaretAnimator(CaretAnimationClient&);
 
 private:
-    void updateAnimationProperties(ReducedResolutionSeconds) final;
-    void start(ReducedResolutionSeconds) final;
+    void updateAnimationProperties() final;
+    void start() final;
     FloatRect tailRect() const;
 
     String debugDescription() const final;
@@ -64,7 +64,7 @@ private:
     void updateGlowTail(float caretPosition, Seconds elapsedTime);
     void resetGlowTail(FloatRect);
     void updateGlowTail(Seconds elapsedTime);
-    void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&, const std::optional<VisibleSelection>&) const final;
+    void paint(GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&) const final;
     LayoutRect caretRepaintRectForLocalRect(LayoutRect repaintRect) const final;
     Path makeDictationTailConePath(const FloatRect&) const;
     void fillCaretTail(const FloatRect&, GraphicsContext&, const Color&) const;
@@ -74,7 +74,7 @@ private:
     FloatRoundedRect expandedCaretRect(const FloatRect&, bool fillTail) const;
     int computeScrollLeft() const;
 
-    ReducedResolutionSeconds m_lastUpdateTime;
+    MonotonicTime m_lastUpdateTime;
     size_t m_currentKeyframeIndex { 1 };
     FloatRect m_localCaretRect;
     FloatRect m_tailRect, m_previousTailRect;

--- a/Source/WebCore/platform/OpacityCaretAnimator.h
+++ b/Source/WebCore/platform/OpacityCaretAnimator.h
@@ -36,9 +36,9 @@ public:
     explicit OpacityCaretAnimator(CaretAnimationClient&, std::optional<LayoutRect> = std::nullopt);
 
 private:
-    void updateAnimationProperties(ReducedResolutionSeconds) final;
-    void start(ReducedResolutionSeconds) final;
-    void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&, const std::optional<VisibleSelection>&) const final;
+    void updateAnimationProperties() final;
+    void start() final;
+    void paint(GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&) const final;
 
     String debugDescription() const final;
 
@@ -58,7 +58,7 @@ private:
     Seconds keyframeTimeDelta() const;
     LayoutRect caretRepaintRectForLocalRect(LayoutRect) const final;
 
-    ReducedResolutionSeconds m_lastTimeCaretOpacityWasToggled;
+    MonotonicTime m_lastTimeCaretOpacityWasToggled;
     size_t m_currentKeyframeIndex { 1 };
     std::optional<LayoutRect> m_overrideRepaintRect;
 };

--- a/Source/WebCore/platform/SimpleCaretAnimator.cpp
+++ b/Source/WebCore/platform/SimpleCaretAnimator.cpp
@@ -35,8 +35,9 @@ SimpleCaretAnimator::SimpleCaretAnimator(CaretAnimationClient& client)
 {
 }
 
-void SimpleCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds currentTime)
+void SimpleCaretAnimator::updateAnimationProperties()
 {
+    auto currentTime = MonotonicTime::now();
     auto caretBlinkInterval = RenderTheme::singleton().caretBlinkInterval();
 
     setBlinkingSuspended(!caretBlinkInterval);
@@ -59,10 +60,10 @@ void SimpleCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds cur
     }
 }
 
-void SimpleCaretAnimator::start(ReducedResolutionSeconds currentTime)
+void SimpleCaretAnimator::start()
 {
-    m_lastTimeCaretPaintWasToggled = currentTime;
-    didStart(currentTime, RenderTheme::singleton().caretBlinkInterval());
+    m_lastTimeCaretPaintWasToggled = MonotonicTime::now();
+    didStart(m_lastTimeCaretPaintWasToggled, RenderTheme::singleton().caretBlinkInterval());
 }
 
 String SimpleCaretAnimator::debugDescription() const

--- a/Source/WebCore/platform/SimpleCaretAnimator.h
+++ b/Source/WebCore/platform/SimpleCaretAnimator.h
@@ -34,8 +34,8 @@ public:
     explicit SimpleCaretAnimator(CaretAnimationClient&);
 
 private:
-    void updateAnimationProperties(ReducedResolutionSeconds) final;
-    void start(ReducedResolutionSeconds) final;
+    void updateAnimationProperties() final;
+    void start() final;
 
     String debugDescription() const final;
 
@@ -50,7 +50,7 @@ private:
         m_client.caretAnimationDidUpdate(*this);
     }
 
-    ReducedResolutionSeconds m_lastTimeCaretPaintWasToggled;
+    MonotonicTime m_lastTimeCaretPaintWasToggled;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1373,7 +1373,7 @@ Color RenderThemeIOS::insertionPointColor()
 
 Color RenderThemeIOS::autocorrectionReplacementMarkerColor(const RenderText& renderer) const
 {
-    auto caretColor = CaretBase::computeCaretColor(renderer.style(), renderer.textNode());
+    auto caretColor = CaretBase::computeCaretColor(renderer.style(), renderer.textNode(), std::nullopt);
     if (!caretColor.isValid())
         caretColor = insertionPointColor();
 

--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -55,18 +55,18 @@
 
 - (void)dictationDidStart
 {
-    if (_caretType == WebCore::CaretAnimatorType::Alternate) {
+    if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
             _webView->page().setCaretBlinkingSuspended(false);
         return;
     }
 
-    _caretType = WebCore::CaretAnimatorType::Alternate;
+    _caretType = WebCore::CaretAnimatorType::Dictation;
     if (_webView) {
         if (NSTextInputContext *context = _webView->inputContext())
             context.showsCursorAccessories = YES;
 
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Alternate);
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
     }
 }
 
@@ -88,15 +88,15 @@
 
 - (void)dictationDidResume
 {
-    if (_caretType == WebCore::CaretAnimatorType::Alternate) {
+    if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
             _webView->page().setCaretBlinkingSuspended(false);
         return;
     }
 
-    _caretType = WebCore::CaretAnimatorType::Alternate;
+    _caretType = WebCore::CaretAnimatorType::Dictation;
     if (_webView)
-        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Alternate);
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
 }
 
 @end

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5068,7 +5068,7 @@ header: <WebCore/AcceleratedEffect.h>
 header: <WebCore/CaretAnimator.h>
 [CustomHeader] enum class WebCore::CaretAnimatorType : uint8_t {
     Default,
-    Alternate,
+    Dictation,
 };
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -377,9 +377,8 @@ public:
     bool validateUserInterfaceItem(id <NSValidatedUserInterfaceItem>);
     void setEditableElementIsFocused(bool);
 
-    // FIXME: Rename to `updateCursorAccessoryPlacement` (rdar://110802729).
 #if HAVE(REDESIGNED_TEXT_CURSOR)
-    void updateCaretDecorationPlacement();
+    void updateCursorAccessoryPlacement();
 #endif
 
     void startSpeaking();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2719,7 +2719,7 @@ void WebViewImpl::selectionDidChange()
 
 #if HAVE(REDESIGNED_TEXT_CURSOR)
     if (m_page->editorState().hasPostLayoutData())
-        updateCaretDecorationPlacement();
+        updateCursorAccessoryPlacement();
 #endif
 
     NSWindow *window = [m_view window];
@@ -6128,7 +6128,7 @@ void WebViewImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 #endif // HAVE(TOUCH_BAR)
 
 #if HAVE(REDESIGNED_TEXT_CURSOR)
-void WebViewImpl::updateCaretDecorationPlacement()
+void WebViewImpl::updateCursorAccessoryPlacement()
 {
     const EditorState& editorState = m_page->editorState();
     if (!editorState.hasPostLayoutData())
@@ -6140,7 +6140,7 @@ void WebViewImpl::updateCaretDecorationPlacement()
     if (!context)
         return;
 
-    if ([_textInputNotifications caretType] == WebCore::CaretAnimatorType::Alternate) {
+    if ([_textInputNotifications caretType] == WebCore::CaretAnimatorType::Dictation) {
         // The dictation cursor accessory should always be visible no matter what, since it is
         // the only prominent way a user can tell if dictation is active.
         context.showsCursorAccessories = YES;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -382,7 +382,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
             // rather than the focused element. This causes caret colors in editable children to be
             // ignored in favor of the editing host's caret color. See: <https://webkit.org/b/229809>.
             if (RefPtr editableRoot = selection.rootEditableElement(); editableRoot && editableRoot->renderer())
-                postLayoutData.caretColor = CaretBase::computeCaretColor(editableRoot->renderer()->style(), editableRoot.get());
+                postLayoutData.caretColor = CaretBase::computeCaretColor(editableRoot->renderer()->style(), editableRoot.get(), std::nullopt);
         }
 
         computeEditableRootHasContentAndPlainText(selection, postLayoutData);

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1387,7 +1387,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     auto* renderer = focusedElement->renderer();
     if (!renderer)
         return nil;
-    auto color = WebCore::CaretBase::computeCaretColor(renderer->style(), renderer->element());
+    auto color = WebCore::CaretBase::computeCaretColor(renderer->style(), renderer->element(), std::nullopt);
     return color.isValid() ? cachedCGColor(color).autorelease() : nil;
 }
 


### PR DESCRIPTION
#### 1041ca48066bb678e125595f2a4aaff90ff65ad3
<pre>
Refactor various parts of caret animation code post-upstreaming
<a href="https://bugs.webkit.org/show_bug.cgi?id=258386">https://bugs.webkit.org/show_bug.cgi?id=258386</a>
rdar://110802729

Reviewed by Mike Wyrzykowski.

Refactors some logic in and around caret animation logic:

* Fixes typo of `dictationCaretAnimatorUpdateRate` inside `DictationCaretAnimator.cpp`
* Simplifies all the various caret color computing logic into `computeCaretColor`
* Renames `CaretAnimatorType::Alternate` to `CaretAnimatorType::Dictation`
* Renames `updateCaretDecorationPlacement` to `updateCursorAccessoryPlacement`
* Removes `currentTimeSinceEpoch` and instead directly uses `MonotonicTime` for the timekeeping variables
* Removes unnecessary `ReducedResolutionSeconds` parameter for various caret animator methods

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::serviceCaretAnimation):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::createCaretAnimator):
(WebCore::CaretBase::computeCaretColor):
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::updateAppearance):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/platform/CaretAnimator.cpp:
(WebCore::CaretAnimator::serviceCaretAnimation):
(WebCore::CaretAnimator::paint const):
* Source/WebCore/platform/CaretAnimator.h:
(WebCore::CaretAnimator::didStart):
(WebCore::currentTimeSinceEpoch): Deleted.
(WebCore::platformCaretColor): Deleted.
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::keyframe):
(WebCore::DictationCaretAnimator::keyframeCount const):
(WebCore::DictationCaretAnimator::keyframeTimeDelta const):
(WebCore::DictationCaretAnimator::updateAnimationProperties):
(WebCore::DictationCaretAnimator::start):
(WebCore::DictationCaretAnimator::paint const):
* Source/WebCore/platform/DictationCaretAnimator.h:
* Source/WebCore/platform/OpacityCaretAnimator.cpp:
(WebCore::OpacityCaretAnimator::updateAnimationProperties):
(WebCore::OpacityCaretAnimator::start):
(WebCore::OpacityCaretAnimator::paint const):
* Source/WebCore/platform/OpacityCaretAnimator.h:
* Source/WebCore/platform/SimpleCaretAnimator.cpp:
(WebCore::SimpleCaretAnimator::updateAnimationProperties):
(WebCore::SimpleCaretAnimator::start):
* Source/WebCore/platform/SimpleCaretAnimator.h:
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::autocorrectionReplacementMarkerColor const):
* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm:
(-[_WKWebViewTextInputNotifications dictationDidStart]):
(-[_WKWebViewTextInputNotifications dictationDidResume]):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::updateCursorAccessoryPlacement):
(WebKit::WebViewImpl::updateCaretDecorationPlacement): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame caretColor]):

Canonical link: <a href="https://commits.webkit.org/265430@main">https://commits.webkit.org/265430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb1e6d04a1fb0060824b3cc81f1a9b3540a7de57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10783 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11003 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12432 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10798 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13239 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12836 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16980 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10214 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13125 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10354 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8441 "14 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9512 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2607 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->