### PR TITLE
Ignore ::-webkit-scrollbar styles when scrollbar-color is not auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scrollbar-color non-auto on the root overrides ::-webkit-scrollbar assert_less_than: viewport has a scrollbar expected a number less than 800 but got 800
+PASS scrollbar-color non-auto on the root overrides ::-webkit-scrollbar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt
@@ -3,5 +3,5 @@ auto
 themed
 
 PASS scrollbar-color auto defers to ::-webkit-scrollbar
-FAIL scrollbar-color yellow blue overrides ::-webkit-scrollbar assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+PASS scrollbar-color yellow blue overrides ::-webkit-scrollbar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt
@@ -1,5 +1,5 @@
 Test scrollbar-color: vertical scrollbar
 themed
 
-FAIL scrollbar-color yellow blue on body overrides ::-webkit-scrollbar assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+PASS scrollbar-color yellow blue on body overrides ::-webkit-scrollbar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt
@@ -1,5 +1,5 @@
 Test scrollbar-color: vertical scrollbar
 themed
 
-FAIL scrollbar-color yellow blue on body overrides ::-webkit-scrollbar on scrollable area assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+PASS scrollbar-color yellow blue on body overrides ::-webkit-scrollbar on scrollable area
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -521,12 +521,12 @@ RefPtr<Element> LocalFrameView::rootElementForCustomScrollbarPartStyle() const
     // Try the <body> element first as a scrollbar source.
     auto* body = document->bodyOrFrameset();
     // scrollbar-width on root element should override custom scrollbars declared on body element, so check that here..
-    if (body && body->renderer() && body->renderer()->style().hasCustomScrollbarStyle() && scrollbarWidthStyle() == ScrollbarWidth::Auto)
+    if (body && body->renderer() && body->renderer()->style().usesLegacyScrollbarStyle() && scrollbarWidthStyle() == ScrollbarWidth::Auto)
         return body;
 
     // If the <body> didn't have a custom style, then the root element might.
     auto* docElement = document->documentElement();
-    if (docElement && docElement->renderer() && docElement->renderer()->style().hasCustomScrollbarStyle())
+    if (docElement && docElement->renderer() && docElement->renderer()->style().usesLegacyScrollbarStyle())
         return docElement;
 
     return nullptr;
@@ -540,7 +540,7 @@ Ref<Scrollbar> LocalFrameView::createScrollbar(ScrollbarOrientation orientation)
     // If we have an owning iframe/frame element, then it can set the custom scrollbar also.
     // FIXME: Seems bad to do this for cross-origin frames.
     RenderWidget* frameRenderer = m_frame->ownerRenderer();
-    if (frameRenderer && frameRenderer->style().hasCustomScrollbarStyle())
+    if (frameRenderer && frameRenderer->style().usesLegacyScrollbarStyle())
         return RenderScrollbar::createCustomScrollbar(*this, orientation, nullptr, m_frame.ptr());
 
     // Nobody set a custom style, so we just use a native scrollbar.
