### PR TITLE
[WPE] Build error when casting GLNativeWindowType to EGLNativeWindowType for target rpi4-32bits-mesa.

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
@@ -52,7 +52,10 @@ GLContext::GLContext(PlatformDisplay& display, EGLContext context, EGLSurface su
 
 EGLSurface GLContext::createWindowSurfaceWPE(EGLDisplay display, EGLConfig config, GLNativeWindowType window)
 {
-    return eglCreateWindowSurface(display, config, reinterpret_cast<EGLNativeWindowType>(window), nullptr);
+    // EGLNativeWindowType changes depending on the EGL implementation, reinterpret_cast
+    // would work for pointers, and static_cast for numeric types only; so use a plain
+    // C cast expression which works in all possible cases.
+    return eglCreateWindowSurface(display, config, (EGLNativeWindowType) window, nullptr);
 }
 
 std::unique_ptr<GLContext> GLContext::createWPEContext(PlatformDisplay& platformDisplay, EGLContext sharingContext)


### PR DESCRIPTION
#### 56a67774797aad0ff8d0c9c6caf1b7c8668f3605
<pre>
[WPE] Build error when casting GLNativeWindowType to EGLNativeWindowType for target rpi4-32bits-mesa.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258563">https://bugs.webkit.org/show_bug.cgi?id=258563</a>

Reviewed by Michael Catanzaro.

EGLNativeWindowType changes depending on the EGL implementation, reinterpret_cast
would work for pointers, and static_cast for numeric types only; so use a plain
C cast expression which works in all possible cases.

The same fix is currently applied at files:
 - Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp
 - Source/WebCore/platform/graphics/egl/GLContext.cpp

* Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp:
(WebCore::GLContext::createWindowSurfaceWPE):

Canonical link: <a href="https://commits.webkit.org/265551@main">https://commits.webkit.org/265551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/824f9066ca498c291bd16f823a60ad38e683e4bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10691 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13606 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13268 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17348 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10621 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8819 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9902 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14176 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1267 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->