### PR TITLE
Implement "scrollbar-color" support for mock scrollbars

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6446,9 +6446,9 @@ imported/w3c/web-platform-tests/css/css-color/system-color-hightlights-vs-getSel
 imported/w3c/web-platform-tests/screen-orientation/nested-documents.html [ Pass Failure ]
 
 # Skipping scrollbar-color tests until the feature gets implemented. webkit.org/b/231590
-imported/w3c/web-platform-tests/css/css-scrollbars/transparent-on-root.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar-body.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5.html [ Skip ]
 
 # These tests rely on dynamic scrollbar styling which isn't implemented yet. webkit.org/b/211219
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-paint-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-expected.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: blue blue;
+    color: blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-ref.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: blue blue;
+    color: blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color with current color works correctly</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-011-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  :root {
+    scrollbar-color: currentColor currentColor;
+    color: blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-expected.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: blue green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-ref.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: blue green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Dynamically set scrollbar-colors and ensure scrollbars update</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
+<link rel="match" href="scrollbar-color-dynamic-1-ref.html" />
+<script src="/common/reftest-wait.js"></script>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div class="container">
+  <div class="content"></div>
+</div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.documentElement.style.scrollbarColor = 'blue green';
+
+    takeScreenshot();
+  }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-expected.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: blue green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: blue green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Dynamically set scrollbar color and ensure overflow scroll scrollbars update</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
+<link rel="match" href="scrollbar-color-dynamic-2-ref.html" />
+<script src="/common/reftest-wait.js"></script>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.documentElement.style.scrollbarColor = 'blue green';
+
+    takeScreenshot();
+  }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-expected.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-ref.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Dynamically set scrollbar-color on container and ensure scrollbars update</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
+<link rel="match" href="scrollbar-color-dynamic-3-ref.html" />
+<script src="/common/reftest-wait.js"></script>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div class="container">
+  <div class="content"></div>
+</div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.querySelector(".container").style.scrollbarColor = 'blue green';
+
+    takeScreenshot();
+  }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-color: blue green;
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Dynamically set scrollbar-color on container with overflow scroll and ensure scrollbars update</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars/#valdef-scrollbar-color-auto" />
+<link rel="match" href="scrollbar-color-dynamic-4-ref.html" />
+<script src="/common/reftest-wait.js"></script>
+<style>
+  :root {
+    scrollbar-color: red yellow;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    overflow: scroll;
+  }
+  .container {
+    scrollbar-gutter: stable;
+    overflow: scroll;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+</style>
+<div class="container"></div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.querySelector(".container").style.scrollbarColor = 'blue green';
+
+    takeScreenshot();
+  }));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-expected.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: green green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-ref.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<style>
+  :root {
+    scrollbar-color: green green;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    flex: 0 0;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+
+<div class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Dynamically set color and ensure scrollbars using currentcolor update</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars" />
+<link rel="match" href="scrollbar-color-dynamic-5-ref.html" />
+<script src="/common/reftest-wait.js"></script>
+<style>
+  :root {
+    scrollbar-color: currentColor currentColor;
+    color: blue;
+  }
+  body {
+    display: flex;
+    flex-wrap: wrap;
+    width: 200vw;
+    height: 200vh;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    flex: 0 0;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div class="container">
+  <div class="content"></div>
+</div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.documentElement.style.color = 'green';
+
+    takeScreenshot();
+  }));
+</script>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2429,6 +2429,8 @@ imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html [ Sk
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar-body.html [ Skip ]
 
 # Skipping scrollbar-gutter tests that don't work with overlay scrollbars
 imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-001.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2566,6 +2566,11 @@ imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html  [ S
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html  [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html  [ Skip ]
 
+# Skipping scrollbar-color tests until the feature gets implemented in WK1. webkit.org/b/231590
+imported/w3c/web-platform-tests/css/css-scrollbars/transparent-on-root.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/viewport-scrollbar-body.html [ Skip ]
+
 # webkit.org/b/258628 Skipping some newly imported pointerevents WPT
 imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouse-on-object.html [ Skip ]
 imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouse-pointer-preventdefault-passive.html [ Skip ]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6311,6 +6311,24 @@ OverscrollBehavior LocalFrameView::verticalOverscrollBehavior()  const
     return OverscrollBehavior::Auto;
 }
 
+Color LocalFrameView::scrollbarThumbColorStyle() const
+{
+    auto* document = m_frame->document();
+    auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
+    if (scrollingObject)
+        return scrollingObject->style().effectiveScrollbarThumbColor();
+    return { };
+}
+
+Color LocalFrameView::scrollbarTrackColorStyle() const
+{
+    auto* document = m_frame->document();
+    auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
+    if (scrollingObject)
+        return scrollingObject->style().effectiveScrollbarTrackColor();
+    return { };
+}
+
 ScrollbarGutter LocalFrameView::scrollbarGutterStyle()  const
 {
     auto* document = m_frame->document();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -732,6 +732,8 @@ public:
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
+    Color scrollbarThumbColorStyle() const final;
+    Color scrollbarTrackColorStyle() const final;
     ScrollbarGutter scrollbarGutterStyle() const final;
     ScrollbarWidth scrollbarWidthStyle() const final;
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -41,6 +41,7 @@
 #include "Logging.h"
 #include "PlatformWheelEvent.h"
 #include "ScrollAnimator.h"
+#include "ScrollbarColor.h"
 #include "ScrollbarGutter.h"
 #include "ScrollbarTheme.h"
 #include "ScrollbarsControllerMock.h"
@@ -509,6 +510,16 @@ String ScrollableArea::horizontalScrollbarStateForTesting() const
 String ScrollableArea::verticalScrollbarStateForTesting() const
 {
     return scrollbarsController().verticalScrollbarStateForTesting();
+}
+
+Color ScrollableArea::scrollbarThumbColorStyle() const
+{
+    return { };
+}
+
+Color ScrollableArea::scrollbarTrackColorStyle() const
+{
+    return { };
 }
 
 ScrollbarGutter ScrollableArea::scrollbarGutterStyle() const

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -31,6 +31,7 @@
 #include "ScrollSnapOffsetsInfo.h"
 #include "ScrollTypes.h"
 #include "Scrollbar.h"
+#include "ScrollbarColor.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
@@ -54,6 +55,7 @@ class TiledBacking;
 
 enum class WheelScrollGestureState : uint8_t;
 
+struct ScrollbarColor;
 struct ScrollbarGutter;
 
 inline int offsetForOrientation(ScrollOffset offset, ScrollbarOrientation orientation)
@@ -143,6 +145,8 @@ public:
     virtual OverscrollBehavior horizontalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
     virtual OverscrollBehavior verticalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
 
+    WEBCORE_EXPORT virtual Color scrollbarThumbColorStyle() const;
+    WEBCORE_EXPORT virtual Color scrollbarTrackColorStyle() const;
     WEBCORE_EXPORT virtual ScrollbarGutter scrollbarGutterStyle() const;
     virtual ScrollbarWidth scrollbarWidthStyle() const { return ScrollbarWidth::Auto; }
 

--- a/Source/WebCore/platform/ScrollbarTheme.cpp
+++ b/Source/WebCore/platform/ScrollbarTheme.cpp
@@ -28,6 +28,7 @@
 
 #include "DeprecatedGlobalSettings.h"
 #include "PlatformMouseEvent.h"
+#include "ScrollableArea.h"
 #include "ScrollbarThemeMock.h"
 #include <wtf/NeverDestroyed.h>
 
@@ -40,6 +41,17 @@ ScrollbarTheme& ScrollbarTheme::theme()
         return mockTheme;
     }
     return nativeTheme();
+}
+
+void ScrollbarTheme::paintScrollCorner(ScrollableArea& area, GraphicsContext& context, const IntRect& cornerRect)
+{
+    Color color = Color::white;
+
+    auto scrollbarTrackColorStyle = area.scrollbarTrackColorStyle();
+
+    if (scrollbarTrackColorStyle.isValid())
+        color = scrollbarTrackColorStyle;
+    context.fillRect(cornerRect, color);
 }
 
 ScrollbarButtonPressAction ScrollbarTheme::handleMousePressEvent(Scrollbar&, const PlatformMouseEvent& event, ScrollbarPart pressedPart)

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -84,9 +84,7 @@ public:
 
     virtual void invalidatePart(Scrollbar&, ScrollbarPart) { }
 
-    virtual void paintScrollCorner(ScrollableArea& area, GraphicsContext& context, const IntRect& cornerRect) { defaultPaintScrollCorner(area, context, cornerRect); }
-    static void defaultPaintScrollCorner(ScrollableArea&, GraphicsContext& context, const IntRect& cornerRect) { context.fillRect(cornerRect, Color::white); }
-
+    virtual void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect&);
     virtual void paintTickmarks(GraphicsContext&, Scrollbar&, const IntRect&) { }
     virtual void paintOverhangAreas(ScrollView&, GraphicsContext&, const IntRect&, const IntRect&, const IntRect&) { }
 

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
@@ -28,6 +28,7 @@
 
 // FIXME: This is a layering violation.
 #include "DeprecatedGlobalSettings.h"
