### PR TITLE
[visionOS] Add button to control scene dimming in element fullscreen

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2719,6 +2719,20 @@ FullscreenRequirementForScreenOrientationLockingEnabled:
     WebCore:
       default: true
 
+FullscreenSceneDimmingEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Fullscreen scene dimming"
+  humanReadableDescription: "Enable scene dimming in Fullscreen"
+  condition: PLATFORM(VISION)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GStreamerEnabled:
   type: bool
   status: embedder

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -34,6 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKFullScreenViewController : UIViewController
 @property (retain, nonatomic) id target;
 @property (assign, nonatomic) SEL exitFullScreenAction;
+#if PLATFORM(VISION)
+@property (assign, nonatomic) SEL toggleDimmingAction;
+#endif
 @property (copy, nonatomic) NSString *location;
 @property (assign, nonatomic) BOOL prefersStatusBarHidden;
 @property (assign, nonatomic) BOOL prefersHomeIndicatorAutoHidden;
@@ -52,7 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;
 - (void)resetSupportedOrientations;
 #if PLATFORM(VISION)
-- (void)hideCancelAndPIPButtons:(BOOL)hidden;
+- (void)setSceneDimmed:(BOOL)dimmed;
+- (void)hideCustomControls:(BOOL)hidden;
 #endif
 @end
 


### PR DESCRIPTION
#### 215882f10b4576ca5bf383c234b589dfb722655e
<pre>
[visionOS] Add button to control scene dimming in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=258476">https://bugs.webkit.org/show_bug.cgi?id=258476</a>
rdar://110674947

Reviewed by Wenson Hsieh.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Add an off-by-default preference to support scene dimming. A button to toggle
will be shown when the preference is enabled.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController hideCustomControls:]):

Rename method to `hideCustomControls`, since it is now responsible for more
than the cancel and PiP buttons.

(-[WKFullScreenViewController setSceneDimmed:]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _toggleDimmingAction:]):
(-[WKFullScreenViewController _createButtonWithExtrinsicContentSize:]):
(-[WKFullScreenViewController hideCancelAndPIPButtons:]): Deleted.
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:

Adjust the duration of the dimming animation.

(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController _sceneDimmingEnabled]):

Scene dimming is only supported if the preference is enabled.

(-[WKFullScreenWindowController _prefersSceneDimming]):

Rely on a user default to maintain the user&apos;s dimming preference. If scene dimming
is supported, the scene will be dimmed by default.

(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Drive-by: Remove early return, as the animation is not intended to be interruptible.

(-[WKFullScreenWindowController _toggleSceneDimming]):

Canonical link: <a href="https://commits.webkit.org/265559@main">https://commits.webkit.org/265559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/391a17e42bea8767adec7a34eaa3d5c264de7562

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12040 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9259 "3 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17157 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9300 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10080 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13325 "10 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8606 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11091 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9690 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3030 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2689 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13959 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11402 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10372 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2798 "Passed tests") | 
<!--EWS-Status-Bubble-End-->