### PR TITLE
Merge InspectorInstrumentation::performanceMarkImpl

### DIFF
--- a/LayoutTests/inspector/timeline/timeline-event-performance-mark.html
+++ b/LayoutTests/inspector/timeline/timeline-event-performance-mark.html
@@ -27,12 +27,12 @@ function test()
 
             let recording = WI.timelineManager.activeRecording;
 
-            InspectorTest.expectEqual(recording.markers.length, 2);
-            InspectorTest.expectEqual(recording.markers[0].type, "timestamp");
-            InspectorTest.expectEqual(recording.markers[0].details, "foo");
-            InspectorTest.expectEqual(recording.markers[1].type, "timestamp");
-            InspectorTest.expectEqual(recording.markers[1].details, "bar");
-            InspectorTest.assert(recording.markers[0].time > recording.markers[1].time);
+            InspectorTest.expectEqual(recording.markersForTesting.length, 2);
+            InspectorTest.expectEqual(recording.markersForTesting[0].type, "timestamp");
+            InspectorTest.expectEqual(recording.markersForTesting[0].details, "foo");
+            InspectorTest.expectEqual(recording.markersForTesting[1].type, "timestamp");
+            InspectorTest.expectEqual(recording.markersForTesting[1].details, "bar");
+            InspectorTest.assert(recording.markersForTesting[0].time > recording.markersForTesting[1].time);
         }
     });
 

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1036,16 +1036,10 @@ void InspectorInstrumentation::stopProfilingImpl(InstrumentingAgents& instrument
         timelineAgent->stopFromConsole(exec, title);
 }
 
-void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, const String& label, std::optional<MonotonicTime> timestamp)
+void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, const String& label, std::optional<MonotonicTime> timestamp, LocalFrame* frame)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didPerformanceMark(label, timestamp, &frame);
-}
-
-void InspectorInstrumentation::performanceMarkImpl(InstrumentingAgents& instrumentingAgents, const String& label, std::optional<MonotonicTime> timestamp)
-{
-    if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent())
-        timelineAgent->didPerformanceMark(label, timestamp, nullptr);
+        timelineAgent->didPerformanceMark(label, timestamp, frame);
 }
 
 void InspectorInstrumentation::consoleStartRecordingCanvasImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context, JSC::JSGlobalObject& exec, JSC::JSObject* options)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -269,8 +269,7 @@ public:
     static void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvas(CanvasRenderingContext&);
 
-    static void performanceMark(LocalFrame&, const String&, std::optional<MonotonicTime>);
-    static void performanceMark(WorkerOrWorkletGlobalScope&, const String&, std::optional<MonotonicTime>);
+    static void performanceMark(ScriptExecutionContext&, const String&, std::optional<MonotonicTime>, LocalFrame*);
 
     static void didRequestAnimationFrame(Document&, int callbackId);
     static void didCancelAnimationFrame(Document&, int callbackId);
@@ -479,8 +478,7 @@ private:
     static void consoleStartRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     static void consoleStopRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&);
 
-    static void performanceMarkImpl(InstrumentingAgents&, LocalFrame&, const String& label, std::optional<MonotonicTime> timestamp);
-    static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime> timestamp);
+    static void performanceMarkImpl(InstrumentingAgents&, const String& label, std::optional<MonotonicTime>, LocalFrame*);
 
     static void didRequestAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
     static void didCancelAnimationFrameImpl(InstrumentingAgents&, int callbackId, Document&);
@@ -1683,16 +1681,11 @@ inline void InspectorInstrumentation::consoleStopRecordingCanvas(CanvasRendering
         consoleStopRecordingCanvasImpl(*agents, context);
 }
 
