### PR TITLE
[build.webkit.org] Skip WebDriver tests in GTK4 bot

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -99,7 +99,7 @@
                   { "name": "gtk-linux-bot-15", "platform": "gtk" },
                   { "name": "gtk-linux-bot-16", "platform": "gtk" },
                   { "name": "gtk-linux-bot-17", "platform": "gtk" },
-                  { "name": "gtk-linux-bot-18", "platform": "gtk" },
+                  { "name": "gtk-linux-bot-18", "platform": "gtk4" },
                   { "name": "gtk-linux-bot-19", "platform": "gtk" },
                   { "name": "gtk-linux-bot-20", "platform": "gtk" },
                   { "name": "gtk-linux-bot-21", "platform": "gtk" },
@@ -448,7 +448,7 @@
                   },
                   {
                     "name": "GTK-Linux-64-bit-Release-GTK4-Tests", "factory": "BuildAndTestAndArchiveAllButJSCFactory",
-                    "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
+                    "platform": "gtk4", "configuration": "release", "architectures": ["x86_64"],
                     "workernames": ["gtk-linux-bot-18"]
                   },
                   {

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -46,7 +46,7 @@ class Factory(factory.BuildFactory):
         if self.shouldInstallDependencies:
             if platform == "win":
                 self.addStep(InstallWin32Dependencies())
-            if platform == "gtk":
+            if platform.startswith("gtk"):
                 self.addStep(InstallGtkDependencies())
             if platform == "wpe":
                 self.addStep(InstallWpeDependencies())
@@ -72,7 +72,7 @@ class BuildFactory(Factory):
             self.addStep(GenerateMiniBrowserBundle())
 
         if triggers:
-            if platform == "gtk":
+            if platform.startswith("gtk"):
                 self.addStep(InstallBuiltProduct())
 
             self.addStep(ArchiveBuiltProduct())
@@ -137,7 +137,7 @@ class TestFactory(Factory):
         if platform.startswith('mac') or platform.startswith('ios-simulator'):
             self.addStep(TriggerCrashLogSubmission())
 
-        if platform == "gtk":
+        if platform.startswith("gtk"):
             self.addStep(RunGtkAPITests())
             if additionalArguments and "--display-server=wayland" in additionalArguments:
                 self.addStep(RunWebDriverTests())
@@ -194,7 +194,8 @@ class BuildAndTestAndArchiveAllButJSCFactory(BuildAndTestFactory):
         # The parent class will already archive if triggered
         if not triggers:
             self.addStep(ArchiveBuiltProduct())
-        self.addStep(RunWebDriverTests())
+        if platform != "gtk4":
+            self.addStep(RunWebDriverTests())
 
 
 class BuildAndGenerateJSCBundleFactory(BuildFactory):
@@ -272,7 +273,7 @@ class BuildAndPerfTestFactory(Factory):
         Factory.__init__(self, platform, configuration, architectures, False, additionalArguments, device_model, **kwargs)
         self.addStep(CompileWebKit())
         self.addStep(RunAndUploadPerfTests())
-        if platform == "gtk":
+        if platform.startswith("gtk"):
             self.addStep(RunBenchmarkTests(timeout=2000))
 
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1142,8 +1142,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'bindings-generation-tests',
             'builtins-generator-tests',
             'API-tests',
-            'archive-built-product',
-            'webdriver-test'
+            'archive-built-product'
         ],
         'GTK-Linux-64-bit-Release-Skip-Failing-Tests': [
             'configure-build',


### PR DESCRIPTION
#### 7ba47d488186584f3d22f62ba5354a1b210473f8
<pre>
[build.webkit.org] Skip WebDriver tests in GTK4 bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=258432">https://bugs.webkit.org/show_bug.cgi?id=258432</a>

Reviewed by Jonathan Bedard.

WebDriver tests are not running successfully in WebKitGTK GTK4 bot,
causing very lengthy build times.

Skip this test suite for now.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(Factory.__init__):
(BuildFactory.__init__):
(TestFactory.__init__):
(BuildAndTestAndArchiveAllButJSCFactory.__init__):
(BuildAndPerfTestFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/265487@main">https://commits.webkit.org/265487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c6ac330faf414fd6fc0a4d17f5e72000777bb98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13352 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13245 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8541 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/10814 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9625 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2648 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13892 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->