### PR TITLE
Non unified build fixes, lateish June 2023 edition

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityTable.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTable.cpp
@@ -50,6 +50,8 @@
 
 namespace WebCore {
 
+using namespace HTMLNames;
+
 AccessibilityTable::AccessibilityTable(RenderObject* renderer)
     : AccessibilityRenderObject(renderer)
     , m_headerContainer(nullptr)

--- a/Source/WebCore/accessibility/AccessibilityTableCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableCell.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "AccessibilityTableCell.h"
 
+#include "AXObjectCache.h"
 #include "AccessibilityTable.h"
 #include "AccessibilityTableRow.h"
 #include "HTMLParserIdioms.h"
@@ -36,6 +37,8 @@
 #include "RenderTableCell.h"
 
 namespace WebCore {
+
+using namespace HTMLNames;
 
 AccessibilityTableCell::AccessibilityTableCell(RenderObject* renderer)
     : AccessibilityRenderObject(renderer)

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -31,6 +31,7 @@
 #include "CanvasRenderingContext.h"
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp
@@ -34,6 +34,7 @@
 #include "KeyboardEvent.h"
 #include "RenderBlock.h"
 #include "RenderStyleInlines.h"
+#include "RenderStyleSetters.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextBreakIterator.h>

--- a/Source/WebCore/layout/LayoutContext.cpp
+++ b/Source/WebCore/layout/LayoutContext.cpp
@@ -38,6 +38,7 @@
 #include "LayoutPhase.h"
 #include "LayoutTreeBuilder.h"
 #include "RenderStyleConstants.h"
+#include "RenderStyleSetters.h"
 #include "RenderView.h"
 #include "TableFormattingContext.h"
 #include "TableFormattingState.h"

--- a/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp
@@ -26,8 +26,14 @@
 #include "config.h"
 #include "FlexLayout.h"
 
+#include "FlexFormattingContext.h"
+#include "FlexFormattingGeometry.h"
 #include "FlexRect.h"
+#include "RenderStyleSetters.h"
+#include "StyleContentAlignmentData.h"
+#include "StyleSelfAlignmentData.h"
 #include <wtf/FixedVector.h>
+#include <wtf/ListHashSet.h>
 
 namespace WebCore {
 namespace Layout {

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -33,6 +33,7 @@
 namespace WebCore {
 
 class Page;
+class OpportunisticTaskScheduler;
 
 class OpportunisticTaskDeferralScope {
     WTF_MAKE_NONCOPYABLE(OpportunisticTaskDeferralScope); WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -28,6 +28,7 @@
 #include "PerformanceUserTiming.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "InspectorInstrumentation.h"
 #include "MessagePort.h"
 #include "PerformanceMarkOptions.h"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
@@ -30,6 +30,7 @@
 
 #include "RenderMathMLFenced.h"
 #include "RenderMathMLFencedOperator.h"
+#include "RenderStyleSetters.h"
 #include "RenderTreeBuilderBlock.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -43,6 +43,7 @@
 #include "Quirks.h"
 #include "RenderElement.h"
 #include "RenderStyleSetters.h"
+#include "RenderView.h"
 #include "ResolvedStyle.h"
 #include "Settings.h"
 #include "ShadowRoot.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLMapElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLMapElement.cpp
@@ -24,6 +24,7 @@
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>
 #include <WebCore/Document.h>
+#include <WebCore/ElementInlines.h>
 #include "GObjectEventListener.h"
 #include <WebCore/HTMLNames.h>
 #include <WebCore/JSExecState.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -28,11 +28,10 @@
 
 #if ENABLE(CONTEXT_MENUS)
 
+#include "WebPage.h"
 #include <WebCore/ContextMenuClient.h>
 
 namespace WebKit {
-
-class WebPage;
 
 class WebContextMenuClient : public WebCore::ContextMenuClient {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
+++ b/Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WebPage.h"
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -35,8 +36,6 @@ class Icon;
 }
 
 namespace WebKit {
-
-class WebPage;
 
 class WebOpenPanelResultListener : public RefCounted<WebOpenPanelResultListener> {
 public:


### PR DESCRIPTION
#### 97cb18e2c790a27b9358fdf38ae4243731b55f1e
<pre>
Non unified build fixes, lateish June 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=258549">https://bugs.webkit.org/show_bug.cgi?id=258549</a>

Unreviewed non-unified build fix.

Fixes for non-unified build. Missing includes or using namespaces.

* Source/WebCore/accessibility/AccessibilityTable.cpp:
* Source/WebCore/accessibility/AccessibilityTableCell.cpp:
* Source/WebCore/html/CustomPaintCanvas.cpp:
* Source/WebCore/html/shadow/DateTimeSymbolicFieldElement.cpp:
* Source/WebCore/layout/LayoutContext.cpp:
* Source/WebCore/layout/formattingContexts/flex/FlexLayout.cpp:
* Source/WebCore/page/OpportunisticTaskScheduler.h:
* Source/WebCore/page/PerformanceUserTiming.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLMapElement.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebPage/WebOpenPanelResultListener.h:

Canonical link: <a href="https://commits.webkit.org/265545@main">https://commits.webkit.org/265545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36047cdebf4e1f8614e9ad090a261ea92d5206f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13598 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13259 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17339 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10613 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13511 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8811 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14168 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1265 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->