+#include "ScrollableArea.h"
 #include "Scrollbar.h"
 
 namespace WebCore {
@@ -53,13 +54,28 @@ int ScrollbarThemeMock::scrollbarThickness(ScrollbarWidth scrollbarWidth, Scroll
 
 void ScrollbarThemeMock::paintTrackBackground(GraphicsContext& context, Scrollbar& scrollbar, const IntRect& trackRect)
 {
-    context.fillRect(trackRect, scrollbar.enabled() ? Color::lightGray : SRGBA<uint8_t> { 224, 224, 224 });
+    Color trackColor = scrollbar.enabled() ? Color::lightGray : SRGBA<uint8_t> { 224, 224, 224 };
+
+    auto scrollbarTrackColorStyle = scrollbar.scrollableArea().scrollbarTrackColorStyle();
+
+    if (scrollbarTrackColorStyle.isValid())
+        trackColor = scrollbarTrackColorStyle;
+
+    context.fillRect(trackRect, trackColor);
 }
 
 void ScrollbarThemeMock::paintThumb(GraphicsContext& context, Scrollbar& scrollbar, const IntRect& thumbRect)
 {
-    if (scrollbar.enabled())
-        context.fillRect(thumbRect, Color::darkGray);
+    if (scrollbar.enabled()) {
+        Color thumbColor = Color::darkGray;
+
+        auto scrollbarThumbColorStyle = scrollbar.scrollableArea().scrollbarThumbColorStyle();
+
+        if (scrollbarThumbColorStyle.isValid())
+            thumbColor = scrollbarThumbColorStyle;
+
+        context.fillRect(thumbRect, thumbColor);
+    }
 }
 
 bool ScrollbarThemeMock::usesOverlayScrollbars() const

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -372,6 +372,11 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     }
 #endif
 
+    if (layer() && oldStyle && oldStyle->scrollbarColor() != newStyle.scrollbarColor()) {
+        if (auto* scrollableArea = layer()->scrollableArea())
+            scrollableArea->invalidateScrollbars();
+    }
+
     // Our opaqueness might have changed without triggering layout.
     if (diff >= StyleDifference::Repaint && diff <= StyleDifference::RepaintLayer) {
         auto parentToInvalidate = parent();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1017,6 +1017,20 @@ OverscrollBehavior RenderLayerScrollableArea::verticalOverscrollBehavior() const
     return OverscrollBehavior::Auto;
 }
 
+Color RenderLayerScrollableArea::scrollbarThumbColorStyle() const
+{
+    if (auto* renderer = m_layer.renderBox())
+        return renderer->style().effectiveScrollbarThumbColor();
+    return { };
+}
+
+Color RenderLayerScrollableArea::scrollbarTrackColorStyle() const
+{
+    if (auto* renderer = m_layer.renderBox())
+        return renderer->style().effectiveScrollbarTrackColor();
+    return { };
+}
+
 ScrollbarGutter RenderLayerScrollableArea::scrollbarGutterStyle()  const
 {
     if (auto* renderer = m_layer.renderBox())

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -109,6 +109,8 @@ public:
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
+    Color scrollbarThumbColorStyle() const final;
+    Color scrollbarTrackColorStyle() const final;
     ScrollbarGutter scrollbarGutterStyle() const final;
     ScrollbarWidth scrollbarWidthStyle() const final;
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1224,6 +1224,7 @@ static bool rareInheritedDataChangeRequiresRepaint(const StyleRareInheritedData&
 #if ENABLE(DARK_MODE_CSS)
         || first.colorScheme != second.colorScheme
 #endif
+        || first.scrollbarColor != second.scrollbarColor
     ;
 }
 
@@ -2466,6 +2467,28 @@ Color RenderStyle::effectiveAccentColor() const
         return colorByApplyingColorFilter(colorResolvingCurrentColor(accentColor()));
 
     return colorResolvingCurrentColor(accentColor());
+}
+
+Color RenderStyle::effectiveScrollbarThumbColor() const
+{
+    if (!scrollbarColor().has_value())
+        return { };
+
+    if (hasAppleColorFilter())
+        return colorByApplyingColorFilter(colorResolvingCurrentColor(scrollbarColor().value().thumbColor));
+
+    return colorResolvingCurrentColor(scrollbarColor().value().thumbColor);
+}
+
+Color RenderStyle::effectiveScrollbarTrackColor() const
+{
+    if (!scrollbarColor().has_value())
+        return { };
+
+    if (hasAppleColorFilter())
+        return colorByApplyingColorFilter(colorResolvingCurrentColor(scrollbarColor().value().trackColor));
+
+    return colorResolvingCurrentColor(scrollbarColor().value().trackColor);
 }
 
 const BorderValue& RenderStyle::borderBefore() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -971,6 +971,8 @@ public:
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
 
+    Color effectiveScrollbarThumbColor() const;
+    Color effectiveScrollbarTrackColor() const;
     inline std::optional<ScrollbarColor> scrollbarColor() const;
     inline const StyleColor& scrollbarThumbColor() const;
     inline const StyleColor& scrollbarTrackColor() const;


### PR DESCRIPTION
#### 36af8787ca1a26769e66c159d743105edee822a9
<pre>
Implement &quot;scrollbar-color&quot; support for mock scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=258457">https://bugs.webkit.org/show_bug.cgi?id=258457</a>

Reviewed by NOBODY (OOPS!).

This makes use of the scrollbar-color CSS styling inside of the Mock
Scrollbar theme.

The default rendering of the scroll corner has been changed to make use of
the scrollbar color track color value too.

Support for WebKit legacy will be added in a follow up patch

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-1.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-2.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-3.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-4.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-5.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollbarThumbColorStyle const):
(WebCore::LocalFrameView::scrollbarTrackColorStyle const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollbarThumbColorStyle const):
(WebCore::ScrollableArea::scrollbarTrackColorStyle const):
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/platform/ScrollbarTheme.cpp:
(WebCore::ScrollbarTheme::paintScrollCorner):
* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::paintScrollCorner): Deleted.
(WebCore::ScrollbarTheme::defaultPaintScrollCorner): Deleted.
* Source/WebCore/platform/mock/ScrollbarThemeMock.cpp:
(WebCore::ScrollbarThemeMock::paintTrackBackground):
(WebCore::ScrollbarThemeMock::paintThumb):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::styleDidChange):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollbarThumbColorStyle const):
(WebCore::RenderLayerScrollableArea::scrollbarTrackColorStyle const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareInheritedDataChangeRequiresRepaint):
(WebCore::RenderStyle::effectiveScrollbarThumbColor const):
(WebCore::RenderStyle::effectiveScrollbarTrackColor const):
* Source/WebCore/rendering/style/RenderStyle.h:

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-011.html: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36af8787ca1a26769e66c159d743105edee822a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14730 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16243 "14 flakes 159 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16799 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19939 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16305 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12790 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->