### PR TITLE
[buildbot] Clean-up unit tests

### DIFF
--- a/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
@@ -33,7 +33,8 @@ import loadConfig
 class ConfigDotJSONTest(unittest.TestCase):
     def get_config(self):
         cwd = os.path.dirname(os.path.abspath(__file__))
-        return json.load(open(os.path.join(cwd, 'config.json')))
+        with open(os.path.join(cwd, 'config.json')) as f:
+            return json.load(f)
 
     def test_configuration(self):
         cwd = os.path.dirname(os.path.abspath(__file__))

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -111,7 +111,7 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, master_prefix_path='./'):
                    project=FixedParameter(name='project', default=''),
                    branch=FixedParameter(name='branch', default=''))],
         # Add custom properties needed
-        properties=[StringParameter(name='patch_id', label='Patch id (not bug number)', regex='^[4-9]\d{5}$', required=True, maxsize=6),
+        properties=[StringParameter(name='patch_id', label='Patch id (not bug number)', regex=r'^[4-9]\d{5}$', required=True, maxsize=6),
                     StringParameter(name='ews_revision', label='WebKit git hash to checkout before trying patch (optional)', required=False, maxsize=40)],
     )
     c['schedulers'].append(forceScheduler)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -157,7 +157,7 @@ class GitHub(object):
     @defer.inlineCallbacks
     def email_for_owners(cls, owners):
         if not owners:
-            return defer.returnValue((None, 'No owners defined, so email cannot be extracted'))
+            return defer.returnValue((None, ['No owners defined, so email cannot be extracted']))
         contributors, errors = yield Contributors.load()
         return defer.returnValue((contributors.get(owners[0].lower(), {}).get('email'), errors))
 
@@ -658,7 +658,6 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
         if owners:
             email, errors = yield GitHub.email_for_owners(owners)
             for error in errors:
-                print(error)
                 yield self._addToLog('stdio', error)
             if email:
                 display_name = '{} ({})'.format(email, owners[0])
@@ -1060,7 +1059,7 @@ class CommitPatch(steps.ShellSequence, CompositeStepMixin, ShellMixin):
 import sys
 
 lines = [l for l in sys.stdin]
-for s in re.split(r' (Need the bug URL \(OOPS!\).)|(\S+:\/\/\S+)', lines[0].rstrip()):
+for s in re.split(r' (Need the bug URL \\(OOPS!\\).)|(\\S+:\\/\\/\\S+)', lines[0].rstrip()):
     if s and s != ' ':
         print(s)
 for l in lines[1:]:
@@ -1834,7 +1833,6 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
             change_string = 'Hash {}'.format(sha)
             change_author, errors = yield GitHub.email_for_owners(self.getProperty('owners', []))
             for error in errors:
-                print(error)
                 yield self._addToLog('stdio', error)
 
             if not change_author:
@@ -1937,7 +1935,6 @@ class ValidateCommitterAndReviewer(buildstep.BuildStep, GitHubMixin, AddToLogMix
     def run(self):
         self.contributors, errors = yield Contributors.load(use_network=True)
         for error in errors:
-            print(error)
             yield self._addToLog('stdio', error)
 
         if not self.contributors:
@@ -2905,7 +2902,6 @@ class AnalyzeCompileWebKitResults(buildstep.BuildStep, BugzillaMixin, GitHubMixi
                 change_string = 'Hash {}'.format(sha)
                 change_author, errors = yield GitHub.email_for_owners(self.getProperty('owners', []))
                 for error in errors:
-                    print(error)
                     yield self._addToLog('stdio', error)
 
             if not change_author:
@@ -3885,7 +3881,6 @@ class AnalyzeLayoutTestsResults(buildstep.BuildStep, BugzillaMixin, GitHubMixin)
                 change_string = 'Hash {}'.format(sha)
                 change_author, errors = yield GitHub.email_for_owners(self.getProperty('owners', []))
                 for error in errors:
-                    print(error)
                     yield self._addToLog('stdio', error)
 
             if not change_author:
@@ -5705,7 +5700,6 @@ class ValidateCommitMessage(steps.ShellSequence, ShellMixin, AddToLogMixin):
 
         self.contributors, errors = yield Contributors.load(use_network=True)
         for error in errors:
-            print(error)
             self._addToLog('stdio', error)
 
         reviewers, log_text = self.extract_reviewers(self.log_observer.getStdout())
@@ -5770,7 +5764,6 @@ class Canonicalize(steps.ShellSequence, ShellMixin, AddToLogMixin):
         self.commands = []
         self.contributors, errors = yield Contributors.load(use_network=True)
         for error in errors:
-            print(error)
             yield self._addToLog('stdio', error)
 
         base_ref = self.getProperty('github.base.ref', DEFAULT_BRANCH)


### PR DESCRIPTION
#### 3a0aed5a7de59af70e3596b4db8c03156ce479b6
<pre>
[buildbot] Clean-up unit tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=258523">https://bugs.webkit.org/show_bug.cgi?id=258523</a>
rdar://111337319

Reviewed by Aakash Jain.

* Tools/CISupport/build-webkit-org/loadConfig_unittest.py:
(ConfigDotJSONTest.get_config): Close file after using it.
* Tools/CISupport/ews-build/loadConfig.py:
(loadBuilderConfig): Encode regex string as a regex.
* Tools/CISupport/ews-build/steps.py:
(GitHub.email_for_owners): Treat entire string as error, not each character.
(ConfigureBuild.add_pr_details): Error is logged in step, don&apos;t log on master.
(ValidateChange.send_email_for_github_failure): Escape escape sequences.
(ValidateCommitterAndReviewer.run): Error is logged in step, don&apos;t log on master.
(AnalyzeCompileWebKitResults.send_email_for_new_build_failure): Ditto.
(AnalyzeLayoutTestsResults.send_email_for_new_test_failures): Ditto.
(ValidateCommitMessage.run): Ditto.
(Canonicalize.run): Ditto.

Canonical link: <a href="https://commits.webkit.org/265523@main">https://commits.webkit.org/265523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c137e6324b968be5e3193e83b5ff10aa4c7dbbb1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11330 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11296 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13190 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9479 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10549 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/11033 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14105 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1256 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->