### PR TITLE
REGRESSION: Space bar for page down works intermittently

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel-expected.txt
@@ -1,0 +1,5 @@
+PASS endScrollY > startScrollY is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        async function runTest()
+        {
+            const wheelEventSquence = {
+                "events" : [
+                    // Normal scroll with momentum
+                    {
+                        type : "wheel",
+                        viewX : 100,
+                        viewY : 100,
+                        deltaY : -10,
+                        phase : "began"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : -100,
+                        phase : "changed"
+                    },
+                    {
+                        type : "wheel",
+                        phase : "ended"
+                    },
+                    {
+                        type : "wheel",
+                        deltaY : -100,
+                        momentumPhase : "began"
+                    },
+                    {
+                        type: "wheel",
+                        deltaY: -80,
+                        momentumPhase: "changed"
+                    },
+                    {
+                        type : "wheel",
+                        momentumPhase : "ended"
+                    },
+                    // Tapping with two fingers
+                    {
+                        type : "wheel",
+                        phase : "maybegin"
+                    },
+                    {
+                        type : "wheel",
+                        phase : "cancelled"
+                    },
+                ]
+            };
+
+            await UIHelper.mouseWheelSequence(wheelEventSquence);
+
+            startScrollY = window.scrollY;
+
+            await UIHelper.rawKeyDown('downArrow');
+            await UIHelper.renderingUpdate();
+
+            await UIHelper.delayFor(100);
+            await UIHelper.rawKeyUp('downArrow');
+            await UIHelper.renderingUpdate();
+
+            endScrollY = window.scrollY;
+
+            shouldBeTrue('endScrollY > startScrollY');
+
+            finishJSTest();
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div style="height: 5000px;"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -91,7 +91,7 @@ public:
 
     bool isUserScrollInProgressForNode(ScrollingNodeID);
     void setUserScrollInProgressForNode(ScrollingNodeID, bool);
-    void clearNodesWithUserScrollInProgress();
+    WEBCORE_EXPORT virtual void clearNodesWithUserScrollInProgress();
 
     bool isScrollSnapInProgressForNode(ScrollingNodeID);
     void setNodeScrollSnapInProgress(ScrollingNodeID, bool);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp
@@ -96,4 +96,13 @@ void RemoteScrollingUIState::removeNodeWithActiveUserScroll(WebCore::ScrollingNo
         m_changes.add(Changes::UserScrollNodes);
 }
 
+void RemoteScrollingUIState::clearNodesWithActiveUserScroll()
+{
+    if (m_nodesWithActiveUserScrolls.isEmpty())
+        return;
+
+    m_nodesWithActiveUserScrolls.clear();
+    m_changes.add(Changes::UserScrollNodes);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h
@@ -64,6 +64,7 @@ public:
     const HashSet<WebCore::ScrollingNodeID>& nodesWithActiveUserScrolls() const { return m_nodesWithActiveUserScrolls; }
     void addNodeWithActiveUserScroll(WebCore::ScrollingNodeID);
     void removeNodeWithActiveUserScroll(WebCore::ScrollingNodeID);
+    void clearNodesWithActiveUserScroll();
 
 private:
     OptionSet<RemoteScrollingUIStateChanges> m_changes;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -120,6 +120,7 @@ public:
     virtual void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) { }
     virtual void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) { }
     virtual void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) { }
+    virtual void clearNodesWithUserScrollInProgress() { }
     virtual void hasNodeWithAnimatedScrollChanged(bool) { }
     virtual void setRootNodeIsInUserScroll(bool) { }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -119,6 +119,14 @@ void RemoteScrollingTree::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
         m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScroll(nodeID);
 }
 
