### PR TITLE
Upstream redesigned text cursor support for WebKit

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h
@@ -35,6 +35,10 @@
 - (void)handleEvent:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler;
 - (void)handleEventByInputMethod:(NSEvent *)event completionHandler:(void(^)(BOOL handled))completionHandler;
 - (BOOL)handleEventByKeyboardLayout:(NSEvent *)event;
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+@property BOOL showsCursorAccessories;
+#endif
 @end
 
 #endif

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -321,6 +321,8 @@ private:
 
     Document* document() final;
 
+    Node* caretNode() final;
+
     bool dispatchSelectStart();
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -25,8 +25,13 @@
 
 #pragma once
 
+#include "Document.h"
+#include "ElementInlines.h"
 #include "LayoutRect.h"
 #include "ReducedResolutionSeconds.h"
+#include "RenderStyle.h"
+#include "RenderStyleInlines.h"
+#include "RenderTheme.h"
 #include "Timer.h"
 
 namespace WebCore {
@@ -40,6 +45,7 @@ class Node;
 class Page;
 class VisibleSelection;
 
+// FIXME: Rename "Alternate" to "Dictation" (rdar://110802729).
 enum class CaretAnimatorType : uint8_t {
     Default,
     Alternate
@@ -50,6 +56,37 @@ enum class CaretAnimatorStopReason : uint8_t {
     CaretRectChanged,
 };
 
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+// FIXME: Use MonotonicTime type throughout instead of converting to Seconds (rdar://110802729)
+[[maybe_unused]] static Seconds currentTimeSinceEpoch()
+{
+    return MonotonicTime::now().secondsSinceEpoch();
+}
+
+// FIXME: Move to FrameSelection (rdar://110802729)
+[[maybe_unused]] static Color platformCaretColor(const RenderStyle& elementStyle, const Node* node)
+{
+#if PLATFORM(MAC)
+    if (elementStyle.hasAutoCaretColor()) {
+        auto styleColorOptions = node->document().styleColorOptions(&elementStyle);
+        return RenderTheme::singleton().systemColor(CSSValueAppleSystemControlAccent, styleColorOptions | StyleColorOptions::UseSystemAppearance);
+    }
+
+    return elementStyle.colorResolvingCurrentColor(elementStyle.caretColor());
+#else
+    UNUSED_PARAM(node);
+    return elementStyle.visitedDependentColorWithColorFilter(CSSPropertyCaretColor);
+#endif
+}
+
+struct KeyFrame {
+    Seconds time;
+    float value;
+};
+
+#endif
+
 class CaretAnimationClient {
 public:
     virtual ~CaretAnimationClient() = default;
@@ -58,6 +95,8 @@ public:
     virtual LayoutRect localCaretRect() const = 0;
 
     virtual Document* document() = 0;
+
+    virtual Node* caretNode() = 0;
 };
 
 class CaretAnimator {
@@ -90,6 +129,8 @@ public:
     virtual void setVisible(bool) = 0;
 
     PresentationProperties presentationProperties() const { return m_presentationProperties; }
+    // FIXME: The caret animators should not be the things painting the caret.
+    // Remove this method and insstead augment PresentationProperties (rdar://110802729).
     virtual void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&, const std::optional<VisibleSelection>&) const;
     virtual LayoutRect caretRepaintRectForLocalRect(LayoutRect) const;
 

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DictationCaretAnimator.h"
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+#include "Editing.h"
+#include "FloatRoundedRect.h"
+#include "Path.h"
+#include "RenderBlock.h"
+#include "VisibleSelection.h"
+
+namespace WebCore {
+
+static constexpr size_t dicationCaretAnimatorUpdateRate = 60;
+
+static constexpr KeyFrame keyframe(size_t i)
+{
+    i %= dicationCaretAnimatorUpdateRate;
+    constexpr float inverseFrameRate = 1.f / static_cast<float>(dicationCaretAnimatorUpdateRate);
+    return KeyFrame { Seconds(i * inverseFrameRate), fabs(sinf(static_cast<float>(M_PI * i * inverseFrameRate))) };
+}
+
+constexpr auto tailBlurRadius(float cursorHeight)
+{
+    return (10.f * cursorHeight) / 12.f;
+}
+constexpr auto caretBlurRadius(float cursorHeight)
+{
+    return (8.f * cursorHeight) / 12.f;
+}
+
+constexpr auto coneStart(float cursorHeight)
+{
+    return (4.f * cursorHeight) / 38.f;
+}
+
+constexpr auto coneEnd(float cursorHeight)
+{
+    return (152.f * cursorHeight) / 38.f;
+}
+
+size_t DictationCaretAnimator::keyframeCount() const
+{
+    return 2 * dicationCaretAnimatorUpdateRate;
+}
+
+DictationCaretAnimator::DictationCaretAnimator(CaretAnimationClient& client)
+    : CaretAnimator(client)
+{
+}
+
+Seconds DictationCaretAnimator::keyframeTimeDelta() const
+{
+    return Seconds(1.f / static_cast<float>(dicationCaretAnimatorUpdateRate));
+}
+
+void DictationCaretAnimator::setBlinkingSuspended(bool suspended)
+{
+    if (suspended == isBlinkingSuspended())
+        return;
+
+    if (!suspended) {
+        m_currentKeyframeIndex = 1;
+        m_blinkTimer.startOneShot(keyframeTimeDelta());
+        resetGlowTail(m_client.localCaretRect());
+    }
+
+    CaretAnimator::setBlinkingSuspended(suspended);
+}
+
+FloatRect DictationCaretAnimator::computeTailRect() const
+{
+    auto caretX = m_localCaretRect.x();
+    auto cursorHeight = m_localCaretRect.height();
+
+    return { std::min(m_glowStart, caretX), m_localCaretRect.y(), fabs(caretX - m_glowStart), cursorHeight };
+}
+
+int DictationCaretAnimator::computeScrollLeft() const
+{
+    auto document = m_client.document();
+    if (!document)
+        return 0;
+
+    if (auto* caretNode = m_client.caretNode()) {
+        if (auto* rendererForCaret = rendererForCaretPainting(caretNode))
+            return rendererForCaret->scrollLeft();
+    }
+
+    return 0;
+}
+
+void DictationCaretAnimator::updateGlowTail(Seconds elapsedTime)
+{
+    auto document = m_client.document();
+    if (!document)
+        return;
+
+    m_previousTailRect = computeTailRect();
+
+    auto previousScrollLeft = m_scrollLeft;
+    m_scrollLeft = computeScrollLeft();
+    auto deltaScrollLeft = m_scrollLeft - previousScrollLeft;
+    m_glowStart -= deltaScrollLeft;
+
+    auto caretRect = m_client.localCaretRect();
+
+    float caretPosition = caretRect.x();
+    if (caretRect.y() != m_localCaretRect.y())
+        resetGlowTail(caretRect);
+
+    m_localCaretRect = caretRect;
+
+    if (caretPosition != m_glowStart)
+        updateGlowTail(caretPosition, elapsedTime);
+    else
+        resetGlowTail(caretRect);
+
+    m_tailRect = computeTailRect();
+}
+
+void DictationCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds)
+{
+    auto currentTime = currentTimeSinceEpoch();
+    auto elapsedTime = currentTime - m_lastUpdateTime;
+    if (elapsedTime >= keyframeTimeDelta()) {
+        setOpacity(keyframe(m_currentKeyframeIndex).value);
+        m_lastUpdateTime = currentTime;
+
+        if (m_currentKeyframeIndex >= keyframeCount() - 1)
+            m_currentKeyframeIndex = 0;
+
+        m_currentKeyframeIndex++;
+        updateGlowTail(elapsedTime);
+        constexpr auto scaleAnimationSpeed = 2.f;
+        m_initialScale = std::max(0.f, m_initialScale - scaleAnimationSpeed * static_cast<float>(elapsedTime.value()));
+
+        m_blinkTimer.startOneShot(keyframeTimeDelta());
+    }
+}
+
+void DictationCaretAnimator::start(ReducedResolutionSeconds)
+{
+    // The default/start value of `m_currentKeyframeIndex` should be `1` since the keyframe
+    // delta is the difference between `m_currentKeyframeIndex` and `m_currentKeyframeIndex - 1`
+    m_currentKeyframeIndex = 1;
+    m_lastUpdateTime = currentTimeSinceEpoch();
+    m_initialScale = M_PI_2;
+    didStart(m_lastUpdateTime, keyframeTimeDelta());
+
+    resetGlowTail(m_client.localCaretRect());
+    m_previousTailRect = computeTailRect();
+}
+
+String DictationCaretAnimator::debugDescription() const
+{
+    TextStream textStream;
+    textStream << "DictationCaretAnimator " << this << " glowStart " << m_glowStart << " glowEnd = " << m_localCaretRect.x();
+    return textStream.release();
+}
+
+void DictationCaretAnimator::updateGlowTail(float caretPosition, Seconds elapsedSeconds)
+{
+    auto distanceFromPrevious = caretPosition - m_glowStart;
+
+    auto elapsedTime = static_cast<float>(elapsedSeconds.value());
+
+    constexpr auto easeInMultiplier = .12f;
+    constexpr auto maxAnimationSpeed = .2f;
+    constexpr auto minimumVelocityMultiplier = 1.0f;
+    constexpr auto acceleration = .1f;
+    m_animationSpeed = std::min(maxAnimationSpeed, m_animationSpeed + acceleration * elapsedTime);
+    auto direction = distanceFromPrevious > 0.f ? 1.f : -1.f;
+    distanceFromPrevious *= direction;
+    if (distanceFromPrevious > 0) {
+        if (elapsedTime <= 0)
+            m_glowStart = caretPosition;
+        else {
+            m_glowStart += direction * std::max(1.f, elapsedTime * m_animationSpeed * std::max(minimumVelocityMultiplier, distanceFromPrevious * distanceFromPrevious * easeInMultiplier));
+            if (direction * (m_glowStart - caretPosition) > 0)
+                m_glowStart = caretPosition;
+        }
+    }
+}
+
+void DictationCaretAnimator::resetGlowTail(FloatRect localCaretRect)
+{
+    m_animationSpeed = 0;
+    m_glowStart = localCaretRect.x();
+    m_localCaretRect = localCaretRect;
+    m_tailRect = computeTailRect();
+
+    m_scrollLeft = computeScrollLeft();
+}
+
+FloatRect DictationCaretAnimator::tailRect() const
+{
+    return m_tailRect;
+}
+
+Path DictationCaretAnimator::makeDictationTailConePath(const FloatRect& rect) const
+{
+    const auto width = rect.width();
+    const auto height = rect.height();
+    const float minimumTailWidth = coneStart(height);
+    const auto nonTruncatedTailWidth = coneEnd(height);
+    const auto coneRectangleMorphConstant = (width - minimumTailWidth) / (nonTruncatedTailWidth - minimumTailWidth);
+    auto verticalOffset = -height * .3f + height * 0.5f * std::min(1.f, std::max(0.f, coneRectangleMorphConstant));
+    bool isLTR = isLeftToRightLayout();
+
+    const auto verticalOffsetLTR = isLTR ? verticalOffset : 0.f;
+    const auto verticalOffsetRTL = isLTR ? 0.f : verticalOffset;
+
+    return Path::polygonPathFromPoints({
+        { rect.x(), rect.y() + verticalOffsetLTR },
+        { rect.x(), rect.maxY() - verticalOffsetLTR },
+        { rect.maxX(), rect.maxY() - verticalOffsetRTL },
+        { rect.maxX(), rect.y() + verticalOffsetRTL }
+    });
+}
+
+void DictationCaretAnimator::fillCaretTail(const FloatRect& rect, GraphicsContext& context, const Color& tailColor) const
+{
+    ASSERT(!rect.isZero());
+
+    float height = rect.height();
+    float width = rect.width();
+    float midY = rect.y() + 0.5f * height;
+
+    auto gradient = Gradient::create(Gradient::LinearData { FloatPoint(rect.x(), midY), FloatPoint(rect.x() + width, midY) }, { ColorInterpolationMethod::SRGB { }, AlphaPremultiplication::Unpremultiplied });
+    constexpr auto glowOpacity = .75f;
+    bool isLTR = isLeftToRightLayout();
+    gradient->addColorStop({ isLTR ? 0.f : 1.f, tailColor.colorWithAlpha(0.1f * glowOpacity) });
+    gradient->addColorStop({ isLTR ? 1.f : 0.f, tailColor.colorWithAlpha(0.35f * glowOpacity) });
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=253139 - this should be computed based on the render area
+    constexpr auto shadowOffset = 10000.f;
+    DropShadow dropShadow = {
+        .offset = FloatSize(shadowOffset, shadowOffset),
+        .blurRadius = tailBlurRadius(rect.height()),
+        .color = tailColor.colorWithAlpha(glowOpacity),
+        .radiusMode = ShadowRadiusMode::Default,
+    };
+    context.setDropShadow(dropShadow);
+    context.translate(-dropShadow.offset);
+    context.setFillGradient(WTFMove(gradient));
+    context.fillPath(makeDictationTailConePath(rect));
+}
+
+FloatRoundedRect DictationCaretAnimator::expandedCaretRect(const FloatRect& rect, bool fillTail) const
+{
+    if (m_initialScale <= 0.f && fillTail)
+        return FloatRoundedRect { rect, FloatRoundedRect::Radii { 1.f } };
+
+    auto extraScaleFactor = 1.f;
+    auto pulseExpansion = 1.f;
+    if (m_initialScale > 0.f)
+        extraScaleFactor = 1.f + sinf(2.f * m_initialScale);
+    else
+        pulseExpansion = 0.75f * m_presentationProperties.opacity * extraScaleFactor;
+
+    float horizontalPulseExpansion = 0.5f * pulseExpansion;
+    float verticalPulseExpansion = pulseExpansion * (1.f + 3.f * (extraScaleFactor - 1.f)) - 1.f;
+    FloatRect expandedRect = rect;
+    expandedRect.expand(FloatBoxExtent { verticalPulseExpansion, horizontalPulseExpansion, verticalPulseExpansion, horizontalPulseExpansion });
+    return FloatRoundedRect { expandedRect, FloatRoundedRect::Radii(1.f + std::max(0.f, .5f * horizontalPulseExpansion), 1.f + std::max(0.f, .5f * horizontalPulseExpansion)) };
+}
+
+void DictationCaretAnimator::paint(const Node& node, GraphicsContext& context, const FloatRect& rect, const Color& oldCaretColor, const LayoutPoint& paintOffset, const std::optional<VisibleSelection>& selection) const
+{
+    auto tailRect = computeTailRect();
+    bool blinkingSuspended = isBlinkingSuspended();
+    bool fillTail = !blinkingSuspended && tailRect.width() > 0.f;
+
+    auto caretColor = [&] {
+        if (!selection) {
+            auto* element = is<Element>(node) ? downcast<Element>(&node) : node.parentElement();
+            if (element && element->renderer())
+                return platformCaretColor(element->renderer()->style(), &node);
+
+            return oldCaretColor;
+        }
+
+        if (RefPtr editableRoot = selection->rootEditableElement(); editableRoot && editableRoot->renderer())
+            return platformCaretColor(editableRoot->renderer()->style(), &node);
+
+        return oldCaretColor;
+    }();
+
+    GraphicsContextStateSaver stateSaver(context);
+    context.resetClip();
+    const auto targetOpacity = (fillTail ? 1.0 : m_presentationProperties.opacity) - m_initialScale;
+    if (targetOpacity > 0 && !blinkingSuspended) {
+        context.setDropShadow({
+            .offset = { },
+            .blurRadius = caretBlurRadius(rect.height()),
+            .color = caretColor.colorWithAlpha(targetOpacity),
+            .radiusMode = ShadowRadiusMode::Default,
+        });
+    }
+
+    context.fillRoundedRect(expandedCaretRect(rect, fillTail), caretColor);
+
+    if (fillTail) {
+        tailRect.moveBy(paintOffset);
+        fillCaretTail(tailRect, context, caretColor);
+    }
+}
+
+bool DictationCaretAnimator::isLeftToRightLayout() const
+{
+    return m_glowStart <= m_localCaretRect.x();
+}
+
+LayoutRect DictationCaretAnimator::caretRepaintRectForLocalRect(LayoutRect repaintRect) const
+{
+    auto tailRect = unionRect(this->tailRect(), m_previousTailRect);
+    tailRect = expandedCaretRect(tailRect, !isBlinkingSuspended() && tailRect.width() > 0.f).rect();
+    auto height = static_cast<float>(tailRect.height());
+    const auto maxBlurDiameter = 2.f * std::max(caretBlurRadius(height), tailBlurRadius(height));
+    if (isLeftToRightLayout())
+        repaintRect.move(LayoutSize(FloatSize(-tailRect.width() - 2 * maxBlurDiameter, -maxBlurDiameter)));
+    else
+        repaintRect.move(LayoutSize(FloatSize(-2 * maxBlurDiameter, -maxBlurDiameter)));
+
+    auto heightOffset = std::max(0.f, height - static_cast<float>(repaintRect.height()));
+    repaintRect.expand(LayoutSize(FloatSize(tailRect.width() + 4 * maxBlurDiameter, heightOffset + 2 * maxBlurDiameter)));
+
+    return repaintRect;
+}
+
+void DictationCaretAnimator::stop(CaretAnimatorStopReason reason)
+{
+    if (reason == CaretAnimatorStopReason::Default)
+        CaretAnimator::stop();
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/DictationCaretAnimator.h
+++ b/Source/WebCore/platform/DictationCaretAnimator.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CaretAnimator.h"
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+namespace WebCore {
+
+class Path;
+
+class DictationCaretAnimator final : public CaretAnimator {
+public:
+    explicit DictationCaretAnimator(CaretAnimationClient&);
+
+private:
+    void updateAnimationProperties(ReducedResolutionSeconds) final;
+    void start(ReducedResolutionSeconds) final;
+    FloatRect tailRect() const;
+
+    String debugDescription() const final;
+
+    void setVisible(bool visible) final { setOpacity(visible ? 1.0 : 0.0); }
+
+    void setOpacity(float opacity)
+    {
+        if (m_presentationProperties.opacity == opacity)
+            return;
+
+        m_presentationProperties.opacity = opacity;
+        m_client.caretAnimationDidUpdate(*this);
+    }
+
+    void setBlinkingSuspended(bool) final;
+
+    void stop(CaretAnimatorStopReason) final;
+
+    Seconds keyframeTimeDelta() const;
+    size_t keyframeCount() const;
+    void updateGlowTail(float caretPosition, Seconds elapsedTime);
+    void resetGlowTail(FloatRect);
+    void updateGlowTail(Seconds elapsedTime);
+    void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&, const std::optional<VisibleSelection>&) const final;
+    LayoutRect caretRepaintRectForLocalRect(LayoutRect repaintRect) const final;
+    Path makeDictationTailConePath(const FloatRect&) const;
+    void fillCaretTail(const FloatRect&, GraphicsContext&, const Color&) const;
+
+    FloatRect computeTailRect() const;
+    bool isLeftToRightLayout() const;
+    FloatRoundedRect expandedCaretRect(const FloatRect&, bool fillTail) const;
+    int computeScrollLeft() const;
+
+    ReducedResolutionSeconds m_lastUpdateTime;
+    size_t m_currentKeyframeIndex { 1 };
+    FloatRect m_localCaretRect;
+    FloatRect m_tailRect, m_previousTailRect;
+    float m_animationSpeed { 0 };
+    float m_glowStart { 0 };
+    float m_initialScale { 0 };
+    float m_scrollLeft { 0 };
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/OpacityCaretAnimator.cpp
+++ b/Source/WebCore/platform/OpacityCaretAnimator.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "OpacityCaretAnimator.h"
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+#include "FloatRoundedRect.h"
+#include "VisibleSelection.h"
+
+namespace WebCore {
+
+static constexpr std::array keyframes = {
+    KeyFrame { 0.0_s   , 1.00 },
+    KeyFrame { 0.5_s   , 1.00 },
+    KeyFrame { 0.5375_s, 0.75 },
+    KeyFrame { 0.575_s , 0.50 },
+    KeyFrame { 0.6125_s, 0.25 },
+    KeyFrame { 0.65_s  , 0.00 },
+    KeyFrame { 0.85_s  , 0.00 },
+    KeyFrame { 0.8875_s, 0.25 },
+    KeyFrame { 0.925_s , 0.50 },
+    KeyFrame { 0.9625_s, 0.75 },
+    KeyFrame { 1.0_s   , 1.00 },
+};
+
+OpacityCaretAnimator::OpacityCaretAnimator(CaretAnimationClient& client, std::optional<LayoutRect> repaintExpansionRect)
+    : CaretAnimator(client)
+    , m_overrideRepaintRect(repaintExpansionRect)
+{
+}
+
+Seconds OpacityCaretAnimator::keyframeTimeDelta() const
+{
+    ASSERT(m_currentKeyframeIndex > 0 && m_currentKeyframeIndex < keyframes.size());
+    return keyframes[m_currentKeyframeIndex].time - keyframes[m_currentKeyframeIndex - 1].time;
+}
+
+void OpacityCaretAnimator::setBlinkingSuspended(bool suspended)
+{
+    if (suspended == isBlinkingSuspended())
+        return;
+
+    if (!suspended) {
+        m_currentKeyframeIndex = 1;
+        m_blinkTimer.startOneShot(keyframeTimeDelta());
+    }
+
+    CaretAnimator::setBlinkingSuspended(suspended);
+}
+
+void OpacityCaretAnimator::updateAnimationProperties(ReducedResolutionSeconds)
+{
+    if (isBlinkingSuspended() && m_presentationProperties.opacity >= 1.0)
+        return;
+
+    auto currentTime = currentTimeSinceEpoch();
+    if (currentTime - m_lastTimeCaretOpacityWasToggled >= keyframeTimeDelta()) {
+        setOpacity(keyframes[m_currentKeyframeIndex].value);
+        m_lastTimeCaretOpacityWasToggled = currentTime;
+
+        if (m_currentKeyframeIndex == keyframes.size() - 1)
+            m_currentKeyframeIndex = 0;
+
+        m_currentKeyframeIndex++;
+
+        m_blinkTimer.startOneShot(keyframeTimeDelta());
+
+        m_overrideRepaintRect = std::nullopt;
+    }
+}
+
+void OpacityCaretAnimator::start(ReducedResolutionSeconds)
+{
+    // The default/start value of `m_currentKeyframeIndex` should be `1` since the keyframe
+    // delta is the difference between `m_currentKeyframeIndex` and `m_currentKeyframeIndex - 1`
+    m_currentKeyframeIndex = 1;
+    m_lastTimeCaretOpacityWasToggled = currentTimeSinceEpoch();
+    didStart(m_lastTimeCaretOpacityWasToggled, keyframeTimeDelta());
+}
+
+String OpacityCaretAnimator::debugDescription() const
+{
+    TextStream textStream;
+    textStream << "OpacityCaretAnimator " << this << " active " << isActive() << " opacity = " << m_presentationProperties.opacity;
+    return textStream.release();
+}
+
+void OpacityCaretAnimator::paint(const Node& node, GraphicsContext& context, const FloatRect& rect, const Color& oldCaretColor, const LayoutPoint&, const std::optional<VisibleSelection>& selection) const
+{
+    auto caretColor = [&] {
+        if (!selection) {
+            auto* element = is<Element>(node) ? downcast<Element>(&node) : node.parentElement();
+            if (element && element->renderer())
+                return platformCaretColor(element->renderer()->style(), &node);
+
+            return oldCaretColor;
+        }
+
+        if (RefPtr editableRoot = selection->rootEditableElement(); editableRoot && editableRoot->renderer())
+            return platformCaretColor(editableRoot->renderer()->style(), &node);
+
+        return oldCaretColor;
+    }();
+
+    auto caretPresentationProperties = presentationProperties();
+
+    if (caretColor != Color::transparentBlack)
+        caretColor = caretColor.colorWithAlpha(caretPresentationProperties.opacity);
+
+    context.fillRoundedRect(FloatRoundedRect { rect, FloatRoundedRect::Radii { 1.0 } }, caretColor);
+}
+
+LayoutRect OpacityCaretAnimator::caretRepaintRectForLocalRect(LayoutRect repaintRect) const
+{
+    if (!m_overrideRepaintRect)
+        return CaretAnimator::caretRepaintRectForLocalRect(repaintRect);
+
+    auto rect = *m_overrideRepaintRect;
+    repaintRect.moveBy(rect.location());
+    repaintRect.expand(rect.size());
+
+    return repaintRect;
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/platform/OpacityCaretAnimator.h
+++ b/Source/WebCore/platform/OpacityCaretAnimator.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CaretAnimator.h"
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+namespace WebCore {
+
+class OpacityCaretAnimator final : public CaretAnimator {
+public:
+    explicit OpacityCaretAnimator(CaretAnimationClient&, std::optional<LayoutRect> = std::nullopt);
+
+private:
+    void updateAnimationProperties(ReducedResolutionSeconds) final;
+    void start(ReducedResolutionSeconds) final;
+    void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&, const std::optional<VisibleSelection>&) const final;
+
+    String debugDescription() const final;
+
+    void setVisible(bool visible) final { setOpacity(visible ? 1.0 : 0.0); }
+
+    void setOpacity(float opacity)
+    {
+        if (m_presentationProperties.opacity == opacity)
+            return;
+
+        m_presentationProperties.opacity = opacity;
+        m_client.caretAnimationDidUpdate(*this);
+    }
+
+    void setBlinkingSuspended(bool) final;
+
+    Seconds keyframeTimeDelta() const;
+    LayoutRect caretRepaintRectForLocalRect(LayoutRect) const final;
+
+    ReducedResolutionSeconds m_lastTimeCaretOpacityWasToggled;
+    size_t m_currentKeyframeIndex { 1 };
+    std::optional<LayoutRect> m_overrideRepaintRect;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/rendering/CaretRectComputation.cpp
+++ b/Source/WebCore/rendering/CaretRectComputation.cpp
@@ -43,18 +43,16 @@
 
 namespace WebCore {
 
-#if USE(APPLE_INTERNAL_SDK) && PLATFORM(MAC)
-#import <WebKitAdditions/CaretRectComputationAdditions.cpp>
-#else
 int caretWidth()
 {
 #if PLATFORM(IOS_FAMILY)
     return 2; // This value should be kept in sync with UIKit. See <rdar://problem/15580601>.
+#elif PLATFORM(MAC) && HAVE(REDESIGNED_TEXT_CURSOR)
+    return redesignedTextCursorEnabled() ? 2 : 1;
 #else
     return 1;
 #endif
 }
-#endif
 
 static LayoutRect computeCaretRectForEmptyElement(const RenderBoxModelObject& renderer, LayoutUnit width, LayoutUnit textIndentOffset, CaretRectMode caretRectMode)
 {

--- a/Source/WebCore/rendering/CaretRectComputation.h
+++ b/Source/WebCore/rendering/CaretRectComputation.h
@@ -28,6 +28,10 @@
 #include "InlineRunAndOffset.h"
 #include "RenderObjectEnums.h"
 
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+#include <pal/spi/cocoa/FeatureFlagsSPI.h>
+#endif
+
 namespace WebCore {
 
 enum class CaretRectMode {
@@ -38,5 +42,18 @@ enum class CaretRectMode {
 int caretWidth();
 
 LayoutRect computeLocalCaretRect(const RenderObject&, const InlineBoxAndOffset&, CaretRectMode = CaretRectMode::Normal);
+
+// FIXME: Remove this feature flag check when possible (rdar://110802729).
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+static inline bool redesignedTextCursorEnabled()
+{
+    static bool enabled;
+    static std::once_flag flag;
+    std::call_once(flag, [] {
+        enabled = os_feature_enabled(UIKit, redesigned_text_cursor);
+    });
+    return enabled;
+}
+#endif
 
 };

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -27,6 +27,7 @@
 #import "RenderThemeCocoa.h"
 
 #import "AttachmentLayout.h"
+#import "CaretRectComputation.h"
 #import "DrawGlyphsRecorder.h"
 #import "FloatRoundedRect.h"
 #import "FontCacheCoreText.h"
@@ -77,14 +78,14 @@ constexpr int kThumbnailBorderCornerRadius = 1;
 constexpr int kVisibleBackgroundImageWidth = 1;
 constexpr int kMultipleThumbnailShrinkSize = 2;
 
-#if USE(APPLE_INTERNAL_SDK)
-#include <WebKitAdditions/RenderThemeCocoaAdditions.mm>
-#else
 static inline bool canShowCapsLockIndicator()
 {
+#if HAVE(ACCELERATED_TEXT_INPUT)
+    if (redesignedTextCursorEnabled())
+        return false;
+#endif
     return true;
 }
-#endif
 
 RenderThemeCocoa& RenderThemeCocoa::singleton()
 {

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -673,39 +673,197 @@ void TextBoxPainter<TextBoxPath>::paintForegroundDecorations(TextDecorationPaint
         m_paintInfo.context().concatCTM(rotation(m_paintRect, Counterclockwise));
 }
 
-#if USE(APPLE_INTERNAL_SDK)
-#include <WebKitAdditions/TextBoxPainterAdditions.cpp>
-#else
-static FloatRoundedRect::Radii radiiForUnderline(const CompositionUnderline&, unsigned, unsigned)
+static FloatRoundedRect::Radii radiiForUnderline(const CompositionUnderline& underline, unsigned markedTextStartOffset, unsigned markedTextEndOffset)
 {
-    return FloatRoundedRect::Radii { 0 };
+    auto radii = FloatRoundedRect::Radii { 0 };
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+    if (!redesignedTextCursorEnabled())
+        return radii;
+
+    if (underline.startOffset >= markedTextStartOffset) {
+        radii.setTopLeft({ 1, 1 });
+        radii.setBottomLeft({ 1, 1 });
+    }
+
+    if (underline.endOffset <= markedTextEndOffset) {
+        radii.setTopRight({ 1, 1 });
+        radii.setBottomRight({ 1, 1 });
+    }
+#else
+    UNUSED_PARAM(underline);
+    UNUSED_PARAM(markedTextStartOffset);
+    UNUSED_PARAM(markedTextEndOffset);
+#endif
+
+    return radii;
 }
 
-template<typename TextBoxPath>
-void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const FloatRoundedRect::Radii&, bool) const
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+enum class TrimSide : bool {
+    Left,
+    Right,
+};
+
+static FloatRoundedRect::Radii trimRadii(const FloatRoundedRect::Radii& radii, TrimSide trimSide)
 {
+    switch (trimSide) {
+    case TrimSide::Left:
+        return { { }, radii.topRight(), { }, radii.bottomRight() };
+    case TrimSide::Right:
+        return { radii.topLeft(), { }, radii.bottomLeft(), { } };
+    }
+}
+
+enum class SnapDirection : uint8_t {
+    Left,
+    Right,
+    Both,
+};
+
+static FloatRect snapRectToDevicePixelsInDirection(const FloatRect& rect, float deviceScaleFactor, SnapDirection snapDirection)
+{
+    const auto layoutRect = LayoutRect { rect };
+    switch (snapDirection) {
+    case SnapDirection::Left:
+        return snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, true);
+    case SnapDirection::Right:
+        return snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, false);
+    case SnapDirection::Both:
+        auto snappedRectLeft = snapRectToDevicePixelsWithWritingDirection(layoutRect, deviceScaleFactor, true);
+        return snapRectToDevicePixelsWithWritingDirection(LayoutRect { snappedRectLeft }, deviceScaleFactor, false);
+    }
+}
+
+enum class LayoutBoxLocation : uint8_t {
+    OnlyBox,
+    StartOfSequence,
+    EndOfSequence,
+    MiddleOfSequence,
+    Unknown,
+};
+
+static LayoutBoxLocation layoutBoxSequenceLocation(const InlineIterator::BoxModernPath& textBox)
+{
+    auto isFirstForLayoutBox = textBox.box().isFirstForLayoutBox();
+    auto isLastForLayoutBox = textBox.box().isLastForLayoutBox();
+    if (isFirstForLayoutBox && isLastForLayoutBox)
+        return LayoutBoxLocation::OnlyBox;
+    if (isFirstForLayoutBox)
+        return LayoutBoxLocation::StartOfSequence;
+    if (isLastForLayoutBox)
+        return LayoutBoxLocation::EndOfSequence;
+    return LayoutBoxLocation::MiddleOfSequence;
+}
+
+static LayoutBoxLocation layoutBoxSequenceLocation(const InlineIterator::BoxLegacyPath&)
+{
+    return LayoutBoxLocation::Unknown;
+}
+#endif
+
+template<typename TextBoxPath>
+void TextBoxPainter<TextBoxPath>::fillCompositionUnderline(float start, float width, const CompositionUnderline& underline, const FloatRoundedRect::Radii& radii, bool hasLiveConversion) const
+{
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+    if (!redesignedTextCursorEnabled())
+#endif
+    {
+        // Thick marked text underlines are 2px thick as long as there is room for the 2px line under the baseline.
+        // All other marked text underlines are 1px thick.
+        // If there's not enough space the underline will touch or overlap characters.
+        int lineThickness = 1;
+        int baseline = m_style.metricsOfPrimaryFont().ascent();
+        if (underline.thick && m_logicalRect.height() - baseline >= 2)
+            lineThickness = 2;
+
+        // We need to have some space between underlines of subsequent clauses, because some input methods do not use different underline styles for those.
+        // We make each line shorter, which has a harmless side effect of shortening the first and last clauses, too.
+        start += 1;
+        width -= 2;
+
+        auto& style = m_renderer.style();
+        auto underlineColor = underline.compositionUnderlineColor == CompositionUnderlineColor::TextColor ? style.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor) : style.colorByApplyingColorFilter(underline.color);
+
+        auto& context = m_paintInfo.context();
+        context.setStrokeColor(underlineColor);
+        context.setStrokeThickness(lineThickness);
+        context.drawLineForText(FloatRect(m_paintRect.x() + start, m_paintRect.y() + m_logicalRect.height() - lineThickness, width, lineThickness), m_isPrinting);
+        return;
+    }
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+    if (!underline.color.isVisible())
+        return;
+
     // Thick marked text underlines are 2px thick as long as there is room for the 2px line under the baseline.
     // All other marked text underlines are 1px thick.
     // If there's not enough space the underline will touch or overlap characters.
     int lineThickness = 1;
     int baseline = m_style.metricsOfPrimaryFont().ascent();
-    if (underline.thick && m_logicalRect.height() - baseline >= 2)
+    if (m_logicalRect.height() - baseline >= 2)
         lineThickness = 2;
 
-    // We need to have some space between underlines of subsequent clauses, because some input methods do not use different underline styles for those.
-    // We make each line shorter, which has a harmless side effect of shortening the first and last clauses, too.
-    start += 1;
-    width -= 2;
+    auto underlineColor = [this] {
+#if PLATFORM(MAC)
+        auto cssColorValue = CSSValueAppleSystemControlAccent;
+#else
+        auto cssColorValue = CSSValueAppleSystemBlue;
+#endif
+        auto styleColorOptions = m_renderer.styleColorOptions();
+        return RenderTheme::singleton().systemColor(cssColorValue, styleColorOptions | StyleColorOptions::UseSystemAppearance);
+    }();
 
-    auto& style = m_renderer.style();
-    auto underlineColor = underline.compositionUnderlineColor == CompositionUnderlineColor::TextColor ? style.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor) : style.colorByApplyingColorFilter(underline.color);
+    if (!underline.thick && hasLiveConversion)
+        underlineColor = underlineColor.colorWithAlpha(0.35);
 
     auto& context = m_paintInfo.context();
     context.setStrokeColor(underlineColor);
     context.setStrokeThickness(lineThickness);
-    context.drawLineForText(FloatRect(m_paintRect.x() + start, m_paintRect.y() + m_logicalRect.height() - lineThickness, width, lineThickness), m_isPrinting);
-}
+
+    auto rect = FloatRect(m_paintRect.x() + start, m_paintRect.y() + m_logicalRect.height() - lineThickness, width, lineThickness);
+
+    if (radii.isZero()) {
+        context.drawLineForText(rect, m_isPrinting);
+        return;
+    }
+
+    // We cannot directly draw rounded edges for every rect, since a single textbox path may be split up over multiple rects.
+    // Drawing rounded edges unconditionally could then produce broken underlines between continuous rects.
+    // As a mitigation, we consult the textbox path to understand the current rect's position in the textbox path.
+    // If we're the only box in the path, then we fallback to unconditionally drawing rounded edges.
+    // If not, we flatten out the right, left, or both edges depending on whether we're at the start, end, or middle of a path, respectively.
+
+    auto deviceScaleFactor = m_document.deviceScaleFactor();
+
+    switch (layoutBoxSequenceLocation(m_textBox)) {
+    case LayoutBoxLocation::Unknown:
+    case LayoutBoxLocation::OnlyBox: {
+        context.fillRoundedRect(FloatRoundedRect { rect, radii }, underlineColor);
+        return;
+    }
+    case LayoutBoxLocation::StartOfSequence: {
+        auto snappedRectRight = snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Right);
+        context.fillRoundedRect(FloatRoundedRect { snappedRectRight, trimRadii(radii, TrimSide::Right) }, underlineColor);
+        return;
+    }
+    case LayoutBoxLocation::EndOfSequence: {
+        auto snappedRectLeft = snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Left);
+        context.fillRoundedRect(FloatRoundedRect { snappedRectLeft, trimRadii(radii, TrimSide::Left) }, underlineColor);
+        return;
+    }
+    case LayoutBoxLocation::MiddleOfSequence: {
+        auto snappedRectBoth = snapRectToDevicePixelsInDirection(rect, deviceScaleFactor, SnapDirection::Both);
+        context.fillRect(snappedRectBoth, underlineColor);
+        return;
+    }
+    }
+    ASSERT_NOT_REACHED("Unexpected LayoutBoxLocation value, underline not drawn");
+#else
+    UNUSED_PARAM(radii);
+    UNUSED_PARAM(hasLiveConversion);
 #endif
+}
 
 template<typename TextBoxPath>
 void TextBoxPainter<TextBoxPath>::paintCompositionUnderlines()

--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.h
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+
+#import <WebCore/CaretAnimator.h>
+
+namespace WebKit {
+class WebViewImpl;
+}
+
+@interface _WKWebViewTextInputNotifications : NSObject
+- (instancetype)initWithWebView:(WebKit::WebViewImpl*)webView;
+- (void)dictationDidStart;
+- (void)dictationDidEnd;
+- (void)dictationDidPause;
+- (void)dictationDidResume;
+
+- (WebCore::CaretAnimatorType)caretType;
+@end
+
+#endif

--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "_WKWebViewTextInputNotifications.h"
+
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+
+#import "WebPageProxy.h"
+#import "WebViewImpl.h"
+#import <pal/spi/mac/NSTextInputContextSPI.h>
+
+@implementation _WKWebViewTextInputNotifications {
+    WeakPtr<WebKit::WebViewImpl> _webView;
+    WebCore::CaretAnimatorType _caretType;
+}
+
+- (WebCore::CaretAnimatorType)caretType
+{
+    return _caretType;
+}
+
+- (instancetype)initWithWebView:(WebKit::WebViewImpl*)webView
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _webView = webView;
+    _caretType = WebCore::CaretAnimatorType::Default;
+
+    return self;
+}
+
+- (void)dictationDidStart
+{
+    if (_caretType == WebCore::CaretAnimatorType::Alternate) {
+        if (_webView)
+            _webView->page().setCaretBlinkingSuspended(false);
+        return;
+    }
+
+    _caretType = WebCore::CaretAnimatorType::Alternate;
+    if (_webView) {
+        if (NSTextInputContext *context = _webView->inputContext())
+            context.showsCursorAccessories = YES;
+
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Alternate);
+    }
+}
+
+- (void)dictationDidEnd
+{
+    if (_caretType == WebCore::CaretAnimatorType::Default)
+        return;
+
+    _caretType = WebCore::CaretAnimatorType::Default;
+    if (_webView)
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
+}
+
+- (void)dictationDidPause
+{
+    if (_webView)
+        _webView->page().setCaretBlinkingSuspended(true);
+}
+
+- (void)dictationDidResume
+{
+    if (_caretType == WebCore::CaretAnimatorType::Alternate) {
+        if (_webView)
+            _webView->page().setCaretBlinkingSuspended(false);
+        return;
+    }
+
+    _caretType = WebCore::CaretAnimatorType::Alternate;
+    if (_webView)
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Alternate);
+}
+
+@end
+
+#endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -90,6 +90,10 @@ OBJC_CLASS WKPDFHUDView;
 OBJC_CLASS VKCImageAnalysis;
 OBJC_CLASS VKCImageAnalysisOverlayView;
 
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+OBJC_CLASS _WKWebViewTextInputNotifications;
+#endif
+
 namespace API {
 class HitTestResult;
 class Object;
@@ -373,7 +377,10 @@ public:
     bool validateUserInterfaceItem(id <NSValidatedUserInterfaceItem>);
     void setEditableElementIsFocused(bool);
 
+    // FIXME: Rename to `updateCursorAccessoryPlacement` (rdar://110802729).
+#if HAVE(REDESIGNED_TEXT_CURSOR)
     void updateCaretDecorationPlacement();
+#endif
 
     void startSpeaking();
     void stopSpeaking(id);
@@ -945,7 +952,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     WeakObjCPtr<NSPopover> m_lastContextMenuTranslationPopover;
 #endif
 
-    RetainPtr<NSObject> _textInputNotifications;
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+    RetainPtr<_WKWebViewTextInputNotifications> _textInputNotifications;
+#endif
 };
     
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -81,10 +81,12 @@
 #import "_WKDragActionsInternal.h"
 #import "_WKRemoteObjectRegistryInternal.h"
 #import "_WKThumbnailViewInternal.h"
+#import "_WKWebViewTextInputNotifications.h"
 #import <Carbon/Carbon.h>
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/ActivityState.h>
 #import <WebCore/AttributedString.h>
+#import <WebCore/CaretRectComputation.h>
 #import <WebCore/ColorMac.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/CompositionHighlight.h>
@@ -1132,7 +1134,9 @@ static NSTrackingAreaOptions trackingAreaOptions()
     return options;
 }
 
