### PR TITLE
[JSC] Improve RegExp Lookbehind Character Class Backtracking

### DIFF
--- a/JSTests/stress/regexp-lookaround-captures.js
+++ b/JSTests/stress/regexp-lookaround-captures.js
@@ -106,3 +106,10 @@ testRegExp(/(?<!(\D){3})f|f/, "abcdef", ["f", undefined]);
 testRegExp(/((?<!\D{3}))f|f/, "abcdef", ["f", undefined]);
 testRegExp(/(?<!(\w{3}))f(?=(\w{3}))|(?<=(\w+?))c(?=(\w{2}))|(?<=(\w{4}))c(?=(\w{3})$)/, "abcdef", ["c",undefined,undefined,"b","de",undefined,undefined]);
 testRegExp(/abc|(efg).*\!|xyz/, "efg xyz", ["xyz", undefined]);
+
+// Test 21
+testRegExp(/abc(?=([iA-\u{103ff}]*)([A-\u{ffff}]+)([A-z]+))/u, "abcABCDEFGHIJK", ["abc", "ABCDEFGHI", "J", "K"]);
+testRegExp(/abc(?=([iA-\u{103ff}]*)([A-\u{ffff}]+)([A-z]+))/u, "abcABCDEFGHIJK\u{10308}\u{273b}X", ["abc", "ABCDEFGHIJK\u{10308}", "\u{273b}", "X"]);
+testRegExp(/(?<=([A-z]+)([A-\u{ffff}]+)([A-\u{103ff}]*))abc/u, "ABCDEFGHIJKabc", ["abc", "A", "B", "CDEFGHIJK"]);
+testRegExp(/(?<=([A-z]+)([A-\u{ffff}]+)([A-\u{103ff}]*))abc/u, "1\u{10420}X\u{273b}\u{10308}ABCDEFGHIJKabc", ["abc", "X", "\u{273b}", "\u{10308}ABCDEFGHIJK"]);
+testRegExp(/(?<=([A]+)([A-\u{103ff}]*))abc/u, "A\u{10420}X\u{273b}\u{10308}ABCDEFGHIJKabc", ["abc", "A", "BCDEFGHIJK"]);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -840,7 +840,6 @@ public:
 
         case QuantifierType::Greedy: {
             unsigned position = input.getPos();
-            backTrack->begin = position;
             unsigned matchAmount = 0;
             if (term.matchDirection() == Forward) {
                 while ((matchAmount < term.atom.quantityMaxCount) && input.checkInput(1)) {
@@ -895,27 +894,17 @@ public:
         case QuantifierType::Greedy:
             if (backTrack->matchAmount) {
                 if (isEitherUnicodeCompilation()) {
-                    // Rematch one less match
+                    // Unmatch one codepoint
                     if (term.matchDirection() == Forward) {
-                        input.setPos(backTrack->begin);
                         --backTrack->matchAmount;
-                        for (unsigned matchAmount = 0; (matchAmount < backTrack->matchAmount) && input.checkInput(1); ++matchAmount) {
-                            if (!checkCharacterClass(term, term.inputPosition + 1)) {
-                                input.uncheckInput(1);
-                                break;
-                            }
-                        }
+                        input.uncheckInput(1);
+                        input.tryReadBackward(term.inputPosition);
                         return true;
                     }
                     // matchDirection Backwards
-                    input.setPos(backTrack->begin);
                     --backTrack->matchAmount;
-                    for (unsigned matchAmount = 0; (matchAmount < backTrack->matchAmount) && input.tryUncheckInput(1); ++matchAmount) {
-                        if (!checkCharacterClass(term, term.inputPosition)) {
-                            input.checkInput(1);
-                            break;
-                        }
-                    }
+                    input.readChecked(term.inputPosition);
+                    input.checkInput(1);
                     return true;
                 }
                 --backTrack->matchAmount;


### PR DESCRIPTION
#### 8e5b3f5761f011abfa644ddab3f0f1f6561ec5fd
<pre>
[JSC] Improve RegExp Lookbehind Character Class Backtracking
<a href="https://bugs.webkit.org/show_bug.cgi?id=258531">https://bugs.webkit.org/show_bug.cgi?id=258531</a>
rdar://111051833

Reviewed by Yusuke Suzuki.

Changed character class backtracking in the Yarr interpreter to unread one codepoint instead of rematching
one less codepoint.  This can dramatically improve matching performance for large strings where we need to
backtrack a large number of codepoints.

Added test cases that specifically test backtracking character classes that need to backtrack both BMP and
non-BMP codepoints when processing the input string.

* JSTests/stress/regexp-lookaround-captures.js:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchCharacterClass):
(JSC::Yarr::Interpreter::backtrackCharacterClass):

Canonical link: <a href="https://commits.webkit.org/265593@main">https://commits.webkit.org/265593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbc3ccea38ac6f78bdd22aa27e1ff5c9c6d7e53c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10807 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12374 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13405 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10276 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9632 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10738 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10433 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13645 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10757 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8932 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11432 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10021 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3092 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14296 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11754 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1280 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10704 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2864 "Passed tests") | 
<!--EWS-Status-Bubble-End-->