@@ -1534,15 +1534,15 @@ String LocalFrameView::debugDescription() const
 
 bool LocalFrameView::canShowNonOverlayScrollbars() const
 {
-    auto hasCustomScrollbarStyle = [&] {
+    auto usesLegacyScrollbarStyle = [&] {
         auto element = rootElementForCustomScrollbarPartStyle();
         if (!element || !is<RenderBox>(element->renderer()))
             return false;
 
-        return downcast<RenderBox>(*element->renderer()).style().hasCustomScrollbarStyle();
+        return downcast<RenderBox>(*element->renderer()).style().usesLegacyScrollbarStyle();
     }();
 
-    return canHaveScrollbars() && (hasCustomScrollbarStyle || !ScrollbarTheme::theme().usesOverlayScrollbars());
+    return canHaveScrollbars() && (usesLegacyScrollbarStyle || !ScrollbarTheme::theme().usesOverlayScrollbars());
 }
 
 bool LocalFrameView::styleHidesScrollbarWithOrientation(ScrollbarOrientation orientation) const

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1086,7 +1086,7 @@ void RenderBox::panScroll(const IntPoint& source)
 
 bool RenderBox::canUseOverlayScrollbars() const
 {
-    return !style().hasCustomScrollbarStyle() && ScrollbarTheme::theme().usesOverlayScrollbars();
+    return !style().usesLegacyScrollbarStyle() && ScrollbarTheme::theme().usesOverlayScrollbars();
 }
 
 bool RenderBox::hasAutoScrollbar(ScrollbarOrientation orientation) const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -872,9 +872,9 @@ Ref<Scrollbar> RenderLayerScrollableArea::createScrollbar(ScrollbarOrientation o
     RefPtr<Scrollbar> widget;
     ASSERT(rendererForScrollbar(renderer));
     auto& actualRenderer = *rendererForScrollbar(renderer);
-    bool hasCustomScrollbarStyle = is<RenderBox>(actualRenderer) && downcast<RenderBox>(actualRenderer).style().hasCustomScrollbarStyle();
+    bool usesLegacyScrollbarStyle = is<RenderBox>(actualRenderer) && downcast<RenderBox>(actualRenderer).style().usesLegacyScrollbarStyle();
     auto element = downcast<RenderBox>(actualRenderer).element();
-    if (hasCustomScrollbarStyle && element)
+    if (usesLegacyScrollbarStyle && element)
         widget = RenderScrollbar::createCustomScrollbar(*this, orientation, element);
     else {
         widget = Scrollbar::createNativeScrollbar(*this, orientation, scrollbarWidthStyle());

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -975,8 +975,8 @@ void RenderListBox::didStartScrollAnimation()
 Ref<Scrollbar> RenderListBox::createScrollbar()
 {
     RefPtr<Scrollbar> widget;
-    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
-    if (hasCustomScrollbarStyle)
+    bool usesLegacyScrollbarStyle = style().usesLegacyScrollbarStyle();
+    if (usesLegacyScrollbarStyle)
         widget = RenderScrollbar::createCustomScrollbar(*this, ScrollbarOrientation::Vertical, &selectElement());
     else {
         widget = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, theme().scrollbarWidthStyleForPart(StyleAppearance::Listbox));

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -562,8 +562,8 @@ HostWindow* RenderMenuList::hostWindow() const
 
 Ref<Scrollbar> RenderMenuList::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
-    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
-    if (hasCustomScrollbarStyle)
+    bool usesLegacyScrollbarStyle = style().usesLegacyScrollbarStyle();
+    if (usesLegacyScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &selectElement());
     return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);
 }

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -374,8 +374,8 @@ HostWindow* RenderSearchField::hostWindow() const
 
 Ref<Scrollbar> RenderSearchField::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
-    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
-    if (hasCustomScrollbarStyle)
+    bool usesLegacyScrollbarStyle = style().usesLegacyScrollbarStyle();
+    if (usesLegacyScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &inputElement());
     return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1042,7 +1042,7 @@ public:
 
     bool shouldPlaceVerticalScrollbarOnLeft() const;
 
-    inline bool hasCustomScrollbarStyle() const;
+    inline bool usesLegacyScrollbarStyle() const;
 
 #if ENABLE(APPLE_PAY)
     inline ApplePayButtonStyle applePayButtonStyle() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -723,7 +723,7 @@ constexpr LengthType RenderStyle::zeroLength() { return LengthType::Fixed; }
 inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 
 // ignore non-standard ::-webkit-scrollbar when standard properties are in use
-inline bool RenderStyle::hasCustomScrollbarStyle() const { return hasPseudoStyle(PseudoId::Scrollbar) && scrollbarWidth() == ScrollbarWidth::Auto; }
+inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoId::Scrollbar) && scrollbarWidth() == ScrollbarWidth::Auto && !scrollbarColor().has_value(); }
 
 #if ENABLE(APPLE_PAY)
 inline ApplePayButtonStyle RenderStyle::applePayButtonStyle() const { return static_cast<ApplePayButtonStyle>(m_nonInheritedData->rareData->applePayButtonStyle); }


### PR DESCRIPTION
#### f056156a42b6e3c32320293c36b6e0f44451f509
<pre>
Ignore ::-webkit-scrollbar styles when scrollbar-color is not auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=257617">https://bugs.webkit.org/show_bug.cgi?id=257617</a>

Reviewed by Tim Nguyen.

Rename hasCustomScrollbarStyle to usesLegacyScrollbarStyle to avoid confusion.

RenderStyle::usesLegacyScrollbarStyle() now returns true if a custom style
for the scrollbar has been set via ::-webkit-scrollbar, the value of
scrollbar-width is auto (default), and the value of scrollbar-color is auto (default).

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt:

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::rootElementForCustomScrollbarPartStyle const):
(WebCore::LocalFrameView::createScrollbar):
(WebCore::LocalFrameView::canShowNonOverlayScrollbars const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::canUseOverlayScrollbars const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::createScrollbar):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::createScrollbar):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::createScrollbar):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::createScrollbar):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usesLegacyScrollbarStyle const):
(WebCore::RenderStyle::hasCustomScrollbarStyle const): Deleted.

Canonical link: <a href="https://commits.webkit.org/265423@main">https://commits.webkit.org/265423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78c9078f22c9092129ffa3c6b00a5f8bfddeb496

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12491 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12896 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17037 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10408 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9568 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2596 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13841 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->