### PR TITLE
Upstream visionOS-specific trait collection logic

### DIFF
--- a/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
+++ b/Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm
@@ -29,23 +29,20 @@
 
 #import <pal/ios/UIKitSoftLink.h>
 
-#if HAVE(OS_DARK_MODE_SUPPORT)
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/LocalCurrentTraitCollectionAdditions.mm>)
-#import <WebKitAdditions/LocalCurrentTraitCollectionAdditions.mm>
-#else
 namespace WebCore {
 
+#if HAVE(OS_DARK_MODE_SUPPORT)
 static UITraitCollection *adjustedTraitCollection(UITraitCollection *traitCollection)
 {
+#if PLATFORM(VISION)
+    // Use the iPad idiom instead of the Reality idiom, since some system colors are transparent
+    // in the Reality idiom, and are not web-compatible.
+    if (traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomReality)
+        return [PAL::getUITraitCollectionClass() traitCollectionWithTraitsFromCollections:@[ traitCollection, [PAL::getUITraitCollectionClass() traitCollectionWithUserInterfaceIdiom:UIUserInterfaceIdiomPad] ]];
+#endif
     return traitCollection;
 }
-
-}
 #endif
-#endif // HAVE(OS_DARK_MODE_SUPPORT)
-
-
-namespace WebCore {
 
 LocalCurrentTraitCollection::LocalCurrentTraitCollection(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 {


### PR DESCRIPTION
#### 6172ecd8b1485a5387d034f7e623a36b8f5a45fc
<pre>
Upstream visionOS-specific trait collection logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=258416">https://bugs.webkit.org/show_bug.cgi?id=258416</a>
rdar://111178036

Reviewed by Tim Horton.

* Source/WebCore/platform/ios/LocalCurrentTraitCollection.mm:
(WebCore::adjustedTraitCollection):

Canonical link: <a href="https://commits.webkit.org/265426@main">https://commits.webkit.org/265426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a553c60d34a0b116cf11e466ad1726dee30604fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13307 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12910 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9215 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17049 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10286 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13201 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9581 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13854 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->