### PR TITLE
Upstream visionOS fullscreen transition logic

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if PLATFORM(VISION)
+
+#import "RealitySimulationServicesSPI.h"
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <MRUIKit/MRUIStage.h>
+#import <MRUIKit/UIApplication+MRUIKit.h>
+#import <MRUIKit/UIWindowScene+MRUIKit.h>
+
+#else
+
+typedef NS_ENUM(NSUInteger, MRUIDarknessPreference) {
+    MRUIDarknessPreferenceUnspecified = 0,
+    MRUIDarknessPreferenceDim,
+    MRUIDarknessPreferenceDark,
+    MRUIDarknessPreferenceVeryDark,
+};
+
+@interface MRUIStage : NSObject
+@property (nonatomic, readwrite) MRUIDarknessPreference preferredDarkness;
+@end
+
+typedef NS_ENUM(NSUInteger, MRUISceneResizingBehavior) {
+    MRUISceneResizingBehaviorUnspecified = 0,
+    MRUISceneResizingBehaviorNone,
+    MRUISceneResizingBehaviorUniform,
+    MRUISceneResizingBehaviorFreeform,
+};
+
+@interface MRUIWindowScenePlacement : NSObject
+@property (nonatomic, assign) MRUISceneResizingBehavior preferredResizingBehavior;
+@property (nonatomic, assign) RSSSceneChromeOptions preferredChromeOptions;
+@end
+
+typedef NS_ENUM(NSInteger, MRUICloseWindowSceneReason) {
+    MRUICloseReasonCloseButton,
+    MRUICloseReasonCommandKey,
+};
+
+@protocol MRUIWindowSceneDelegate <UIWindowSceneDelegate>
+@optional
+- (BOOL)windowScene:(UIWindowScene *)windowScene shouldCloseForReason:(MRUICloseWindowSceneReason)reason;
+@end
+
+@interface UIApplication (MRUIKit)
+@property (nonatomic, readonly) MRUIStage *mrui_activeStage;
+@end
+
+@class MRUIWindowSceneResizeRequestOptions;
+
+typedef void (^MRUIWindowSceneResizeRequestCompletion)(CGSize grantedSize, NSError *error);
+
+@interface UIWindowScene (MRUIKit)
+
+- (void)mrui_requestResizeToSize:(CGSize)size options:(MRUIWindowSceneResizeRequestOptions *)options completion:(MRUIWindowSceneResizeRequestCompletion)completion;
+
+@property (nonatomic, readonly) MRUIWindowScenePlacement *mrui_placement;
+
+@end
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // PLATFORM(VISION)

--- a/Source/WebKit/Platform/spi/visionos/RealitySimulationServicesSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/RealitySimulationServicesSPI.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if PLATFORM(VISION)
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <RealitySimulationServices/RealitySimulationServices.h>
+
+#else
+
+typedef NS_OPTIONS(NSUInteger, RSSSceneChromeOptions) {
+    RSSSceneChromeOptionsNone = 0,
+};
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#endif // PLATFORM(VISION)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2146,6 +2146,8 @@
 		E50620922542102000C43091 /* ContactsUISPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E50620912542102000C43091 /* ContactsUISPI.h */; };
 		E5227D8427A11261008EAB57 /* WebFoundTextRange.h in Headers */ = {isa = PBXBuildFile; fileRef = E5227D8227A11231008EAB57 /* WebFoundTextRange.h */; };
 		E52CF55220A35C3A00DADA27 /* WebDataListSuggestionPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E52CF55020A35C3A00DADA27 /* WebDataListSuggestionPicker.h */; };
+		E539DFEB2A44A6A600769F09 /* MRUIKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */; };
+		E539DFED2A44A78600769F09 /* RealitySimulationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */; };
 		E55CD1F524CF747D0042DB9C /* WebDateTimeChooser.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD1F324CF747D0042DB9C /* WebDateTimeChooser.h */; };
 		E55CD20024D08D8F0042DB9C /* WebDateTimePicker.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD1FC24D0880B0042DB9C /* WebDateTimePicker.h */; };
 		E55CD20324D09F1F0042DB9C /* WebDateTimePickerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = E55CD20124D09F1F0042DB9C /* WebDateTimePickerMac.h */; };
