### PR TITLE
Opener should not be set on navigations via window.open(..., "_self")

### DIFF
--- a/LayoutTests/fast/dom/Window/resources/destination-no-opener.html
+++ b/LayoutTests/fast/dom/Window/resources/destination-no-opener.html
@@ -1,0 +1,2 @@
+<p>Hooray, you got here! If the test timed out, there was an opener.</p>
+<script>if (window.testRunner && !window.opener) testRunner.notifyDone();</script>

--- a/LayoutTests/fast/dom/Window/window-open-self-no-opener-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-open-self-no-opener-expected.txt
@@ -1,0 +1,1 @@
+Hooray, you got here! If the test timed out, there was an opener.

--- a/LayoutTests/fast/dom/Window/window-open-self-no-opener.html
+++ b/LayoutTests/fast/dom/Window/window-open-self-no-opener.html
@@ -1,0 +1,8 @@
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+window.open("resources/destination-no-opener.html", "_self");
+</script>
+<p>If you can still see this text, then the test of window.open(URL, "_self") has failed.</p>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2610,7 +2610,7 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
         return RefPtr<LocalFrame> { nullptr };
 
     bool noopener = windowFeatures.noopener || windowFeatures.noreferrer;
-    if (!noopener)
+    if (!noopener && created)
         newFrame->loader().setOpener(&openerFrame);
 
     if (created)


### PR DESCRIPTION
#### 965a31b456f106cb69f67ec99319970e0fbf743d
<pre>
Opener should not be set on navigations via window.open(..., &quot;_self&quot;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=258479">https://bugs.webkit.org/show_bug.cgi?id=258479</a>
rdar://problem/111231401

Reviewed by NOBODY (OOPS!).

We currently don&apos;t implement the HTML spec with respect to setting the opener exactly.
According to the spec, whenever name is &quot;_self&quot; we do not create a new top level traversable,
which means we do not follow step 8.8 (1) which creates a new top-level traversable with an opener.
Whenever the currentNavigable is selected in step 4, there is no step to set an opener. In practice,
both Blink and Gecko do not set opener on window.open(..., &quot;_self&quot;).

This patch fixes this by not setting opener whenever a new top level traversable is not created.

(1): <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#navigable-target-names">https://html.spec.whatwg.org/multipage/document-sequences.html#navigable-target-names</a>

* LayoutTests/fast/dom/Window/resources/destination-no-opener.html: Added.
* LayoutTests/fast/dom/Window/window-open-self-no-opener-expected.txt: Added.
* LayoutTests/fast/dom/Window/window-open-self-no-opener.html: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/965a31b456f106cb69f67ec99319970e0fbf743d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11157 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12053 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13050 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9346 "3 flakes 4 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9939 "5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17158 "1 flakes 104 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10417 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10093 "2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13326 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10528 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8615 "10 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9830 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->