### PR TITLE
[web-animations] css/css-fonts/animations/font-style-interpolation.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-style-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-style-interpolation-expected.txt
@@ -1,132 +1,132 @@
 TT
 
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg] assert_equals: expected "oblique - 20deg " but got "oblique 10deg "
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg] assert_equals: expected "oblique - 2.5deg " but got "oblique 10deg "
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal] assert_equals: expected "normal " but got "oblique 10deg "
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg] assert_equals: expected "oblique 3deg " but got "oblique 10deg "
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 10deg "
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg]
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg]
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal]
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg]
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg]
 PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (1) should be [oblique 10deg]
-FAIL CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg] assert_equals: expected "oblique 15deg " but got "oblique 10deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg] assert_equals: expected "oblique - 20deg " but got "oblique 10deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg] assert_equals: expected "oblique - 2.5deg " but got "oblique 10deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal] assert_equals: expected "normal " but got "oblique 10deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg] assert_equals: expected "oblique 3deg " but got "oblique 10deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 10deg "
+PASS CSS Transitions: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg]
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg]
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg]
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal]
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg]
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg]
 PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (1) should be [oblique 10deg]
-FAIL CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg] assert_equals: expected "oblique 15deg " but got "oblique 10deg "
-FAIL CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg] assert_equals: expected "oblique - 20deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg] assert_equals: expected "oblique - 2.5deg " but got "normal "
+PASS CSS Transitions with transition: all: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg]
+PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg]
+PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg]
 PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal]
-FAIL CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg] assert_equals: expected "oblique 3deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 10deg "
+PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg]
+PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg]
 PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (1) should be [oblique 10deg]
-FAIL CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg] assert_equals: expected "oblique 15deg " but got "oblique 10deg "
-FAIL Web Animations: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg] assert_equals: expected "oblique - 20deg " but got "normal "
-FAIL Web Animations: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg] assert_equals: expected "oblique - 2.5deg " but got "normal "
+PASS CSS Animations: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg]
+PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (-2) should be [oblique -20deg]
+PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (-0.25) should be [oblique -2.5deg]
 PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (0) should be [normal]
-FAIL Web Animations: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg] assert_equals: expected "oblique 3deg " but got "normal "
-FAIL Web Animations: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 10deg "
+PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (0.3) should be [oblique 3deg]
+PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (0.6) should be [oblique 6deg]
 PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (1) should be [oblique 10deg]
-FAIL Web Animations: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg] assert_equals: expected "oblique 15deg " but got "oblique 10deg "
-FAIL CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg] assert_equals: expected "oblique - 15deg " but got "normal "
+PASS Web Animations: property <font-style> from [normal] to [oblique 10deg] at (1.5) should be [oblique 15deg]
+PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-0.25) should be [oblique 2.5deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0) should be [oblique 5deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.3) should be [oblique 8deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.6) should be [oblique 11deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1) should be [oblique 15deg]
 PASS CSS Transitions: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1.5) should be [oblique 20deg]
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg] assert_equals: expected "oblique - 15deg " but got "normal "
+PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-0.25) should be [oblique 2.5deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0) should be [oblique 5deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.3) should be [oblique 8deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.6) should be [oblique 11deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1) should be [oblique 15deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1.5) should be [oblique 20deg]
-FAIL CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg] assert_equals: expected "oblique - 15deg " but got "normal "
+PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-0.25) should be [oblique 2.5deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0) should be [oblique 5deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.3) should be [oblique 8deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.6) should be [oblique 11deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1) should be [oblique 15deg]
 PASS CSS Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1.5) should be [oblique 20deg]
-FAIL Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg] assert_equals: expected "oblique - 15deg " but got "normal "
+PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-2) should be [oblique -15deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (-0.25) should be [oblique 2.5deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0) should be [oblique 5deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.3) should be [oblique 8deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (0.6) should be [oblique 11deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1) should be [oblique 15deg]
 PASS Web Animations: property <font-style> from [oblique 5deg] to [oblique 15deg] at (1.5) should be [oblique 20deg]
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg] assert_equals: expected "oblique - 40deg " but got "oblique 20deg "
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg] assert_equals: expected "oblique - 5deg " but got "oblique 20deg "
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (0) should be [normal] assert_equals: expected "normal " but got "oblique 20deg "
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 20deg "
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg] assert_equals: expected "oblique 12deg " but got "oblique 20deg "
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg]
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg]
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (0) should be [normal]
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg]
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg]
 PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (1) should be [oblique 20deg]
-FAIL CSS Transitions: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg] assert_equals: expected "oblique 30deg " but got "oblique 20deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg] assert_equals: expected "oblique - 40deg " but got "oblique 20deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg] assert_equals: expected "oblique - 5deg " but got "oblique 20deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0) should be [normal] assert_equals: expected "normal " but got "oblique 20deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "oblique 20deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg] assert_equals: expected "oblique 12deg " but got "oblique 20deg "
+PASS CSS Transitions: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg]
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg]
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg]
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0) should be [normal]
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg]
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg]
 PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (1) should be [oblique 20deg]
