### PR TITLE
[macOS Sonoma] Avoid redeclaration of PKApplePayLaterAvailability

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -300,20 +300,6 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
 @end
 #endif
 
-#if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
-
-typedef NS_ENUM(NSInteger, PKApplePayLaterAvailability) {
-    PKApplePayLaterAvailable,
-    PKApplePayLaterUnavailableItemIneligible,
-    PKApplePayLaterUnavailableRecurringTransaction,
-};
-
-@interface PKPaymentRequest ()
-@property (nonatomic, assign) PKApplePayLaterAvailability applePayLaterAvailability;
-@end
-
-#endif
-
 NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK)


### PR DESCRIPTION
#### 4880ef75f75a5316289e1ad8b734aaa9882abb19
<pre>
[macOS Sonoma] Avoid redeclaration of PKApplePayLaterAvailability
<a href="https://bugs.webkit.org/show_bug.cgi?id=258474">https://bugs.webkit.org/show_bug.cgi?id=258474</a>

Reviewed by Alexey Proskuryakov and Aditya Keerthi.

Work towards making the build functional on macOS Sonoma.

* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h: Remove enum and
  PKPaymentRequest declarations that are part of the public SDK.

Canonical link: <a href="https://commits.webkit.org/265479@main">https://commits.webkit.org/265479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0da4de9fd79023bc9857351cceca85eb515fedd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12627 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10486 "Failed to checkout and rebase branch from PR 15255") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13033 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17147 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13310 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10514 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9686 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->