### PR TITLE
AX: Ignore the aria-required if equivalent HTML attribute is present

### DIFF
--- a/LayoutTests/accessibility/aria-required-expected.txt
+++ b/LayoutTests/accessibility/aria-required-expected.txt
@@ -3,30 +3,31 @@ This tests that aria-required is a usable attribute.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-Elements to test: 35
+Elements to test: 36
 
 PASS textfield isRequired is false
 PASS textfield_required isRequired is true
 PASS textfield_required_ariarequired isRequired is true
 PASS textfield_ariarequiredfalse isRequired is false
-PASS textfield5 isRequired is true
+PASS textfield_required_ariarequiredfalse isRequired is true
+PASS textfield_requiredfalse_ariarequiredtrue isRequired is true
 PASS checkbox isRequired is false
 PASS checkbox_required isRequired is true
 PASS checkbox_required_ariarequired isRequired is true
 PASS checkbox_ariarequiredfalse isRequired is false
-PASS checkbox_required_ariarequiredfalse isRequired is false
+PASS checkbox_required_ariarequiredfalse isRequired is true
 PASS checkbox_requiredfalse_ariarequiredtrue isRequired is true
 PASS select isRequired is false
 PASS select_required isRequired is true
 PASS select_required_ariarequired isRequired is true
 PASS select_ariarequiredfalse isRequired is false
-PASS select_required_ariarequiredfalse isRequired is false
+PASS select_required_ariarequiredfalse isRequired is true
 PASS select_requiredfalse_ariarequiredtrue isRequired is true
 PASS textarea isRequired is false
 PASS textarea_required isRequired is true
 PASS textarea_required_ariarequired isRequired is true
 PASS textarea_ariarequiredfalse isRequired is false
-PASS textarea_required_ariarequiredfalse isRequired is false
+PASS textarea_required_ariarequiredfalse isRequired is true
 PASS textarea_requiredfalse_ariarequiredtrue isRequired is true
 PASS listbox_ariarequiredtrue isRequired is true
 PASS listbox_ariarequiredfalse isRequired is false

--- a/LayoutTests/accessibility/aria-required.html
+++ b/LayoutTests/accessibility/aria-required.html
@@ -14,10 +14,8 @@
   <input type="text" required aria-required="true" id="textfield_required_ariarequired" data-expectedrequired="true">
   <input type="text" aria-required="false" id="textfield_ariarequiredfalse" data-expectedrequired="false">
   <!-- these last ones conflict with implicit value of @required, so host language attr should win -->
-  <input type="text" aria-required="textfield_required_ariarequiredfalse" required id="textfield5" data-expectedrequired="true">
-  <!-- BLOCKED by http://webkit.org/b/119988
-  <input type="text" aria-required="true" id="textfield_requiredfalse_ariarequiredtrue" data-expectedrequired="false">
-  -->
+  <input type="text" aria-required="false" required id="textfield_required_ariarequiredfalse" data-expectedrequired="true">
+  <input type="text" aria-required="true" id="textfield_requiredfalse_ariarequiredtrue" data-expectedrequired="true">
 
 
   <!-- checkboxes -->
@@ -26,7 +24,7 @@
   <input type="checkbox" required aria-required="true" id="checkbox_required_ariarequired" data-expectedrequired="true">
   <input type="checkbox" aria-required="false" id="checkbox_ariarequiredfalse" data-expectedrequired="false">
   <!-- these last ones conflict with implicit value of @required, so ARIA should win -->
-  <input type="checkbox" aria-required="false" required id="checkbox_required_ariarequiredfalse" data-expectedrequired="false">
+  <input type="checkbox" aria-required="false" required id="checkbox_required_ariarequiredfalse" data-expectedrequired="true">
   <input type="checkbox" aria-required="true" id="checkbox_requiredfalse_ariarequiredtrue" data-expectedrequired="true">
 
 
@@ -36,7 +34,7 @@
   <select required aria-required="true" id="select_required_ariarequired" data-expectedrequired="true"><option>test</option></select>
   <select aria-required="false" id="select_ariarequiredfalse" data-expectedrequired="false"><option>test</option></select>
   <!-- these last ones conflict with implicit value of @required, so ARIA should win -->
-  <select aria-required="false" required id="select_required_ariarequiredfalse" data-expectedrequired="false"><option>test</option></select>
+  <select aria-required="false" required id="select_required_ariarequiredfalse" data-expectedrequired="true"><option>test</option></select>
   <select aria-required="true" id="select_requiredfalse_ariarequiredtrue" data-expectedrequired="true"><option>test</option></select>
 
   
@@ -46,7 +44,7 @@
   <textarea required aria-required="true" id="textarea_required_ariarequired" data-expectedrequired="true"></textarea>
   <textarea aria-required="false" id="textarea_ariarequiredfalse" data-expectedrequired="false"></textarea>
   <!-- these last ones conflict with implicit value of @required, so ARIA should win -->
-  <textarea aria-required="false" required id="textarea_required_ariarequiredfalse" data-expectedrequired="false"></textarea>
+  <textarea aria-required="false" required id="textarea_required_ariarequiredfalse" data-expectedrequired="true"></textarea>
   <textarea aria-required="true" id="textarea_requiredfalse_ariarequiredtrue" data-expectedrequired="true"></textarea>
   
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -823,16 +823,15 @@ bool AccessibilityNodeObject::isMultiSelectable() const
 
 bool AccessibilityNodeObject::isRequired() const
 {
-    // Explicit aria-required values should trump native required attributes.
+    auto* formControlElement = dynamicDowncast<HTMLFormControlElement>(node());
+    if (formControlElement && formControlElement->isRequired())
+        return true;
+
     const AtomString& requiredValue = getAttribute(aria_requiredAttr);
     if (equalLettersIgnoringASCIICase(requiredValue, "true"_s))
         return true;
     if (equalLettersIgnoringASCIICase(requiredValue, "false"_s))
         return false;
-
-    Node* n = this->node();
-    if (is<HTMLFormControlElement>(n))
-        return downcast<HTMLFormControlElement>(*n).isRequired();
 
     return false;
 }


### PR DESCRIPTION
#### 640ead36a4acc8ac8dbbf4542395f2a1c346283e
<pre>
AX: Ignore the aria-required if equivalent HTML attribute is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=258548">https://bugs.webkit.org/show_bug.cgi?id=258548</a>
rdar://problem/111370591

Reviewed by Tyler Wilcock.

Modify to prioritize the HTML attribute when both `aria-required` and
`required` attribute are present.

* LayoutTests/accessibility/aria-required-expected.txt:
* LayoutTests/accessibility/aria-required.html:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::isRequired const):

Canonical link: <a href="https://commits.webkit.org/265552@main">https://commits.webkit.org/265552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ee2663f4353ca6debc7f67fbc7baa8bfd5ec1e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13587 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13248 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13500 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10018 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14157 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10566 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->