### PR TITLE
Throw when constructing a SharedWorker in a detached document

### DIFF
--- a/LayoutTests/http/tests/workers/shared/resources/start-worker-detached-frame-iframe.html
+++ b/LayoutTests/http/tests/workers/shared/resources/start-worker-detached-frame-iframe.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script>
+onload = () => {
+    let parentWindow = window.parent;
+    // Detach iframe.
+    parentWindow.document.getElementById("testFrame").remove();
+    try {
+        new SharedWorker('../../navigation/resources/shared-worker-script.js');
+        parentWindow.testFailed("Starting the shared worker in a detached iframe did not throw an exception");
+    } catch (e) {
+	parentWindow.testPassed("Starting the shared worker in a detached iframe threw an exception: " + e);
+    }
+    parentWindow.finishJSTest();
+};
+</script>

--- a/LayoutTests/http/tests/workers/shared/start-worker-detached-frame-expected.txt
+++ b/LayoutTests/http/tests/workers/shared/start-worker-detached-frame-expected.txt
@@ -1,0 +1,10 @@
+Tests starting a shared worker in a frame that is already detached.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Starting the shared worker in a detached iframe threw an exception: InvalidStateError: No browsing context
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/workers/shared/start-worker-detached-frame.html
+++ b/LayoutTests/http/tests/workers/shared/start-worker-detached-frame.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests starting a shared worker in a frame that is already detached.");
+jsTestIsAsync = true;
+</script>
+<iframe id="testFrame" src="resources/start-worker-detached-frame-iframe.html"></iframe>
+</body>
+</html>

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -29,6 +29,7 @@
 #include "ClientOrigin.h"
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "EventNames.h"
 #include "Logging.h"
 #include "MessageChannel.h"
@@ -70,6 +71,9 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, String&&
 {
     if (!mainThreadConnection())
         return Exception { NotSupportedError, "Shared workers are not supported"_s };
+
+    if (!document.hasBrowsingContext())
+        return Exception { InvalidStateError, "No browsing context"_s };
 
     auto url = document.completeURL(scriptURLString);
     if (!url.isValid())


### PR DESCRIPTION
#### 677b4473a8cb849af5d8af685b7b9e72e838cb3c
<pre>
Throw when constructing a SharedWorker in a detached document
<a href="https://bugs.webkit.org/show_bug.cgi?id=258477">https://bugs.webkit.org/show_bug.cgi?id=258477</a>
rdar://110231627

Reviewed by Sihui Liu and Brent Fulgham.

Throw an exception when constructing a SharedWorker in a detached iframe, similarly
to what Chrome and Firefox are already doing. Previously, we would successfully
create the SharedWorker but the topOrigin would be wrong in the case of a third-party
iframe and we would hit an assertion later on.

* LayoutTests/http/tests/workers/shared/resources/start-worker-detached-frame-iframe.html: Added.
* LayoutTests/http/tests/workers/shared/start-worker-detached-frame-expected.txt: Added.
* LayoutTests/http/tests/workers/shared/start-worker-detached-frame.html: Added.
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):

Canonical link: <a href="https://commits.webkit.org/265483@main">https://commits.webkit.org/265483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0b34d2131ba79b2ec82bbe95fc43c89c72af96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12641 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13424 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12048 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13046 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9934 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10380 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->