### PR TITLE
[WebVTT] Cues with position setting containing aligment parse as 'auto'

### DIFF
--- a/LayoutTests/media/track/captions-webvtt/position-align.vtt
+++ b/LayoutTests/media/track/captions-webvtt/position-align.vtt
@@ -1,0 +1,18 @@
+WEBVTT
+Valid and invalid position values with alignments
+
+1
+00:00:00.000 --> 00:00:01.000 position:0%,line-left
+position:0%,line-left
+
+2
+00:00:01.000 --> 00:00:02.000 position:50%,center
+position:50%,center
+
+3
+00:00:02.000 --> 00:00:03.000 position:100%,line-right
+position:100%,line-right
+
+4
+00:00:03.000 --> 00:00:04.000 position:50%,middle
+position:50%,middle (invalid)

--- a/LayoutTests/media/track/webvtt-position-align-expected.txt
+++ b/LayoutTests/media/track/webvtt-position-align-expected.txt
@@ -1,0 +1,15 @@
+
+EVENT(load)
+
+*** Testing text track 0
+EXPECTED (cues.length == '4') OK
+EXPECTED (cues[0].position == '0') OK
+EXPECTED (cues[0].positionAlign == 'line-left') OK
+EXPECTED (cues[1].position == '50') OK
+EXPECTED (cues[1].positionAlign == 'center') OK
+EXPECTED (cues[2].position == '100') OK
+EXPECTED (cues[2].positionAlign == 'line-right') OK
+EXPECTED (cues[3].position == 'auto') OK
+EXPECTED (cues[3].positionAlign == 'auto') OK
+END OF TEST
+

--- a/LayoutTests/media/track/webvtt-position-align.html
+++ b/LayoutTests/media/track/webvtt-position-align.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../video-test.js></script>
+        <script>
+        async function runTest() {
+            findMediaElement();
+
+            let trackElement = video.appendChild(document.createElement('track'));
+            trackElement.src = 'captions-webvtt/position-align.vtt';
+            trackElement.track.mode = 'showing';
+
+            waitFor(trackElement, 'error').then(failTest);
+            await waitFor(trackElement, 'load');
+
+            let expected = {
+                length: 4,
+                tests: [
+                    { property: 'position', values: [0, 50, 100, 'auto']},
+                    { property: 'positionAlign', values: ['line-left', 'center', 'line-right', 'auto']},
+                ],
+            };
+            testCues(0, expected);
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        })
+        </script>
+    </head>
+    <body">
+        <video></video>
+    </body>
+</html>


### PR DESCRIPTION
#### 7798da0bec55b133d9d63ea9dd37c9be06f4b1bf
<pre>
[WebVTT] Cues with position setting containing aligment parse as &apos;auto&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258431">https://bugs.webkit.org/show_bug.cgi?id=258431</a>
rdar://111196313

Reviewed by Eric Carlson.

WebVTT cues which include position alignment values have those positions rejected
by the parser, leading to broken layout issues. Even without adding full support
for those alignments, we can at least not reject those values and achieve partially
correct layouts.

* LayoutTests/media/track/captions-webvtt/position-align.vtt: Added.
* LayoutTests/media/track/webvtt-position-align-expected.txt: Added.
* LayoutTests/media/track/webvtt-position-align.html: Added.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::setCueSettings):

Canonical link: <a href="https://commits.webkit.org/265465@main">https://commits.webkit.org/265465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb9b86410d21f1f1ce73faca0d1c338ac827dd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12958 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17083 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9742 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2633 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->