### PR TITLE
Clean-up RenderIFrame.cpp|h by removing dead code

### DIFF
--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -69,13 +69,6 @@ bool RenderIFrame::requiresLayer() const
     return RenderFrameBase::requiresLayer() || style().resize() != Resize::None;
 }
 
-RenderView* RenderIFrame::contentRootRenderer() const
-{
-    auto* childFrameView = childView();
-    auto* localFrame = childFrameView ? dynamicDowncast<LocalFrame>(childFrameView->frame()) : nullptr;
-    return localFrame ? localFrame->contentRenderer() : nullptr;
-}
-
 bool RenderIFrame::isFullScreenIFrame() const
 {
     // Some authors implement fullscreen popups as out-of-flow iframes with size set to full viewport (using vw/vh units).

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -52,8 +52,6 @@ private:
 
     bool requiresLayer() const override;
 
-    RenderView* contentRootRenderer() const;
-
     bool isFullScreenIFrame() const;
 };
 


### PR DESCRIPTION
#### 926f459c107ad7801841c3295661145f1b8b02bb
<pre>
Clean-up RenderIFrame.cpp|h by removing dead code

<a href="https://bugs.webkit.org/show_bug.cgi?id=258406">https://bugs.webkit.org/show_bug.cgi?id=258406</a>

Reviewed by Tim Nguyen.

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=171899

This patch removes dead and unused code in &apos;RenderIFrame.cpp&apos; and &apos;RenderIFrame.h&apos;.

* Source/WebCore/rendering/RenderIFrame.cpp:
(RenderIFrame::contentRootRenderer): Deleted
* Source/WebCore/rendering/RenderIFrame.h: Delete &apos;contentRootRenderer&apos; definition

Canonical link: <a href="https://commits.webkit.org/265418@main">https://commits.webkit.org/265418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/497baaa5908210956d9ec05e8cf0a174cca82b92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10848 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13287 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12883 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9776 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13176 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10397 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8483 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9556 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2595 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->