-FAIL CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg] assert_equals: expected "oblique 30deg " but got "oblique 20deg "
-FAIL CSS Animations: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg] assert_equals: expected "oblique - 40deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg] assert_equals: expected "oblique - 5deg " but got "normal "
+PASS CSS Transitions with transition: all: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg]
+PASS CSS Animations: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg]
+PASS CSS Animations: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg]
 PASS CSS Animations: property <font-style> from [initial] to [inherit] at (0) should be [normal]
-FAIL CSS Animations: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg] assert_equals: expected "oblique 12deg " but got "oblique 20deg "
+PASS CSS Animations: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg]
+PASS CSS Animations: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg]
 PASS CSS Animations: property <font-style> from [initial] to [inherit] at (1) should be [oblique 20deg]
-FAIL CSS Animations: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg] assert_equals: expected "oblique 30deg " but got "oblique 20deg "
-FAIL Web Animations: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg] assert_equals: expected "oblique - 40deg " but got "normal "
-FAIL Web Animations: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg] assert_equals: expected "oblique - 5deg " but got "normal "
+PASS CSS Animations: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg]
+PASS Web Animations: property <font-style> from [initial] to [inherit] at (-2) should be [oblique -40deg]
+PASS Web Animations: property <font-style> from [initial] to [inherit] at (-0.25) should be [oblique -5deg]
 PASS Web Animations: property <font-style> from [initial] to [inherit] at (0) should be [normal]
-FAIL Web Animations: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg] assert_equals: expected "oblique 6deg " but got "normal "
-FAIL Web Animations: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg] assert_equals: expected "oblique 12deg " but got "oblique 20deg "
+PASS Web Animations: property <font-style> from [initial] to [inherit] at (0.3) should be [oblique 6deg]
+PASS Web Animations: property <font-style> from [initial] to [inherit] at (0.6) should be [oblique 12deg]
 PASS Web Animations: property <font-style> from [initial] to [inherit] at (1) should be [oblique 20deg]
-FAIL Web Animations: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg] assert_equals: expected "oblique 30deg " but got "oblique 20deg "
-FAIL CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg] assert_equals: expected "oblique 40deg " but got "normal "
-FAIL CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg] assert_equals: expected "oblique 20deg " but got "normal "
-FAIL CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg] assert_equals: expected "oblique 10deg " but got "normal "
+PASS Web Animations: property <font-style> from [initial] to [inherit] at (1.5) should be [oblique 30deg]
+PASS CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg]
+PASS CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg]
+PASS CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg]
 PASS CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (1) should be [normal]
-FAIL CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg] assert_equals: expected "oblique - 10deg " but got "normal "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg] assert_equals: expected "oblique 40deg " but got "normal "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg] assert_equals: expected "oblique 20deg " but got "normal "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg] assert_equals: expected "oblique 10deg " but got "normal "
+PASS CSS Transitions: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (1) should be [normal]
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg] assert_equals: expected "oblique - 10deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg] assert_equals: expected "oblique 40deg " but got "oblique 20deg "
+PASS CSS Transitions with transition: all: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg]
+PASS CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg]
 PASS CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg]
-FAIL CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg] assert_equals: expected "oblique 10deg " but got "normal "
+PASS CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg]
 PASS CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (1) should be [normal]
-FAIL CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg] assert_equals: expected "oblique - 10deg " but got "normal "
-FAIL Web Animations: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg] assert_equals: expected "oblique 40deg " but got "oblique 20deg "
+PASS CSS Animations: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg]
+PASS Web Animations: property <font-style> from [oblique 20deg] to [normal] at (-1) should be [oblique 40deg]
 PASS Web Animations: property <font-style> from [oblique 20deg] to [normal] at (0) should be [oblique 20deg]
-FAIL Web Animations: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg] assert_equals: expected "oblique 10deg " but got "normal "
+PASS Web Animations: property <font-style> from [oblique 20deg] to [normal] at (0.5) should be [oblique 10deg]
 PASS Web Animations: property <font-style> from [oblique 20deg] to [normal] at (1) should be [normal]
-FAIL Web Animations: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg] assert_equals: expected "oblique - 10deg " but got "normal "
-FAIL CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
+PASS Web Animations: property <font-style> from [oblique 20deg] to [normal] at (1.5) should be [oblique -10deg]
+PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-FAIL CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg] assert_equals: expected "oblique 90deg " but got "oblique 180deg "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
+PASS CSS Transitions: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-FAIL CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg] assert_equals: expected "oblique 90deg " but got "oblique 180deg "
-FAIL CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
+PASS CSS Transitions with transition: all: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-FAIL CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg] assert_equals: expected "oblique 90deg " but got "oblique 180deg "
-FAIL Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
-FAIL Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg] assert_equals: expected "oblique - 90deg " but got "normal "
+PASS CSS Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-2) should be [oblique -90deg]
+PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (-1) should be [oblique -90deg]
+PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0) should be [oblique -90deg]
 PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (0.5) should be [normal]
 PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1) should be [oblique 90deg]
