### PR TITLE
Fix redundant menu toggle checkboxes on webkit.org.

### DIFF
--- a/Websites/webkit.org/wp-content/themes/webkit/functions.php
+++ b/Websites/webkit.org/wp-content/themes/webkit/functions.php
@@ -422,15 +422,14 @@ class Responsive_Toggle_Walker_Nav_Menu extends Walker_Nav_Menu {
 
         $before = $args->link_before;
         $after = $args->link_after;
-
+        $toggle = "";
+        
         if ( in_array('menu-item-has-children', $item->classes) && 0 == $depth ) {
             $this->toggleid = $item->ID;
-            $args->before .= "<input type=\"checkbox\" id=\"toggle-{$item->ID}\" class=\"menu-toggle\" />";
+            $toggle = "<input type=\"checkbox\" id=\"toggle-{$item->ID}\" class=\"menu-toggle\" />";
             $args->link_before = "<label for=\"toggle-{$item->ID}\" class=\"label-toggle\">" . $args->link_before;
             $args->link_after .= "</label>";
             $item->url = '#nav-sub-menu';
-        } elseif ( in_array('menu-item-has-children', $item->classes) && 1 == $depth ) {
-            // $item->role = "presentation";
         } else $toggleid = null;
 
         $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
@@ -470,7 +469,7 @@ class Responsive_Toggle_Walker_Nav_Menu extends Walker_Nav_Menu {
             }
         }
 
-        $item_output = $args->before;
+        $item_output = $args->before . $toggle;
         $item_output .= '<a'. $attributes .'>';
         $item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
         $item_output .= '</a>';


### PR DESCRIPTION
#### 4164abf9631b3ed7b431f108e2edc39a8bc959d8
<pre>
Fix redundant menu toggle checkboxes on webkit.org.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258521">https://bugs.webkit.org/show_bug.cgi?id=258521</a>

Reviewed by Alexey Proskuryakov.

This change prevents passing the generated checkbox into nested calls
propagating the checkbox into sub-menu items where it shouldn&apos;t exist.

* Websites/webkit.org/wp-content/themes/webkit/functions.php:

Canonical link: <a href="https://commits.webkit.org/265542@main">https://commits.webkit.org/265542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4476916eab2c284c8a1a689d94f9729cbd5f760e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10621 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13186 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9473 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17271 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10221 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13443 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8741 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9826 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14101 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1264 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10508 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->