### PR TITLE
[CSS-Text-Decoration] Text decorations should propagate into tables

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Test: text-decoration propagation - Tables</title>
+<div>
+  <table>
+    <tr>
+      <td style="text-decoration: underline">This should be underlined</td>
+    </tr>
+  </table>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: text-decoration propagation - Tables</title>
+<link rel="author" title="Timothy Loh" href="mailto:timloh@chromium.org" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<link rel="match" href="reference/text-decoration-propagation-05-ref.html">
+<style>
+div { text-decoration: underline }
+</style>
+<div>
+  <table>
+    <tr>
+      <td>This should be underlined</td>
+    </tr>
+  </table>
+</div>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -183,7 +183,6 @@ static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const
         return false;
 
     switch (style.display()) {
-    case DisplayType::Table:
     case DisplayType::InlineTable:
     case DisplayType::InlineBlock:
     case DisplayType::InlineGrid:


### PR DESCRIPTION
#### 8da68845476a06674ef08f1639f124cb7ac535c9
<pre>
[CSS-Text-Decoration] Text decorations should propagate into tables

<a href="https://bugs.webkit.org/show_bug.cgi?id=258465">https://bugs.webkit.org/show_bug.cgi?id=258465</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Spec [1]:

Partial Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=199637

This patch fixes our text-decoration propagation logic to allow
propagation into &quot;display: table&quot; elements. These elements are
block-level element which participates in a block formatting context
and so decorations should propagate into them.

[1] <a href="https://drafts.csswg.org/css-text-decor-3/#line-decoration">https://drafts.csswg.org/css-text-decor-3/#line-decoration</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(shouldInheritTextDecorationsInEffect): Remove &apos;Table&apos; as per commit log
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05.html: Add Test Case
* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-propagation-05-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/265488@main">https://commits.webkit.org/265488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6c2903b9c9b6fc35075a716c4e5f2c40a88dea1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12637 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12043 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13043 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17152 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10407 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13318 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8613 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2649 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->