### PR TITLE
[macOS Sonoma] Set HAVE_CORE_LOCATION_AUTHORIZED_WHEN_IN_USE in public SDK builds

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1060,8 +1060,8 @@
 
 #if PLATFORM(COCOA)
 #define HAVE_CORE_LOCATION 1
-// kCLAuthorizationStatusAuthorizedWhenInUse is only available on macOS as part of the internal SDK.
-#if PLATFORM(IOS_FAMILY) || (defined __has_include && __has_include(<CoreFoundation/CFPriv.h>))
+// kCLAuthorizationStatusAuthorizedWhenInUse is SPI on macOS until 14.0.
+#if PLATFORM(IOS_FAMILY) || (defined __has_include && __has_include(<CoreFoundation/CFPriv.h>)) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
 #define HAVE_CORE_LOCATION_AUTHORIZED_WHEN_IN_USE 1
 #endif
 #endif


### PR DESCRIPTION
#### 9cabbb1cc67d5d0fb345b5e59d3a2378eb87428e
<pre>
[macOS Sonoma] Set HAVE_CORE_LOCATION_AUTHORIZED_WHEN_IN_USE in public SDK builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=258470">https://bugs.webkit.org/show_bug.cgi?id=258470</a>

Reviewed by Alexey Proskuryakov and Jonathan Bedard.

Work towards making the build functional on macOS Sonoma.

* Source/WTF/wtf/PlatformHave.h: The enum case guarded by this flag
  (kCLAuthorizationStatusAuthorizedWhenInUse) has been promoted to API
  in macOS 14.

Canonical link: <a href="https://commits.webkit.org/265535@main">https://commits.webkit.org/265535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/325f455c4baf23335f27f9f272ff8795a66c992d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10478 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11166 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13024 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17138 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9289 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13300 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8595 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11078 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9678 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3025 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13947 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11389 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10360 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2793 "Passed tests") | 
<!--EWS-Status-Bubble-End-->