-FAIL Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg] assert_equals: expected "oblique 90deg " but got "oblique 180deg "
-FAIL An interpolation to inherit updates correctly on a parent style change. assert_equals: expected "oblique 10deg" but got "oblique 20deg"
+PASS Web Animations: property <font-style> from [oblique -90deg] to [oblique 90deg] at (1.5) should be [oblique 90deg]
+PASS An interpolation to inherit updates correctly on a parent style change.
 

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -46,6 +46,7 @@
 #include "FloatConversion.h"
 #include "FontCascade.h"
 #include "FontSelectionAlgorithm.h"
+#include "FontSelectionValueInlines.h"
 #include "FontTaggedSettings.h"
 #include "GridPositionsResolver.h"
 #include "IdentityTransformOperation.h"
@@ -533,7 +534,16 @@ static inline FontSelectionValue blendFunc(FontSelectionValue from, FontSelectio
 
 static inline std::optional<FontSelectionValue> blendFunc(std::optional<FontSelectionValue> from, std::optional<FontSelectionValue> to, const CSSPropertyBlendingContext& context)
 {
-    return blendFunc(*from, *to, context);
+    if (!from && !to)
+        return std::nullopt;
+
+    auto valueOrDefault = [](std::optional<FontSelectionValue> fontSelectionValue) {
+        if (!fontSelectionValue)
+            return 0.0f;
+        return static_cast<float>(fontSelectionValue.value());
+    };
+
+    return normalizedFontItalicValue(blendFunc(valueOrDefault(from), valueOrDefault(to), context));
 }
 
 static inline bool canInterpolate(const GridTrackList& from, const GridTrackList& to)
@@ -2589,7 +2599,7 @@ public:
 private:
     bool canInterpolate(const RenderStyle& from, const RenderStyle& to, CompositeOperation) const final
     {
-        return from.fontItalic() && to.fontItalic() && from.fontDescription().fontStyleAxis() == FontStyleAxis::slnt && to.fontDescription().fontStyleAxis() == FontStyleAxis::slnt;
+        return from.fontDescription().fontStyleAxis() == FontStyleAxis::slnt && to.fontDescription().fontStyleAxis() == FontStyleAxis::slnt;
     }
 
     void blend(RenderStyle& destination, const RenderStyle& from, const RenderStyle& to, const CSSPropertyBlendingContext& context) const final

--- a/Source/WebCore/css/FontSelectionValueInlines.h
+++ b/Source/WebCore/css/FontSelectionValueInlines.h
@@ -103,4 +103,9 @@ inline std::optional<CSSValueID> fontStyleKeyword(std::optional<FontSelectionVal
     return std::nullopt;
 }
 
+inline FontSelectionValue normalizedFontItalicValue(float inputValue)
+{
+    return FontSelectionValue { std::clamp(inputValue, -90.0f, 90.0f) };
+}
+
 }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1526,7 +1526,7 @@ inline FontSelectionValue BuilderConverter::convertFontStretchFromValue(const CS
 
 inline FontSelectionValue BuilderConverter::convertFontStyleAngle(const CSSValue& value)
 {
-    return FontSelectionValue { std::clamp(downcast<CSSPrimitiveValue>(value).value<float>(CSSUnitType::CSS_DEG), -90.0f, 90.0f) };
+    return normalizedFontItalicValue(downcast<CSSPrimitiveValue>(value).value<float>(CSSUnitType::CSS_DEG));
 }
 
 // The input value needs to parsed and valid, this function returns std::nullopt if the input was "normal".


### PR DESCRIPTION
#### ae677e6c0b775cd9c91fd4f9d3da3035e7c6844e
<pre>
[web-animations] css/css-fonts/animations/font-style-interpolation.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=258510">https://bugs.webkit.org/show_bug.cgi?id=258510</a>

Reviewed by Myles C. Maxfield.

We failed to properly blend the `font-style` oblique angle because:

a. we would treat any interpolation with a `normal` value as discrete
b. we would not correctly clamp the oblique value to be within the `-90deg` to `90deg` range

We now handle optional values correctly when blending `nullopt` `std::optional&lt;FontSelectionValue&gt;` values
and factored the `-90deg` to `90deg` range clamping to be shared across `BuilderConverter::convertFontStyleAngle()`
and `std::optional&lt;FontSelectionValue&gt;` blending with a new `normalizedFontItalicValue()` function.

We now pass all tests in the WPT test `css/css-fonts/animations/font-style-interpolation.html`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-style-interpolation-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
* Source/WebCore/css/FontSelectionValueInlines.h:
(WebCore::normalizedFontItalicValue):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertFontStyleAngle):

Canonical link: <a href="https://commits.webkit.org/265512@main">https://commits.webkit.org/265512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7732a55d9f96208490a48931d587905295a64450

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13515 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12163 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9375 "3 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13167 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17255 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13428 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8724 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9807 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14082 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->