### PR TITLE
Simplify a case statement in Decimal.cpp slightly

### DIFF
--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -142,7 +142,6 @@ public:
 private:
     static uint32_t highUInt32(uint64_t x) { return static_cast<uint32_t>(x >> 32); }
     static uint32_t lowUInt32(uint64_t x) { return static_cast<uint32_t>(x & ((static_cast<uint64_t>(1) << 32) - 1)); }
-    bool isZero() const { return !m_low && !m_high; }
     static uint64_t makeUInt64(uint32_t low, uint32_t high) { return low | (static_cast<uint64_t>(high) << 32); }
 
     static uint64_t multiplyHigh(uint64_t, uint64_t);
@@ -750,19 +749,6 @@ Decimal Decimal::fromString(StringView str)
             return nan();
 
         case StateDot:
-            if (isASCIIDigit(ch)) {
-                if (numberOfDigits < Precision) {
-                    ++numberOfDigits;
-                    ++numberOfDigitsAfterDot;
-                    accumulator *= 10;
-                    accumulator += ch - '0';
-                }
-                state = StateDotDigit;
-                break;
-            }
-            // FIXME: <http://webkit.org/b/127667> Decimal::fromString's EBNF documentation does not match implementation
-            FALLTHROUGH;
-
         case StateDotDigit:
             if (isASCIIDigit(ch)) {
                 if (numberOfDigits < Precision) {
@@ -771,6 +757,8 @@ Decimal Decimal::fromString(StringView str)
                     accumulator *= 10;
                     accumulator += ch - '0';
                 }
+                // FIXME: <http://webkit.org/b/127667> Decimal::fromString's EBNF documentation does not match implementation.
+                state = StateDotDigit;
                 break;
             }
 


### PR DESCRIPTION
#### 2b9d1a6ea04f101aa4cbc3277aeca15e97c25463
<pre>
Simplify a case statement in Decimal.cpp slightly

<a href="https://bugs.webkit.org/show_bug.cgi?id=258418">https://bugs.webkit.org/show_bug.cgi?id=258418</a>

Reviewed by Chris Dumez.

Inspired: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=164071

Handling for StateDot and StateDotDigit was identical save for a
&quot;state = StateDotDigit;&quot; in the StateDot case that&apos;s a no-op in the
StateDotDigit case anyway.
This also removes unused &apos;isZero&apos; as fly-by fix.

* Source/WebCore/platform/Decimal.cpp: Remove unused &apos;isZero&apos;
(Decimal::fromString): Use &apos;StateDotDigit&apos; code for &apos;StateDot&apos; as simplification

Canonical link: <a href="https://commits.webkit.org/265567@main">https://commits.webkit.org/265567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/081fb4f9a59056255c26c121226bc7f34533b5d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13312 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12916 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17052 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13204 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8506 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9585 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2695 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->