### PR TITLE
REGRESSION (264242@main): http/tests/workers/service/postmessage-after-terminating-hung-worker.html is frequently hitting ASSERTION FAILED: state == ServiceWorkerState::Activating

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1055,6 +1055,7 @@ void SWServer::runServiceWorkerAndFireActivateEvent(SWServerWorker& worker)
             return;
 
         RELEASE_LOG(ServiceWorker, "SWServer::runServiceWorkerAndFireActivateEvent on worker %llu", worker->identifier().toUInt64());
+        worker->markActivateEventAsFired();
         contextConnection->fireActivateEvent(worker->identifier());
     });
 }

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -364,13 +364,15 @@ void SWServerWorker::setState(State state)
     case State::Terminating:
         callWhenActivatedHandler(false);
         break;
-    case State::NotRunning:
+    case State::NotRunning: {
+        bool isActivateEventAlreadyFired = m_isActivateEventFired;
         terminationCompleted();
-
         callWhenActivatedHandler(false);
+
         // As per https://w3c.github.io/ServiceWorker/#activate, a worker goes to activated even if activating fails.
-        if (m_data.state == ServiceWorkerState::Activating)
+        if (m_data.state == ServiceWorkerState::Activating && isActivateEventAlreadyFired)
             didFinishActivation();
+        }
         break;
     }
 }

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -149,6 +149,8 @@ public:
     const MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>& scriptResourceMap() const { return m_scriptResourceMap; }
     bool matchingImportedScripts(const Vector<std::pair<URL, ScriptBuffer>>&) const;
 
+    void markActivateEventAsFired() { m_isActivateEventFired = true; }
+
 private:
     SWServerWorker(SWServer&, SWServerRegistration&, const URL&, const ScriptBuffer&, const CertificateInfo&, const ContentSecurityPolicyResponseHeaders&, const CrossOriginEmbedderPolicy&, String&& referrerPolicy, WorkerType, ServiceWorkerIdentifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&&);
 
@@ -186,6 +188,7 @@ private:
     LastNavigationWasAppInitiated m_lastNavigationWasAppInitiated;
     int m_functionalEventCounter { 0 };
     bool m_isInspected { false };
+    bool m_isActivateEventFired { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 42b406d0e2bc3cf1d47684ce0b3aa900c9950f0e
<pre>
REGRESSION (264242@main): http/tests/workers/service/postmessage-after-terminating-hung-worker.html is frequently hitting ASSERTION FAILED: state == ServiceWorkerState::Activating
<a href="https://bugs.webkit.org/show_bug.cgi?id=258502">https://bugs.webkit.org/show_bug.cgi?id=258502</a>
rdar://111299016

Reviewed by Chris Dumez.

We added support for restarting a service worker when firing the activate event.
The assertion failure is due to the following case:
1. The service worker, while installing, is set to terminating
2. The service worker finishes its install and goes to activating. We try firing the activate event but delay until the worker is terminated.
3. The service worker gets terminated. At that point, the service worker state is set to NotRunning.
3a. First we execute callbacks, which triggers running the service worker and firing the activate event synchronously.
3b. Then we check whether the worker is activating, and given it was terminated, we set it as activated in SWServerWorker::setState.
4. We receive the didFinishActivation message and hit the assert, since the worker state is already activated.

To prevent this, we add a boolean on SWServerWorker to know whether the activate event is fired.
When the worker goes in NotRunning state, we first check whether the activate event was fired.
We then run the termination callbacks.
Then, if the activatee vent was fired before the callbacks, we immediately activate the worker.
This fixes locally the ASSERT.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::runServiceWorkerAndFireActivateEvent):
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::setState):
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::markActivateEventAsFired):

Canonical link: <a href="https://commits.webkit.org/265553@main">https://commits.webkit.org/265553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b1701827ec420706b5fb9bb2380e80b45234c29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10675 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13590 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13251 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17332 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13504 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9886 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2686 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->