### PR TITLE
[css-text-4] Implement multi-value syntax for white-space CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt
@@ -1,52 +1,52 @@
 
-FAIL e.style['white-space'] = "collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'collapse' assert_true: 'collapse' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "wrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'wrap' assert_true: 'wrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "collapse wrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'collapse wrap' assert_true: 'collapse wrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "wrap collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'wrap collapse' assert_true: 'wrap collapse' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve nowrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve nowrap' assert_true: 'preserve nowrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "nowrap preserve" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'nowrap preserve' assert_true: 'nowrap preserve' is a supported value for white-space. expected true got false
+PASS e.style['white-space'] = "collapse" should set the property value
+PASS Property white-space value 'collapse'
+PASS e.style['white-space'] = "wrap" should set the property value
+PASS Property white-space value 'wrap'
+PASS e.style['white-space'] = "collapse wrap" should set the property value
+PASS Property white-space value 'collapse wrap'
+PASS e.style['white-space'] = "wrap collapse" should set the property value
+PASS Property white-space value 'wrap collapse'
+PASS e.style['white-space'] = "preserve nowrap" should set the property value
+PASS Property white-space value 'preserve nowrap'
+PASS e.style['white-space'] = "nowrap preserve" should set the property value
+PASS Property white-space value 'nowrap preserve'
 PASS e.style['white-space'] = "nowrap" should set the property value
 PASS Property white-space value 'nowrap'
-FAIL e.style['white-space'] = "collapse nowrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'collapse nowrap' assert_true: 'collapse nowrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "nowrap collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'nowrap collapse' assert_true: 'nowrap collapse' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve' assert_true: 'preserve' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve wrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve wrap' assert_true: 'preserve wrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "wrap preserve" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'wrap preserve' assert_true: 'wrap preserve' is a supported value for white-space. expected true got false
+PASS e.style['white-space'] = "collapse nowrap" should set the property value
+PASS Property white-space value 'collapse nowrap'
+PASS e.style['white-space'] = "nowrap collapse" should set the property value
+PASS Property white-space value 'nowrap collapse'
+PASS e.style['white-space'] = "preserve" should set the property value
+PASS Property white-space value 'preserve'
+PASS e.style['white-space'] = "preserve wrap" should set the property value
+PASS Property white-space value 'preserve wrap'
+PASS e.style['white-space'] = "wrap preserve" should set the property value
+PASS Property white-space value 'wrap preserve'
 PASS e.style['white-space'] = "break-spaces" should set the property value
 PASS Property white-space value 'break-spaces'
