### PR TITLE
REGRESSION: css3/color-filters/color-filter-caret-color.html is a consistent image failure

### DIFF
--- a/LayoutTests/css3/color-filters/color-filter-caret-color-expected.html
+++ b/LayoutTests/css3/color-filters/color-filter-caret-color-expected.html
@@ -8,30 +8,22 @@
         #test-container {
             height: 50px;
             width: 50px;
-            overflow: hidden;
-            border: 1px solid black;
         }
 
-        #test {
-            background-color: white;
-            transform-origin: left top;
-            transform: scale(50, 50);
-            font-size: 10px; /* Needed for the caret to render in Firefox. */
-            caret-color: green;
+        #mock-caret {
+            width: 50px;
+            height: 100px;
+            position: absolute;
+            top: 100px;
+            left: 8px;
+            background-color: green;
         }
-
         </style>
     </head>
     <body>
         <p>The caret should show as a green flashing square below.</p>
         <div id="test-container">
-            <div id="test" contenteditable="true">
-                <span>&nbsp;<!-- Needed for the caret to render in Firefox. --></span>
-            </div>
+            <div id="mock-caret"></div>
         </div>
-        <script>
-            document.getElementById("test").focus();
-            window.getSelection().modify("move", "left", "character"); // Place the caret at the start of the <span>.
-        </script>
     </body>
 </html>

--- a/LayoutTests/css3/color-filters/color-filter-caret-color.html
+++ b/LayoutTests/css3/color-filters/color-filter-caret-color.html
@@ -8,10 +8,9 @@
         <meta name="assert" content="-apple-color-filter affects caret-color">
         <style>
         #test-container {
-            height: 50px;
-            width: 50px;
+            height: 150px;
+            width: 100px;
             overflow: hidden;
-            border: 1px solid black;
         }
 
         #test {
@@ -19,6 +18,7 @@
             background-color: white;
             transform-origin: left top;
             transform: scale(50, 50);
+            clip-path: inset(1px 99px 0px 0px);
             font-size: 10px; /* Needed for the caret to render in Firefox. */
             caret-color: rgb(255, 128, 255);
         }

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1926,10 +1926,11 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
         auto cssColorValue = CSSValueAppleSystemBlue;
 #endif
         auto styleColorOptions = node->document().styleColorOptions(elementStyleToUse);
-        return RenderTheme::singleton().systemColor(cssColorValue, styleColorOptions | StyleColorOptions::UseSystemAppearance);
+        auto systemAccentColor = RenderTheme::singleton().systemColor(cssColorValue, styleColorOptions | StyleColorOptions::UseSystemAppearance);
+        return elementStyleToUse->colorByApplyingColorFilter(systemAccentColor);
     }
 
-    return elementStyleToUse->colorResolvingCurrentColor(elementStyleToUse->caretColor());
+    return elementStyleToUse->colorByApplyingColorFilter(elementStyleToUse->colorResolvingCurrentColor(elementStyleToUse->caretColor()));
 #else
     UNUSED_PARAM(selection);
     RefPtr parentElement = node ? node->parentElement() : nullptr;


### PR DESCRIPTION
#### 82aa44bd18f4bdea6e6b6f992fb14afc933f0c64
<pre>
REGRESSION: css3/color-filters/color-filter-caret-color.html is a consistent image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=258488">https://bugs.webkit.org/show_bug.cgi?id=258488</a>
rdar://111077813

Reviewed by Simon Fraser.

Apply the color filter when computing the caret color.

Also fixes the test to account for the new shape of the redesigned text cursor.

* LayoutTests/css3/color-filters/color-filter-caret-color-expected.html:
* LayoutTests/css3/color-filters/color-filter-caret-color.html:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):

Canonical link: <a href="https://commits.webkit.org/265524@main">https://commits.webkit.org/265524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe649f6a3bb90ed85d158de2f79cfab33d3a9e88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11035 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13073 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17176 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8634 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13991 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->