-static RetainPtr<NSObject> subscribeToTextInputNotifications(WebViewImpl*);
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+static RetainPtr<_WKWebViewTextInputNotifications> subscribeToTextInputNotifications(WebViewImpl*);
+#endif
 
 static bool isInRecoveryOS()
 {
@@ -1242,7 +1246,9 @@ WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWeb
     m_lastScrollViewFrame = scrollViewFrame();
 #endif
 
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
     _textInputNotifications = subscribeToTextInputNotifications(this);
+#endif
 
     WebProcessPool::statistics().wkViewCount++;
 }
@@ -2711,8 +2717,10 @@ void WebViewImpl::selectionDidChange()
         requestCandidatesForSelectionIfNeeded();
 #endif
 
+#if HAVE(REDESIGNED_TEXT_CURSOR)
     if (m_page->editorState().hasPostLayoutData())
         updateCaretDecorationPlacement();
+#endif
 
     NSWindow *window = [m_view window];
     if (window.firstResponder == m_view.get().get()) {
@@ -6119,16 +6127,45 @@ void WebViewImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 
 #endif // HAVE(TOUCH_BAR)
 
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/WebViewImplAdditions.mm>
-#else
+#if HAVE(REDESIGNED_TEXT_CURSOR)
 void WebViewImpl::updateCaretDecorationPlacement()
 {
-}
+    const EditorState& editorState = m_page->editorState();
+    if (!editorState.hasPostLayoutData())
+        return;
 
-static RetainPtr<NSObject> subscribeToTextInputNotifications(WebViewImpl*)
+    auto& postLayoutData = *editorState.postLayoutData;
+
+    NSTextInputContext *context = [m_view _web_superInputContext];
+    if (!context)
+        return;
+
+    if ([_textInputNotifications caretType] == WebCore::CaretAnimatorType::Alternate) {
+        // The dictation cursor accessory should always be visible no matter what, since it is
+        // the only prominent way a user can tell if dictation is active.
+        context.showsCursorAccessories = YES;
+        return;
+    }
+
+    // Otherwise, the cursor accessory should be hidden if it will not show up in the correct position.
+    context.showsCursorAccessories = !postLayoutData.editableRootIsTransparentOrFullyClipped;
+}
+#endif
+
+#if HAVE(REDESIGNED_TEXT_CURSOR) && PLATFORM(MAC)
+static RetainPtr<_WKWebViewTextInputNotifications> subscribeToTextInputNotifications(WebViewImpl* webView)
 {
-    return nullptr;
+    if (!redesignedTextCursorEnabled())
+        return nullptr;
+
+    auto textInputNotifications = adoptNS([[_WKWebViewTextInputNotifications alloc] initWithWebView:webView]);
+
+    [[NSNotificationCenter defaultCenter] addObserver:textInputNotifications.get() selector:@selector(dictationDidStart) name:@"_NSTextInputContextDictationDidStartNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:textInputNotifications.get() selector:@selector(dictationDidEnd) name:@"_NSTextInputContextDictationDidEndNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:textInputNotifications.get() selector:@selector(dictationDidPause) name:@"_NSTextInputContextDictationDidPauseNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:textInputNotifications.get() selector:@selector(dictationDidResume) name:@"_NSTextInputContextDictationDidResumeNotification" object:nil];
+
+    return textInputNotifications;
 }
 #endif
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -131,6 +131,8 @@
 		07A5EBBC1C7BA43E00B9CA69 /* WKFrameHandleRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A5EBBA1C7BA43E00B9CA69 /* WKFrameHandleRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07E19EF823D401F00094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp */; };
 		07E19EFC23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E19EF923D401F00094FFB4 /* MediaPlayerPrivateRemoteMessages.h */; };
