### PR TITLE
[JSC] __proto__ produces incorrect value after Object.prototype.__proto__ changes

### DIFF
--- a/JSTests/stress/intrinsic-getter-object-proto-getter-change.js
+++ b/JSTests/stress/intrinsic-getter-object-proto-getter-change.js
@@ -1,0 +1,25 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0.1", "--useDFGJIT=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function getter() { return {}.__proto__ }
+noDFG(getter)
+
+function test() {
+    for (var i = 0; i < 1e5; i++)
+        shouldBe(getter(), Object.prototype)
+
+    var expectedPrototype = {};
+
+    Object.defineProperty(Object.prototype, "__proto__", {
+        get: () => expectedPrototype,
+    })
+
+    shouldBe(getter(), expectedPrototype);
+}
+
+noDFG(test)
+test()

--- a/JSTests/stress/intrinsic-getter-typed-array-byteLength-getter-change.js
+++ b/JSTests/stress/intrinsic-getter-typed-array-byteLength-getter-change.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0.1", "--useDFGJIT=0")
+
+Object.defineProperty(Float32Array.prototype.__proto__, "byteLength", {
+    set() {},
+})
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+var arr = new Float32Array(10)
+function getter() { return arr.byteLength }
+noDFG(getter)
+
+function test() {
+    for (var i = 0; i < 1e5; i++)
+        shouldBe(getter(), 40)
+
+    Object.defineProperty(Float32Array.prototype.__proto__, "byteLength", {
+        get: function() { return 0 },
+    })
+
+    shouldBe(getter(), 0)
+}
+
+noDFG(test)
+test()

--- a/JSTests/stress/intrinsic-getter-typed-array-byteOffset-getter-change.js
+++ b/JSTests/stress/intrinsic-getter-typed-array-byteOffset-getter-change.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0.1", "--useDFGJIT=0")
+
+Object.defineProperty(Uint8Array.prototype.__proto__, "byteOffset", {
+    set() {},
+})
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+var arr = new Uint8Array(10)
+function getter() { return arr.byteOffset }
+noDFG(getter)
+
+function test() {
+    for (var i = 0; i < 1e5; i++)
+        shouldBe(getter(), 0)
+
+    Object.defineProperty(Uint8Array.prototype.__proto__, "byteOffset", {
+        get: function() { return 42 },
+    })
+
+    shouldBe(getter(), 42)
+}
+
+noDFG(test)
+test()

--- a/JSTests/stress/intrinsic-getter-typed-array-length-getter-change.js
+++ b/JSTests/stress/intrinsic-getter-typed-array-length-getter-change.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0.1", "--useDFGJIT=0")
+
+Object.defineProperty(Int8Array.prototype.__proto__, "length", {
+    set() {},
+})
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function getter() { return (new Int8Array(10)).length }
+noDFG(getter)
+
+function test() {
+    for (var i = 0; i < 1e5; i++)
+        shouldBe(getter(), 10)
+
+    Object.defineProperty(Int8Array.prototype.__proto__, "length", {
+        get() { return 42 },
+    })
+
+    shouldBe(getter(), 42)
+}
+
+noDFG(test)
+test()

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -381,13 +381,15 @@ ObjectPropertyConditionSet generateConditionsForIndexedMiss(VM& vm, JSCell* owne
 
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHit(
     VM& vm, JSCell* owner, JSGlobalObject* globalObject, Structure* headStructure, JSObject* prototype,
-    UniquedStringImpl* uid)
+    UniquedStringImpl* uid, PropertyCondition::Kind prototypeConditionKind)
 {
+    ASSERT(prototypeConditionKind == PropertyCondition::Presence || prototypeConditionKind == PropertyCondition::Equivalence);
+
     return generateConditions(
         globalObject, headStructure, prototype, uid,
         [&](auto& conditions, JSObject* object, Structure* structure) -> bool {
             PropertyCondition::Kind kind =
-                object == prototype ? PropertyCondition::Presence : PropertyCondition::Absence;
+                object == prototype ? prototypeConditionKind : PropertyCondition::Absence;
             ObjectPropertyCondition result =
                 generateCondition(vm, owner, object, structure, uid, kind, Concurrency::MainThread);
             if (!result)

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
@@ -168,7 +168,7 @@ ObjectPropertyConditionSet generateConditionsForPropertySetterMiss(
 ObjectPropertyConditionSet generateConditionsForIndexedMiss(VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure);
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHit(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, JSObject* prototype,
-    UniquedStringImpl* uid);
+    UniquedStringImpl* uid, PropertyCondition::Kind prototypeConditionKind = PropertyCondition::Presence);
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHitCustom(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, JSObject* prototype,
     UniquedStringImpl* uid, unsigned attributes);


### PR DESCRIPTION
#### 667a7374f1ddff4f597489916022e7856e4e2664
<pre>
[JSC] __proto__ produces incorrect value after Object.prototype.__proto__ changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257774">https://bugs.webkit.org/show_bug.cgi?id=257774</a>
&lt;rdar://problem/110464460&gt;

Reviewed by Yusuke Suzuki.

Before this change, PropertyCondition::Presence was generated for intrinsic getters just as for
userland getters, causing IC bug if the built-in getter was redefined after compilation:
compiled code was still calling the old intrinsic getter.

The above-mentioned bug was caused by the fact that PropertyCondition::Presence merely validates
only StructureID, property offset, and the attributes. The bug was observed only when both getter
and setter were present, like by default in Object.prototype.__proto__ accessor.

This change fixes the bug by generating PropertyCondition::Equivalence for all intrinsic getters.

* JSTests/stress/intrinsic-getter-object-proto-getter-change.js: Added.
* JSTests/stress/intrinsic-getter-typed-array-byteLength-getter-change.js: Added.
* JSTests/stress/intrinsic-getter-typed-array-byteOffset-getter-change.js: Added.
* JSTests/stress/intrinsic-getter-typed-array-length-getter-change.js: Added.
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::generateConditionsForPrototypePropertyHit):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):

Canonical link: <a href="https://commits.webkit.org/265594@main">https://commits.webkit.org/265594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a13f42dd1e1d27b5f8150315f52928df987381c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13001 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11546 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9646 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10772 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11447 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10036 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14310 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11771 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1281 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->