### PR TITLE
[JSC] Align duplicate declaration checks in EvalDeclarationInstantiation with the spec

### DIFF
--- a/JSTests/ChakraCore/test/Closures/bug_OS_2299723.baseline-jsc
+++ b/JSTests/ChakraCore/test/Closures/bug_OS_2299723.baseline-jsc
@@ -1,4 +1,5 @@
+eval('var x = 5') threw 'Can't create duplicate variable in eval: 'x''
 x: 5
-eval('var y = 5') threw 'Attempted to assign to readonly property.'
+eval('var y = 5') threw 'Can't create duplicate variable in eval: 'y''
 eval('y = 5') threw 'Attempted to assign to readonly property.'
 y: 1

--- a/JSTests/stress/const-not-strict-mode.js
+++ b/JSTests/stress/const-not-strict-mode.js
@@ -62,13 +62,13 @@ function foo() {
         try {
             eval("var x = 20;");
         } catch(e) {
-            if (e.name.indexOf("TypeError") !== -1 && e.message.indexOf("readonly") !== -1)
-                threw = true;
+            threw = true;
+            assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'x'");
         }
         assert(threw);
         assert(x === 40);
     }
-    assert(x === undefined);
+    assert(typeof x === "undefined");
 }
 
 function bar() {
@@ -87,13 +87,13 @@ function bar() {
         try {
             eval("var x = 20;");
         } catch(e) {
-            if (e.name.indexOf("TypeError") !== -1 && e.message.indexOf("readonly") !== -1)
-                threw = true;
+            threw = true;
+            assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'x'");
         }
         assert(threw);
         assert(x === 40);
     }
-    assert(x === undefined);
+    assert(typeof x === "undefined");
 }
 
 function baz() {

--- a/JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js
+++ b/JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js
@@ -1,4 +1,5 @@
 var err = new Error();
+err.e = "foo";
 
 function assert(x) {
     if (!x)
@@ -25,7 +26,31 @@ function shouldThrow(func, errorMessage) {
         throw err;
     } catch (e) {
         eval(`function e() { return 1; }`); // no error
+        assert(e === err);
     }
+    assert(e() === 1);
+})();
+
+(function() {
+    var e = 1;
+    try {
+        throw err;
+    } catch (e) {
+        eval(`if (true) { function e() { return 1; } }`); // no error
+        assert(e === err);
+    }
+    assert(e() === 1);
+})();
+
+(function() {
+    var e = 1;
+    try {
+        throw err;
+    } catch ({e}) {
+        eval(`if (true) { function e() { return 1; } }`); // no error
+        assert(e === "foo");
+    }
+    assert(e === 1);
 })();
 
 shouldThrow(function() {
@@ -34,5 +59,22 @@ shouldThrow(function() {
         throw err;
     } catch ({e}) {
         eval(`function e() { return 1; }`); // syntax error
+    }
+}, "SyntaxError: Can't create duplicate variable in eval: 'e'");
+
+shouldThrow(function() {
+    var e = 2;
+    try {
+        throw err;
+    } catch ({e}) {
+        eval(`var e = 1;`); // syntax error
+    }
+}, "SyntaxError: Can't create duplicate variable in eval: 'e'");
+
+shouldThrow(function() {
+    try {
+        throw err;
+    } catch ({...e}) {
+        eval(`var e;`); // syntax error
     }
 }, "SyntaxError: Can't create duplicate variable in eval: 'e'");

--- a/JSTests/stress/eval-func-decl-in-global-of-eval.js
+++ b/JSTests/stress/eval-func-decl-in-global-of-eval.js
@@ -64,3 +64,46 @@ function foobar() {
 foobar();
 assertThrow(() => g, "ReferenceError: Can't find variable: g");
 
+(function() {
+    try {
+        let b;
+        let c;
+        eval('var a; var b; var c;');
+    } catch (e) {
+        var error = e;
+    }
+
+    assert(error.toString(), "SyntaxError: Can't create duplicate variable in eval: 'c'");
+    assertThrow(() => a, "ReferenceError: Can't find variable: a");
+    assertThrow(() => b, "ReferenceError: Can't find variable: b");
+    assertThrow(() => c, "ReferenceError: Can't find variable: c");
+})();
+
+(function() {
+    try {
+        let x1;
+        eval('function x1() {} function x2() {} function x3() {}');
+    } catch (e) {
+        var error = e;
+    }
+
+    assert(error.toString(), "SyntaxError: Can't create duplicate variable in eval: 'x1'");
+    assertThrow(() => x1, "ReferenceError: Can't find variable: x1");
+    assertThrow(() => x2, "ReferenceError: Can't find variable: x2");
+    assertThrow(() => x3, "ReferenceError: Can't find variable: x3");
+})();
+
+(function() {
+    var x3;
+    try {
+        let x2;
+        eval('function x1() {} function x2() {} function x3() {}');
+    } catch (e) {
+        var error = e;
+    }
+
+    assert(error.toString(), "SyntaxError: Can't create duplicate variable in eval: 'x2'");
+    assertThrow(() => x1, "ReferenceError: Can't find variable: x1");
+    assertThrow(() => x2, "ReferenceError: Can't find variable: x2");
+    assert(x3, undefined);
+})();

--- a/JSTests/stress/eval-func-decl-within-eval-with-reassign-to-var.js
+++ b/JSTests/stress/eval-func-decl-within-eval-with-reassign-to-var.js
@@ -57,10 +57,8 @@ for (var i = 0; i < 10000; i++){
     assertThrow(() => _bar, "ReferenceError: Can't find variable: _bar");
 }
 
-// Fixme:  https://bugs.webkit.org/show_bug.cgi?id=167837
 // Current test does not work because it should raise exception
 // that f could not be redeclared
-/*
 function goo() {
     {   
         var error = false;
@@ -79,13 +77,14 @@ for (var i = 0; i < 10000; i++) {
     goo();
     assert(typeof f, "undefined", "#7");
 }
-*/
 
 function hoo() {
     {
         let h = 20;
-        eval('var h = 15; eval(" if (false){ function h() { }; } ");');
-        assert(h, 15);
+        try { eval('var h = 15;'); } catch (e) { var evalError = e; }
+        assert(evalError.toString(), "SyntaxError: Can't create duplicate variable in eval: 'h'");
+        eval('eval("if (false) { function h() {} } ");');
+        assert(h, 20);
     }
     assert(typeof h, "undefined");
 }
@@ -125,6 +124,8 @@ for (var i = 0; i < 10000; i++){
 
 function loo() { 
     let h = 20; 
+    // FIXME: This should throw SyntaxError.
+    // https://bugs.webkit.org/show_bug.cgi?id=258507
     eval("var h; if (false) { function h() { } }"); 
     return h; 
 }

--- a/JSTests/stress/eval-let-const-redeclararion.js
+++ b/JSTests/stress/eval-let-const-redeclararion.js
@@ -1,0 +1,217 @@
+// author: Oleksandr Skachkov <gskachkov@gmail.com>
+
+var noError = false;
+function assert(cond, msg) {
+    if (!cond)
+        throw new Error(msg || "broke assertion");
+}
+try {
+    (function () { let a; eval('var a'); })();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+try {
+    (function () { let a; eval('{ var a = 10; }'); })();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+try {
+    function foo() { let a; eval('{ var a = 10; }'); }
+    foo();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+try {
+    (function () { const a = ''; eval('var a'); })();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+try {
+    (function () { const a = ''; eval('{ var a = 10; }'); })();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+try {
+    function boo() { const a = ''; eval('{ var a = 10; }'); }
+    boo();
+} catch (e) {
+    noError = e instanceof SyntaxError;
+}
+assert(noError, 'Expected syntax error in case var tried shadow let/const');
+noError = false;
+function goo() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('var e = 10;');
+        noError = noError && e === 10;
+    }
+    noError = noError && typeof e === 'undefined';
+}
+goo();
+assert(noError, 'Expected that var in eval can override variable in catch block');
+noError = false;
+function baz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('function e() { return "abcd"; }');
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcd';
+}
+baz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block');
+noError = false;
+function caz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('function e2() { return "abcde"; } \n  eval(" function e() { return \'abcd\'; }");');
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcd';
+}
+caz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block');
+noError = false;
+function eaz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('function e() { return "abcde"; } \n  eval(" function e() { return \'abcd\'; }");');
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcd';
+}
+eaz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block');
+noError = false;
+function daz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        {
+            let obj = { e: 1234 };
+            noError = noError && obj.e === 1234;
+            with (obj) {
+                eval('function e() { return "abcde"; }');
+            }
+            noError = noError && obj.e === 1234 && e instanceof Error;
+        } 
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcde';
+}
+daz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block, in block scope and with scope');
+noError = false;
+function faz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        {
+            let e = 1234;
+            noError = noError && e === 1234;
+            try {
+                eval('function e() { return "abcde"; }');
+                noError = false;
+            } catch (error) {
+                noError = noError && error instanceof SyntaxError;
+            }
+        }
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && typeof e === 'undefined';
+}
+faz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block and raise exception if faced wihh let variable');
+noError = false;
+function gaz() {
+    var e = 4321;
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('function e() { return "abcde"; }');
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcde';
+}
+gaz();
+assert(noError, 'Expected that function in eval can override variable in catch block');
+noError = false;
+function jaz() {
+    try {
+        throw new Error('error');
+    } catch (e) {
+        noError = e instanceof Error;
+        eval('{ function e() { return "abcd"; } }');
+        noError = noError && e instanceof Error;
+    }
+    noError = noError && e() === 'abcd';
+}
+jaz();
+assert(noError, 'Expected that function in eval can\'t override variable in catch block');
+noError = false;
+try {
+    (function () {
+        var o = { a: '1' };
+        let a;
+        with (o) {
+            eval('var a');
+        }
+    })();
+} catch (error) {
+    noError = error instanceof SyntaxError;
+}
+assert(noError, 'Expected `with` is not affect early SyntaxError in eval');
+noError = false;
+(function () {
+    var o = { a: '1' };
+    with (o) {
+        eval('var a = 10;');
+    }
+    noError = a === undefined && o.a === 10;
+})();
+assert(noError, 'Expected `with` is not affect early SyntaxError in eval');
+noError = false;
+{
+    let a = 10;
+    noError = a === 10;
+    (function () {
+        noError = noError && a === 10;
+        eval('var a = 20');
+        noError = noError && a === 20;
+    })();
+    noError = noError && a === 10;
+}
+assert(noError, 'Expected `with` is not affect early SyntaxError in eval');
+noError = false;
+{
+    const a = 10;
+    noError = a === 10;
+    (function () {
+        noError = noError && a === 10;
+        eval('var a = 20');
+        noError = noError && a === 20;
+    })();
+    noError = noError && a === 10;
+}
+assert(noError, 'Expected `with` is not affect early SyntaxError in eval');

--- a/JSTests/stress/global-lexical-var-injection.js
+++ b/JSTests/stress/global-lexical-var-injection.js
@@ -18,20 +18,51 @@ for (let i = 0; i < 100; i++) {
     assert(foo === "foo");
     assert(bar === "bar");
     assert(INJECTION === 20);
+
     let threw = false;
     try {
         eval("var foo;");
     } catch(e) {
         threw = true;
-        assert(e.message.indexOf("Can't create duplicate global variable in eval") !== -1);
+        assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'foo'");
     }
     assert(threw);
+
+
     threw = false;
     try {
         eval("var bar;");
     } catch(e) {
         threw = true;
-        assert(e.message.indexOf("Can't create duplicate global variable in eval") !== -1);
+        assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'bar'");
+    }
+    assert(threw);
+
+
+    assert(foo === "foo");
+    assert(bar === "bar");
+    assert(INJECTION === 20);
+
+    threw = false;
+    try {
+        eval("function foo() {}");
+    } catch(e) {
+        threw = true;
+        assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'foo'");
+    }
+    assert(threw);
+
+
+    assert(foo === "foo");
+    assert(bar === "bar");
+    assert(INJECTION === 20);
+
+    threw = false;
+    try {
+        eval("function bar() {}");
+    } catch(e) {
+        threw = true;
+        assert(e.toString() === "SyntaxError: Can't create duplicate variable in eval: 'bar'");
     }
     assert(threw);
 

--- a/JSTests/stress/lexical-let-not-strict-mode.js
+++ b/JSTests/stress/lexical-let-not-strict-mode.js
@@ -42,21 +42,18 @@ function foo() {
     }
     assert(hadError);
 
-    if (truth()) {
-        // This eval is enterpreted as follows:
-        // eval("var x; x = 20");
-        // We first assign undefined to the "var x".
-        // Then, we interperet an assignment expression
-        // into the resolved variable x. x resolves to the lexical "let x;"
-        // Look at ECMA section 13.3.2.4 of the ES6 spec:
-        // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-variable-statement-runtime-semantics-evaluation
-        // And also look at section 8.3.1 ResolveBinding:
-        // http://www.ecma-international.org/ecma-262/6.0/index.html#sec-resolvebinding
-        let x = 40;
-        eval("var x = 20;");
-        assert(x === 20);
+    var hadSyntaxErrorForEval = false;
+    try {
+        if (truth()) {
+            let x = 40;
+            eval("var x = 20;");
+        }
+    } catch (e) {
+        hadSyntaxErrorForEval = e instanceof SyntaxError;
     }
-    assert(x === undefined);
+
+    assert(hadSyntaxErrorForEval);
+    assert(typeof x === "undefined");
 }
 
 function bar() {
@@ -68,13 +65,19 @@ function bar() {
     }
     assert(hadError);
 
-    if (truth()) {
-        let x = 40;
-        function capX() { return x; }
-        eval("var x = 20;");
-        assert(x === 20);
+    var hadSyntaxErrorForEval = false;
+    try {
+        if (truth()) {
+            let x = 40;
+            function capX() { return x; }
+            eval("var x = 20;");
+        } 
+    } catch (e) {
+        hadSyntaxErrorForEval = e instanceof SyntaxError;
     }
-    assert(x === undefined);
+
+    assert(hadSyntaxErrorForEval);
+    assert(typeof x === "undefined");
 }
 
 function baz() {

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1306,14 +1306,6 @@ test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-f
   default: 'Test262: This statement should not be evaluated.'
 test/language/block-scope/syntax/redeclaration/var-redeclaration-attempt-after-generator.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign.js:
@@ -1330,270 +1322,6 @@ test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-p
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
 test/language/eval-code/direct/arrow-fn-no-pre-existing-arguments-bindings-are-present-arrow-func-declare-arguments-assign.js:
   default: 'Test262Error: globalThis.arguments unchanged Expected SameValue(«param», «undefined») to be true'
-test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-func-expr-nameless-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-a-following-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-a-preceding-parameter-is-named-arguments-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-func-decl-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-fn-body-cntns-arguments-var-bind-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/eval-code/direct/meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/eval-code/direct/non-definable-function-with-function.js:
   default: 'Test262Error: Expected SameValue(«[object Object]», «undefined») to be true'
 test/language/eval-code/direct/non-definable-function-with-variable.js:
@@ -1604,10 +1332,6 @@ test/language/eval-code/direct/non-definable-global-generator.js:
   default: 'Test262Error: Expected true but got false'
 test/language/eval-code/direct/var-env-func-init-global-update-configurable.js:
   default: 'Test262Error: Expected obj[f] to have enumerable:true.'
-test/language/eval-code/direct/var-env-global-lex-non-strict.js:
-  default: "TypeError: Can't create duplicate global variable in eval: 'x'"
-test/language/eval-code/direct/var-env-lower-lex-non-strict.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/eval-code/indirect/non-definable-function-with-function.js:
   default: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
   strict mode: 'Test262Error: declaration preceding Expected SameValue(«[object Object]», «undefined») to be true'
@@ -1623,13 +1347,6 @@ test/language/eval-code/indirect/non-definable-global-generator.js:
 test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js:
   default: 'Test262Error: Expected obj[f] to have enumerable:true.'
   strict mode: 'Test262Error: Expected obj[f] to have enumerable:true.'
-test/language/eval-code/indirect/var-env-global-lex-non-strict.js:
-  default: 'Test262Error: Expected SameValue(«function TypeError() {'
-  strict mode: 'Test262Error: Expected SameValue(«function TypeError() {'
-test/language/expressions/arrow-function/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/arrow-function/scope-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/arrow-function/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/assignment/S11.13.1_A7_T3.js:
@@ -1716,13 +1433,9 @@ test/language/expressions/assignmenttargettype/parenthesized-callexpression-argu
   default: 'Test262: This statement should not be evaluated.'
 test/language/expressions/async-generator/early-errors-expression-yield-as-function-binding-identifier.js:
   default: 'Test262: This statement should not be evaluated.'
-test/language/expressions/async-generator/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/async-generator/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
-test/language/expressions/async-generator/named-eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/call/eval-realm-indirect.js:
   default: 'Test262Error: Expected SameValue(«inside», «outside») to be true'
 test/language/expressions/call/eval-spread-empty-leading.js:
@@ -1800,19 +1513,11 @@ test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-eva
 test/language/expressions/dynamic-import/for-await-resolution-and-error-agen-yield.js:
   default: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «foo») to be true'
   strict mode: 'Test262:AsyncTestFailure:Test262Error: Test262Error: f Expected SameValue(«null», «foo») to be true'
-test/language/expressions/function/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/function/scope-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/function/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/expressions/generators/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/generators/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false'
-test/language/expressions/generators/scope-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/generators/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/expressions/instanceof/prototype-getter-with-primitive.js:
@@ -1827,24 +1532,10 @@ test/language/expressions/logical-assignment/lgcl-or-assignment-operator-non-sim
 test/language/expressions/new/non-ctor-err-realm.js:
   default: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: production including Arguments Expected a TypeError but got a different error constructor with the same name'
-test/language/expressions/object/method-definition/async-gen-meth-eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/object/method-definition/gen-meth-eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/object/method-definition/meth-eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/object/scope-gen-meth-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/object/scope-gen-meth-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/expressions/object/scope-getter-body-lex-distinc.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/expressions/object/scope-meth-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/object/scope-meth-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/expressions/object/scope-setter-body-lex-distinc.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/expressions/postfix-decrement/S11.3.2_A6_T3.js:
   default: 'Test262Error: Expected true but got false'
   strict mode: 'Test262Error: Expected true but got false'
@@ -1933,8 +1624,6 @@ test/language/module-code/parse-err-hoist-lex-fun.js:
   module: 'Test262: This statement should not be evaluated.'
 test/language/module-code/parse-err-hoist-lex-gen.js:
   module: 'Test262: This statement should not be evaluated.'
-test/language/statements/async-generator/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/statements/async-generator/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object AsyncGenerator]», «[object AsyncGenerator]») to be false'
@@ -2094,19 +1783,11 @@ test/language/statements/for/head-lhs-let.js:
 test/language/statements/for/scope-body-lex-open.js:
   default: 'Test262Error: Expected SameValue(«inside», «outside») to be true'
   strict mode: 'Test262Error: Expected SameValue(«inside», «outside») to be true'
-test/language/statements/function/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
-test/language/statements/function/scope-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/statements/function/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
-test/language/statements/generators/eval-var-scope-syntax-err.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/statements/generators/generator-created-after-decl-inst.js:
   default: 'Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false'
   strict mode: 'Test262Error: Expected SameValue(«[object Generator]», «[object Generator]») to be false'
-test/language/statements/generators/scope-body-lex-distinct.js:
-  default: 'Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all'
 test/language/statements/generators/scope-param-rest-elem-var-open.js:
   default: 'Test262Error: Expected SameValue(«outside», «inside») to be true'
 test/language/statements/labeled/decl-async-function.js:

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -845,6 +845,7 @@ namespace JSC {
         RegisterID* emitResolveScope(RegisterID* dst, const Variable&);
         RegisterID* emitGetFromScope(RegisterID* dst, RegisterID* scope, const Variable&, ResolveMode);
         RegisterID* emitPutToScope(RegisterID* scope, const Variable&, RegisterID* value, ResolveMode, InitializationMode);
+        RegisterID* emitPutToScopeDynamic(RegisterID* scope, const Identifier&, RegisterID* value, ResolveMode, InitializationMode);
 
         RegisterID* emitResolveScopeForHoistingFuncDeclInEval(RegisterID* dst, const Identifier&);
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1291,26 +1291,6 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
     }
     UnlinkedEvalCodeBlock* unlinkedCodeBlock = codeBlock->unlinkedEvalCodeBlock();
 
-    // We can't declare a "var"/"function" that overwrites a global "let"/"const"/"class" in a sloppy-mode eval.
-    if (variableObject->isGlobalObject() && !eval->isInStrictContext() && (numVariables || numTopLevelFunctionDecls)) {
-        JSGlobalLexicalEnvironment* globalLexicalEnvironment = jsCast<JSGlobalObject*>(variableObject)->globalLexicalEnvironment();
-        for (unsigned i = 0; i < numVariables; ++i) {
-            const Identifier& ident = unlinkedCodeBlock->variable(i);
-            PropertySlot slot(globalLexicalEnvironment, PropertySlot::InternalMethodType::VMInquiry, &vm);
-            if (JSGlobalLexicalEnvironment::getOwnPropertySlot(globalLexicalEnvironment, globalObject, ident, slot)) {
-                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '"_s, StringView(ident.impl()), '\''));
-            }
-        }
-
-        for (unsigned i = 0; i < numTopLevelFunctionDecls; ++i) {
-            FunctionExecutable* function = codeBlock->functionDecl(i);
-            PropertySlot slot(globalLexicalEnvironment, PropertySlot::InternalMethodType::VMInquiry, &vm);
-            if (JSGlobalLexicalEnvironment::getOwnPropertySlot(globalLexicalEnvironment, globalObject, function->name(), slot)) {
-                return throwTypeError(globalObject, throwScope, makeString("Can't create duplicate global variable in eval: '"_s, StringView(function->name().impl()), '\''));
-            }
-        }
-    }
-
     if (variableObject->structure()->isUncacheableDictionary())
         variableObject->flattenDictionaryObject(vm);
 
