### PR TITLE
input type=tel test case fail in css/selectors/dir-pseudo-on-input-element.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt
@@ -1,7 +1,6 @@
 
-
 PASS input element whose type attribute is in the telephone state
-FAIL input element whose type attribute is in the telephone state in a RTL block assert_equals: expected "ltr" but got "rtl"
+PASS input element whose type attribute is in the telephone state in a RTL block
 PASS input element whose type attribute is in the text state
 PASS input element whose type attribute is in the search state
 PASS input element whose type attribute is in the url state

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt
@@ -1,7 +1,6 @@
 
-
 PASS input element whose type attribute is in the telephone state
-FAIL input element whose type attribute is in the telephone state in a RTL block assert_equals: expected "ltr" but got "rtl"
+PASS input element whose type attribute is in the telephone state in a RTL block
 PASS input element whose type attribute is in the text state
 PASS input element whose type attribute is in the search state
 PASS input element whose type attribute is in the url state

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1388,6 +1388,8 @@ bdi, output {
     unicode-bidi: isolate;
 }
 
+input[type=tel i]:dir(ltr) { direction: ltr; }
+
 bdo {
     unicode-bidi: bidi-override;
 }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -960,6 +960,11 @@ void HTMLElement::updateEffectiveDirectionalityOfDirAuto()
         invalidateStyleForSubtree();
 }
 
+void HTMLElement::updateTextDirectionalityAfterTelephoneInputTypeChange()
+{
+    dirAttributeChanged(attributeWithoutSynchronization(dirAttr));
+}
+
 void HTMLElement::adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type changeType)
 {
     // FIXME: This function looks suspicious.

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -191,6 +191,7 @@ protected:
     unsigned parseBorderWidthAttribute(const AtomString&) const;
 
     void childrenChanged(const ChildChange&) override;
+    void updateTextDirectionalityAfterTelephoneInputTypeChange();
     void updateEffectiveDirectionalityOfDirAuto();
 
     using EventHandlerNameMap = HashMap<AtomStringImpl*, AtomString>;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -532,11 +532,15 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
 
     m_inputType->destroyShadowSubtree();
     m_inputType->detachFromElement();
+    auto oldType = m_inputType->type();
 
     bool previouslySelectable = m_inputType->supportsSelectionAPI();
 
     m_inputType = WTFMove(newType);
     m_inputType->createShadowSubtreeIfNeeded();
+
+    if (oldType == InputType::Type::Telephone || m_inputType->type() == InputType::Type::Telephone)
+        updateTextDirectionalityAfterTelephoneInputTypeChange();
 
     if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
         emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClassReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClassReadOnly, willSupportReadOnly } });


### PR DESCRIPTION
#### 1f2d2a92eeb831bedd01bbb5b694a0e29fa9af81
<pre>
input type=tel test case fail in css/selectors/dir-pseudo-on-input-element.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=258326">https://bugs.webkit.org/show_bug.cgi?id=258326</a>

Reviewed by Tim Nguyen.

The bug was caused by the missing :dir rule to force direction: ltr on input[type=tel] when there isn&apos;t
a valid dir content attribute specified on the element as well as the lack of style invalidation when
input element&apos;s type changes. This patch fixes both problems.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/selectors/dir-pseudo-on-input-element-expected.txt:
* Source/WebCore/css/html.css:
(input[type=tel i]:dir(ltr)):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::updateTextDirectionalityAfterTelephoneInputTypeChange):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):

Canonical link: <a href="https://commits.webkit.org/265500@main">https://commits.webkit.org/265500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f09e6af6ca0eb09e2ec72c11a4d4e6aa973ebe8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11062 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13474 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13100 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17203 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13372 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8660 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14018 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1241 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->