### PR TITLE
DFG should update backwards propogation after fixup.

### DIFF
--- a/JSTests/stress/propogate-PureInt-double-use.js
+++ b/JSTests/stress/propogate-PureInt-double-use.js
@@ -1,0 +1,24 @@
+function opt(v)
+{
+    let a = (-1 >>> v)
+    let b = (a + -0.2)
+    let c = b | 0
+    return c
+}
+noInline(opt)
+
+function o(v) {
+    opt(v)
+}
+noInline(o)
+
+function main() {
+    for (let i = 0; i < 10000; i++)
+        o(0)
+    for (let i = 0; i < 10000; ++i)
+     opt(32)
+    if (opt(32) != -2)
+        throw "wrong value"
+}
+noInline(main)
+main()

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
@@ -32,10 +32,19 @@ namespace JSC { namespace DFG {
 
 class Graph;
 
-// Infer basic information about how nodes are used by doing a block-local
+// Infer basic information about how nodes are likely to be used by doing a block-local
 // backwards flow analysis.
 
 void performBackwardsPropagation(Graph&);
+
+// Infer information after fixup has run. This should only pessimize the existing information.
+// By this point, we ensure that any new uses inserted by fixup are accounted for.
+//
+// For example, consider:
+// b = (a + 0.1)
+// If b is PureInt, then we would propogate that to a originally because that is what we expect.
+// But we don't actually know until after fixup if a may be used as a double, as it is here.
+bool performBackwardsPropagationAfterFixup(Graph&);
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -442,9 +442,7 @@ private:
             
         case UInt32ToNumber: {
             fixIntConvertingEdge(node->child1());
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
-                node->convertToIdentity();
-            else if (node->canSpeculateInt32(FixupPass))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) || node->canSpeculateInt32(FixupPass))
                 node->setArithMode(Arith::CheckOverflow);
             else {
                 node->setArithMode(Arith::DoOverflow);

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGArgumentsEliminationPhase.h"
+#include "DFGBackwardsPropagationPhase.h"
 #include "DFGByteCodeParser.h"
 #include "DFGCFAPhase.h"
 #include "DFGCFGSimplificationPhase.h"
@@ -270,6 +271,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
     if (validationEnabled())
         validate(dfg);
         
+    RUN_PHASE(performBackwardsPropagationAfterFixup);
     RUN_PHASE(performStrengthReduction);
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performCFA);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -3544,7 +3544,6 @@ void SpeculativeJIT::compileUInt32ToNumber(Node* node)
     GPRTemporary result(this);
 
     move(op1.gpr(), result.gpr());
-
     speculationCheck(ExitKind::Overflow, JSValueRegs(), nullptr, Base::branch32(LessThan, result.gpr(), TrustedImm32(0)));
 
     strictInt32Result(result.gpr(), node, op1.format());

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -114,6 +114,10 @@ private:
                 m_changed = true;
                 break;
             }
+            if (bytecodeCanTruncateInteger(m_node->arithNodeFlags())) {
+                m_node->convertToIdentity();
+                m_changed = true;
+            }
             break;
             
         case ArithAdd:


### PR DESCRIPTION
#### 2f7262436c990b072f944bc6ed08cf55746fb017
<pre>
DFG should update backwards propogation after fixup.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257949">https://bugs.webkit.org/show_bug.cgi?id=257949</a>
rdar://110661900

Reviewed by Keith Miller.

PureInt means that we cannot observe a difference between this value when
represented as a double or when represented as a UInt32.

Today, PureInt is not a proven property, but rather a speculation guide.
The DFG fixup phase is responsible for inserting speculations and fixing
up edges to ensure that we can prove the properties that we want.

UInt32ToNumber speculates that a value fits in an Int32. DoubleRep takes
an Int32 and stuffs the bits appropriately to turn it into a double.

ValueAdd is expecting a DoubleRep because it has a double argument.

In FixupPhase, we remove UInt32ToNumber because we see that it is PureInt.
If it is actually PureInt, then this is fine. But DoubleRep can observe it
as non-PureInt, and DoubleRep not inserted until well after BackwardsPropogationPhase has run.

We add a separate phase that runs after fixup, and pessimizes these speculation properties.
Then, we are free to use them as proven properties.

Finally, we move any checks in fixup that use these properties to strength reduction.

* JSTests/stress/propogate-PureInt-double-use.js: Added.
(opt):
(noInline.opt.o):
(noInline.o.main):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::BackwardsPropagationPhase):
(JSC::DFG::BackwardsPropagationPhase::propagate):
(JSC::DFG::performBackwardsPropagation):
(JSC::DFG::performBackwardsPropagationAfterFixup):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h:
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileUInt32ToNumber):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

fix

.

Canonical link: <a href="https://commits.webkit.org/265833@main">https://commits.webkit.org/265833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c92a89a6fdc6565a81f87ca273ee1c20d2754d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11592 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14286 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14167 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18023 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10186 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14224 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11363 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9504 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12090 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10758 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15082 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12427 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11395 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2992 "Passed tests") | 
<!--EWS-Status-Bubble-End-->