### PR TITLE
Revert [265365@main] [WPE] Crash in `WebKit.OnDeviceChangeCrash` API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp
@@ -108,15 +108,14 @@ static void didCrashCallback(WKPageRef, const void*)
 
 TEST(WebKit, OnDeviceChangeCrash)
 {
-    auto context = adoptWK(WKContextCreateWithConfiguration(nullptr));
-
-    WKRetainPtr<WKPageGroupRef> pageGroup = adoptWK(WKPageGroupCreateWithIdentifier(Util::toWK("GetUserMedia").get()));
-    WKPreferencesRef preferences = WKPageGroupGetPreferences(pageGroup.get());
-    WKPreferencesSetMediaDevicesEnabled(preferences, true);
-    WKPreferencesSetFileAccessFromFileURLsAllowed(preferences, true);
-    WKPreferencesSetMediaCaptureRequiresSecureConnection(preferences, false);
-    WKPreferencesSetMockCaptureDevicesEnabled(preferences, true);
-    WKPreferencesSetGetUserMediaRequiresFocus(preferences, false);
+    auto configuration = adoptWK(WKPageConfigurationCreate());
+    auto preferences = adoptWK(WKPreferencesCreate());
+    WKPreferencesSetMediaDevicesEnabled(preferences.get(), true);
+    WKPreferencesSetFileAccessFromFileURLsAllowed(preferences.get(), true);
+    WKPreferencesSetMediaCaptureRequiresSecureConnection(preferences.get(), false);
+    WKPreferencesSetMockCaptureDevicesEnabled(preferences.get(), true);
+    WKPreferencesSetGetUserMediaRequiresFocus(preferences.get(), false);
+    WKPageConfigurationSetPreferences(configuration.get(), preferences.get());
 
     WKPageUIClientV6 uiClient;
     memset(&uiClient, 0, sizeof(uiClient));
@@ -124,7 +123,7 @@ TEST(WebKit, OnDeviceChangeCrash)
     uiClient.decidePolicyForUserMediaPermissionRequest = decidePolicyForUserMediaPermissionRequestCallBack;
     uiClient.checkUserMediaPermissionForOrigin = checkUserMediaPermissionCallback;
 
-    PlatformWebView webView(context.get(), pageGroup.get());
+    PlatformWebView webView(configuration.get());
     WKPageSetPageUIClient(webView.page(), &uiClient.base);
 
     // Load a page registering ondevicechange handler.

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -241,6 +241,9 @@
             "WebKit.FocusedFrameAfterCrash": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}
             },
+            "WebKit.OnDeviceChangeCrash": {
+                "expected": {"gtk": {"status": ["CRASH", "TIMEOUT", "PASS"], "bug": "webkit.org/b/214805"}}
+            },
             "WebKit.PrivateBrowsingPushStateNoHistoryCallback": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
             },


### PR DESCRIPTION
#### 55c1230cb9f38777923cc78824dcd7c9617ba7f3
<pre>
Revert [265365@main] [WPE] Crash in `WebKit.OnDeviceChangeCrash` API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=258353">https://bugs.webkit.org/show_bug.cgi?id=258353</a>
rdar://problem/111234270

Unreviewed revert.

* Tools/TestWebKitAPI/Tests/WebKit/UserMedia.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265482@main">https://commits.webkit.org/265482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1fbcd3ec13f54d44f4aa6b116ef94db5a5d240d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12648 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11195 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11160 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13053 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/9941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10531 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13974 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1234 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->