-FAIL e.style['white-space'] = "break-spaces wrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'break-spaces wrap' assert_true: 'break-spaces wrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "wrap break-spaces" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'wrap break-spaces' assert_true: 'wrap break-spaces' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve-breaks" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve-breaks' assert_true: 'preserve-breaks' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve-breaks wrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve-breaks wrap' assert_true: 'preserve-breaks wrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "wrap preserve-breaks" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'wrap preserve-breaks' assert_true: 'wrap preserve-breaks' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve-breaks nowrap" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve-breaks nowrap' assert_true: 'preserve-breaks nowrap' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "nowrap preserve-breaks" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'nowrap preserve-breaks' assert_true: 'nowrap preserve-breaks' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "balance" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'balance' assert_true: 'balance' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "collapse balance" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'collapse balance' assert_true: 'collapse balance' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "balance collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'balance collapse' assert_true: 'balance collapse' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "preserve balance" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'preserve balance' assert_true: 'preserve balance' is a supported value for white-space. expected true got false
-FAIL e.style['white-space'] = "balance preserve" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL Property white-space value 'balance preserve' assert_true: 'balance preserve' is a supported value for white-space. expected true got false
+PASS e.style['white-space'] = "break-spaces wrap" should set the property value
+PASS Property white-space value 'break-spaces wrap'
+PASS e.style['white-space'] = "wrap break-spaces" should set the property value
+PASS Property white-space value 'wrap break-spaces'
+PASS e.style['white-space'] = "preserve-breaks" should set the property value
+PASS Property white-space value 'preserve-breaks'
+PASS e.style['white-space'] = "preserve-breaks wrap" should set the property value
+PASS Property white-space value 'preserve-breaks wrap'
+PASS e.style['white-space'] = "wrap preserve-breaks" should set the property value
+PASS Property white-space value 'wrap preserve-breaks'
+PASS e.style['white-space'] = "preserve-breaks nowrap" should set the property value
+PASS Property white-space value 'preserve-breaks nowrap'
+PASS e.style['white-space'] = "nowrap preserve-breaks" should set the property value
+PASS Property white-space value 'nowrap preserve-breaks'
+PASS e.style['white-space'] = "balance" should set the property value
+PASS Property white-space value 'balance'
+PASS e.style['white-space'] = "collapse balance" should set the property value
+PASS Property white-space value 'collapse balance'
+PASS e.style['white-space'] = "balance collapse" should set the property value
+PASS Property white-space value 'balance collapse'
+PASS e.style['white-space'] = "preserve balance" should set the property value
+PASS Property white-space value 'preserve balance'
+PASS e.style['white-space'] = "balance preserve" should set the property value
+PASS Property white-space value 'balance preserve'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt
@@ -5,10 +5,10 @@ PASS Can set 'white-space-collapse' to CSS-wide keywords: unset
 PASS Can set 'white-space-collapse' to CSS-wide keywords: revert
 PASS Can set 'white-space-collapse' to var() references:  var(--A)
 PASS Can set 'white-space-collapse' to the 'collapse' keyword: collapse
-PASS Can set 'white-space-collapse' to the 'discard' keyword: discard
+FAIL Can set 'white-space-collapse' to the 'discard' keyword: discard Invalid values
 PASS Can set 'white-space-collapse' to the 'preserve' keyword: preserve
 PASS Can set 'white-space-collapse' to the 'preserve-breaks' keyword: preserve-breaks
-PASS Can set 'white-space-collapse' to the 'preserve-spaces' keyword: preserve-spaces
+FAIL Can set 'white-space-collapse' to the 'preserve-spaces' keyword: preserve-spaces Invalid values
 PASS Can set 'white-space-collapse' to the 'break-spaces' keyword: break-spaces
 PASS Setting 'white-space-collapse' to a length: 0px throws TypeError
 PASS Setting 'white-space-collapse' to a length: -3.14em throws TypeError

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1348,7 +1348,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef FOR_EACH
 
 #define TYPE WhiteSpaceCollapse
