### PR TITLE
ASSERTION FAILED: firstChild():[ macOS ] media/track/track-cues-missed.html is a flaky test.

### DIFF
--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -76,7 +76,6 @@ void RenderVTTCue::layout()
 
 bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& position)
 {
-    ASSERT(firstChild());
     if (!firstChild())
         return false;
 
@@ -158,6 +157,9 @@ void RenderVTTCue::placeBoxInDefaultPosition(LayoutUnit position, bool& switched
 
 bool RenderVTTCue::isOutside() const
 {
+    if (!firstChild())
+        return false;
+
     return !rectIsWithinContainer(backdropBox().absoluteBoundingBoxRect());
 }
 
@@ -169,11 +171,16 @@ bool RenderVTTCue::rectIsWithinContainer(const IntRect& rect) const
 
 bool RenderVTTCue::isOverlapping() const
 {
+    if (!firstChild())
+        return false;
+
     return overlappingObject();
 }
 
 RenderVTTCue* RenderVTTCue::overlappingObject() const
 {
+    ASSERT(firstChild());
+
     return overlappingObjectForRect(backdropBox().absoluteBoundingBoxRect());
 }
 
@@ -257,6 +264,9 @@ bool RenderVTTCue::switchDirection(bool& switched, LayoutUnit& step)
 
 void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
 {
+    if (!firstChild())
+        return;
+
     IntRect containerRect = containingBlock()->absoluteBoundingBoxRect();
     IntRect cueRect = backdropBox().absoluteBoundingBoxRect();
 
@@ -287,6 +297,9 @@ void RenderVTTCue::moveIfNecessaryToKeepWithinContainer()
 
 bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
 {
+    if (!firstChild())
+        return false;
+
     newX = x();
     newY = y();
     IntRect srcRect = backdropBox().absoluteBoundingBoxRect();
@@ -407,6 +420,7 @@ RenderBlockFlow& RenderVTTCue::backdropBox() const
 
 RenderInline& RenderVTTCue::cueBox() const
 {
+    ASSERT(firstChild());
     return downcast<RenderInline>(*backdropBox().firstChild());
 }
 


### PR DESCRIPTION
#### b33adedfb11722f4b58923457939f6fabe613a4b
<pre>
ASSERTION FAILED: firstChild():[ macOS ] media/track/track-cues-missed.html is a flaky test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258183">https://bugs.webkit.org/show_bug.cgi?id=258183</a>
rdar://110876540

Reviewed by Andy Estes.

* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::isOutside const): Return early if firstChild() return null.
(WebCore::RenderVTTCue::isOverlapping const): Ditto.
(WebCore::RenderVTTCue::overlappingObject const): Ditto.
(WebCore::RenderVTTCue::moveIfNecessaryToKeepWithinContainer): Ditto.
(WebCore::RenderVTTCue::findNonOverlappingPosition const): Ditto.

Canonical link: <a href="https://commits.webkit.org/265420@main">https://commits.webkit.org/265420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f59d7fbaeb0f4ff1f10c108a4b29414d0d7e43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12494 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13297 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12898 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9785 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13189 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2600 "Built successfully and passed tests") | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13843 "Failed to checkout and rebase branch from PR 15205") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->