### PR TITLE
[Debug] imported/w3c/web-platform-tests/dom/events/preventDefault-during-activation-behavior.html is crashing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6417,7 +6417,6 @@ imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across
 webkit.org/b/242658 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Slow Pass Failure ]
 
 # These tests are crashing in debug since its import.
-webkit.org/b/256847 [ Debug ] imported/w3c/web-platform-tests/dom/events/preventDefault-during-activation-behavior.html [ Skip ]
 webkit.org/b/256976 [ Debug ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-nav.html [ Skip ]
 webkit.org/b/256976 [ Debug ] imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/same-document-nav-cross-document-traversal.html [ Skip ]
 

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -63,17 +63,15 @@ static void callDefaultEventHandlersInBubblingOrder(Event& event, const EventPat
     // Non-bubbling events call only one default event handler, the one for the target.
     Ref rootNode { *path.contextAt(0).node() };
     rootNode->defaultEventHandler(event);
-    ASSERT(!event.defaultPrevented());
 
-    if (event.defaultHandled() || !event.bubbles())
+    if (event.defaultHandled() || !event.bubbles() || event.defaultPrevented())
         return;
 
     size_t size = path.size();
     for (size_t i = 1; i < size; ++i) {
         Ref currentNode { *path.contextAt(i).node() };
         currentNode->defaultEventHandler(event);
-        ASSERT(!event.defaultPrevented());
-        if (event.defaultHandled())
+        if (event.defaultPrevented() || event.defaultHandled())
             return;
     }
 }


### PR DESCRIPTION
#### 889de359af7c2d00ebd3fca2a3222ce1d4a25a62
<pre>
[Debug] imported/w3c/web-platform-tests/dom/events/preventDefault-during-activation-behavior.html is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=256847">https://bugs.webkit.org/show_bug.cgi?id=256847</a>
rdar://109723482

Reviewed by Ryosuke Niwa.

Replace assertions with runtime checks since the JS can call preventDefault
in the default event handler. This is a cherry-pick from Blink:
- <a href="https://chromium-review.googlesource.com/c/chromium/src/+/4451027">https://chromium-review.googlesource.com/c/chromium/src/+/4451027</a>
- <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=1197032">https://bugs.chromium.org/p/chromium/issues/detail?id=1197032</a>

* LayoutTests/TestExpectations:
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::callDefaultEventHandlersInBubblingOrder):

Canonical link: <a href="https://commits.webkit.org/265538@main">https://commits.webkit.org/265538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c30c1c2283fe9b9f839d7ec576bef6e45c6ca57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11319 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12207 "1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13213 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9501 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17297 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10571 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13468 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8769 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9852 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2676 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->