-#define FOR_EACH(CASE) CASE(Collapse) CASE(Discard) CASE(Preserve) CASE(PreserveBreaks) CASE(PreserveSpaces) CASE(BreakSpaces)
+#define FOR_EACH(CASE) CASE(Collapse) CASE(Preserve) CASE(PreserveBreaks) CASE(BreakSpaces)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5870,7 +5870,8 @@
             ],
             "codegen-properties": {
                 "settings-flag": "cssWhiteSpaceLonghandsEnabled",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-text",
@@ -6073,15 +6074,14 @@
             "inherited": true,
             "values": [
                 "collapse",
-                "discard",
                 "preserve",
                 "preserve-breaks",
-                "preserve-spaces",
                 "break-spaces"
             ],
             "codegen-properties": {
                 "settings-flag": "cssWhiteSpaceLonghandsEnabled",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-text",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -829,13 +829,6 @@ stable
 pretty
 
 //
-// CSS_PROP__KHTML_MARGIN_COLLAPSE
-//
-// collapse
-// separate
-discard
-
-//
 // CSS_PROP_TEXT_*_COLOR
 //
 dot-dash
@@ -868,11 +861,13 @@ break-spaces
 // CSS_PROP_WHITE_SPACE_COLLAPSE
 //
 // collapse
-// discard
 preserve
 preserve-breaks
-preserve-spaces
 // break-spaces
+
+// Unimplemented:
+// discard
+// preserve-spaces
 
 //
 // CSS_PROP__KHTML_NBSP_MODE

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -579,21 +579,24 @@ RefPtr<CSSValue> ComputedStyleExtractor::whiteSpaceShorthandValue(const RenderSt
 {
     auto whiteSpaceCollapse = style.whiteSpaceCollapse();
     auto textWrap = style.textWrap();
-    if (whiteSpaceCollapse == WhiteSpaceCollapse::BreakSpaces && textWrap == TextWrap::Wrap)
-        return CSSPrimitiveValue::create(CSSValueBreakSpaces);
+
+    // Convert to backwards-compatible keywords if possible.
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrap == TextWrap::Wrap)
         return CSSPrimitiveValue::create(CSSValueNormal);
-    if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse && textWrap == TextWrap::NoWrap)
-        return CSSPrimitiveValue::create(CSSValueNowrap);
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrap == TextWrap::NoWrap)
         return CSSPrimitiveValue::create(CSSValuePre);
-    if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrap == TextWrap::Wrap)
-        return CSSPrimitiveValue::create(CSSValuePreLine);
     if (whiteSpaceCollapse == WhiteSpaceCollapse::Preserve && textWrap == TextWrap::Wrap)
         return CSSPrimitiveValue::create(CSSValuePreWrap);
+    if (whiteSpaceCollapse == WhiteSpaceCollapse::PreserveBreaks && textWrap == TextWrap::Wrap)
+        return CSSPrimitiveValue::create(CSSValuePreLine);
 
