### PR TITLE
[JSC] Use dup-and-ins instead of ins-and-ins to construct SIMD vector

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2742,8 +2742,12 @@ public:
 
     void materializeVector(v128_t value, FPRegisterID dest)
     {
+        if (bitEquals(value, vectorAllZeros())) {
+            moveZeroToVector(dest);
+            return;
+        }
         move(TrustedImm64(value.u64x2[0]), scratchRegister());
-        vectorReplaceLaneInt64(TrustedImm32(0), scratchRegister(), dest);
+        vectorSplatInt64(scratchRegister(), dest);
         move(TrustedImm64(value.u64x2[1]), scratchRegister());
         vectorReplaceLaneInt64(TrustedImm32(1), scratchRegister(), dest);
     }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1307,6 +1307,10 @@ public:
 
     void materializeVector(v128_t value, FPRegisterID dest)
     {
+        if (bitEquals(value, vectorAllZeros())) {
+            moveZeroToVector(dest);
+            return;
+        }
         move(TrustedImm64(value.u64x2[0]), scratchRegister());
         vectorReplaceLaneInt64(TrustedImm32(0), scratchRegister(), dest);
         move(TrustedImm64(value.u64x2[1]), scratchRegister());

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -176,8 +176,7 @@ void lowerMacros(Code& code)
 
                 insertionSet.insert(instIndex, Mul64, origin, lhsLower, rhsLower);
                 insertionSet.insert(instIndex, Mul64, origin, lhsUpper, rhsUpper);
-                insertionSet.insert(instIndex, MoveZeroToVector, origin, dst);
-                insertionSet.insert(instIndex, VectorReplaceLaneInt64, origin, Arg::imm(0), rhsLower, dst);
+                insertionSet.insert(instIndex, VectorSplatInt64, origin, rhsLower, dst);
                 insertionSet.insert(instIndex, VectorReplaceLaneInt64, origin, Arg::imm(1), rhsUpper, dst);
 
                 inst = Inst();
@@ -400,8 +399,7 @@ void lowerMacros(Code& code)
                     // FIXME: this is bad, we should load
                     auto gpTmp = code.newTmp(GP);
                     insertionSet.insert(instIndex, Move, origin, Arg::bigImm(towerOfPower.u64x2[0]), gpTmp);
-                    insertionSet.insert(instIndex, MoveZeroToVector, origin, maskTmp);
-                    insertionSet.insert(instIndex, VectorReplaceLaneInt64, origin, Arg::imm(0), gpTmp, maskTmp);
+                    insertionSet.insert(instIndex, VectorSplatInt64, origin, gpTmp, maskTmp);
                     insertionSet.insert(instIndex, Move, origin, Arg::bigImm(towerOfPower.u64x2[1]), gpTmp);
                     insertionSet.insert(instIndex, VectorReplaceLaneInt64, origin, Arg::imm(1), gpTmp, maskTmp);
                 }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -8320,7 +8320,7 @@ public:
             m_jit.vectorExtractLaneInt64(TrustedImm32(1), srcLocation.asFPR(), scratches.gpr(1));
             m_jit.rshift64(shiftRCX, scratches.gpr(0));
             m_jit.rshift64(shiftRCX, scratches.gpr(1));
-            m_jit.vectorReplaceLaneInt64(TrustedImm32(0), scratches.gpr(0), resultLocation.asFPR());
+            m_jit.vectorSplatInt64(scratches.gpr(0), resultLocation.asFPR());
             m_jit.vectorReplaceLaneInt64(TrustedImm32(1), scratches.gpr(1), resultLocation.asFPR());
             return { };
         }
@@ -8366,15 +8366,17 @@ public:
 
         LOG_INSTRUCTION("Vector", op, left, leftLocation, right, rightLocation, RESULT(result));
 
+        ScratchScope<0, 1> scratches(*this, leftLocation, rightLocation, resultLocation);
+        FPRReg scratchFPR = scratches.fpr(0);
         if (op == SIMDLaneOperation::ExtmulLow) {
-            m_jit.vectorExtendLow(info, leftLocation.asFPR(), wasmScratchFPR);
+            m_jit.vectorExtendLow(info, leftLocation.asFPR(), scratchFPR);
             m_jit.vectorExtendLow(info, rightLocation.asFPR(), resultLocation.asFPR());
         } else {
             ASSERT(op == SIMDLaneOperation::ExtmulHigh);
-            m_jit.vectorExtendHigh(info, leftLocation.asFPR(), wasmScratchFPR);
+            m_jit.vectorExtendHigh(info, leftLocation.asFPR(), scratchFPR);
             m_jit.vectorExtendHigh(info, rightLocation.asFPR(), resultLocation.asFPR());
         }
-        emitVectorMul(info, Location::fromFPR(wasmScratchFPR), resultLocation, resultLocation);
+        emitVectorMul(info, Location::fromFPR(scratchFPR), resultLocation, resultLocation);
 
         return { };
     }
@@ -9076,11 +9078,11 @@ public:
             m_jit.vectorExtractLaneInt64(TrustedImm32(0), left.asFPR(), wasmScratchGPR);
             m_jit.vectorExtractLaneInt64(TrustedImm32(0), right.asFPR(), dataScratchGPR);
             m_jit.mul64(wasmScratchGPR, dataScratchGPR, wasmScratchGPR);
-            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(0), wasmScratchGPR, wasmScratchFPR);
+            m_jit.vectorSplatInt64(wasmScratchGPR, wasmScratchFPR);
             m_jit.vectorExtractLaneInt64(TrustedImm32(1), left.asFPR(), wasmScratchGPR);
             m_jit.vectorExtractLaneInt64(TrustedImm32(1), right.asFPR(), dataScratchGPR);
             m_jit.mul64(wasmScratchGPR, dataScratchGPR, wasmScratchGPR);
-            m_jit.vectorReplaceLane(SIMDLane::i64x2, TrustedImm32(1), wasmScratchGPR, wasmScratchFPR);
+            m_jit.vectorReplaceLaneInt64(TrustedImm32(1), wasmScratchGPR, wasmScratchFPR);
             m_jit.moveVector(wasmScratchFPR, result.asFPR());
         } else
             m_jit.vectorMul(info, left.asFPR(), right.asFPR(), result.asFPR());


### PR DESCRIPTION
#### d6403c45b3745fedf7afcd4f6b1872ea5b3c173f
<pre>
[JSC] Use dup-and-ins instead of ins-and-ins to construct SIMD vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=258498">https://bugs.webkit.org/show_bug.cgi?id=258498</a>
rdar://111283281

Reviewed by Michael Saboff.

Use DUP-and-INS instead of INS-and-INS to remove partial dependency to the old vector value.

* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::materializeVector):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSIMDShift):
(JSC::Wasm::BBQJIT::emitVectorMul):

Canonical link: <a href="https://commits.webkit.org/265520@main">https://commits.webkit.org/265520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59f08168e21cc8b472e48cab97a4015bd6a7c438

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10576 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13134 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17230 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9388 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13401 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10506 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8692 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11185 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9779 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3054 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14052 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11499 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1254 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10463 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2825 "Passed tests") | 
<!--EWS-Status-Bubble-End-->