### PR TITLE
Fix imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any.html test

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test VideoColorSpace toJSON() works. Illegal constructor
+PASS Test VideoColorSpace toJSON() works.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test VideoColorSpace toJSON() works. Illegal constructor
+PASS Test VideoColorSpace toJSON() works.
 

--- a/Source/WebCore/Modules/webcodecs/VideoColorPrimaries.idl
+++ b/Source/WebCore/Modules/webcodecs/VideoColorPrimaries.idl
@@ -33,7 +33,7 @@
   "bt2020",
   "smpteSt4281",
   "smpteRp431",
-  "smpteEg432",
+  "smpte432",
   "jedecP22Phosphors",
   "unspecified",
 };

--- a/Source/WebCore/Modules/webcodecs/VideoColorSpace.idl
+++ b/Source/WebCore/Modules/webcodecs/VideoColorSpace.idl
@@ -28,6 +28,8 @@
     Exposed=(Window,Worker),
 ]
 interface VideoColorSpace {
+  constructor(optional VideoColorSpaceInit init = {});
+
   readonly attribute VideoColorPrimaries? primaries;
   readonly attribute VideoTransferCharacteristics? transfer;
   readonly attribute VideoMatrixCoefficients? matrix;


### PR DESCRIPTION
#### a3704f2543bc83cd160a72aac8219c30b8d953d6
<pre>
Fix imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any.html test
<a href="https://bugs.webkit.org/show_bug.cgi?id=258448">https://bugs.webkit.org/show_bug.cgi?id=258448</a>
rdar://111210254

Reviewed by Eric Carlson.

Add constructor to VideoColorSpace as per <a href="https://w3c.github.io/webcodecs/#dom-videocolorspace-videocolorspace">https://w3c.github.io/webcodecs/#dom-videocolorspace-videocolorspace</a>
Update VideoColorPrimaries to change VideoColorPrimaries &quot;smpteEg432&quot; as &quot;smpte432&quot;, as per <a href="https://w3c.github.io/webcodecs/#enumdef-videocolorprimaries.">https://w3c.github.io/webcodecs/#enumdef-videocolorprimaries.</a>

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoColorSpace.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/VideoColorPrimaries.idl:
* Source/WebCore/Modules/webcodecs/VideoColorSpace.idl:

Canonical link: <a href="https://commits.webkit.org/265460@main">https://commits.webkit.org/265460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa160ae03fbbc86d666df18ab13f01e465e27e48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13383 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13000 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17118 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13279 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9656 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2631 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->