### PR TITLE
Update 'assert-selection.js' to not use hardcoded name

### DIFF
--- a/LayoutTests/editing/inserting/insert-space-expected.txt
+++ b/LayoutTests/editing/inserting/insert-space-expected.txt
@@ -4,11 +4,11 @@ PASS insert a plain space in the middle of text node
 PASS insert a plain space between two inserted text nodes
 PASS Insert a &nbsp; instead of plain space when it is inserted before the empty text node
 PASS Insert a &nbsp; instead of plain space when it is inserted before the text node that has a leading plain space
-FAIL Insert spaces into the editable <div> that only has <br> and space as child resources/assert-selection.js:939:30
+FAIL Insert spaces into the editable <div> that only has <br> and space as child editing/inserting/insert-space.html:51:28
 	 expected <div contenteditable>   | </div>,
 	 but got  <div contenteditable>   |</div>,
 	 sameupto <div contenteditable>   |
-FAIL Insert spaces into the editable <div> that only has <br> and enter as child resources/assert-selection.js:939:30
+FAIL Insert spaces into the editable <div> that only has <br> and enter as child editing/inserting/insert-space.html:61:28
 	 expected <div contenteditable>   |
 </div>,
 	 but got  <div contenteditable>   |</div>,

--- a/LayoutTests/resources/assert-selection.js
+++ b/LayoutTests/resources/assert-selection.js
@@ -935,7 +935,7 @@ function assembleDescription() {
     return stack
   }
 
-  const RE_IN_ASSERT_SELECTION = new RegExp('assert_selection\\.js');
+  const RE_IN_ASSERT_SELECTION = new RegExp('assert-selection\\.js');
   for (const line of getStack()) {
     const match = RE_IN_ASSERT_SELECTION.exec(line);
     if (!match) {


### PR DESCRIPTION
#### d164f4ce0298194a402976a89e4cb7a599a60485
<pre>
Update &apos;assert-selection.js&apos; to not use hardcoded name

<a href="https://bugs.webkit.org/show_bug.cgi?id=258528">https://bugs.webkit.org/show_bug.cgi?id=258528</a>

Reviewed by Ryosuke Niwa.

This patch just update hardcoded name in &apos;assert-selection.js&apos;,
to WebKit one and update test output as needed.

* LayoutTests/resources/assert-selection.js: Update &apos;hard-coded&apos; name
* LayoutTests/editing/inserting/insert-space-expected.txt: Update &apos;test&apos; expectation to get test failure rather than script error

Canonical link: <a href="https://commits.webkit.org/265531@main">https://commits.webkit.org/265531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da28e79d4f2b64fe2d5b5b58d02d84771a90f5e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10639 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12203 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13208 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10093 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10567 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13463 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10677 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9847 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2671 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10530 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->