### PR TITLE
Remove Blob's top origin member

### DIFF
--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -119,7 +119,6 @@ Blob::Blob(UninitializedContructor, ScriptExecutionContext* context, URL&& url, 
     : ActiveDOMObject(context)
     , m_type(WTFMove(type))
     , m_internalURL(WTFMove(url))
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
 }
 
@@ -127,7 +126,6 @@ Blob::Blob(ScriptExecutionContext* context)
     : ActiveDOMObject(context)
     , m_size(0)
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { }, { });
 }
@@ -167,7 +165,6 @@ Blob::Blob(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVa
     , m_type(normalizedContentType(propertyBag.type))
     , m_memoryCost(computeMemoryCost(blobPartVariants))
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context.topOrigin().data())
 {
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, buildBlobData(WTFMove(blobPartVariants), propertyBag), m_type);
 }
@@ -178,7 +175,6 @@ Blob::Blob(ScriptExecutionContext* context, Vector<uint8_t>&& data, const String
     , m_size(data.size())
     , m_memoryCost(data.size())
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { BlobPart(WTFMove(data)) }, contentType);
 }
@@ -189,7 +185,6 @@ Blob::Blob(ReferencingExistingBlobConstructor, ScriptExecutionContext* context, 
     , m_size(blob.size())
     , m_memoryCost(blob.memoryCost())
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     ThreadableBlobRegistry::registerInternalBlobURL(m_internalURL, { BlobPart(blob.url()) } , m_type);
 }
@@ -200,7 +195,6 @@ Blob::Blob(DeserializationContructor, ScriptExecutionContext* context, const URL
     , m_size(size)
     , m_memoryCost(memoryCost)
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
 {
     if (fileBackedPath.isEmpty())
         ThreadableBlobRegistry::registerBlobURL(nullptr, { }, m_internalURL, srcURL);
@@ -213,7 +207,6 @@ Blob::Blob(ScriptExecutionContext* context, const URL& srcURL, long long start, 
     , m_type(normalizedContentType(type))
     , m_memoryCost(memoryCost)
     , m_internalURL(BlobURL::createInternalURL())
-    , m_topOrigin(context ? context->topOrigin().data() : SecurityOriginData::createOpaque())
     // m_size is not necessarily equal to end - start so we do not initialize it here.
 {
     ThreadableBlobRegistry::registerInternalBlobURLForSlice(m_internalURL, srcURL, start, end, m_type);

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -156,7 +156,6 @@ private:
     // as an identifier for this blob. The internal URL is never used to source the blob's content
     // into an HTML or for FileRead'ing, public blob URLs must be used for those purposes.
     URL m_internalURL;
-    SecurityOriginData m_topOrigin;
 
     HashSet<std::unique_ptr<BlobLoader>> m_blobLoaders;
 };


### PR DESCRIPTION
#### 7837a8da3bfb002dfb6580ec8b7bd1c320c48bd2
<pre>
Remove Blob&apos;s top origin member
<a href="https://bugs.webkit.org/show_bug.cgi?id=258468">https://bugs.webkit.org/show_bug.cgi?id=258468</a>
rdar://111222723

Reviewed by Chris Dumez.

The top origin member was added in 260266@main, but that addition was incorrect
because a blob does not have a top security origin and it is transferrable
across top origin contexts. In this patch, we delete that property.

* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::Blob):
* Source/WebCore/fileapi/Blob.h:

Canonical link: <a href="https://commits.webkit.org/265861@main">https://commits.webkit.org/265861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d74fbaf551a952288b47e43bd523080caf85a5ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13997 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17960 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14160 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11400 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10577 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14860 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->