### PR TITLE
REGRESSION (263722@main): Unable to scroll language picker on etrade.com

### DIFF
--- a/LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that toggling visibility on an overflow scrolling container's ancestor makes the overflow scrolling container scrollable or non-scrollable. To manually run the test, load the page and scroll the red box.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS hasOverflowScroller() is false
+PASS hasOverflowScroller() is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This box should be scrollable.
+

--- a/LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change.html
+++ b/LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {
+    margin: 0;
+}
+
+#description {
+    margin-top: 300px;
+}
+
+.outer-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 1px solid tomato;
+    display: block;
+    visibility: hidden;
+    font-size: 24px;
+}
+
+.scroller {
+    overflow: auto;
+    width: 250px;
+    height: 250px;
+}
+
+.tall {
+    height: 1000px;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+description("This test verifies that toggling visibility on an overflow scrolling container's ancestor makes the overflow scrolling container scrollable or non-scrollable. To manually run the test, load the page and scroll the red box.");
+
+function hasOverflowScroller() {
+    return internals.scrollingStateTreeAsText().includes("Overflow scrolling node");
+}
+
+addEventListener("load", async () => {
+    await UIHelper.delayFor(0);
+    if (window.testRunner)
+        shouldBe("hasOverflowScroller()", "false");
+
+    document.querySelector(".outer-container").style.visibility = "visible";
+    await UIHelper.renderingUpdate();
+    if (window.testRunner)
+        shouldBe("hasOverflowScroller()", "true");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="outer-container">
+        <div class="scroller">
+            <div class="tall">This box should be scrollable.</div>
+        </div>
+    </div>
+    <pre id="description"></pre>
+    <pre id="console"></pre>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5421,7 +5421,7 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
         // Visibility and scrollability are input to canUseCompositedScrolling().
         if (m_scrollableArea) {
             if (visibilityChanged || oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
-                m_scrollableArea->computeHasCompositedScrollableOverflow(LayoutUpToDate::No);
+                m_scrollableArea->computeHasCompositedScrollableOverflow(diff <= StyleDifference::RepaintLayer ? LayoutUpToDate::Yes : LayoutUpToDate::No);
         }
     }
 


### PR DESCRIPTION
#### ac10daa79e26b4f062cb2c1842b4787698574899
<pre>
REGRESSION (263722@main): Unable to scroll language picker on etrade.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=258433">https://bugs.webkit.org/show_bug.cgi?id=258433</a>
rdar://109613133

Reviewed by Simon Fraser.

After the changes in 263722@main, certain overflow scrolling containers on etrade.com are no longer
scrollable via pan gesture or mouse wheel on iOS; this is because we fail to create corresponding
native child scroll views corresponding to these regions in the view hierarchy, which in turn is
because we never end up setting `m_hasCompositedScrollableOverflow` to `true` inside of
`RenderLayerScrollableArea::computeHasCompositedScrollableOverflow()`, despite the fact that we have
vertical scrollable overflow and we can use composited scrolling.

The overflow scrolling container in question is shown by removing `visibility: hidden;` on an
ancestor of these containers, which currently triggers only a style update (calling into the above
method with `LayoutUpToDate::No`) with no subsequent layout update, causing
`m_hasCompositedScrollableOverflow` to remain `false`.

To address this, we make an adjustment in `RenderLayer::styleChanged` to pass `LayoutUpToDate::Yes`
into `computeHasCompositedScrollableOverflow`, in the case where the style difference only triggers
at most a layer repaint (or recomposite). In the case where we&apos;re only issuing a repaint as a result
of the style change (e.g. when toggling visibility), the overflow amount isn&apos;t going to change, so
it&apos;s safe to compute `m_hasCompositedScrollableOverflow` then and there. However, in the case where
the style difference is going to trigger layout, it&apos;s safe to just run the computation using
`LayoutUpToDate::No`, since we&apos;ll eventually recompute it with `LayoutUpToDate::Yes` after we finish
performing layout.

* LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/overflow-scroll-after-visibility-change.html: Added.

Add a layout test to verify that we propagate overflow scrolling regions via scrolling state tree to
the UI process in this scenario, after toggling `visibility` to `visible`.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/265624@main">https://commits.webkit.org/265624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/995640f3819c9200419a9b656cb95e4f7cb10ae7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13731 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11511 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12385 "2 flakes 3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13417 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17481 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10443 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13661 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8942 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10033 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2746 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->