### PR TITLE
Re-landing: Skip JIT memory allocation in ExecutableAllocator::disableJIT() when running on an open source XNU.

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "CPU.h"
 
-#if (CPU(X86) || CPU(X86_64) || CPU(ARM64E)) && OS(DARWIN)
+#if (CPU(X86) || CPU(X86_64) || CPU(ARM64)) && OS(DARWIN)
 #include <mutex>
 #include <sys/sysctl.h>
 #endif
@@ -36,6 +36,15 @@
 #endif
 
 namespace JSC {
+
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+bool isKernOpenSource()
+{
+    uint32_t val = 0;
+    size_t valSize = sizeof(val);
+    return !sysctlbyname("kern.opensource_kernel", &val, &valSize, nullptr, 0) && val;
+}
+#endif
 
 #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 bool isKernTCSMAvailable()

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -203,6 +203,10 @@ inline bool hasSensibleDoubleToInt()
     return optimizeForX86();
 }
 
+#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+bool isKernOpenSource();
+#endif
+
 #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 bool isKernTCSMAvailable();
 bool enableKernTCSM();

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -171,11 +171,11 @@ void ExecutableAllocator::disableJIT()
 
 #if HAVE(IOS_JIT_RESTRICTIONS) || HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    bool hasJITEntitlement = processHasEntitlement("dynamic-codesigning"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s);
 #else
-    bool hasJITEntitlement = processHasEntitlement("com.apple.security.cs.allow-jit"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("com.apple.security.cs.allow-jit"_s) && !isKernOpenSource();
 #endif
-    if (hasJITEntitlement) {
+    if (shouldDisableJITMemory) {
         // Because of an OS quirk, even after the JIT region has been unmapped,
         // the OS thinks that region is reserved, and as such, can cause Gigacage
         // allocation to fail. We work around this by initializing the Gigacage


### PR DESCRIPTION
#### ee19c59a58e727d26bc3d36b0d8e63b06a1371a8
<pre>
Re-landing: Skip JIT memory allocation in ExecutableAllocator::disableJIT() when running on an open source XNU.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258409">https://bugs.webkit.org/show_bug.cgi?id=258409</a>
rdar://111170164

Reviewed by Yusuke Suzuki.

The open source XNU does not support special handling of JIT memory.  However, macOS Safari and
WebKit binaries still need to be able to run on the open source XNU, albeit without JIT.

However, ExecutableAllocator::disableJIT() is still trying to allocated JIT memory if the JIT
entitlement is present (which is defined by the WebKit binary, not the kernel), and currently,
will assert that the allocation succeeds.  We need to skip this allocation and assertion when
running on open source XNU because the allocation is not necessary, and the assertion is invalid
for the open source kernel and will fail every time.  This patch implements this skipping.

Update: added build fix for PLATFORM(MACCATALYST).

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::isKernOpenSource):
* Source/JavaScriptCore/assembler/CPU.h:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::disableJIT):

Canonical link: <a href="https://commits.webkit.org/265446@main">https://commits.webkit.org/265446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f6109db71f9b033b65ce8a940f78c56052a44d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12568 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11115 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11080 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12972 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/9242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/10354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11030 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/13899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11339 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1224 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->