-    // The white-space property cannot be properly expressed in terms of its longhands
-    return nullptr;
+    // Omit default longhand values.
+    if (whiteSpaceCollapse == WhiteSpaceCollapse::Collapse)
+        return createConvertingToCSSValueID(textWrap);
+    if (textWrap == TextWrap::Wrap)
+        return createConvertingToCSSValueID(whiteSpaceCollapse);
+
+    return CSSValuePair::create(createConvertingToCSSValueID(whiteSpaceCollapse), createConvertingToCSSValueID(textWrap));
 }
 
 Ref<CSSPrimitiveValue> ComputedStyleExtractor::currentColorOrValidColor(const RenderStyle& style, const StyleColor& color)

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -1171,20 +1171,24 @@ String ShorthandSerializer::serializeWhiteSpace() const
 {
     auto whiteSpaceCollapse = longhandValueID(0);
     auto textWrap = longhandValueID(1);
-    if (whiteSpaceCollapse == CSSValueBreakSpaces && textWrap == CSSValueWrap)
-        return nameString(CSSValueBreakSpaces);
+
+    // Convert to backwards-compatible keywords if possible.
     if (whiteSpaceCollapse == CSSValueCollapse && textWrap == CSSValueWrap)
         return nameString(CSSValueNormal);
-    if (whiteSpaceCollapse == CSSValueCollapse && textWrap == CSSValueNowrap)
-        return nameString(CSSValueNowrap);
     if (whiteSpaceCollapse == CSSValuePreserve && textWrap == CSSValueNowrap)
         return nameString(CSSValuePre);
-    if (whiteSpaceCollapse == CSSValuePreserveBreaks && textWrap == CSSValueWrap)
-        return nameString(CSSValuePreLine);
     if (whiteSpaceCollapse == CSSValuePreserve && textWrap == CSSValueWrap)
         return nameString(CSSValuePreWrap);
+    if (whiteSpaceCollapse == CSSValuePreserveBreaks && textWrap == CSSValueWrap)
+        return nameString(CSSValuePreLine);
 
-    return String();
+    // Omit default longhand values.
+    if (whiteSpaceCollapse == CSSValueCollapse)
+        return nameString(textWrap);
+    if (textWrap == CSSValueWrap)
+        return nameString(whiteSpaceCollapse);
+
+    return makeString(nameLiteral(whiteSpaceCollapse), ' ', nameLiteral(textWrap));
 }
 
 String serializeShorthandValue(const StyleProperties& properties, CSSPropertyID shorthand)

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1312,10 +1312,8 @@ TextStream& operator<<(TextStream& ts, WhiteSpaceCollapse whiteSpaceCollapse)
 {
     switch (whiteSpaceCollapse) {
     case WhiteSpaceCollapse::Collapse: ts << "collapse"; break;
-    case WhiteSpaceCollapse::Discard: ts << "discard"; break;
     case WhiteSpaceCollapse::Preserve: ts << "preserve"; break;
     case WhiteSpaceCollapse::PreserveBreaks: ts << "preserve-breaks"; break;
-    case WhiteSpaceCollapse::PreserveSpaces: ts << "preserve-spaces"; break;
     case WhiteSpaceCollapse::BreakSpaces: ts << "break-spaces"; break;
     }
     return ts;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -598,10 +598,8 @@ enum class WhiteSpace : uint8_t {
 
 enum class WhiteSpaceCollapse : uint8_t {
     Collapse,
-    Discard,
     Preserve,
     PreserveBreaks,
-    PreserveSpaces,
     BreakSpaces
 };
 


### PR DESCRIPTION
#### 30f3214ab2d13ea5977cdba2f97ea230a4d5d5d9
<pre>
[css-text-4] Implement multi-value syntax for white-space CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=256926">https://bugs.webkit.org/show_bug.cgi?id=256926</a>
rdar://109486180

Reviewed by Antti Koivisto and Darin Adler.

Implement `&lt;white-space-collapse&gt; || &lt;text-wrap&gt;` syntax from: <a href="https://drafts.csswg.org/css-text-4/#white-space-property">https://drafts.csswg.org/css-text-4/#white-space-property</a>

This allows new combinations to be expressed using the shorthand, notably:
- white-space-collapse: preserve-breaks; with text-wrap: nowrap;
- white-space-collapse: break-spaces; with text-wrap: nowrap;

Gate the new syntax behind the CSSWhiteSpaceLonghandsEnabled preference, since we don&apos;t have full layout support for those new combinations yet.

Also remove discard/preserve-spaces values from white-space-collapse that we don&apos;t plan to implement in the layout engine in the near future.
They can be re-added later easily once we get to implementing them.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-shorthand-expected.txt:
Rebaseline now passing test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/white-space-expected.txt:
Rebaseline test now that we removed discard/preserve-spaces.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
Remove white-space-collapse values that aren&apos;t planned in the near future (discard &amp; preserve-spaces).

* Source/WebCore/css/CSSProperties.json:
Remove white-space-collapse values that aren&apos;t planned in the near future (discard &amp; preserve-spaces).
Also export parsers for white-space-collapse/text-wrap so they can be reused in CSSPropertyParser.cpp.

* Source/WebCore/css/CSSValueKeywords.in:
Remove white-space-collapse values that aren&apos;t planned in the near future (discard &amp; preserve-spaces).

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::whiteSpaceShorthandValue):
Implement computed style serialization for the previously unsupported combinations of text-wrap/white-space-collapse.

* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::serializeWhiteSpace const):
Implement specified style serialization for the previously unsupported combinations of text-wrap/white-space-collapse.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeWhiteSpaceShorthand):
Add parsing support for the multi-value syntax.

* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
Remove white-space-collapse values that aren&apos;t planned to be implemented in the layout engine (discard &amp; preserve-spaces).

Canonical link: <a href="https://commits.webkit.org/265588@main">https://commits.webkit.org/265588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ee27c1924b020217f4f9d950b52a7a68242c90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13710 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12368 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13398 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10271 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17462 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10732 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10428 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10015 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2713 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->