### PR TITLE
[macOS] Update ScreenCaptureKit API used

### DIFF
--- a/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h
@@ -37,10 +37,6 @@
 #if __has_include(<ScreenCaptureKit/SCContentSharingPicker.h>)
 #import <ScreenCaptureKit/SCContentSharingPicker.h>
 #endif
-
-#if __has_include(<ScreenCaptureKit/SCContentSharingPicker_Private.h>)
-#import <ScreenCaptureKit/SCContentSharingPicker_Private.h>
-#endif
 #endif // HAVE(SC_CONTENT_SHARING_PICKER)
 
 #else // USE(APPLE_INTERNAL_SDK)
@@ -92,43 +88,6 @@ typedef NS_ENUM(NSInteger, SCContentFilterType) {
 
 @interface SCStream (SCContentSharing) <SCContentSharingSessionProtocol>
 - (instancetype)initWithSharingSession:(SCContentSharingSession *)session captureOutputProperties:(SCStreamConfiguration *)streamConfig delegate:(id<SCStreamDelegate>)delegate;
-@end
-
-@protocol SCContentSharingPickerDelegate <NSObject>
-@required
-@optional
-- (void)contentSharingPicker:(SCContentSharingPicker *)picker didCancelForStream:(nullable SCStream *)stream;
-- (void)contentSharingPickerStartDidFailWithError:(NSError *)error;
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(nullable SCStream *)stream;
-@end
-
-typedef NS_OPTIONS(NSUInteger, SCContentSharingAllowedPickerModes) {
-    SCContentSharingPickerAllowedModeSingleWindow          = 1 << 0,
-    SCContentSharingPickerAllowedModeMultipleWindows       = 1 << 1,
-    SCContentSharingPickerAllowedModeSingleApplication     = 1 << 2,
-    SCContentSharingPickerAllowedModeSingleDisplay         = 1 << 3,
-};
-
-// FIXME: Drop deprecated method names once we no longer support Ventura. These
-// SPI methods all have public equivalents in Sonoma.
-@interface SCContentSharingPickerConfiguration
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    ()
-#else
-    : NSObject
-#endif
-@property (nonatomic, assign) SCContentSharingAllowedPickerModes allowedPickingModes;
-@end
-
-@interface SCContentSharingPicker
-#if HAVE(SC_CONTENT_SHARING_PICKER)
-    ()
-#else
-    : NSObject
-#endif
-@property (nonatomic, weak, nullable) id<SCContentSharingPickerDelegate> delegate;
-@property (nonatomic, nullable, strong) NSNumber *maxStreamCount;
-@property (nonatomic, nullable, copy) SCContentSharingPickerConfiguration *configuration;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm
@@ -42,28 +42,14 @@
 
 using namespace WebCore;
 
-typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
-    WKSCContentSharingPickerModeSingleWindow          = 1 << 0,
-    WKSCContentSharingPickerModeMultipleWindows       = 1 << 1,
-    WKSCContentSharingPickerModeSingleApplication     = 1 << 2,
-    WKSCContentSharingPickerModeMultipleApplications  = 1 << 3,
-    WKSCContentSharingPickerModeSingleDisplay         = 1 << 4
-};
-
-@protocol WKSCContentSharingPickerDelegate <NSObject>
-@required
-- (void)contentSharingPicker:(SCContentSharingPicker *)picker didUpdateWithFilter:(SCContentFilter *)filter forStream:(SCStream *)stream;
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream;
-- (void)contentSharingPickerStartDidFailWithError:(NSError *)error;
-@end
-
 @interface WebDisplayMediaPromptHelper : NSObject <SCContentSharingSessionProtocol
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-    , WKSCContentSharingPickerDelegate
+    , SCContentSharingPickerObserver
 #endif
     > {
     WeakPtr<ScreenCaptureKitSharingSessionManager> _callback;
     Vector<RetainPtr<SCContentSharingSession>> _sessions;
+    BOOL _observingPicker;
 }
 
 - (instancetype)initWithCallback:(ScreenCaptureKitSharingSessionManager*)callback;
@@ -74,8 +60,10 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 - (void)sessionDidChangeContent:(SCContentSharingSession *)session;
 - (void)pickerCanceledForSession:(SCContentSharingSession *)session;
 #if HAVE(SC_CONTENT_SHARING_PICKER)
+- (void)startObservingPicker:(SCContentSharingPicker *)session;
+- (void)stopObservingPicker:(SCContentSharingPicker *)session;
 - (void)contentSharingPicker:(SCContentSharingPicker *)picker didUpdateWithFilter:(SCContentFilter *)filter forStream:(SCStream *)stream;
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream;
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker didCancelForStream:(SCStream *)stream;
 - (void)contentSharingPickerStartDidFailWithError:(NSError *)error;
 #endif
 @end
@@ -84,8 +72,10 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 - (instancetype)initWithCallback:(ScreenCaptureKitSharingSessionManager*)callback
 {
     self = [super init];
-    if (self)
+    if (self) {
         _callback = WeakPtr { callback };
+        _observingPicker = NO;
+    }
 
     return self;
 }
