### PR TITLE
Remove unnecessary soft linking of Data Detector framework

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -268,16 +268,6 @@ static Boolean isAXAuthenticatedCallback(audit_token_t auditToken)
 }
 #endif
 
-static void softlinkDataDetectorsFrameworks()
-{
-#if ENABLE(DATA_DETECTION)
-    PAL::isDataDetectorsCoreFrameworkAvailable();
-#if PLATFORM(IOS_FAMILY)
-    PAL::isDataDetectorsUIFrameworkAvailable();
-#endif // PLATFORM(IOS_FAMILY)
-#endif // ENABLE(DATA_DETECTION)
-}
-
 enum class VideoDecoderBehavior : uint8_t {
     AvoidHardware               = 1 << 0,
     AvoidIOSurface              = 1 << 1,
@@ -536,10 +526,6 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
 #endif
 
     disableURLSchemeCheckInDataDetectors();
-
-    // Soft link frameworks related to Data Detection before we disconnect from launchd because these frameworks connect to
-    // launchd temporarily at link time to register XPC services. See rdar://93598951 (my feature request to stop doing that)
-    softlinkDataDetectorsFrameworks();
 
 #if HAVE(VIDEO_RESTRICTED_DECODING) && PLATFORM(MAC)
     if (codeCheckSemaphore)


### PR DESCRIPTION
#### 9a99108f9c33f2eaabcc36abba533335c5032a8d
<pre>
Remove unnecessary soft linking of Data Detector framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=258469">https://bugs.webkit.org/show_bug.cgi?id=258469</a>
rdar://111222985

Reviewed by Chris Dumez.

This soft linking is no longer needed, since the WebContent process is no longer being terminated when accessing launchd.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::softlinkDataDetectorsFrameworks): Deleted.

Canonical link: <a href="https://commits.webkit.org/265473@main">https://commits.webkit.org/265473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96e25457ff8483ceed01c22693b8f78e180fb182

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13399 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13018 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9314 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17134 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13296 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8591 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9674 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2640 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->