### PR TITLE
Disable the background responsiveness timer when RunningBoard is used

### DIFF
--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -133,14 +133,14 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
 
 bool BackgroundProcessResponsivenessTimer::shouldBeActive() const
 {
-#if !PLATFORM(IOS_FAMILY)
+#if !USE(RUNNINGBOARD)
     if (m_webProcessProxy.visiblePageCount())
         return false;
     if (m_webProcessProxy.isStandaloneServiceWorkerProcess())
         return true;
     return m_webProcessProxy.pageCount();
 #else
-    // Disable background process responsiveness checking on iOS since such processes usually get suspended.
+    // Disable background process responsiveness checking when using RunningBoard since such processes usually get suspended.
     return false;
 #endif
 }


### PR DESCRIPTION
#### 4224c4b333f825c83fa5f85a2b61c9479477a52b
<pre>
Disable the background responsiveness timer when RunningBoard is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=258534">https://bugs.webkit.org/show_bug.cgi?id=258534</a>

Reviewed by Ben Nham.

Disable the background responsiveness timer when RunningBoard is used. We used
to only disable it on iOS because we only used RunningBoard on iOS. However,
now that we use RunningBoard on macOS too, we should disable it on this
platform too. Background processes now get a very low priority and eventually
get suspended. This would cause false reports of unresponsive processes.

* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::shouldBeActive const):

Canonical link: <a href="https://commits.webkit.org/265536@main">https://commits.webkit.org/265536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c85ff1e396e369343177d5ebc6ada9c3cae9686

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12805 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10640 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13555 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13209 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9500 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17293 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10570 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9848 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2675 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->