@@ -144,7 +134,7 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
 }
 
 #if HAVE(SC_CONTENT_SHARING_PICKER)
-- (void)contentSharingPickerDidCancel:(SCContentSharingPicker *)picker forStream:(SCStream *)stream
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker didCancelForStream:(SCStream *)stream
 {
     UNUSED_PARAM(picker);
     RunLoop::main().dispatch([self, protectedSelf = RetainPtr { self }]() mutable {
@@ -167,6 +157,24 @@ typedef NS_OPTIONS(NSUInteger, WKSCContentSharingPickerMode) {
         if (_callback)
             _callback->contentSharingPickerUpdatedFilterForStream(filter.get(), stream.get());
     });
+}
+
+- (void)startObservingPicker:(SCContentSharingPicker *)picker
+{
+    if (_observingPicker)
+        return;
+
+    _observingPicker = YES;
+    [picker addObserver:self];
+}
+
+- (void)stopObservingPicker:(SCContentSharingPicker *)picker
+{
+    if (!_observingPicker)
+        return;
+
+    _observingPicker = NO;
+    [picker removeObserver:self];
 }
 #endif
 
@@ -206,12 +214,13 @@ ScreenCaptureKitSharingSessionManager::ScreenCaptureKitSharingSessionManager()
 
 ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager()
 {
+    m_activeSources.clear();
+    cancelPicking();
+
     if (m_promptHelper) {
         [m_promptHelper disconnect];
         m_promptHelper = nullptr;
     }
-
-    cancelPicking();
 }
 
 void ScreenCaptureKitSharingSessionManager::cancelPicking()
@@ -229,7 +238,8 @@ void ScreenCaptureKitSharingSessionManager::cancelPicking()
     if (useSCContentSharingPicker()) {
         SCContentSharingPicker* picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
         picker.active = NO;
-        picker.delegate = nullptr;
+        if (m_activeSources.isEmpty())
+            [m_promptHelper stopObservingPicker:picker];
     }
 #endif
 
@@ -424,21 +434,21 @@ bool ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker(Dis
     auto configuration = adoptNS([PAL::allocSCContentSharingPickerConfigurationInstance() init]);
     switch (promptType) {
     case DisplayCapturePromptType::Window:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)WKSCContentSharingPickerModeSingleWindow];
+        [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleWindow];
         break;
     case DisplayCapturePromptType::Screen:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)WKSCContentSharingPickerModeSingleDisplay];
+        [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleDisplay];
         break;
     case DisplayCapturePromptType::UserChoose:
-        [configuration setAllowedPickingModes:(SCContentSharingPickerMode)(WKSCContentSharingPickerModeSingleWindow | WKSCContentSharingPickerModeSingleDisplay)];
+        [configuration setAllowedPickerModes:SCContentSharingPickerModeSingleWindow | SCContentSharingPickerModeSingleDisplay];
         break;
     }
 
     SCContentSharingPicker* picker = [PAL::getSCContentSharingPickerClass() sharedPicker];
     picker.active = YES;
-    picker.maxStreamCount = @(1);
-    picker.configuration = configuration.get();
-    picker.delegate = (id<SCContentSharingPickerDelegate> _Nullable)m_promptHelper.get();
+    picker.maximumStreamCount = @(1);
+    picker.defaultConfiguration = configuration.get();
+    [m_promptHelper startObservingPicker:picker];
     [picker present];
 
     return true;


### PR DESCRIPTION
#### 7550c63a5a8bfdf3c3286f3d09d338af3bfc345a
<pre>
[macOS] Update ScreenCaptureKit API used
<a href="https://bugs.webkit.org/show_bug.cgi?id=257816">https://bugs.webkit.org/show_bug.cgi?id=257816</a>
rdar://110408877

Reviewed by Youenn Fablet.

Update to the most recent version of ScreenCaptureKit API.

* Source/WebCore/PAL/pal/spi/mac/ScreenCaptureKitSPI.h:
* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitSharingSessionManager.mm:
(-[WebDisplayMediaPromptHelper initWithCallback:]):
(-[WebDisplayMediaPromptHelper contentSharingPicker:didCancelForStream:]):
(-[WebDisplayMediaPromptHelper startObservingPicker:]):
(-[WebDisplayMediaPromptHelper stopObservingPicker:]):
(WebCore::ScreenCaptureKitSharingSessionManager::~ScreenCaptureKitSharingSessionManager):
(WebCore::ScreenCaptureKitSharingSessionManager::cancelPicking):
(WebCore::ScreenCaptureKitSharingSessionManager::promptWithSCContentSharingPicker):
(-[WebDisplayMediaPromptHelper contentSharingPickerDidCancel:forStream:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/265722@main">https://commits.webkit.org/265722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d9d75fd4b7d4c57f25dd9adbd3a79001aaff0d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14031 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13786 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10644 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11094 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13970 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10375 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->