### PR TITLE
WebPage_LoadRequest IPC fails decoding in PingDuoDuo app

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "PlatformUtilities.h"
 #import "RemoteObjectRegistry.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"
@@ -646,6 +647,50 @@ TEST(IPCTestingAPI, CGColorInNSSecureCoding)
     ASSERT_EQ(CGColorGetNumberOfComponents(resultValue), CGColorGetNumberOfComponents(value.get()));
     for (size_t i = 0; i < CGColorGetNumberOfComponents(resultValue); ++i)
         EXPECT_EQ(CGColorGetComponents(resultValue)[i], CGColorGetComponents(value.get())[i]);
+    [unarchiver finishDecoding];
+    unarchiver.get().delegate = nil;
+}
+
+TEST(IPCTestingAPI, NSURLWithBaseURLInNSSecureCoding)
+{
+    auto archiver = adoptNS([[NSKeyedArchiver alloc] initRequiringSecureCoding:YES]);
+
+    RetainPtr<id<NSKeyedArchiverDelegate, NSKeyedUnarchiverDelegate>> delegate = adoptNS([[NSClassFromString(@"WKSecureCodingArchivingDelegate") alloc] init]);
+    archiver.get().delegate = delegate.get();
+
+    NSString *key = @"SomeString";
+    NSURL *value = [NSURL URLWithString:@"/garden_home.html" relativeToURL:[NSURL URLWithString:@"amcomponent://com.xunmeng.pinduoduo/"]];
+    EXPECT_WK_STREQ(value.baseURL.absoluteString, @"amcomponent://com.xunmeng.pinduoduo/");
+    EXPECT_WK_STREQ(value.relativeString, @"/garden_home.html");
+    EXPECT_WK_STREQ(value.absoluteString, @"amcomponent://com.xunmeng.pinduoduo/garden_home.html");
+
+    auto payload = @{ key : static_cast<id>(value) };
+    [archiver encodeObject:payload forKey:NSKeyedArchiveRootObjectKey];
+    [archiver finishEncoding];
+    [archiver setDelegate:nil];
+
+    auto data = [archiver encodedData];
+
+    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nullptr]);
+    unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
+    unarchiver.get().delegate = delegate.get();
+
+    auto allowedClassSet = adoptNS([NSMutableSet new]);
+    [allowedClassSet addObject:NSDictionary.class];
+    [allowedClassSet addObject:NSString.class];
+    [allowedClassSet addObject:NSClassFromString(@"WKSecureCodingURLWrapper")];
+
+    NSDictionary *result = [unarchiver decodeObjectOfClasses:allowedClassSet.get() forKey:NSKeyedArchiveRootObjectKey];
+
+    EXPECT_EQ(result.count, static_cast<NSUInteger>(1));
+    NSString *resultKey = result.allKeys[0];
+    EXPECT_TRUE([key isEqual:resultKey]);
+    NSURL *resultValue = (NSURL *)(result.allValues[0]);
+
+    // Our coder resolves the URL so we end up with an absolute URL instead of base URL + relative string.
+    EXPECT_WK_STREQ(resultValue.baseURL.absoluteString, @"");
+    EXPECT_WK_STREQ(resultValue.baseURL.relativeString, @"");
+    EXPECT_WK_STREQ(resultValue.absoluteString, @"amcomponent://com.xunmeng.pinduoduo/garden_home.html");
     [unarchiver finishDecoding];
     unarchiver.get().delegate = nil;
 }


### PR DESCRIPTION
#### 0ba9e6c4473fcc7d78aaa785794cbd884e61a094
<pre>
WebPage_LoadRequest IPC fails decoding in PingDuoDuo app
<a href="https://bugs.webkit.org/show_bug.cgi?id=258486">https://bugs.webkit.org/show_bug.cgi?id=258486</a>
rdar://111161160

Reviewed by Tim Horton.

WebPage_LoadRequest IPC was failing decoding in PingDuoDuo app.
The issue was due to getting a WKSecureCodingURLWrapper instead
of a NSURL when decoding the baseURL of a NSURL.

I am not sure how we ended up in this situation but I made the
bug go away by simplifying the code. The coder used to encode
the URL in two parts:
1. The baseURL
2. The bytes from the URL&apos;s relative string

Then it would decode the URL in 2 parts:
1. The baseURL
2. The bytes from the URL&apos;s relative string

It would then call CFURLCreateAbsoluteURLWithBytes() with those
2 parts, which would result in an *absolute* URL. The information
about baseURL / relative string would be lost.

As a result, I have decided to simply encode the URL in one part,
the absolute URL bytes. The decoding results ends up being the
same (an absolute URL). It simplifies both coding and decoding
and makes the bug go away since it was about decoding baseURLs.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(-[WKSecureCodingURLWrapper encodeWithCoder:]):
(-[WKSecureCodingURLWrapper initWithCoder:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/265529@main">https://commits.webkit.org/265529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/477aef53592f781b8419ee83936d80bf1abc35b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13445 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13067 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17171 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13340 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10542 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8628 "35 flakes 23 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9714 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2668 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->