### PR TITLE
[Curl] Fix coding style issue in ResourceResponse.h

### DIFF
--- a/Source/WebCore/platform/network/curl/ResourceResponse.h
+++ b/Source/WebCore/platform/network/curl/ResourceResponse.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 class CurlResponse;
 
-class WEBCORE_EXPORT ResourceResponse : public ResourceResponseBase {
+class ResourceResponse : public ResourceResponseBase {
 public:
     ResourceResponse()
         : ResourceResponseBase()
@@ -44,28 +44,25 @@ public:
     {
     }
 
-    ResourceResponse(CurlResponse&);
-    
     ResourceResponse(ResourceResponseBase&& base)
         : ResourceResponseBase(WTFMove(base))
     {
     }
 
-    void appendHTTPHeaderField(const String&);
+    WEBCORE_EXPORT ResourceResponse(CurlResponse&);
 
-    bool shouldRedirect();
-    bool isMovedPermanently() const;
-    bool isFound() const;
-    bool isSeeOther() const;
-    bool isNotModified() const;
-    bool isUnauthorized() const;
-    bool isProxyAuthenticationRequired() const;
+    bool isMovedPermanently() const { return httpStatusCode() == 301; };
+    bool isFound() const { return httpStatusCode() == 302; }
+    bool isSeeOther() const { return httpStatusCode() == 303; }
+    bool isUnauthorized() const { return httpStatusCode() == 401; }
+    bool isProxyAuthenticationRequired() const { return httpStatusCode() == 407; }
 
 private:
     friend class ResourceResponseBase;
 
-    static bool isAppendableHeader(const String &key);
     String platformSuggestedFilename() const;
+
+    void appendHTTPHeaderField(const String&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-bool ResourceResponse::isAppendableHeader(const String &key)
+static bool isAppendableHeader(const String &key)
 {
     static constexpr ASCIILiteral appendableHeaders[] = {
         "access-control-allow-headers"_s,
@@ -136,52 +136,6 @@ String ResourceResponse::platformSuggestedFilename() const
     if (contentDisposition.is8Bit())
         return String::fromUTF8WithLatin1Fallback(contentDisposition.characters8(), contentDisposition.length());
     return contentDisposition.toString();
-}
-
-bool ResourceResponse::shouldRedirect()
-{
-    auto statusCode = httpStatusCode();
-    if (statusCode < 300 || 400 <= statusCode)
-        return false;
-
-    // Some 3xx status codes aren't actually redirects.
-    if (statusCode == 300 || statusCode == 304 || statusCode == 305 || statusCode == 306)
-        return false;
-
-    if (httpHeaderField(HTTPHeaderName::Location).isEmpty())
-        return false;
-
-    return true;
-}
-
-bool ResourceResponse::isMovedPermanently() const
-{
-    return httpStatusCode() == 301;
-}
-
-bool ResourceResponse::isFound() const
-{
-    return httpStatusCode() == 302;
-}
-
-bool ResourceResponse::isSeeOther() const
-{
-    return httpStatusCode() == 303;
-}
-
-bool ResourceResponse::isNotModified() const
-{
-    return httpStatusCode() == 304;
-}
-
-bool ResourceResponse::isUnauthorized() const
-{
-    return httpStatusCode() == 401;
-}
-
-bool ResourceResponse::isProxyAuthenticationRequired() const
-{
-    return httpStatusCode() == 407;
 }
 
 }

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
@@ -77,6 +77,7 @@ private:
 
     void invokeDidReceiveResponse();
 
+    bool shouldStartHTTPRedirection();
     bool shouldRedirectAsGET(const WebCore::ResourceRequest&, bool crossOrigin);
     void willPerformHTTPRedirection();
 


### PR DESCRIPTION
#### 593b1ac9407246d57189e138f4a1c18886616063
<pre>
[Curl] Fix coding style issue in ResourceResponse.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=258509">https://bugs.webkit.org/show_bug.cgi?id=258509</a>

Reviewed by Fujii Hironori.

Fix coding style issue in ResourceResponse.h.

* Source/WebCore/platform/network/curl/ResourceResponse.h:
(WebCore::ResourceResponse::isMovedPermanently const):
(WebCore::ResourceResponse::isFound const):
(WebCore::ResourceResponse::isSeeOther const):
(WebCore::ResourceResponse::isUnauthorized const):
(WebCore::ResourceResponse::isProxyAuthenticationRequired const):
(): Deleted.
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::isAppendableHeader):
(WebCore::ResourceResponse::isAppendableHeader): Deleted.
(WebCore::ResourceResponse::shouldRedirect): Deleted.
(WebCore::ResourceResponse::isMovedPermanently const): Deleted.
(WebCore::ResourceResponse::isFound const): Deleted.
(WebCore::ResourceResponse::isSeeOther const): Deleted.
(WebCore::ResourceResponse::isNotModified const): Deleted.
(WebCore::ResourceResponse::isUnauthorized const): Deleted.
(WebCore::ResourceResponse::isProxyAuthenticationRequired const): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveResponse):
(WebKit::NetworkDataTaskCurl::shouldStartHTTPRedirection):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h:

Canonical link: <a href="https://commits.webkit.org/265537@main">https://commits.webkit.org/265537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/973fe83013882a23deab5ea68c8d64a0df74fd80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13231 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17311 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13483 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10697 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9868 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14142 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1260 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->