### PR TITLE
[WebVTT] Cues with line setting containing aligment parse as 'start'

### DIFF
--- a/LayoutTests/media/track/captions-webvtt/line-align.vtt
+++ b/LayoutTests/media/track/captions-webvtt/line-align.vtt
@@ -1,0 +1,18 @@
+WEBVTT
+Valid and invalid line values with alignments
+
+1
+00:00:00.000 --> 00:00:01.000 line:0%,start
+line:0%,start
+
+2
+00:00:01.000 --> 00:00:02.000 line:50%,center
+line:50%,center
+
+3
+00:00:02.000 --> 00:00:03.000 line:100%,end
+line:100%,end
+
+4
+00:00:03.000 --> 00:00:04.000 line:50%,middle
+line:50%,middle (invalid)

--- a/LayoutTests/media/track/webvtt-line-align-expected.txt
+++ b/LayoutTests/media/track/webvtt-line-align-expected.txt
@@ -1,0 +1,15 @@
+
+EVENT(load)
+
+*** Testing text track 0
+EXPECTED (cues.length == '4') OK
+EXPECTED (cues[0].line == '0') OK
+EXPECTED (cues[0].lineAlign == 'start') OK
+EXPECTED (cues[1].line == '50') OK
+EXPECTED (cues[1].lineAlign == 'center') OK
+EXPECTED (cues[2].line == '100') OK
+EXPECTED (cues[2].lineAlign == 'end') OK
+EXPECTED (cues[3].line == 'auto') OK
+EXPECTED (cues[3].lineAlign == 'start') OK
+END OF TEST
+

--- a/LayoutTests/media/track/webvtt-line-align.html
+++ b/LayoutTests/media/track/webvtt-line-align.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../video-test.js></script>
+        <script>
+        async function runTest() {
+            findMediaElement();
+
+            let trackElement = video.appendChild(document.createElement('track'));
+            trackElement.src = 'captions-webvtt/line-align.vtt';
+            trackElement.track.mode = 'showing';
+
+            waitFor(trackElement, 'error').then(failTest);
+            await waitFor(trackElement, 'load');
+
+            let expected = {
+                length: 4,
+                tests: [
+                    { property: 'line', values: [0, 50, 100, 'auto']},
+                    { property: 'lineAlign', values: ['start', 'center', 'end', 'start']},
+                ],
+            };
+            testCues(0, expected);
+        }
+
+        window.addEventListener('load', event => {
+            runTest().then(endTest).catch(failTest);
+        })
+        </script>
+    </head>
+    <body">
+        <video></video>
+    </body>
+</html>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1179,14 +1179,19 @@ void VTTCue::setCueSettings(const String& inputString)
                 if (!input.scanFloat(linePosition, &isNegative))
                     break;
 
+                CueLignAlignment alignment { LignAlignmentStart };
                 bool isPercentage = input.scan('%');
                 if (!input.isAt(valueRun.end())) {
                     if (!input.scan(','))
                         break;
-                    // FIXME: implement handling of line setting alignment.
-                    if (!input.scan(startKeyword().characters8(), startKeyword().length())
-                        && !input.scan(centerKeyword().characters8(), centerKeyword().length())
-                        && !input.scan(endKeyword().characters8(), endKeyword().length())) {
+
+                    if (input.scan(startKeyword().characters8(), startKeyword().length()))
+                        alignment = LignAlignmentStart;
+                    else if (input.scan(centerKeyword().characters8(), centerKeyword().length()))
+                        alignment = LignAlignmentCenter;
+                    else if (input.scan(endKeyword().characters8(), endKeyword().length()))
+                        alignment = LignAlignmentEnd;
+                    else {
                         LOG(Media, "VTTCue::setCueSettings, invalid line setting alignment");
                         break;
                     }
@@ -1224,6 +1229,7 @@ void VTTCue::setCueSettings(const String& inputString)
                 }
                 
                 m_linePosition = linePosition;
+                m_lineAlignment = alignment;
                 isValid = true;
             } while (0);
 


### PR DESCRIPTION
#### b2c434a9b4567ec35d7a1038784cf144b2e050bc
<pre>
[WebVTT] Cues with line setting containing aligment parse as &apos;start&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258456">https://bugs.webkit.org/show_bug.cgi?id=258456</a>
rdar://111220055

Reviewed by Eric Carlson.

The line alignment settings are already parsed, but not stored in
an ivar. Even though layout using those alignment values is not
yet implemented, we should at least parse the correct values from
source WebVTT.

* LayoutTests/media/track/captions-webvtt/line-align.vtt: Added.
* LayoutTests/media/track/webvtt-line-align-expected.txt: Added.
* LayoutTests/media/track/webvtt-line-align.html: Added.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::settingName):
(WebCore::VTTCue::setCueSettings):

Canonical link: <a href="https://commits.webkit.org/265472@main">https://commits.webkit.org/265472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6f9cecd548022c728d55e2417623440a1fb1b01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12605 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13011 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17129 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13291 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8585 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->