### PR TITLE
Skip JIT memory allocation in ExecutableAllocator::disableJIT() when running on an open source XNU.

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "CPU.h"
 
-#if (CPU(X86) || CPU(X86_64) || CPU(ARM64E)) && OS(DARWIN)
+#if (CPU(X86) || CPU(X86_64) || CPU(ARM64)) && OS(DARWIN)
 #include <mutex>
 #include <sys/sysctl.h>
 #endif
@@ -36,6 +36,15 @@
 #endif
 
 namespace JSC {
+
+#if PLATFORM(MAC)
+bool isKernOpenSource()
+{
+    uint32_t val = 0;
+    size_t valSize = sizeof(val);
+    return !sysctlbyname("kern.opensource_kernel", &val, &valSize, nullptr, 0) && val;
+}
+#endif
 
 #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 bool isKernTCSMAvailable()

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -203,6 +203,10 @@ inline bool hasSensibleDoubleToInt()
     return optimizeForX86();
 }
 
+#if PLATFORM(MAC)
+bool isKernOpenSource();
+#endif
+
 #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 bool isKernTCSMAvailable();
 bool enableKernTCSM();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -171,11 +171,11 @@ void ExecutableAllocator::disableJIT()
 
 #if HAVE(IOS_JIT_RESTRICTIONS) || HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    bool hasJITEntitlement = processHasEntitlement("dynamic-codesigning"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s);
 #else
-    bool hasJITEntitlement = processHasEntitlement("com.apple.security.cs.allow-jit"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("com.apple.security.cs.allow-jit"_s) && !isKernOpenSource();
 #endif
-    if (hasJITEntitlement) {
+    if (shouldDisableJITMemory) {
         // Because of an OS quirk, even after the JIT region has been unmapped,
         // the OS thinks that region is reserved, and as such, can cause Gigacage
         // allocation to fail. We work around this by initializing the Gigacage


### PR DESCRIPTION
#### 6063bc484b4f523c354231080d5bc2fca0b536f1
<pre>
Skip JIT memory allocation in ExecutableAllocator::disableJIT() when running on an open source XNU.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258409">https://bugs.webkit.org/show_bug.cgi?id=258409</a>
rdar://111170164

Reviewed by Yusuke Suzuki.

The open source XNU does not support special handling of JIT memory.  However, macOS Safari and
WebKit binaries still need to be able to run on the open source XNU, albeit without JIT.

However, ExecutableAllocator::disableJIT() is still trying to allocated JIT memory if the JIT
entitlement is present (which is defined by the WebKit binary, not the kernel), and currently,
will assert that the allocation succeeds.  We need to skip this allocation and assertion when
running on open source XNU because the allocation is not necessary, and the assertion is invalid
for the open source kernel and will fail every time.  This patch implements this skipping.

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::isKernOpenSource):
* Source/JavaScriptCore/assembler/CPU.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::disableJIT):

Canonical link: <a href="https://commits.webkit.org/265435@main">https://commits.webkit.org/265435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/571f98656c84a6ea97238970e91d141f73dfe838

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13305 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12900 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17046 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9194 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13198 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10293 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10412 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10958 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9572 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13845 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11266 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10273 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2751 "Passed tests") | 
<!--EWS-Status-Bubble-End-->