### PR TITLE
[JSC] Enhance NumericStrings cache and reduce strength of StrCat for Int32

### DIFF
--- a/JSTests/stress/delete-property-check-structure-transition.js
+++ b/JSTests/stress/delete-property-check-structure-transition.js
@@ -108,21 +108,24 @@ function testCanMaterializeDeletes(i) {
 
 noInline(testCanMaterializeDeletes)
 
+function opaque(value) { return value; }
+noInline(opaque);
+
 function testCanFlatten(i) {
     let foo = {}
     for (let j=0; j<500; ++j) {
         const oldId = sid(foo)
 
-        foo["x" + 1000*j + i] = j
+        foo[opaque("x" + 1000*j + i)] = j
         if (j > 0)
-            delete foo["x" + 1000*(j - 1) + i]
+            delete foo[opaque("x" + 1000*(j - 1) + i)]
 
         if (j > 100)
             assert_eq(sid(foo), oldId)
     }
 
     for (let j=0; j<500; ++j) {
-        const val = foo["x" + 1000*j + i]
+        const val = foo[opaque("x" + 1000*j + i)]
         if (j == 499)
             assert_eq(val, j)
         else
@@ -132,7 +135,7 @@ function testCanFlatten(i) {
     $vm.flattenDictionaryObject(foo)
 
     for (let j=0; j<500; ++j) {
-        const val = foo["x" + 1000*j + i]
+        const val = foo[opaque("x" + 1000*j + i)]
         if (j == 499)
             assert_eq(val, j)
         else

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -36,6 +36,7 @@
 #include "JSMap.h"
 #include "JSSet.h"
 #include "JSWeakMap.h"
+#include "NumericStrings.h"
 #include "Symbol.h"
 
 namespace JSC { namespace FTL {
@@ -203,6 +204,7 @@ namespace JSC { namespace FTL {
     macro(structureTable, 0, sizeof(Structure*)) \
     macro(variables, 0, sizeof(Register)) \
     macro(HasOwnPropertyCache, 0, sizeof(HasOwnPropertyCache::Entry)) \
+    macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
     
 #define FOR_EACH_NUMBERED_ABSTRACT_HEAP(macro) \
     macro(properties)

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2184,7 +2184,8 @@ void Heap::finalize()
     vm().keyAtomStringCache.clear();
     vm().stringSplitCache.clear();
     vm().stringReplaceCache.clear();
-    vm().numericStrings.clearOnGarbageCollection();
+    if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full)
+        vm().numericStrings.clearOnGarbageCollection();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -240,6 +240,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     stringStructure.setWithoutWriteBarrier(JSString::createStructure(*this, nullptr, jsNull()));
 
     smallStrings.initializeCommonStrings(*this);
+    numericStrings.initializeSmallIntCache(*this);
 
     propertyNames = new CommonIdentifiers(*this);
     propertyNameEnumeratorStructure.setWithoutWriteBarrier(JSPropertyNameEnumerator::createStructure(*this, nullptr, jsNull()));
@@ -1558,6 +1559,7 @@ template<typename Visitor>
 void VM::visitAggregateImpl(Visitor& visitor)
 {
     m_microtaskQueue.visitAggregate(visitor);
+    numericStrings.visitAggregate(visitor);
 
     visitor.append(structureStructure);
     visitor.append(structureRareDataStructure);

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3422,8 +3422,8 @@ JSC_DEFINE_HOST_FUNCTION(functionFlattenDictionaryObject, (JSGlobalObject* globa
     DollarVMAssertScope assertScope;
     VM& vm = globalObject->vm();
     JSValue value = callFrame->argument(0);
-    RELEASE_ASSERT(value.isObject() && value.getObject()->structure()->isDictionary());
-    value.getObject()->flattenDictionaryObject(vm);
+    if (value.isObject() && value.getObject()->structure()->isDictionary())
+        value.getObject()->flattenDictionaryObject(vm);
     return encodedJSUndefined();
 }
 

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -473,7 +473,7 @@ constexpr unsigned maskForSize(unsigned size)
     return roundUpToPowerOfTwo(size) - 1;
 }
 
-inline unsigned fastLog2(unsigned i)
+inline constexpr unsigned fastLog2(unsigned i)
 {
     unsigned log2 = 0;
     if (i & (i - 1))
@@ -499,7 +499,7 @@ inline unsigned fastLog2(unsigned i)
     return log2;
 }
 
-inline unsigned fastLog2(uint64_t value)
+inline constexpr unsigned fastLog2(uint64_t value)
 {
     unsigned high = static_cast<unsigned>(value >> 32);
     if (high)


### PR DESCRIPTION
#### 7fa8139936ced01652670507cf68153def53ca3b
<pre>
[JSC] Enhance NumericStrings cache and reduce strength of StrCat for Int32
<a href="https://bugs.webkit.org/show_bug.cgi?id=258387">https://bugs.webkit.org/show_bug.cgi?id=258387</a>
rdar://problem/111140791

Reviewed by Mark Lam.

We found that ToString(Int32) happens very frequently. This patch does two things.

1. We convert StrCat(Int32, ...) to MakeRope(ToString(Int32), ...). MakeRope is much faster than StrCat.
   And Int32 stringifying does not have side effect. Doing this in FixupPhase based on speculations.
2. Enhance NumericStrings size to 256 (smallest size in V8). We also make smallIntCache accessible from
   DFG and FTL so small int strings are loaded without C++ function calls. We also mark cached strings
   during eden collections, and clear them in full collection time.

* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::attemptToMakeFastStringAdd):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileToStringOrCallStringConstructorOrStringValueOf):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumericStrings::initializeSmallIntCache):
(JSC::int32ToStringInternal):
* Source/JavaScriptCore/runtime/NumericStrings.h:
(JSC::NumericStrings::StringWithJSString::offsetOfJSString):
(JSC::NumericStrings::clearOnGarbageCollection):
(JSC::NumericStrings::visitAggregateImpl):
(JSC::NumericStrings::smallIntCache):
(JSC::NumericStrings::lookup):
(JSC::NumericStrings::lookupSmallString):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):

Canonical link: <a href="https://commits.webkit.org/265397@main">https://commits.webkit.org/265397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6811b0e4d9f8dc03a97540fef1ecb1829ac4ea2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12438 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11858 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12842 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9734 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16995 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9142 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9886 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13141 "11 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10239 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10904 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9518 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2970 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13791 "Built successfully") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11208 "Failed to checkout and rebase branch from PR 15178") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1216 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10221 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/11208 "Failed to checkout and rebase branch from PR 15178") | 
<!--EWS-Status-Bubble-End-->