+void RemoteScrollingTree::clearNodesWithUserScrollInProgress()
+{
+    ScrollingTree::clearNodesWithUserScrollInProgress();
+
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->clearNodesWithUserScrollInProgress();
+}
+
 void RemoteScrollingTree::scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID nodeID)
 {
     if (m_scrollingCoordinatorProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -63,6 +63,7 @@ public:
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+    void clearNodesWithUserScrollInProgress() override;
 
     void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -52,6 +52,7 @@ private:
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+    void clearNodesWithUserScrollInProgress() override;
 
     void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -116,6 +116,12 @@ void RemoteScrollingCoordinatorProxyMac::hasNodeWithAnimatedScrollChanged(bool h
 #endif
 }
 
+void RemoteScrollingCoordinatorProxyMac::clearNodesWithUserScrollInProgress()
+{
+    m_uiState.clearNodesWithActiveUserScroll();
+    sendUIStateChangedIfNecessary();
+}
+
 void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
 {
     m_uiState.addNodeWithActiveUserScroll(nodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -84,6 +84,7 @@ private:
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
+    void clearNodesWithUserScrollInProgress() override;
 
     void scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -90,6 +90,13 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeI
     });
 }
 
+void RemoteScrollingTreeMac::clearNodesWithUserScrollInProgress()
+{
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this] {
+        RemoteScrollingTree::clearNodesWithUserScrollInProgress();
+    });
+}
+
 void RemoteScrollingTreeMac::scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID nodeID)
 {
     RunLoop::main().dispatch([protectedThis = Ref { *this }, this, nodeID] {


### PR DESCRIPTION
#### f52fe75ad080437a7e5705f3ae3632797d537818
<pre>
REGRESSION: Space bar for page down works intermittently
<a href="https://bugs.webkit.org/show_bug.cgi?id=258434">https://bugs.webkit.org/show_bug.cgi?id=258434</a>
rdar://109638580

Reviewed by Simon Fraser.

Keyboard scrolls do not begin if a user scroll is &quot;in progress&quot;. This uncovered a bug with normal
scrolling, which is that after performing a trackpad scroll with momentum, then tapping with two
fingers, the `isUserScrollInProgress` bool was still `true`, even though at this point the scroll
has stopped and so it should be `false`.

When performing the scroll with momentum, the following sequence of wheel events phases happen:
1. Begin -&gt; `isUserScrollInProgress = true`
2. End -&gt; `isUserScrollInProgress = false`
3. Momentum Begin -&gt; `isUserScrollInProgress = true`
4. Momentum End -&gt; `isUserScrollInProgress = false`

Then, when tapping with two fingers, these wheel event phases happen:
5. May Begin -&gt; `isUserScrollInProgress = true`
6. Cancelled -&gt; No action.

The root problem is that when receiving a wheel event whose phase is &quot;Cancelled&quot;, `isUserScrollInProgress`
is not being set to `false`.

This is because in `RemoteScrollingCoordinator`, the `m_nodesWithActiveUserScrolls` set does not get
cleared when cancelling, which is what `isUserScrollInProgress` depends upon. This set comes from
the state in `RemoteScrollingUIState`.

For wheel events that have a phase that isn&apos;t &quot;Cancelled&quot;, `ScrollingTree::setUserScrollInProgressForNode`
gets called, and `m_treeState.nodesWithActiveUserScrolls` has nodes either added or removed. Then,
`RemoteScrollingCoordinatorProxyMac::scrollingTreeNode{WillStart,DidEnd}Scroll` gets called, which
updates the state of `RemoteScrollingUIState` and sends an update.

However, for &quot;Cancelled&quot; wheel events, `ScrollingTree::clearNodesWithUserScrollInProgress` gets called,
which clears `m_treeState.nodesWithActiveUserScrolls`, but does *not* update the corresponding state of
`RemoteScrollingUIState` or send an update, so `m_nodesWithActiveUserScrolls` still has the stale nodes.

To fix, just update the `RemoteScrollingUIState` state when clearing nodes like we do when adding
or removing them.

* LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/keyboard-scroll-after-wheel-event-cancel.html: Added.
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.cpp:
(WebKit::RemoteScrollingUIState::clearNodesWithActiveUserScroll):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingUIState.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::clearNodesWithUserScrollInProgress):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::clearNodesWithUserScrollInProgress):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::clearNodesWithUserScrollInProgress):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::clearNodesWithUserScrollInProgress):

Canonical link: <a href="https://commits.webkit.org/265602@main">https://commits.webkit.org/265602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e680cc867830ecfc2942f396a8618a86062c85e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10586 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13147 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13405 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2726 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14062 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->