### PR TITLE
Clean-up RenderFrameSet.cpp|h by removing dead code

### DIFF
--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -57,7 +57,6 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderFrameSet);
 RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& style)
     : RenderBox(frameSet, WTFMove(style), 0)
     , m_isResizing(false)
-    , m_isChildResizing(false)
 {
     setInline(false);
 }
@@ -590,19 +589,7 @@ bool RenderFrameSet::userResize(MouseEvent& event)
 void RenderFrameSet::setIsResizing(bool isResizing)
 {
     m_isResizing = isResizing;
-    for (auto& ancestor : ancestorsOfType<RenderFrameSet>(*this))
-        ancestor.m_isChildResizing = isResizing;
     frame().eventHandler().setResizingFrameSet(isResizing ? &frameSetElement() : nullptr);
-}
-
-bool RenderFrameSet::isResizingRow() const
-{
-    return m_isResizing && m_rows.m_splitBeingResized != noSplit;
-}
-
-bool RenderFrameSet::isResizingColumn() const
-{
-    return m_isResizing && m_cols.m_splitBeingResized != noSplit;
 }
 
 bool RenderFrameSet::canResizeRow(const IntPoint& p) const

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -62,9 +62,6 @@ public:
 
     bool userResize(MouseEvent&);
 
-    bool isResizingRow() const;
-    bool isResizingColumn() const;
-
     bool canResizeRow(const IntPoint&) const;
     bool canResizeColumn(const IntPoint&) const;
 
@@ -118,7 +115,6 @@ private:
     GridAxis m_cols;
 
     bool m_isResizing;
-    bool m_isChildResizing;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d0daa5ec56a59238519a0700feb0fad4abbdb69d
<pre>
Clean-up RenderFrameSet.cpp|h by removing dead code

<a href="https://bugs.webkit.org/show_bug.cgi?id=258405">https://bugs.webkit.org/show_bug.cgi?id=258405</a>

Reviewed by Tim Nguyen.

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=171899 &amp;
Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/7985904656b18a02548afcf98cce20f3353a73f9">https://chromium.googlesource.com/chromium/src.git/+/7985904656b18a02548afcf98cce20f3353a73f9</a>

This patch removes dead and unused code in &apos;RenderFrameSet.cpp&apos; and &apos;RenderFrameSet.h&apos;.

* Source/WebCore/rendering/RenderFrameSet.cpp:
(RenderFrameSet::RenderFrameSet): Remove extra member &apos;m_isChildResizing&apos;
(RenderFrameSet::setIsResizing): Remove usage of above member
(RenderFrameSet::isResizingRow): Deleted
(RenderFrameSet::isResizingColumn): Deleted
* Source/WebCore/rendering/RenderFrameSet.h: Remove extra variable and deleted functions definitions

Canonical link: <a href="https://commits.webkit.org/265417@main">https://commits.webkit.org/265417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef702e95cc720b2b6192e1c0275d8f069a4d79ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13285 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9774 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17031 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13181 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10396 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9555 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2594 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->