### PR TITLE
Bogus lang= attributes can cause null pointer derefs (line breaker object fails to be created)

### DIFF
--- a/LayoutTests/fast/text/bogus-lang-expected.txt
+++ b/LayoutTests/fast/text/bogus-lang-expected.txt
@@ -1,0 +1,2 @@
+This test passes if there is no crash in ASAN mode.
+Hèllo this is some text and let's make it a little bit longer.

--- a/LayoutTests/fast/text/bogus-lang.html
+++ b/LayoutTests/fast/text/bogus-lang.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+</head>
+<body>
+This test passes if there is no crash in ASAN mode.
+<div style="width: 1px;" lang="-webkit-min-logical-height: 24px; border-bottom-width: 0px; -webkit-text-decorations-in-effect: underline; column-gap: -webkit-margin-top-collapse: separate">He&#x0300;llo this is some text and let's make it a little bit longer.</div>
+</body>
+</html>

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -62,6 +62,9 @@ public:
         m_priorContextLength = priorContext.length();
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
         m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, localeObject.get()));
+        if (!m_stringTokenizer)
+            m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, nullptr));
+        ASSERT(m_stringTokenizer);
     }
 
     TextBreakIteratorCFStringTokenizer() = delete;

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -60,6 +60,10 @@ public:
 
         UErrorCode status = U_ZERO_ERROR;
         m_iterator = ubrk_open(type, localeWithOptionalBreakKeyword.string().utf8().data(), nullptr, 0, &status);
+        if (!m_iterator) {
+            status = U_ZERO_ERROR;
+            m_iterator = ubrk_open(type, "", nullptr, 0, &status);
+        }
         ASSERT(U_SUCCESS(status));
 
         setText(string, priorContext, priorContextLength);


### PR DESCRIPTION
#### 3f00535f91586f763507aa8085232b947e1354a8
<pre>
Bogus lang= attributes can cause null pointer derefs (line breaker object fails to be created)
<a href="https://bugs.webkit.org/show_bug.cgi?id=258483">https://bugs.webkit.org/show_bug.cgi?id=258483</a>
rdar://110440971

Reviewed by Cameron McCormack.

A bogus lang attribute can cause our line breaker objects to fail to be created, causing
null pointer derefs.

There are 2 possible ways to fix this:
1) If creation fails, try again without a lang
2) If creation fails, mark the text as &quot;there are no line breaking opportunities here&quot;

Option 1) is less likely to break content if the author makes a mistake, so that&apos;s the option
I went with.

* LayoutTests/fast/text/bogus-lang-expected.txt: Added.
* LayoutTests/fast/text/bogus-lang.html: Added.
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::TextBreakIteratorICU):

Canonical link: <a href="https://commits.webkit.org/265495@main">https://commits.webkit.org/265495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8091cd611f7a6d25831a76f79a1fc6baf75ed8e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12654 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10507 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13596 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13438 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13059 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17166 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9317 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10425 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13335 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10435 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10537 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11114 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9709 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9839 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13980 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11425 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10392 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2802 "Passed tests") | 
<!--EWS-Status-Bubble-End-->