### PR TITLE
Attachment: Use image element to show icon/thumbnail

### DIFF
--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x98
       RenderAttachment {ATTACHMENT} at (1,1) size 266x80
         RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
           RenderGrid {DIV} at (0,0) size 68x80
-            RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+            RenderImage {IMG} at (14,14) size 52x52
           RenderGrid {DIV} at (68,0) size 198x80
             RenderGrid {DIV} at (4,40) size 170x0
       RenderText {#text} at (268,54) size 4x18

--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (47,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,46) size 230x0
       RenderBlock {DIV} at (0,109) size 784x109
@@ -18,7 +18,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (39,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,31) size 230x30
       RenderBlock {DIV} at (0,218) size 784x109
@@ -27,7 +27,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (83,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,31) size 230x30
       RenderBlock {DIV} at (0,327) size 784x109
@@ -36,7 +36,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (52,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,22) size 230x48
       RenderBlock {DIV} at (0,436) size 784x109
@@ -45,7 +45,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (40,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,26) size 230x40
                 RenderBlock {DIV} at (190,0) size 40x40
@@ -57,6 +57,7 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (97,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
+              RenderImage {IMG} at (10,10) size 72x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
       RenderBlock {DIV} at (0,654) size 784x109
@@ -65,8 +66,9 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (96,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
-                RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
+              RenderImage {IMG} at (10,10) size 72x72
+              RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
+                RenderBlock {DIV} at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
       RenderBlock {DIV} at (0,763) size 784x109
@@ -75,8 +77,9 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (104,16) size 339x92 [color=#007AFF]
           RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
-                RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
+              RenderImage {IMG} at (10,10) size 72x72
+              RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
+                RenderBlock {DIV} at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
 layer at (129,164) size 230x17
@@ -140,5 +143,5 @@ layer at (195,825) size 230x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (332,486) size 18x40
   RenderBlock {DIV} at (0,0) size 18x40 [bgcolor=#007AFF]
-layer at (116,587) size 56x56
-  RenderBlock {DIV} at (10,18) size 56x56 [bgcolor=#000000]
+layer at (116,579) size 72x72
+  RenderBlock {DIV} at (10,10) size 72x72 [bgcolor=#000000]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -9,7 +9,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (47,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,40) size 170x0
       RenderBlock {DIV} at (0,82) size 769x82
@@ -18,7 +18,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (39,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,26) size 170x28
       RenderBlock {DIV} at (0,164) size 769x82
@@ -27,7 +27,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (83,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,26) size 170x28
       RenderBlock {DIV} at (0,246) size 769x82
@@ -36,7 +36,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (52,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,18) size 170x44
       RenderBlock {DIV} at (0,328) size 769x82
@@ -45,7 +45,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (40,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,26) size 170x28
                 RenderBlock {DIV} at (142,0) size 28x28
@@ -57,6 +57,7 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (97,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
+              RenderImage {IMG} at (14,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,492) size 769x82
@@ -65,8 +66,9 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (96,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
-                RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]
+              RenderImage {IMG} at (14,14) size 52x52
+              RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
+                RenderBlock {DIV} at (0,0) size 52x52 [border: (4px solid #0000007F)]
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,574) size 769x82
@@ -75,8 +77,9 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (104,1) size 267x80
           RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
-                RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]
+              RenderImage {IMG} at (14,14) size 52x52
+              RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
+                RenderBlock {DIV} at (0,0) size 52x52 [border: (4px solid #0000007F)]
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
 layer at (119,117) size 170x16
@@ -140,5 +143,5 @@ layer at (185,615) size 170x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (270,366) size 14x21
   RenderBlock {DIV} at (0,0) size 14x21 [bgcolor=#0000007F]
-layer at (120,439) size 40x40
-  RenderBlock {DIV} at (14,20) size 40x40 [bgcolor=#000000D8]
+layer at (120,433) size 52x52
+  RenderBlock {DIV} at (14,14) size 52x52 [bgcolor=#000000D8]

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4383,9 +4383,6 @@ void Editor::cloneAttachmentData(const String& fromIdentifier, const String& toI
 
 void Editor::didInsertAttachmentElement(HTMLAttachmentElement& attachment)
 {
-    if (attachment.isImageOnly())
-        return;
-
     auto identifier = attachment.uniqueIdentifier();
     if (identifier.isEmpty())
         return;

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -37,7 +37,6 @@ class File;
 class HTMLImageElement;
 class RenderAttachment;
 class ShadowRoot;
-class ShareableBitmap;
 class FragmentedSharedBuffer;
 
 class HTMLAttachmentElement final : public HTMLElement {
@@ -60,8 +59,10 @@ public:
 
     WEBCORE_EXPORT void updateAttributes(std::optional<uint64_t>&& newFileSize, const AtomString& newContentType, const AtomString& newFilename);
     WEBCORE_EXPORT void updateEnclosingImageWithData(const String& contentType, Ref<FragmentedSharedBuffer>&& data);
-    WEBCORE_EXPORT void updateThumbnail(const RefPtr<Image>& thumbnail);
-    WEBCORE_EXPORT void updateIcon(const RefPtr<Image>& icon, const WebCore::FloatSize&);
+    WEBCORE_EXPORT void updateThumbnailForNarrowLayout(const RefPtr<Image>& thumbnail);
+    WEBCORE_EXPORT void updateThumbnailForWideLayout(Vector<uint8_t>&&);
+    WEBCORE_EXPORT void updateIconForNarrowLayout(const RefPtr<Image>& icon, const WebCore::FloatSize&);
+    WEBCORE_EXPORT void updateIconForWideLayout(Vector<uint8_t>&&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
@@ -79,6 +80,7 @@ public:
     RefPtr<Image> thumbnail() const { return m_thumbnail; }
     RefPtr<Image> icon() const { return m_icon; }
     void requestIconWithSize(const FloatSize&) const;
+    void requestWideLayoutIconIfNeeded();
     FloatSize iconSize() const { return m_iconSize; }
     void invalidateRendering();
     DOMRectReadOnly* saveButtonClientRect() const;
@@ -88,9 +90,7 @@ public:
     void setImageMenuEnabled(bool value) { m_isImageMenuEnabled = value; }
 #endif
 
-    bool isImageOnly() const { return m_implementation == Implementation::ImageOnly; }
-
-    bool isWideLayout() const { return m_implementation == Implementation::Modern; }
+    bool isWideLayout() const { return m_implementation == Implementation::WideLayout; }
     HTMLElement* wideLayoutShadowContainer() const { return m_containerElement.get(); }
 
 private:
@@ -100,9 +100,12 @@ private:
     virtual ~HTMLAttachmentElement();
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
-    void ensureModernShadowTree(ShadowRoot&);
+    void ensureWideLayoutShadowTree(ShadowRoot&);
     void updateProgress(const AtomString&);
     void updateSaveButton(bool);
+    void updateImage();
+
+    void setNeedsWideLayoutIconRequest();
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool shouldSelectOnMouseDown() final {
@@ -119,8 +122,8 @@ private:
     bool childShouldCreateRenderer(const Node&) const final;
 #endif
 
-    enum class Implementation: uint8_t { Legacy, Modern, ImageOnly };
-    Implementation m_implementation { Implementation::Legacy };
+    enum class Implementation: uint8_t { NarrowLayout, WideLayout };
+    Implementation m_implementation { Implementation::NarrowLayout };
 
     RefPtr<File> m_file;
     String m_uniqueIdentifier;
@@ -128,7 +131,11 @@ private:
     RefPtr<Image> m_icon;
     FloatSize m_iconSize;
 
-    RefPtr<HTMLAttachmentElement> m_innerLegacyAttachment;
+    // The thumbnail is shown if non-empty, otherwise the icon is shown if non-empty.
+    Vector<uint8_t> m_thumbnailForWideLayout;
+    Vector<uint8_t> m_iconForWideLayout;
+
+    RefPtr<HTMLImageElement> m_imageElement;
     RefPtr<HTMLElement> m_containerElement;
     RefPtr<HTMLElement> m_placeholderElement;
     RefPtr<HTMLElement> m_progressElement;
@@ -139,6 +146,8 @@ private:
     RefPtr<HTMLElement> m_saveArea;
     RefPtr<HTMLElement> m_saveButton;
     mutable RefPtr<DOMRectReadOnly> m_saveButtonClientRect;
+
+    bool m_needsWideLayoutIconRequest { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     bool m_isImageMenuEnabled { false };

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -47,13 +47,13 @@ div#attachment-preview-area {
     grid-row: 1;
     grid-column: 1;
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-    width: 56px; /* Co-dependent with attachmentImageOnlySize.width */
-    height: 72px; /* Co-dependent with attachmentImageOnlySize.height */
+    width: 56px;
+    height: 72px;
     padding: 10px;
     border-radius: 12px 0px 0px 12px;
 #else
     width: 40px;
-    height: 52px; /* Co-dependent with attachmentImageOnlyIconSize */
+    height: 52px;
     padding: 14px;
     border-radius: 8px 0px 0px 8px;
 #endif
@@ -63,15 +63,15 @@ div#attachment-preview-area {
     justify-items: center;
 }
 
-attachment#attachment-preview {
+img#attachment-icon {
     grid-row: 1;
     grid-column: 1;
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-    max-width: 72px;
-    max-height: 72px;
+    width: 72px; /* Co-dependent with iconSize in HTMLAttachmentElement::needWideLayoutIcon */
+    height: 72px;
 #else
-    max-width: 52px;
-    max-height: 52px;
+    width: 52px;
+    height: 52px;
 #endif
     overflow: hidden;
 }

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -47,8 +47,6 @@ constexpr CGFloat attachmentIconSelectionBorderThickness = 1;
 constexpr CGFloat attachmentIconBackgroundRadius = 3;
 constexpr CGFloat attachmentIconToTitleMargin = 2;
 
-constexpr CGFloat attachmentImageOnlyIconSize = 52; // Co-dependent with shadow css div#attachment-preview-area's height.
-
 constexpr auto attachmentIconBackgroundColor = Color::black.colorWithAlphaByte(30);
 constexpr auto attachmentIconBorderColor = Color::white.colorWithAlphaByte(125);
 
@@ -165,13 +163,6 @@ void AttachmentLayout::layOutSubtitle(const RenderAttachment& attachment)
 AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle layoutStyle)
     : style(layoutStyle)
 {
-    if (attachment.attachmentElement().isImageOnly()) {
-        iconRect = FloatRect(0, 0, attachmentImageOnlyIconSize, attachmentImageOnlyIconSize);
-        iconBackgroundRect = iconRect;
-        attachmentRect = encloseRectToDevicePixels(iconBackgroundRect, attachment.document().deviceScaleFactor());
-        return;
-    }
-
     excludeTypographicLeading = false;
     layOutTitle(attachment);
     layOutSubtitle(attachment);
@@ -199,7 +190,6 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
 #if PLATFORM(IOS_FAMILY)
 
 constexpr CGSize attachmentSize = { 160, 119 };
-constexpr CGSize attachmentImageOnlySize = { 56, 72 }; // Co-dependent with shadow css div#attachment-preview-area's width&height.
 
 constexpr CGFloat attachmentBorderRadius = 16;
 constexpr auto attachmentBorderColor = SRGBA<uint8_t> { 204, 204, 204 };
@@ -274,24 +264,6 @@ static CGFloat attachmentDynamicTypeScaleFactor()
 
 AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, AttachmentLayoutStyle)
 {
-    if (attachment.attachmentElement().isImageOnly()) {
-        iconRect = FloatRect(0, 0, attachmentImageOnlySize.width, attachmentImageOnlySize.height);
-        iconBackgroundRect = iconRect;
-        attachmentRect = encloseRectToDevicePixels(iconBackgroundRect, attachment.document().deviceScaleFactor());
-
-        icon = attachment.attachmentElement().icon();
-        if (!icon)
-            attachment.attachmentElement().requestIconWithSize(iconRect.size());
-
-        thumbnailIcon = attachment.attachmentElement().thumbnail();
-
-        hasProgress = getAttachmentProgress(attachment, progress);
-        if (hasProgress)
-            progressRect = FloatRect((attachmentRect.width() / 2) - (attachmentProgressSize / 2), (attachmentRect.height() / 2) - (attachmentProgressSize / 2), attachmentProgressSize, attachmentProgressSize);
-
-        return;
-    }
-
     excludeTypographicLeading = true;
     attachmentRect = FloatRect(0, 0, attachment.width().toFloat(), attachment.height().toFloat());
     wrappingWidth = attachmentWrappingTextMaximumWidth * attachmentDynamicTypeScaleFactor();

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -144,6 +144,8 @@ bool RenderAttachment::paintWideLayoutAttachmentOnly(const PaintInfo& paintInfo,
                 wideLayoutShadowRenderer->paint(shadowPaintInfo, offset);
             }
         }
+
+        attachmentElement().requestWideLayoutIconIfNeeded();
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1651,9 +1651,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return IconAndSize { result, size };
 }
 
-LayoutSize RenderThemeIOS::attachmentIntrinsicSize(const RenderAttachment& renderAttachment) const
+LayoutSize RenderThemeIOS::attachmentIntrinsicSize(const RenderAttachment&) const
 {
-    return LayoutSize(FloatSize(renderAttachment.attachmentElement().isImageOnly() ? attachmentImageOnlySize : attachmentSize) * attachmentDynamicTypeScaleFactor());
+    return LayoutSize(FloatSize(attachmentSize) * attachmentDynamicTypeScaleFactor());
 }
 
 static void paintAttachmentIcon(GraphicsContext& context, AttachmentLayout& info)
@@ -1720,7 +1720,7 @@ bool RenderThemeIOS::paintAttachment(const RenderObject& renderer, const PaintIn
 
     context.translate(toFloatSize(paintRect.location()));
 
-    if (attachment.shouldDrawBorder() && !attachment.attachmentElement().isImageOnly()) {
+    if (attachment.shouldDrawBorder()) {
         auto borderPath = attachmentBorderPath(info);
         paintAttachmentBorder(context, borderPath);
         context.clipPath(borderPath);

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1614,23 +1614,20 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
 
     bool usePlaceholder = validProgress && !progress;
 
-    if (!element.isImageOnly())
-        paintAttachmentIconBackground(attachment, context, layout);
+    paintAttachmentIconBackground(attachment, context, layout);
 
     if (usePlaceholder)
         paintAttachmentIconPlaceholder(attachment, context, layout);
     else
         paintAttachmentIcon(attachment, context, layout);
 
-    if (!element.isImageOnly()) {
-        paintAttachmentTitleBackground(attachment, context, layout);
-        paintAttachmentText(context, &layout);
-    }
+    paintAttachmentTitleBackground(attachment, context, layout);
+    paintAttachmentText(context, &layout);
 
     if (validProgress && progress)
         paintAttachmentProgress(attachment, context, layout, progress);
 
-    if (usePlaceholder && !element.isImageOnly())
+    if (usePlaceholder)
         paintAttachmentPlaceholderBorder(attachment, context, layout);
 
     return true;


### PR DESCRIPTION
#### b0e7ef7b0420de70a7ec57e74412a2202718b9ca
<pre>
Attachment: Use image element to show icon/thumbnail
<a href="https://bugs.webkit.org/show_bug.cgi?id=258437">https://bugs.webkit.org/show_bug.cgi?id=258437</a>
rdar://105252742

Reviewed by Tim Nguyen.

Instead of using an inner attachment with legacy rendering, use a standard img element with a data URL
pointing at a blob that contains the image data.

Widespread changes:
- Removed m_innerLegacyAttachment and all related code.
- Removed image-only code.
- Consistently using &quot;wide-layout&quot; instead of &quot;modern&quot;, and &quot;narrow&quot; instead of &quot;legacy&quot;.

* LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt:
* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::didInsertAttachmentElement):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::create):
(WebCore::HTMLAttachmentElement::didAddUserAgentShadowRoot):
(WebCore::attachmentPlaceholderIdentifier):
(WebCore::attachmentIconIdentifier):
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::HTMLAttachmentElement::updateProgress):
(WebCore::HTMLAttachmentElement::setFile):
(WebCore::HTMLAttachmentElement::attributeChanged):
(WebCore::HTMLAttachmentElement::attachmentActionForDisplay const):
(WebCore::HTMLAttachmentElement::attachmentTitleForDisplay const):
(WebCore::HTMLAttachmentElement::attachmentSubtitleForDisplay const):
(WebCore::HTMLAttachmentElement::updateAttributes):

(WebCore::HTMLAttachmentElement::updateImage):
This sets the img element with the correct &quot;src&quot; data contents (thumbnail or icon or nothing).

(WebCore::HTMLAttachmentElement::updateThumbnailForNarrowLayout):
(WebCore::HTMLAttachmentElement::updateThumbnailForWideLayout):
(WebCore::HTMLAttachmentElement::updateIconForNarrowLayout):
(WebCore::HTMLAttachmentElement::updateIconForWideLayout):
(WebCore::HTMLAttachmentElement::setNeedsWideLayoutIconRequest):
(WebCore::HTMLAttachmentElement::requestWideLayoutIconIfNeeded):
(WebCore::HTMLAttachmentElement::requestIconWithSize const):
(WebCore::attachmentPreviewIdentifier): Deleted.
(WebCore::HTMLAttachmentElement::ensureModernShadowTree): Deleted.
(WebCore::HTMLAttachmentElement::updateThumbnail): Deleted.
(WebCore::HTMLAttachmentElement::updateIcon): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-preview-area):
(img#attachment-icon):
(attachment#attachment-preview): Deleted.
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):
* Source/WebCore/rendering/RenderAttachment.cpp:

(WebCore::RenderAttachment::paintWideLayoutAttachmentOnly const):
Call requestWideLayoutIconIfNeeded when painting the shadow tree.

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::attachmentIntrinsicSize const):
(WebCore::RenderThemeIOS::paintAttachment):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintAttachment):

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateAttachmentThumbnail):
(WebKit::WebPage::updateAttachmentIcon):
Provide data blobs to wide-layout attachments.

Canonical link: <a href="https://commits.webkit.org/265615@main">https://commits.webkit.org/265615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36eb712032bd061018c53fc2b9b57e6d0d196b49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11598 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13477 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17518 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13707 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8985 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10087 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2735 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->