### PR TITLE
PlatformXR::Device should inherit from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<>

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,16 +67,16 @@ public:
     using RefCounted<WebXRSession>::ref;
     using RefCounted<WebXRSession>::deref;
 
-    using TrackingAndRenderingClient::weakPtrFactory;
-    using TrackingAndRenderingClient::WeakValueType;
-    using TrackingAndRenderingClient::WeakPtrImplType;
+    using PlatformXR::TrackingAndRenderingClient::weakPtrFactory;
+    using PlatformXR::TrackingAndRenderingClient::WeakValueType;
+    using PlatformXR::TrackingAndRenderingClient::WeakPtrImplType;
 
     XREnvironmentBlendMode environmentBlendMode() const;
     XRInteractionMode interactionMode() const;
     XRVisibilityState visibilityState() const;
     const WebXRRenderState& renderState() const;
     const WebXRInputSourceArray& inputSources() const;
-    PlatformXR::Device* device() const { return m_device.get(); }
+    RefPtr<PlatformXR::Device> device() const { return m_device.get(); }
 
     ExceptionOr<void> updateRenderState(const XRRenderStateInit&);
     void requestReferenceSpace(XRReferenceSpaceType, RequestReferenceSpacePromise&&);
@@ -142,7 +143,7 @@ private:
 
     WebXRSystem& m_xrSystem;
     XRSessionMode m_mode;
