### PR TITLE
Constructing a VideoFrame from a video element inside the loadeddata event does not always succeed in Safari

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-video-element-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-video-element-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Test we can construct a VideoFrame from a <video> who just fired onloadeddata.
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-video-element.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-video-element.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+promise_test(async t => {
+  let video = document.createElement('video');
+  video.src = '/webcodecs/h264.mp4';
+  video.autoplay = true;
+  video.controls = false;
+  video.muted = false;
+  document.body.appendChild(video);
+
+  const loadVideo = new Promise((resolve) => {
+    video.onloadeddata = () => resolve();
+  });
+  await loadVideo;
+
+  let frame = new VideoFrame(video, {timestamp: 10});
+  frame.close();
+}, 'Test we can construct a VideoFrame from a <video> who just fired onloadeddata.');
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -305,7 +305,10 @@ void QueuedVideoOutput::addVideoFrameEntries(Vector<VideoFrameEntry>&& videoFram
 void QueuedVideoOutput::purgeVideoFrameEntries()
 {
     cancelNextImageTimeObserver();
-    m_videoFrames.clear();
+    if (!m_paused)
+        m_videoFrames.clear();
+    else if (m_videoFrames.size() >= 1)
+        m_videoFrames.erase(m_videoFrames.begin(), --m_videoFrames.end());
 }
 
 void QueuedVideoOutput::purgeImagesBeforeTime(const MediaTime& time)


### PR DESCRIPTION
#### fe5c478d8625ba2f640847b072d1cf2098bf625a
<pre>
Constructing a VideoFrame from a video element inside the loadeddata event does not always succeed in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=258450">https://bugs.webkit.org/show_bug.cgi?id=258450</a>
rdar://111216678

Reviewed by Eric Carlson.

When the video element is not yet playing, we receive a notification that a first frame is there.
At that point, we should be able to construct a VideoFrame from the video element.
The issue is that, when the video element starts to play, QueuedVideoOutput receives a outputSequenceWasFlushed: notification.
It then flushes its VideoFrames, which will happen later on.
Instead, if we receive outputSequenceWasFlushed: we should clear VideoFrames except if we are in paused state.
In the paused state, we should keep at least one video frame.

* LayoutTests/http/wpt/webcodecs/videoFrame-video-element-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-video-element.html: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(WebCore::QueuedVideoOutput::addVideoFrameEntries):

Canonical link: <a href="https://commits.webkit.org/265574@main">https://commits.webkit.org/265574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81740089d459c33c72c6fe503d500a4a117032d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13633 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13307 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17375 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10652 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13551 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8852 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9936 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->