+		07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */; };
+		07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */; };
 		0E97D74D200E900400BF6643 /* SafeBrowsingSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E97D74C200E8FF300BF6643 /* SafeBrowsingSPI.h */; };
 		0EDE85032004E75D00030560 /* WebsitePopUpPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EDE85022004E74900030560 /* WebsitePopUpPolicy.h */; };
 		0F08CF521D63C13A00B48DF1 /* WKFormSelectPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F08CF511D63C13A00B48DF1 /* WKFormSelectPicker.h */; };
@@ -2823,6 +2825,8 @@
 		07E19F0723D4DC880094FFB4 /* RemoteTextTrackProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteTextTrackProxy.cpp; sourceTree = "<group>"; };
 		07E19F0823D533B90094FFB4 /* TextTrackPrivateRemote.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextTrackPrivateRemote.cpp; sourceTree = "<group>"; };
 		07E19F0923D533BA0094FFB4 /* TextTrackPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextTrackPrivateRemote.h; sourceTree = "<group>"; };
+		07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKWebViewTextInputNotifications.h; sourceTree = "<group>"; };
+		07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebViewTextInputNotifications.mm; sourceTree = "<group>"; };
 		07EF0751274593FA0066EA04 /* UserMediaPermissionRequestProxyMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestProxyMac.mm; sourceTree = "<group>"; };
 		07EF0752274593FA0066EA04 /* UserMediaPermissionRequestProxyMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserMediaPermissionRequestProxyMac.h; sourceTree = "<group>"; };
 		07EF07582745A8160066EA04 /* DisplayCaptureSessionManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DisplayCaptureSessionManager.mm; sourceTree = "<group>"; };
@@ -10455,6 +10459,8 @@
 		4450AEBE1DC3FAAC009943F2 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */,