-    WeakPtr<PlatformXR::Device> m_device;
+    ThreadSafeWeakPtr<PlatformXR::Device> m_device;
     FeatureList m_requestedFeatures;
     RefPtr<WebXRRenderState> m_activeRenderState;
     RefPtr<WebXRRenderState> m_pendingRenderState;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia, S.L.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -28,6 +29,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -199,11 +201,15 @@ enum class HandJoint : unsigned {
 
 class TrackingAndRenderingClient;
 
-class Device : public ThreadSafeRefCounted<Device>, public CanMakeWeakPtr<Device> {
+class Device : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(Device);
 public:
     virtual ~Device() = default;
+
+    void ref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::ref(); }
+    void deref() const { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::deref(); }
+    ThreadSafeWeakPtrControlBlock& controlBlock() const { return ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Device>::controlBlock(); }
 
     using FeatureList = Vector<SessionFeature>;
     bool supports(SessionMode mode) const { return m_supportedFeaturesMap.contains(mode); }
@@ -224,7 +230,6 @@ public:
     // to yield the device's max framebuffer resolution. This resolution can be larger than
     // the native resolution if the device supports supersampling.
     virtual double maxFramebufferScalingFactor() const { return nativeFramebufferScalingFactor(); }
-
 
     virtual void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, SessionMode, const FeatureList&) = 0;
     virtual void shutDownTrackingAndRendering() = 0;

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia, S.L.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -52,8 +53,6 @@ OpenXRDevice::OpenXRDevice(XrInstance instance, XrSystemId system, Ref<WorkQueue
     , m_extensions(extensions)
 {
 }
-
-OpenXRDevice::~OpenXRDevice() = default;
 
 void OpenXRDevice::initialize(CompletionHandler<void()>&& callback)
 {
@@ -499,8 +498,9 @@ void OpenXRDevice::endSession()
         return;
 
     // Notify did end event
-    callOnMainThread([this, weakThis = WeakPtr { *this }]() {
-        if (!weakThis)
+    callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
         if (m_trackingAndRenderingClient)
             m_trackingAndRenderingClient->sessionDidEnd();
@@ -588,8 +588,9 @@ void OpenXRDevice::updateInteractionProfile()
 
     didNotifyInputInitialization = true;
     auto inputSources = m_input->collectInputSources(m_frameState);
-    callOnMainThread([this, weakThis = WeakPtr { *this }, inputSources = WTFMove(inputSources)]() mutable {
-        if (!weakThis)
+    callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, inputSources = WTFMove(inputSources)]() mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
         if (m_trackingAndRenderingClient)
             m_trackingAndRenderingClient->sessionDidInitializeInputSources(WTFMove(inputSources));

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia, S.L.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -52,7 +53,7 @@ class OpenXRInput;
 class OpenXRDevice final : public Device {
 public:
     static Ref<OpenXRDevice> create(XrInstance, XrSystemId, Ref<WorkQueue>&&, const OpenXRExtensions&, CompletionHandler<void()>&&);
-    ~OpenXRDevice();
+    virtual ~OpenXRDevice() = default;
 
 private:
     OpenXRDevice(XrInstance, XrSystemId, Ref<WorkQueue>&&, const OpenXRExtensions&);

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -118,8 +119,9 @@ void SimulatedXRDevice::initializeTrackingAndRendering(const WebCore::SecurityOr
         // There is no way to know how many simulateInputConnection calls will the device receive,
         // so notify the input sources have been initialized with an empty list. This is not a problem because
         // WPT tests rely on requestAnimationFrame updates to test the input sources.
-        callOnMainThread([this, weakThis = WeakPtr { *this }]() {
-            if (!weakThis)
+        callOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }]() {
+            auto strongThis = weakThis.get();
+            if (!strongThis)
                 return;
             if (m_trackingAndRenderingClient)
                 m_trackingAndRenderingClient->sessionDidInitializeInputSources({ });

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Igalia S.L. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,7 +74,7 @@ class SimulatedXRDevice final : public PlatformXR::Device {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SimulatedXRDevice();
-    ~SimulatedXRDevice();
+    virtual ~SimulatedXRDevice();
     void setViews(Vector<FrameData::View>&&);
     void setNativeBoundsGeometry(const Vector<FakeXRBoundsPoint>&);
     void setViewerOrigin(const std::optional<FrameData::Pose>&);

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,8 +77,9 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
     // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we
     // should delay this call after the WebXRSession has finished construction.
-    callOnMainRunLoop([this, weakThis = WeakPtr { *this }]() {
-        if (!weakThis)
+    callOnMainRunLoop([this, weakThis = ThreadSafeWeakPtr { *this }]() {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
             return;
 
         if (trackingAndRenderingClient())


### PR DESCRIPTION
#### 67406716ae559868268762cfc8cd5350a4eb1f73
<pre>
PlatformXR::Device should inherit from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258494">https://bugs.webkit.org/show_bug.cgi?id=258494</a>
&lt;rdar://111265303&gt;

Reviewed by Alex Christensen.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::WebXRSession):
- Use `device` argument instead of calling m_device.get().
(WebCore::WebXRSession::~WebXRSession):
(WebCore::WebXRSession::referenceSpaceIsSupported const):
(WebCore::WebXRSession::requestReferenceSpace):
(WebCore::WebXRSession::recommendedWebGLFramebufferResolution const):
(WebCore::WebXRSession::supportsViewportScaling const):
(WebCore::WebXRSession::shutdown):
(WebCore::WebXRSession::didCompleteShutdown):
(WebCore::WebXRSession::requestFrameIfNeeded):
(WebCore::WebXRSession::onFrame):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::WebXRSystem):
- Switch to use DummyInlineDevice::create().
(WebCore::WebXRSystem::ensureImmersiveXRDeviceIsSelected):
(WebCore::WebXRSystem::obtainCurrentDevice):
(WebCore::WebXRSystem::isSessionSupported):
(WebCore::WebXRSystem::resolveRequestedFeatures const):
(WebCore::WebXRSystem::resolveFeaturePermissions const):
(WebCore::WebXRSystem::requestSession):
(WebCore::WebXRSystem::unregisterSimulatedXRDeviceForTesting):
(WebCore::WebXRSystem::DummyInlineDevice::create): Add.
* Source/WebCore/Modules/webxr/WebXRSystem.h:
(WebCore::WebXRSystem::hasActiveImmersiveXRDevice):
- Switch from using `PlatformXR::Device*` to
  `ThreadSafeWeakPtr&lt;PlatformXR::Device&gt;`.
(WebCore::WebXRSystem::DummyInlineDevice::create): Add.

* Source/WebCore/platform/xr/PlatformXR.h:
- Change PlatformXR::Device to inherit from
  ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt; since it currently
  inherits from ThreadSafeRefCounted&lt;&gt; and CanMakeWeakPtr&lt;&gt; separately.
(PlatformXR::Device::ref const): Add.
(PlatformXR::Device::deref const): Add.
(PlatformXR::Device::controlBlock const): Add.
- Add methods needed for
  ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr&lt;&gt;.

* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp:
(PlatformXR::OpenXRDevice::~OpenXRDevice): Remove.
(PlatformXR::OpenXRDevice::endSession):
(PlatformXR::OpenXRDevice::updateInteractionProfile):
- Switch from using `WeakPtr&lt;PlatformXR::Device&gt;` to
  `ThreadSafeWeakPtr&lt;PlatformXR::Device&gt;`.
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.h:
(WebCore::PlatformXR::OpenXRDevice::~OpenXRDevice):
- Make destructor virtual and define as default here.

* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::initializeTrackingAndRendering):
- Switch from using `WeakPtr&lt;PlatformXR::Device&gt;` to
  `ThreadSafeWeakPtr&lt;PlatformXR::Device&gt;`.
* Source/WebCore/testing/WebFakeXRDevice.h:
(WebCore::SimulatedXRDevice::~SimulatedXRDevice):
- Make destructor virtual.
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
- Switch from using `WeakPtr&lt;PlatformXR::Device&gt;` to
  `ThreadSafeWeakPtr&lt;PlatformXR::Device&gt;`.

Canonical link: <a href="https://commits.webkit.org/267114@main">https://commits.webkit.org/267114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a491700b07230d6a5f426035d858d88046294e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16114 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16375 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18215 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14187 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14632 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14940 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/12675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18560 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->