### PR TITLE
[GLib] Misc fixes for GResource file generation

### DIFF
--- a/Source/WebKit/InspectorGResources.cmake
+++ b/Source/WebKit/InspectorGResources.cmake
@@ -11,7 +11,7 @@ macro(WEBKIT_BUILD_INSPECTOR_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/InspectorGResourceBundle.c ${_derived_sources_dir}/InspectorGResourceBundle.deps
         DEPENDS ${_derived_sources_dir}/InspectorGResourceBundle.xml
-        DEPFILE {_derived_sources_dir}/InspectorGResourceBundle.deps
+        DEPFILE ${_derived_sources_dir}/InspectorGResourceBundle.deps
         COMMAND glib-compile-resources --generate --sourcedir=${_derived_sources_dir}/InspectorResources/WebInspectorUI --target=${_derived_sources_dir}/InspectorGResourceBundle.c --dependency-file=${_derived_sources_dir}/InspectorGResourceBundle.deps ${_derived_sources_dir}/InspectorGResourceBundle.xml
         VERBATIM
     )

--- a/Source/WebKit/ModernMediaControlsGResources.cmake
+++ b/Source/WebKit/ModernMediaControlsGResources.cmake
@@ -10,7 +10,7 @@ macro(WEBKIT_BUILD_MODERN_MEDIA_CONTROLS_GRESOURCES _derived_sources_dir)
     add_custom_command(
         OUTPUT ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
         DEPENDS ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
-        DEPFILE {_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
+        DEPFILE ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
         COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/modern-media-controls/images/adwaita --target=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c --dependency-file=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
         VERBATIM
     )

--- a/Source/WebKit/PdfJSGResources.cmake
+++ b/Source/WebKit/PdfJSGResources.cmake
@@ -30,7 +30,7 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
         OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
         DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
+        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c --dependency-file=${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
         VERBATIM
     )
 endmacro()


### PR DESCRIPTION
#### 9ec2b6d3c34850d235939b7007b9454eeb1cf58c
<pre>
[GLib] Misc fixes for GResource file generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=258478">https://bugs.webkit.org/show_bug.cgi?id=258478</a>

Reviewed by Philippe Normand.

This splits some of Lauro&apos;s fixes for GResource dependencies out from
bug #257516. These fixes were developed by Lauro Moura:

* Source/WebKit/InspectorGResources.cmake: Fix typo
* Source/WebKit/ModernMediaControlsGResources.cmake: Fix typo
* Source/WebKit/PdfJSGResources.cmake: Fix failure to generate .deps
  file

Canonical link: <a href="https://commits.webkit.org/265478@main">https://commits.webkit.org/265478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efe3517b0e3a69f5107c5a14d30dd19926a252e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12640 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13425 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12049 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13045 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9342 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10413 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13321 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9697 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2641 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->