-inline void InspectorInstrumentation::performanceMark(LocalFrame& frame, const String& label, std::optional<MonotonicTime> startTime)
+inline void InspectorInstrumentation::performanceMark(ScriptExecutionContext& context, const String& label, std::optional<MonotonicTime> startTime, LocalFrame* frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (auto* agents = instrumentingAgents(frame))
-        performanceMarkImpl(*agents, frame, label, WTFMove(startTime));
-}
-
-inline void InspectorInstrumentation::performanceMark(WorkerOrWorkletGlobalScope& globalScope, const String& label, std::optional<MonotonicTime> startTime)
-{
-    performanceMarkImpl(instrumentingAgents(globalScope), label, WTFMove(startTime));
+    if (auto* agents = instrumentingAgents(context))
+        performanceMarkImpl(*agents, label, WTFMove(startTime), frame);
 }
 
 inline void InspectorInstrumentation::didRequestAnimationFrame(Document& document, int callbackId)

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -98,10 +98,8 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
     std::optional<MonotonicTime> timestamp;
     if (markOptions && markOptions->startTime)
         timestamp = m_performance.monotonicTimeFromRelativeTime(*markOptions->startTime);
-    if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(context.get()))
-        InspectorInstrumentation::performanceMark(*globalScope, markName, timestamp);
-    else if (auto* document = dynamicDowncast<Document>(context.get()); document && document->frame())
-        InspectorInstrumentation::performanceMark(*document->frame(), markName, timestamp);
+
+    InspectorInstrumentation::performanceMark(context.get(), markName, timestamp, is<Document>(context) ? downcast<Document>(context).frame() : nullptr);
 
     auto mark = PerformanceMark::create(globalObject, context, markName, WTFMove(markOptions));
     if (mark.hasException())

--- a/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
@@ -44,7 +44,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
         this._discontinuities = null;
         this._firstRecordOfTypeAfterDiscontinuity = new Set;
 
-        this._markers = null;
+        this._exportDataMarkers = null;
         this._exportDataRecords = null;
         this._exportDataMemoryPressureEvents = null;
         this._exportDataSampleStackTraces = null;
@@ -135,7 +135,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
             discontinuities: this._discontinuities,
             instrumentTypes: this._instruments.map((instrument) => instrument.timelineRecordType),
             records: this._exportDataRecords,
-            markers: this._markers,
+            markers: this._exportDataMarkers,
             memoryPressureEvents: this._exportDataMemoryPressureEvents,
             sampleStackTraces: this._exportDataSampleStackTraces,
             sampleDurations: this._exportDataSampleDurations,
@@ -153,8 +153,6 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
     get imported() { return this._imported; }
     get startTime() { return this._startTime; }
     get endTime() { return this._endTime; }
-
-    get markers() { return this._markers; }
 
     get topDownCallingContextTree() { return this._topDownCallingContextTree; }
     get bottomUpCallingContextTree() { return this._bottomUpCallingContextTree; }
@@ -245,7 +243,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
         this._discontinuities = [];
         this._firstRecordOfTypeAfterDiscontinuity.clear();
 
-        this._markers = [];
+        this._exportDataMarkers = [];
         this._exportDataRecords = [];
         this._exportDataMemoryPressureEvents = [];
         this._exportDataSampleStackTraces = [];
@@ -312,7 +310,7 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
 
     addEventMarker(marker)
     {
-        this._markers.push(marker);
+        this._exportDataMarkers.push(marker);
 
         if (!this._capturing && !this.__importing)
             return;
@@ -460,6 +458,10 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
 
         return true;
     }
+
+    // Testing
+
+    get markersForTesting() { return this._exportDataMarkers; }
 
     // Private
 


### PR DESCRIPTION
#### d5918187d18a309512bf04da9a709f43762634a0
<pre>
Merge InspectorInstrumentation::performanceMarkImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=258489">https://bugs.webkit.org/show_bug.cgi?id=258489</a>

Reviewed by Devin Rousso.

Merge two implementations of InspectorInstrumentation::performanceMarkImpl.

Also renamed TimelineRecording.prototype.get markers to markersForTesting.

* LayoutTests/inspector/timeline/timeline-event-performance-mark.html:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::performanceMarkImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::performanceMark):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::mark):
* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording):
(WI.TimelineRecording.prototype.exportData):
(WI.TimelineRecording.prototype.reset):
(WI.TimelineRecording.prototype.addEventMarker):
(WI.TimelineRecording.prototype.get markersForTesting): Renamed from markers.

Canonical link: <a href="https://commits.webkit.org/265496@main">https://commits.webkit.org/265496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5295e0fcb1a308c7e53e87e47d8d231acceafa32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13458 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13080 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9969 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13351 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8640 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9860 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13998 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1240 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->