@@ -1318,6 +1298,16 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         BatchedTransitionOptimizer optimizer(vm, variableObject);
         if (variableObject->next() && !eval->isInStrictContext())
             variableObject->globalObject()->varInjectionWatchpointSet().fireAll(vm, "Executed eval, fired VarInjection watchpoint");
+
+        if (!eval->isInStrictContext()) {
+            for (unsigned i = 0; i < numVariables; ++i) {
+                const Identifier& ident = unlinkedCodeBlock->variable(i);
+                JSValue resolvedScope = JSScope::resolveScopeForHoistingFuncDeclInEval(globalObject, scope, ident);
+                RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
+                if (resolvedScope.isUndefined())
+                    return throwSyntaxError(globalObject, throwScope, makeString("Can't create duplicate variable in eval: '"_s, StringView(ident.impl()), '\''));
+            }
+        }
 
         for (unsigned i = 0; i < numVariables; ++i) {
             const Identifier& ident = unlinkedCodeBlock->variable(i);
@@ -1331,28 +1321,16 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
                 RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
             }
         }
-        
-        if (eval->isInStrictContext()) {
-            for (unsigned i = 0; i < numTopLevelFunctionDecls; ++i) {
-                FunctionExecutable* function = codeBlock->functionDecl(i);
-                PutPropertySlot slot(variableObject);
-                // We need create this variables because it will be used to emits code by bytecode generator
-                variableObject->methodTable()->put(variableObject, globalObject, function->name(), jsUndefined(), slot);
-                RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
-            }
-        } else {
-            for (unsigned i = 0; i < numTopLevelFunctionDecls; ++i) {
-                FunctionExecutable* function = codeBlock->functionDecl(i);
-                JSValue resolvedScope = JSScope::resolveScopeForHoistingFuncDeclInEval(globalObject, scope, function->name());
-                RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
-                if (resolvedScope.isUndefined())
-                    return throwSyntaxError(globalObject, throwScope, makeString("Can't create duplicate variable in eval: '"_s, StringView(function->name().impl()), '\''));
-                PutPropertySlot slot(variableObject);
-                // We need create this variables because it will be used to emits code by bytecode generator
-                variableObject->methodTable()->put(variableObject, globalObject, function->name(), jsUndefined(), slot);
-                RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
-            }
 
+        for (unsigned i = 0; i < numTopLevelFunctionDecls; ++i) {
+            FunctionExecutable* function = codeBlock->functionDecl(i);
+            PutPropertySlot slot(variableObject);
+            // We need create this variables because it will be used to emits code by bytecode generator
+            variableObject->methodTable()->put(variableObject, globalObject, function->name(), jsUndefined(), slot);
+            RETURN_IF_EXCEPTION(throwScope, throwScope.exception());
+        }
+
+        if (!eval->isInStrictContext()) {
             for (unsigned i = 0; i < numFunctionHoistingCandidates; ++i) {
                 const Identifier& ident = unlinkedCodeBlock->functionHoistingCandidate(i);
                 JSValue resolvedScope = JSScope::resolveScopeForHoistingFuncDeclInEval(globalObject, scope, ident);

--- a/Source/JavaScriptCore/runtime/JSScope.cpp
+++ b/Source/JavaScriptCore/runtime/JSScope.cpp
@@ -285,9 +285,7 @@ JSValue JSScope::resolveScopeForHoistingFuncDeclInEval(JSGlobalObject* globalObj
     bool result = false;
     if (JSScope* scope = jsDynamicCast<JSScope*>(object)) {
         if (SymbolTable* scopeSymbolTable = scope->symbolTable()) {
-            result = scope->isGlobalObject()
-                ? JSObject::isExtensible(object, globalObject)
-                : scopeSymbolTable->scopeType() == SymbolTable::ScopeType::VarScope;
+            result = scope->isGlobalObject() || scopeSymbolTable->scopeType() == SymbolTable::ScopeType::VarScope;
         }
     }
 


### PR DESCRIPTION
#### d0d05739899c9a8d76d166bbc1afbd116fa5eaf8
<pre>
[JSC] Align duplicate declaration checks in EvalDeclarationInstantiation with the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=167837">https://bugs.webkit.org/show_bug.cgi?id=167837</a>
&lt;rdar://problem/111328974&gt;

Reviewed by Yusuke Suzuki.

For the sloppy-mode eval(), this change:

1. Removes slowish TypeError-throwing logic from executeEval() that also wasn&apos;t spec-compliant
   (SyntaxError should be raised instead), harmonizing error messages.

2. Expands resolveScopeForHoistingFuncDeclInEval() to be called for all declared variables, which
   currently includes function declarations as well, ensuring SyntaxError is thrown for duplicates
   with upper yet non-top lexical scopes [1], all while skipping CatchScopeWithSimpleParameter [2].

3. Introduces emitPutToScopeDynamic(), which circumvents default ResolveType resolution that isn&apos;t
   correct wrt skipping CatchScopeWithSimpleParameter as resolveScopeForHoistingFuncDeclInEval() does.

   We can&apos;t possibly tweak BytecodeGenerator::resolveType() to account for eval().

   This fixes both top-level and block-level function declarations to be hoisted correctly from eval()
   within simple parameter catch block by the same name.

4. Removes isExtensible() check from resolveScopeForHoistingFuncDeclInEval() because for declared
   variables, CanDeclareGlobalVar [3] is already implemented, while for Annex B hoisted functions,
   the implementation doesn&apos;t appear correct to unconditionally rely on isExtensible() even if the
   property is already present.

   Furthermore, performing CanDeclareGlobalVar in resolveScopeForHoistingFuncDeclInEval() is kinda
   superfluous given we put jsUndefined() variables in executeEval(), and results in incorrect
   error being thrown (SyntaxError instead of TypeError) if global object is non-extensible.

[1]: <a href="https://tc39.es/ecma262/#sec-evaldeclarationinstantiation">https://tc39.es/ecma262/#sec-evaldeclarationinstantiation</a> (step 3.d.i.2.a.i)
[2]: <a href="https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks">https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks</a>
[3]: <a href="https://tc39.es/ecma262/#sec-candeclareglobalvar">https://tc39.es/ecma262/#sec-candeclareglobalvar</a>

All JSTests changes were proven to align JSC with V8 and SpiderMonkey.

* JSTests/ChakraCore/test/Closures/bug_OS_2299723.baseline-jsc:
* JSTests/stress/const-not-strict-mode.js:
* JSTests/stress/eval-func-decl-in-eval-within-catch-scope.js:
* JSTests/stress/eval-func-decl-in-global-of-eval.js:
* JSTests/stress/eval-func-decl-within-eval-with-reassign-to-var.js:
* JSTests/stress/eval-let-const-redeclararion.js: Added.
* JSTests/stress/global-lexical-var-injection.js:
* JSTests/stress/lexical-let-not-strict-mode.js:
* JSTests/test262/expectations.yaml: Mark 160 tests as passing.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::generate):
(JSC::BytecodeGenerator::hoistSloppyModeFunctionIfNecessary):
(JSC::BytecodeGenerator::emitPutToScopeDynamic):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::executeEval):
* Source/JavaScriptCore/runtime/JSScope.cpp:
(JSC::JSScope::resolveScopeForHoistingFuncDeclInEval):

Co-authored-by: Oleksandr Skachkov &lt;gskachkov@gmail.com&gt;
Canonical link: <a href="https://commits.webkit.org/265614@main">https://commits.webkit.org/265614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6025252ea4866b299b11736001c6f0c1204dc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10616 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11321 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13528 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13181 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9469 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17268 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13440 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10552 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8737 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11227 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9821 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3062 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2734 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14096 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11546 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10503 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2833 "Passed tests") | 
<!--EWS-Status-Bubble-End-->