### PR TITLE
[css-text-decor] Don't propagate decorations to inline-flex/inline-grid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+This text must not be underlined.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="http://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1414859">
+<link rel="match" href="reference/text-decoration-propagation-02-ref.html">
+<style>
+span { text-decoration: underline; }
+</style>
+<span>
+  <div style="display: inline-flex;">
+    This text must not be underlined.
+  </div>
+</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+This text must not be underlined.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="http://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1414859">
+<link rel="match" href="reference/text-decoration-propagation-03-ref.html">
+<style>
+span { text-decoration: underline; }
+</style>
+<span>
+  <div style="display: inline-grid;">
+    This text must not be underlined.
+  </div>
+</span>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -186,6 +186,8 @@ static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const
     case DisplayType::Table:
     case DisplayType::InlineTable:
     case DisplayType::InlineBlock:
+    case DisplayType::InlineGrid:
+    case DisplayType::InlineFlex:
     case DisplayType::InlineBox:
         return false;
     default:


### PR DESCRIPTION
#### 1c13b5adb5e3ed5e11d75560a48c8e2ab21c855c
<pre>
[css-text-decor] Don&apos;t propagate decorations to inline-flex/inline-grid

<a href="https://bugs.webkit.org/show_bug.cgi?id=258420">https://bugs.webkit.org/show_bug.cgi?id=258420</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch extends our &apos;shouldInheritTextDecorations&apos; to also account for
additional atomic inlines (i.e., Inline-Flex and Inline-Grid).

* Source/WebCore/style/StyleAdjuster.cpp:
(shouldInheritTextDecorationsInEffect): Add two more display types to not propagate text decorations
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-02-expected.html: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-03-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/265471@main">https://commits.webkit.org/265471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/291662583edbcdc5848919c46f4bea93f075f4be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9308 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9905 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17128 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13289 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8583 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2636 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->