### PR TITLE
[ANGLE] UBO convert only whole block

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -462,7 +462,7 @@ diff --git a/src/libANGLE/renderer/metal/BufferMtl.mm b/src/libANGLE/renderer/me
 index e261e90255c6de20704e79b01a6575fc120e6f84..dc5a3613d1532a9c6e3162c9fdce996378927a9e 100644
 --- a/src/libANGLE/renderer/metal/BufferMtl.mm
 +++ b/src/libANGLE/renderer/metal/BufferMtl.mm
-@@ -372,7 +372,7 @@ ConversionBufferMtl *BufferMtl::getUniformConversionBuffer(ContextMtl *context,
+@@ -372,7 +372,7 @@
          {
              if (buffer.offset.second <= offset.second &&
                  (offset.second - buffer.offset.second) % buffer.uniformBufferBlockSize == 0)
@@ -475,7 +475,7 @@ diff --git a/src/libANGLE/renderer/metal/ContextMtl.mm b/src/libANGLE/renderer/m
 index 0b5efd4a1a68d2168dead6f5b9fe740b628d8cc2..886c25104c770afd8f2d35fbd3e42f25cd03686c 100644
 --- a/src/libANGLE/renderer/metal/ContextMtl.mm
 +++ b/src/libANGLE/renderer/metal/ContextMtl.mm
-@@ -2462,8 +2462,21 @@ angle::Result ContextMtl::setupDraw(const gl::Context *context,
+@@ -2462,8 +2462,21 @@ static bool isDrawNoOp(const mtl::RenderPipelineDesc &descriptor,
              return angle::Result::Continue;
          }
          // Setup with flushed state should either produce a working encoder or fail with an error
@@ -503,7 +503,7 @@ diff --git a/src/libANGLE/renderer/metal/DisplayMtl.mm b/src/libANGLE/renderer/m
 index 9d18d8bf63862ff9808b94719678ebf582169a95..98b6f6d0111a84026caa80b455105551b3fc8112 100644
 --- a/src/libANGLE/renderer/metal/DisplayMtl.mm
 +++ b/src/libANGLE/renderer/metal/DisplayMtl.mm
-@@ -1405,8 +1405,7 @@ bool DisplayMtl::supportsEitherGPUFamily(uint8_t iOSFamily, uint8_t macFamily) c
+@@ -1405,8 +1405,7 @@ bool IsMetalDisplayAvailable()
  bool DisplayMtl::supports32BitFloatFiltering() const
  {
  #if (defined(__MAC_11_0) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_11_0) ||        \
@@ -517,7 +517,7 @@ diff --git a/src/libANGLE/renderer/metal/FrameBufferMtl.mm b/src/libANGLE/render
 index 4fbf873140d0911f9c903b2dc9749891c9556f1a..1560806d94b304ecce8b0d6a69eedbdb81b4450f 100644
 --- a/src/libANGLE/renderer/metal/FrameBufferMtl.mm
 +++ b/src/libANGLE/renderer/metal/FrameBufferMtl.mm
-@@ -1659,8 +1659,10 @@ angle::Result FramebufferMtl::readPixelsToPBO(const gl::Context *context,
+@@ -1659,8 +1659,10 @@ void RoundValueAndAdjustCorrespondingValue(float a,
  
      ContextMtl *contextMtl = mtl::GetImpl(context);
  
@@ -530,10 +530,123 @@ index 4fbf873140d0911f9c903b2dc9749891c9556f1a..1560806d94b304ecce8b0d6a69eedbdb
  
      BufferMtl *packBufferMtl = mtl::GetImpl(packPixelsParams.packBuffer);
 diff --git a/src/libANGLE/renderer/metal/ProgramMtl.mm b/src/libANGLE/renderer/metal/ProgramMtl.mm
-index f96bb97b51cdd56f4bc6437231261fe99ac593f8..1ec871bc17fda40a7ad90be5dc04c59ac5adb1cd 100644
+index f96bb97b51cdd56f4bc6437231261fe99ac593f8..a3b8b6017208a0a11184c1c4b56f524fdb55942d 100644
 --- a/src/libANGLE/renderer/metal/ProgramMtl.mm
 +++ b/src/libANGLE/renderer/metal/ProgramMtl.mm
-@@ -1540,7 +1540,7 @@ angle::Result ProgramMtl::setupDraw(const gl::Context *glContext,
+@@ -54,8 +54,25 @@
+     std::vector<T> &mArray;
+ };
+ 
++inline void memcpy_guarded(void *dst, const void *src, const void *maxSrcPtr, size_t size)
++{
++    size_t bytesAvailable = maxSrcPtr > src ? (const uint8_t *)maxSrcPtr - (const uint8_t *)src : 0;
++    size_t bytesToCopy    = std::min(size, bytesAvailable);
++    size_t bytesToZero    = size - bytesToCopy;
++
++    if (bytesToCopy)
++        memcpy(dst, src, bytesToCopy);
++    if (bytesToZero)
++        memset((uint8_t *)dst + bytesToCopy, 0, bytesToZero);
++}
++
+ // Copy matrix one column at a time
+-inline void copy_matrix(void *dst, const void *src, size_t srcStride, size_t dstStride, GLenum type)
++inline void copy_matrix(void *dst,
++                        const void *src,
++                        const void *maxSrcPtr,
++                        size_t srcStride,
++                        size_t dstStride,
++                        GLenum type)
+ {
+     size_t elemSize      = mtl::GetMetalSizeForGLType(gl::VariableComponentType(type));
+     const size_t dstRows = gl::VariableRowCount(type);
+@@ -64,14 +81,15 @@ inline void copy_matrix(void *dst, const void *src, size_t srcStride, size_t dst
+     for (size_t col = 0; col < dstCols; col++)
+     {
+         size_t srcOffset = col * srcStride;
+-        memcpy(((uint8_t *)dst) + dstStride * col, (const uint8_t *)src + srcOffset,
+-               elemSize * dstRows);
++        memcpy_guarded(((uint8_t *)dst) + dstStride * col, (const uint8_t *)src + srcOffset,
++                       maxSrcPtr, elemSize * dstRows);
+     }
+ }
+ 
+ // Copy matrix one element at a time to transpose.
+ inline void copy_matrix_row_major(void *dst,
+                                   const void *src,
++                                  const void *maxSrcPtr,
+                                   size_t srcStride,
+                                   size_t dstStride,
+                                   GLenum type)
+@@ -85,8 +103,8 @@ inline void copy_matrix_row_major(void *dst,
+         for (size_t row = 0; row < dstRows; row++)
+         {
+             size_t srcOffset = row * srcStride + col * elemSize;
+-            memcpy((uint8_t *)dst + dstStride * col + row * elemSize,
+-                   (const uint8_t *)src + srcOffset, elemSize);
++            memcpy_guarded((uint8_t *)dst + dstStride * col + row * elemSize,
++                           (const uint8_t *)src + srcOffset, maxSrcPtr, elemSize);
+         }
+     }
+ }
+@@ -105,6 +123,7 @@ bool compareBlockInfo(const sh::BlockMemberInfo &a, const sh::BlockMemberInfo &b
+                                        size_t *bufferOffsetOut)
+ {
+     uint8_t *dst             = nullptr;
++    const uint8_t *maxSrcPtr = sourceData + sizeToCopy;
+     dynamicBuffer->releaseInFlightBuffers(contextMtl);
+ 
+     // When converting a UBO buffer, we convert all of the data
+@@ -149,12 +168,12 @@ bool compareBlockInfo(const sh::BlockMemberInfo &a, const sh::BlockMemberInfo &b
+                     // Transpose matricies into column major order, if they're row major encoded.
+                     if (stdIterator->isRowMajorMatrix)
+                     {
+-                        copy_matrix_row_major(dstMat, srcMat, stdIterator->matrixStride,
++                        copy_matrix_row_major(dstMat, srcMat, maxSrcPtr, stdIterator->matrixStride,
+                                               mtlIterator->matrixStride, mtlIterator->type);
+                     }
+                     else
+                     {
+-                        copy_matrix(dstMat, srcMat, stdIterator->matrixStride,
++                        copy_matrix(dstMat, srcMat, maxSrcPtr, stdIterator->matrixStride,
+                                     mtlIterator->matrixStride, mtlIterator->type);
+                     }
+                 }
+@@ -166,24 +185,25 @@ bool compareBlockInfo(const sh::BlockMemberInfo &a, const sh::BlockMemberInfo &b
+                     for (int boolCol = 0; boolCol < gl::VariableComponentCount(mtlIterator->type);
+                          boolCol++)
+                     {
+-                        const uint8_t *srcOffset =
++                        const uint8_t *srcBool =
+                             (sourceData + stdIterator->offset + stdArrayOffset +
+                              blockConversionInfo.stdSize() * i +
+                              gl::VariableComponentSize(GL_BOOL) * boolCol);
+-                        unsigned int srcValue = *((unsigned int *)(srcOffset));
+-                        bool boolVal          = bool(srcValue);
+-                        memcpy(dst + mtlIterator->offset + mtlArrayOffset +
+-                                   blockConversionInfo.metalSize() * i + sizeof(bool) * boolCol,
+-                               &boolVal, sizeof(bool));
++                        unsigned int srcValue =
++                            srcBool < maxSrcPtr ? *((unsigned int *)(srcBool)) : 0;
++                        uint8_t *dstBool = dst + mtlIterator->offset + mtlArrayOffset +
++                                           blockConversionInfo.metalSize() * i +
++                                           sizeof(bool) * boolCol;
++                        *dstBool = (srcValue != 0);
+                     }
+                 }
+                 else
+                 {
+-                    memcpy(dst + mtlIterator->offset + mtlArrayOffset +
++                    memcpy_guarded(dst + mtlIterator->offset + mtlArrayOffset +
+                                        blockConversionInfo.metalSize() * i,
+                                    sourceData + stdIterator->offset + stdArrayOffset +
+                                        blockConversionInfo.stdSize() * i,
+-                           mtl::GetMetalSizeForGLType(mtlIterator->type));
++                                   maxSrcPtr, mtl::GetMetalSizeForGLType(mtlIterator->type));
+                 }
+             }
+             ++stdIterator;
+@@ -1540,7 +1560,7 @@ void operator()() override
                                      bool uniformBuffersDirty)
  {
      ContextMtl *context = mtl::GetImpl(glContext);
@@ -546,7 +659,7 @@ diff --git a/src/libANGLE/renderer/metal/VertexArrayMtl.mm b/src/libANGLE/render
 index 30f2faac716e9ac4e1a2005cccdaff61faa06233..f66c831fc00fe645206fb0b9b5341abd2927867a 100644
 --- a/src/libANGLE/renderer/metal/VertexArrayMtl.mm
 +++ b/src/libANGLE/renderer/metal/VertexArrayMtl.mm
-@@ -1092,16 +1092,21 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
+@@ -1092,16 +1092,21 @@ inline void SetDefaultVertexBufferLayout(mtl::VertexBufferLayoutDesc *layout)
      ANGLE_TRY(conversion->data.allocate(contextMtl, numVertices * targetStride, nullptr, &newBuffer,
                                          &newBufferOffset));
  
@@ -642,7 +755,7 @@ index 462b17e8f8f7362b12782c125a5bfe5ea510a9a3..595e26b5942e480956596b25e1b80d88
      MTLSize threadsPerThreadgroup = MTLSizeMake(w, 1, 1);
  
      if (contextMtl->getDisplay()->getFeatures().hasNonUniformDispatch.enabled)
-@@ -2548,45 +2549,13 @@ angle::Result MipmapUtils::generateMipmapCS(ContextMtl *contextMtl,
+@@ -2548,45 +2549,13 @@ ANGLE_INLINE void SetPipelineState(ComputeCommandEncoder *encoder,
                                              bool sRGBMipmap,
                                              NativeTexLevelArray *mipmapOutputViews)
  {
@@ -688,7 +801,7 @@ index 462b17e8f8f7362b12782c125a5bfe5ea510a9a3..595e26b5942e480956596b25e1b80d88
      ComputeCommandEncoder *cmdEncoder = contextMtl->getComputeCommandEncoder();
      ASSERT(cmdEncoder);
  
-@@ -2623,8 +2592,29 @@ angle::Result MipmapUtils::generateMipmapCS(ContextMtl *contextMtl,
+@@ -2623,8 +2592,29 @@ ANGLE_INLINE void SetPipelineState(ComputeCommandEncoder *encoder,
              UNREACHABLE();
      }
  
@@ -814,7 +927,7 @@ index ee5937e7415daa63126373d09a8f4124257d383f..d1df5110ef55a7d8eb83345d7e079f0d
  namespace rx
  {
  namespace mtl
-@@ -1067,23 +1074,10 @@ AutoObjCPtr<id<MTLRenderPipelineState>> RenderPipelineCache::createRenderPipelin
+@@ -1067,23 +1074,10 @@ static bool ValidateRenderPipelineState(const MTLRenderPipelineDescriptor *descr
  
          auto objCDesc = CreateMTLRenderPipelineDescriptor(vertShader, fragShader, desc);
  

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm
@@ -54,8 +54,25 @@ class [[nodiscard]] ScopedAutoClearVector
     std::vector<T> &mArray;
 };
 
+inline void memcpy_guarded(void *dst, const void *src, const void *maxSrcPtr, size_t size)
+{
+    size_t bytesAvailable = maxSrcPtr > src ? (const uint8_t *)maxSrcPtr - (const uint8_t *)src : 0;
+    size_t bytesToCopy    = std::min(size, bytesAvailable);
+    size_t bytesToZero    = size - bytesToCopy;
+
+    if (bytesToCopy)
+        memcpy(dst, src, bytesToCopy);
+    if (bytesToZero)
+        memset((uint8_t *)dst + bytesToCopy, 0, bytesToZero);
+}
+
 // Copy matrix one column at a time
-inline void copy_matrix(void *dst, const void *src, size_t srcStride, size_t dstStride, GLenum type)
+inline void copy_matrix(void *dst,
+                        const void *src,
+                        const void *maxSrcPtr,
+                        size_t srcStride,
+                        size_t dstStride,
+                        GLenum type)
 {
     size_t elemSize      = mtl::GetMetalSizeForGLType(gl::VariableComponentType(type));
     const size_t dstRows = gl::VariableRowCount(type);
@@ -64,14 +81,15 @@ inline void copy_matrix(void *dst, const void *src, size_t srcStride, size_t dst
     for (size_t col = 0; col < dstCols; col++)
     {
         size_t srcOffset = col * srcStride;
-        memcpy(((uint8_t *)dst) + dstStride * col, (const uint8_t *)src + srcOffset,
-               elemSize * dstRows);
+        memcpy_guarded(((uint8_t *)dst) + dstStride * col, (const uint8_t *)src + srcOffset,
+                       maxSrcPtr, elemSize * dstRows);
     }
 }
 
 // Copy matrix one element at a time to transpose.
 inline void copy_matrix_row_major(void *dst,
                                   const void *src,
+                                  const void *maxSrcPtr,
                                   size_t srcStride,
                                   size_t dstStride,
                                   GLenum type)
@@ -85,8 +103,8 @@ inline void copy_matrix_row_major(void *dst,
         for (size_t row = 0; row < dstRows; row++)
         {
             size_t srcOffset = row * srcStride + col * elemSize;
-            memcpy((uint8_t *)dst + dstStride * col + row * elemSize,
-                   (const uint8_t *)src + srcOffset, elemSize);
+            memcpy_guarded((uint8_t *)dst + dstStride * col + row * elemSize,
+                           (const uint8_t *)src + srcOffset, maxSrcPtr, elemSize);
         }
     }
 }
@@ -104,7 +122,8 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                                        mtl::BufferRef *bufferOut,
                                        size_t *bufferOffsetOut)
 {
-    uint8_t *dst = nullptr;
+    uint8_t *dst             = nullptr;
+    const uint8_t *maxSrcPtr = sourceData + sizeToCopy;
     dynamicBuffer->releaseInFlightBuffers(contextMtl);
 
     // When converting a UBO buffer, we convert all of the data
@@ -149,12 +168,12 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                     // Transpose matricies into column major order, if they're row major encoded.
                     if (stdIterator->isRowMajorMatrix)
                     {
-                        copy_matrix_row_major(dstMat, srcMat, stdIterator->matrixStride,
+                        copy_matrix_row_major(dstMat, srcMat, maxSrcPtr, stdIterator->matrixStride,
                                               mtlIterator->matrixStride, mtlIterator->type);
                     }
                     else
                     {
-                        copy_matrix(dstMat, srcMat, stdIterator->matrixStride,
+                        copy_matrix(dstMat, srcMat, maxSrcPtr, stdIterator->matrixStride,
                                     mtlIterator->matrixStride, mtlIterator->type);
                     }
                 }
@@ -166,24 +185,25 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                     for (int boolCol = 0; boolCol < gl::VariableComponentCount(mtlIterator->type);
                          boolCol++)
                     {
-                        const uint8_t *srcOffset =
+                        const uint8_t *srcBool =
                             (sourceData + stdIterator->offset + stdArrayOffset +
                              blockConversionInfo.stdSize() * i +
                              gl::VariableComponentSize(GL_BOOL) * boolCol);
-                        unsigned int srcValue = *((unsigned int *)(srcOffset));
-                        bool boolVal          = bool(srcValue);
-                        memcpy(dst + mtlIterator->offset + mtlArrayOffset +
-                                   blockConversionInfo.metalSize() * i + sizeof(bool) * boolCol,
-                               &boolVal, sizeof(bool));
+                        unsigned int srcValue =
+                            srcBool < maxSrcPtr ? *((unsigned int *)(srcBool)) : 0;
+                        uint8_t *dstBool = dst + mtlIterator->offset + mtlArrayOffset +
+                                           blockConversionInfo.metalSize() * i +
+                                           sizeof(bool) * boolCol;
+                        *dstBool = (srcValue != 0);
                     }
                 }
                 else
                 {
-                    memcpy(dst + mtlIterator->offset + mtlArrayOffset +
-                               blockConversionInfo.metalSize() * i,
-                           sourceData + stdIterator->offset + stdArrayOffset +
-                               blockConversionInfo.stdSize() * i,
-                           mtl::GetMetalSizeForGLType(mtlIterator->type));
+                    memcpy_guarded(dst + mtlIterator->offset + mtlArrayOffset +
+                                       blockConversionInfo.metalSize() * i,
+                                   sourceData + stdIterator->offset + stdArrayOffset +
+                                       blockConversionInfo.stdSize() * i,
+                                   maxSrcPtr, mtl::GetMetalSizeForGLType(mtlIterator->type));
                 }
             }
             ++stdIterator;


### PR DESCRIPTION
#### a2b3dcad4f04acf986db93170bebfbe88c991517
<pre>
[ANGLE] UBO convert only whole block
rdar://108349524

[Relanded by David Kilzer after being rolled out by 264786@main.]
[Originally tracked by: rdar://106964250]

Reviewed by Dean Jackson.

OpenGL doesn&apos;t guarantee that the buffer backing uniform blocks needs to be a
multiple of the block size. When converting OpenGL layout blocks to Metal
layout, ConvertUniformBufferData is rounding up the size of the backing buffer
to a multiple of the block size which leads to reading out of bounds.

To ensure we don&apos;t read outside the source buffer, this change replaces calls to
`memcpy` with `memcpy_guarded` which accepts a pointer to the limit of available
data and copies as much data as is available, writing zeroes for any unavailable
amount.

Conversion of bools didn&apos;t use memcpy, so the raw pointer is checked against
maxSrcPtr and only dereferenced if valid, otherwise zero is used.

This has been tested with ASan and UBSan enabled against the OpenGL dEQP tests
for Uniform Buffer Objects in ANGLE.

* Source/ThirdParty/ANGLE/changes.diff:
- Ran `update-angle --regenerate-changes-diff`.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramMtl.mm:

Originally-landed-as: 259548.667@safari-7615-branch (4aa8750579fb). rdar://106964250
Canonical link: <a href="https://commits.webkit.org/265481@main">https://commits.webkit.org/265481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c225a2eabda15bb9ddcf2647cbc0130196d388e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12644 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11191 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13428 "125 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11156 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13049 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9937 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10415 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10527 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13970 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->