### PR TITLE
`PageGroup`'s `Preferences`are ignored when creating `WKWebView`

### DIFF
--- a/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
+++ b/Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm
@@ -51,6 +51,10 @@ void PlatformWebView::initialize(WKPageConfigurationRef pageConfiguration, Class
         configuration.get()._relatedWebView = WKPageGetWebView(relatedPage);
     if (auto* preferences = WKPageConfigurationGetPreferences(pageConfiguration))
         configuration.get().preferences = (WKPreferences *)preferences;
+    else if (auto* pageGroup = WKPageConfigurationGetPageGroup(pageConfiguration)) {
+        if (auto preferences = WKPageGroupGetPreferences(pageGroup))
+            configuration.get().preferences = (WKPreferences *)preferences;
+    }
 
     m_view = [[wkViewSubclass alloc] initWithFrame:rect configuration:configuration.get()];
     [m_view _setWindowOcclusionDetectionEnabled:NO];


### PR DESCRIPTION
#### 50ce4c5d7e9e50fb21eecb2edd02b5db7ac1bbdb
<pre>
`PageGroup`&apos;s `Preferences`are ignored when creating `WKWebView`
<a href="https://bugs.webkit.org/show_bug.cgi?id=258558">https://bugs.webkit.org/show_bug.cgi?id=258558</a>

Reviewed by NOBODY (OOPS!).

There are two APIs to create a `WKWebView`:
- `PlatformWebView(WKPageConfigurationRef configuration)`
- `PlatformWebView(WKContextRef contextRef, WKPageGroupRef pageGroupRef)`

If we want to set some preferences, it&apos;s quite straightforward using `WKPageConfigurationRef`:
```
auto configuration = adoptWK(WKPageConfigurationCreate());
auto preferences = adoptWK(WKPreferencesCreate());
WKPageConfigurationSetPreferences(configuration.get(), preferences.get());
```

When using the context and the page group, we don&apos;t have access to the configuration object.
But it&apos;s possible to set preferences to the page group:
```
WKRetainPtr&lt;WKPageGroupRef&gt; pageGroup = adoptWK(WKPageGroupCreateWithIdentifier(Util::toWK(&quot;GetUserMedia&quot;).get()));
WKPreferencesRef preferences = WKPageGroupGetPreferences(pageGroup.get());
```

When we then create an instance of `WKWebView` we copy `WKPageConfigruation` into `WKWebViewConfigruation` and pass them as a parameter:
```
auto configuration = adoptNS([WKWebViewConfiguration new]);
if (auto* preferences = WKPageConfigurationGetPreferences(pageConfiguration))
    configuration.get().preferences = (WKPreferences *)preferences;
m_view = [[wkViewSubclass alloc] initWithFrame:rect configuration:configuration.get()];
```
But we ignore pageGroup&apos;s preferences.

I must say, that it&apos;s really confusing to have two levels of `Preferences`:
WKPageConfiguration
    |-WKPreferences
    |-WKPageGroup
        |-WKPreferences
but for now, we should at least copy pageGroup&apos;s preferences to WebViewConfiguration.

* Tools/TestWebKitAPI/mac/PlatformWebViewMac.mm:
(TestWebKitAPI::PlatformWebView::initialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ce4c5d7e9e50fb21eecb2edd02b5db7ac1bbdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13264 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17344 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13516 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8816 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9899 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->