### PR TITLE
REGRESSION(265249@main): Infinite recursion in LegacyRenderSVGContainer::layout and SVGRenderSupport::layoutChildren

### DIFF
--- a/LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements-expected.txt
+++ b/LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements-expected.txt
@@ -1,0 +1,1 @@
+PASS - WebKit did not crash

--- a/LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements.html
+++ b/LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements.html
@@ -1,0 +1,9 @@
+<body>
+<svg><g id="g" mask="url(#mask)" /></svg>
+<svg><mask id="mask"><pattern pointsAtY="0"><use href="#g" /></pattern></mask></svg>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+document.querySelector('g').getBoundingClientRect();
+document.body.textContent = 'PASS - WebKit did not crash';
+</script>

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -218,8 +218,11 @@ void SVGContainerLayout::verifyLayoutLocationConsistency(const RenderLayerModelO
 
 void SVGContainerLayout::layoutDifferentRootIfNeeded(const RenderElement& renderer)
 {
-    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer))
-        resources->layoutReferencedRootIfNeeded();
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
+        auto* svgRoot = SVGRenderSupport::findTreeRootObject(renderer);
+        ASSERT(svgRoot);
+        resources->layoutDifferentRootIfNeeded(svgRoot);
+    }
 }
 
 void SVGContainerLayout::invalidateResourcesOfChildren(RenderElement& renderer)

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -232,8 +232,11 @@ bool SVGRenderSupport::transformToRootChanged(RenderElement* ancestor)
 
 void SVGRenderSupport::layoutDifferentRootIfNeeded(const RenderElement& renderer)
 {
-    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer))
-        resources->layoutReferencedRootIfNeeded();
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(renderer)) {
+        auto* svgRoot = SVGRenderSupport::findTreeRootObject(renderer);
+        ASSERT(svgRoot);
+        resources->layoutDifferentRootIfNeeded(svgRoot);
+    }
 }
 
 void SVGRenderSupport::layoutChildren(RenderElement& start, bool selfNeedsLayout)

--- a/Source/WebCore/rendering/svg/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/SVGResources.cpp
@@ -311,13 +311,13 @@ bool SVGResources::buildCachedResources(const RenderElement& renderer, const Ren
     return foundResources;
 }
 
-void SVGResources::layoutReferencedRootIfNeeded()
+void SVGResources::layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot* svgRoot)
 {
     auto layoutDifferentRootIfNeeded = [&](RenderElement* container) {
         if (!container)
             return;
         auto* root = SVGRenderSupport::findTreeRootObject(*container);
-        if (root->isInLayout())
+        if (svgRoot == root || root->isInLayout())
             return;
         container->layoutIfNeeded();
     };

--- a/Source/WebCore/rendering/svg/SVGResources.h
+++ b/Source/WebCore/rendering/svg/SVGResources.h
@@ -45,7 +45,7 @@ public:
     SVGResources();
 
     bool buildCachedResources(const RenderElement&, const RenderStyle&);
-    void layoutReferencedRootIfNeeded();
+    void layoutDifferentRootIfNeeded(const LegacyRenderSVGRoot*);
 
     // Ordinary resources
     RenderSVGResourceClipper* clipper() const { return m_clipperFilterMaskerData ? m_clipperFilterMaskerData->clipper.get() : nullptr; }


### PR DESCRIPTION
#### 76bf4e5df476a9d854011bdaf9bc9252cb3ef5a4
<pre>
REGRESSION(265249@main): Infinite recursion in LegacyRenderSVGContainer::layout and SVGRenderSupport::layoutChildren
<a href="https://bugs.webkit.org/show_bug.cgi?id=258419">https://bugs.webkit.org/show_bug.cgi?id=258419</a>

Reviewed by Darin Adler.

Partially revert 265249@main by restoring the check for the current root.
This turned out be necessary to avoid infinite recursion.

* LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements-expected.txt: Added.
* LayoutTests/svg/custom/svg-reference-cycle-between-two-svg-elements.html: Added.
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutDifferentRootIfNeeded):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::layoutDifferentRootIfNeeded):
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::layoutDifferentRootIfNeeded):
(WebCore::SVGResources::layoutReferencedRootIfNeeded): Deleted.
* Source/WebCore/rendering/svg/SVGResources.h:

Canonical link: <a href="https://commits.webkit.org/265468@main">https://commits.webkit.org/265468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a35b34ad24c624c2bc1c8d1acaffbf1e5f4c40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13325 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11941 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9166 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12932 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17064 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13218 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8513 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9715 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13870 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1230 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->