### PR TITLE
[macOS Sonoma] Use class extensions in ScreenCaptureKitSPI.h

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
@@ -109,11 +109,23 @@ typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
     SCContentSharingPickerAllowedModeSingleDisplay         = 1 << 3,
 };
 
-@interface SCContentSharingPickerConfiguration : NSObject
+// FIXME: Drop deprecated method names once we no longer support Ventura. These
+// SPI methods all have public equivalents in Sonoma.
+@interface SCContentSharingPickerConfiguration
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+    ()
+#else
+    : NSObject
+#endif
 @property (nonatomic, assign) SCContentSharingAllowedPickerModes allowedPickingModes;
 @end
 
-@interface SCContentSharingPicker : NSObject
+@interface SCContentSharingPicker
+#if HAVE(SC_CONTENT_SHARING_PICKER)
+    ()
+#else
+    : NSObject
+#endif
 @property (nonatomic, weak, nullable) id<SCContentSharingPickerDelegate> delegate;
 @property (nonatomic, nullable, strong) NSNumber *maxStreamCount;
 @property (nonatomic, nullable, copy) SCContentSharingPickerConfiguration *configuration;


### PR DESCRIPTION
#### b51d6b6f536c26625ec495c5d9e2a65ed7bd8b2f
<pre>
[macOS Sonoma] Use class extensions in ScreenCaptureKitSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=258466">https://bugs.webkit.org/show_bug.cgi?id=258466</a>

Reviewed by Jonathan Bedard.

Work towards making the build functional on macOS Sonoma.

* Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h:
  SCContentSharingPicker and SCContentSharingPickerConfiguration are
  public in Sonoma, but the Ventura interface is deprecated and remains
  SPI-only.

Canonical link: <a href="https://commits.webkit.org/265534@main">https://commits.webkit.org/265534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a56e7c6feb06c848871571ee1db50392039de8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13060 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17167 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13336 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9710 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13981 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->