@@ -7125,6 +7127,8 @@
 		E52CF55020A35C3A00DADA27 /* WebDataListSuggestionPicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebDataListSuggestionPicker.h; sourceTree = "<group>"; };
 		E52CF55120A35C3A00DADA27 /* WebDataListSuggestionPicker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebDataListSuggestionPicker.cpp; sourceTree = "<group>"; };
 		E5309B7D27A2872F00B10631 /* WebFindOptions.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebFindOptions.cpp; sourceTree = "<group>"; };
+		E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MRUIKitSPI.h; sourceTree = "<group>"; };
+		E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RealitySimulationServicesSPI.h; sourceTree = "<group>"; };
 		E54A14CE20FCFB7B007E13D8 /* WebDataListSuggestionsDropdown.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebDataListSuggestionsDropdown.cpp; sourceTree = "<group>"; };
 		E55CD1F324CF747D0042DB9C /* WebDateTimeChooser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebDateTimeChooser.h; sourceTree = "<group>"; };
 		E55CD1F424CF747D0042DB9C /* WebDateTimeChooser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebDateTimeChooser.cpp; sourceTree = "<group>"; };
@@ -13733,6 +13737,7 @@
 				3754D5411B3A2998003A4C7F /* Cocoa */,
 				CE1A0BCB1A48E6C60054EF74 /* ios */,
 				A1E6886E1F6E2B82007006A6 /* mac */,
+				E5BF52E02A44A5D9005B2848 /* visionos */,
 				AB2750BD2485809100F1C9D8 /* watchos */,
 			);
 			path = spi;
@@ -13894,6 +13899,15 @@
 				AAB145E4223F931200E489D8 /* PrefetchCache.h */,
 			);
 			path = cache;
+			sourceTree = "<group>";
+		};
+		E5BF52E02A44A5D9005B2848 /* visionos */ = {
+			isa = PBXGroup;
+			children = (
+				E539DFEA2A44A69100769F09 /* MRUIKitSPI.h */,
+				E539DFEC2A44A78600769F09 /* RealitySimulationServicesSPI.h */,
+			);
+			path = visionos;
 			sourceTree = "<group>";
 		};
 		EB7D252827B316A6009CB586 /* mac */ = {
@@ -14455,6 +14469,7 @@
 				EBA8D3B327A5E33F00CB7900 /* MockPushServiceConnection.h in Headers */,
 				7137BA8025F1542000914EE3 /* ModelElementController.h in Headers */,
 				C0E3AA7C1209E83C00A49D01 /* Module.h in Headers */,
+				E539DFEB2A44A6A600769F09 /* MRUIKitSPI.h in Headers */,
 				2D50366B1BCDE17900E20BB3 /* NativeWebGestureEvent.h in Headers */,
 				263172CF18B469490065B9C3 /* NativeWebTouchEvent.h in Headers */,
 				4973DF482422941F00E4C26A /* NavigatingToAppBoundDomain.h in Headers */,
@@ -14584,6 +14599,7 @@
 				1A0C227E2451130A00ED614D /* QuickLookThumbnailingSoftLink.h in Headers */,
 				1AEE57252409F142002005D6 /* QuickLookThumbnailLoader.h in Headers */,
 				93B631F327ABAD8000443A44 /* QuotaIncreaseRequestIdentifier.h in Headers */,
+				E539DFED2A44A78600769F09 /* RealitySimulationServicesSPI.h in Headers */,
 				5CB6AE442609799C00B6ED5A /* ReasonSPI.h in Headers */,
 				7BE9326327F5C75A00D5FEFB /* ReceiverMatcher.h in Headers */,
 				950FECF4285027200002DE4E /* RecurringPaymentRequest.h in Headers */,


### PR DESCRIPTION
#### 98669482d5b2a3d1b747881d8b15bbe32f35bb7b
<pre>
Upstream visionOS fullscreen transition logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=258404">https://bugs.webkit.org/show_bug.cgi?id=258404</a>
rdar://111164029

Reviewed by Wenson Hsieh.

* Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h: Added.
* Source/WebKit/Platform/spi/visionos/RealitySimulationServicesSPI.h: Added.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::useSpatialFullScreenTransition):
(WebKit::resizeScene):
(-[WKFixedSizeWindow _shouldResizeWithScene]):
(-[WKFullScreenParentWindowState initWithWindow:]):
(-[WKFullscreenWindowSceneDelegate initWithController:originalDelegate:]):
(-[WKFullscreenWindowSceneDelegate originalDelegate]):
(-[WKFullscreenWindowSceneDelegate windowScene:shouldCloseForReason:]):
(-[WKFullscreenWindowSceneDelegate methodSignatureForSelector:]):
(-[WKFullscreenWindowSceneDelegate respondsToSelector:]):
(-[WKFullscreenWindowSceneDelegate forwardInvocation:]):
(-[WKFullscreenWindowSceneDelegate forwardingTargetForSelector:]):
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
(-[WKFullScreenWindowController _dismissFullscreenViewController]):
(-[WKFullScreenWindowController _configureSpatialFullScreenTransition]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/265416@main">https://commits.webkit.org/265416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4adb8ca09a297dd2a5892a47b61df1fd7f4fa66c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12473 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13281 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10983 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12876 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9186 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17030 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13179 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10392 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9551 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->