+				07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */,
 				1C62747B288B4C3E00CED3A2 /* CocoaHelpers.h */,
 				1C62747C288B4C3E00CED3A2 /* CocoaHelpers.mm */,
 				4482734624528F6000A95493 /* CocoaImage.h */,
@@ -14110,6 +14116,7 @@
 				41C5379021F15B55008B1FAD /* _WKWebsiteDataStoreDelegate.h in Headers */,
 				A115DC72191D82DA00DA8072 /* _WKWebViewPrintFormatter.h in Headers */,
 				A19DD3C01D07D16800AC823B /* _WKWebViewPrintFormatterInternal.h in Headers */,
+				07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */,
 				A182D5B51BE6BD250087A7CC /* AccessibilityIOS.h in Headers */,
 				E3CAAA442413279900CED2E2 /* AccessibilitySupportSPI.h in Headers */,
 				A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */,
@@ -16954,6 +16961,7 @@
 				1C049838289AF5AD0010308B /* _WKWebExtensionPermission.mm in Sources */,
 				337822482947FBA5002106BB /* _WKWebExtensionUtilities.mm in Sources */,
 				337822432947F679002106BB /* _WKWebExtensionWebNavigationURLFilter.mm in Sources */,
+				07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */,
 				572EBBDA2538F6B4000552B3 /* AppAttestInternalSoftLink.mm in Sources */,
 				517B5F7E275E97B6002DC22D /* AppBundleRequest.mm in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,


### PR DESCRIPTION
#### 9d35a12f4192dc72e5c29fd1fd8e8a9a6c9b1eca
<pre>
Upstream redesigned text cursor support for WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=257887">https://bugs.webkit.org/show_bug.cgi?id=257887</a>
rdar://110483283

Reviewed by Mike Wyrzykowski and Tim Horton.

Upstream support for the redesigned text cursor in WebKit.

* Source/WebCore/PAL/pal/spi/mac/NSTextInputContextSPI.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::createCaretAnimator):
(WebCore::FrameSelection::caretNode):
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/platform/CaretAnimator.h:
(WebCore::currentTimeSinceEpoch):
(WebCore::platformCaretColor):
* Source/WebCore/platform/DictationCaretAnimator.cpp: Added.
(WebCore::keyframe):
(WebCore::tailBlurRadius):
(WebCore::caretBlurRadius):
(WebCore::coneStart):
(WebCore::coneEnd):
(WebCore::DictationCaretAnimator::keyframeCount const):
(WebCore::DictationCaretAnimator::DictationCaretAnimator):
(WebCore::DictationCaretAnimator::keyframeTimeDelta const):
(WebCore::DictationCaretAnimator::setBlinkingSuspended):
(WebCore::DictationCaretAnimator::computeTailRect const):
(WebCore::DictationCaretAnimator::computeScrollLeft const):
(WebCore::DictationCaretAnimator::updateGlowTail):
(WebCore::DictationCaretAnimator::updateAnimationProperties):
(WebCore::DictationCaretAnimator::start):
(WebCore::DictationCaretAnimator::debugDescription const):
(WebCore::DictationCaretAnimator::resetGlowTail):
(WebCore::DictationCaretAnimator::tailRect const):
(WebCore::DictationCaretAnimator::makeDictationTailConePath const):
(WebCore::DictationCaretAnimator::fillCaretTail const):
(WebCore::DictationCaretAnimator::expandedCaretRect const):
(WebCore::DictationCaretAnimator::paint const):
(WebCore::DictationCaretAnimator::isLeftToRightLayout const):
(WebCore::DictationCaretAnimator::caretRepaintRectForLocalRect const):
(WebCore::DictationCaretAnimator::stop):
* Source/WebCore/platform/DictationCaretAnimator.h: Added.
* Source/WebCore/platform/OpacityCaretAnimator.cpp: Added.
(WebCore::OpacityCaretAnimator::OpacityCaretAnimator):
(WebCore::OpacityCaretAnimator::keyframeTimeDelta const):
(WebCore::OpacityCaretAnimator::setBlinkingSuspended):
(WebCore::OpacityCaretAnimator::updateAnimationProperties):
(WebCore::OpacityCaretAnimator::start):
(WebCore::OpacityCaretAnimator::debugDescription const):
(WebCore::OpacityCaretAnimator::paint const):
(WebCore::OpacityCaretAnimator::caretRepaintRectForLocalRect const):
* Source/WebCore/platform/OpacityCaretAnimator.h: Added.
* Source/WebCore/rendering/CaretRectComputation.cpp:
(WebCore::caretWidth):
* Source/WebCore/rendering/CaretRectComputation.h:
(WebCore::redesignedTextCursorEnabled):
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::canShowCapsLockIndicator):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::radiiForUnderline):
(WebCore::trimRadii):
(WebCore::snapRectToDevicePixelsInDirection):
(WebCore::layoutBoxSequenceLocation):
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::fillCompositionUnderline const):
* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.h: Added.
* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm: Added.
(-[_WKWebViewTextInputNotifications caretType]):
(-[_WKWebViewTextInputNotifications initWithWebView:]):
(-[_WKWebViewTextInputNotifications dictationDidStart]):
(-[_WKWebViewTextInputNotifications dictationDidEnd]):
(-[_WKWebViewTextInputNotifications dictationDidPause]):
(-[_WKWebViewTextInputNotifications dictationDidResume]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::updateCaretDecorationPlacement):
(WebKit::subscribeToTextInputNotifications):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/265413@main">https://commits.webkit.org/265413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba32808c40a16b2b39bb87022ec69957d29b742e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12483 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10994 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12888 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13833 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1218 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->