### PR TITLE
LocalSampleBufferDisplayLayer gets errored in SVC when going in the background

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -301,6 +301,7 @@ private:
     FloatSize m_videoFrameSize;
     VideoFrameTimeMetadata m_sampleMetadata;
 
+    std::optional<CGRect> m_storedBounds;
     static NativeImageCreator m_nativeImageCreator;
 };
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -441,6 +441,9 @@ void MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized(IntSize size, bo
     scheduleRenderingModeChanged();
 
     m_sampleBufferDisplayLayer->setLogIdentifier(makeString(hex(reinterpret_cast<uintptr_t>(logIdentifier()))));
+    if (m_storedBounds)
+        m_sampleBufferDisplayLayer->updateBoundsAndPosition(*m_storedBounds, m_videoRotation);
+
     m_sampleBufferDisplayLayer->updateDisplayMode(m_displayMode < PausedImage, hideRootLayer());
     m_shouldUpdateDisplayLayer = true;
 
@@ -1201,9 +1204,10 @@ void MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced(const FloatS
 {
     if (!m_sampleBufferDisplayLayer || size.isEmpty())
         return;
-    CGRect bounds = m_sampleBufferDisplayLayer->rootLayer().bounds;
-    bounds.size = size;
-    m_sampleBufferDisplayLayer->updateBoundsAndPosition(bounds, m_videoRotation, fence);
+
+    m_storedBounds = m_sampleBufferDisplayLayer->rootLayer().bounds;
+    m_storedBounds->size = size;
+    m_sampleBufferDisplayLayer->updateBoundsAndPosition(*m_storedBounds, m_videoRotation, fence);
 }
 
 }


### PR DESCRIPTION
#### 6f0659d6fa39e7fd3b80a3934f98015fc6a5b1af
<pre>
LocalSampleBufferDisplayLayer gets errored in SVC when going in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=258401">https://bugs.webkit.org/show_bug.cgi?id=258401</a>
rdar://111157247

Reviewed by Eric Carlson.

In case of LocalSampleBufferDisplayLayer getting errored, we no longer are resetting the bounds of the newly created LocalSampleBufferDisplayLayer.
This was removed as part of <a href="https://bugs.webkit.org/show_bug.cgi?id=256695">https://bugs.webkit.org/show_bug.cgi?id=256695</a> patch as it was creating visible artifacts/flashes.
We are now resetting the bounds of a newly created LocalSampleBufferDisplayLayer in case it is recreated.
We do by storing the bounds of the LocalSampleBufferDisplayLayer.

Manually tested.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced):

Canonical link: <a href="https://commits.webkit.org/265451@main">https://commits.webkit.org/265451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5607658ed551801ec4c2ae20b81fe792422c2d37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12577 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13520 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13368 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12982 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9874 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10352 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10026 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10466 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9640 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2625 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->