### PR TITLE
IPC spends time sending PrepareBuffersForDisplay as out of stream message

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -41,7 +41,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
 
 #if PLATFORM(COCOA)
-    PrepareBuffersForDisplay(Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodable NotStreamEncodableReply
+    PrepareBuffersForDisplay(Vector<WebKit::PrepareBackingStoreBuffersInputData> swapBuffersInput) -> (Vector<WebKit::PrepareBackingStoreBuffersOutputData> swapBuffersOutput) Synchronous NotStreamEncodableReply
 #endif
 
     MarkSurfacesVolatile(WebKit::MarkSurfacesAsVolatileRequestIdentifier requestIdentifier, Vector<WebCore::RenderingResourceIdentifier> renderingResourceIdentifiers)

--- a/Source/WebKit/WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in
@@ -22,7 +22,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
-struct WebKit::BufferIdentifierSet {
+[AdditionalEncoder=StreamConnectionEncoder] struct WebKit::BufferIdentifierSet {
     std::optional<WebCore::RenderingResourceIdentifier> front;
     std::optional<WebCore::RenderingResourceIdentifier> back;
     std::optional<WebCore::RenderingResourceIdentifier> secondaryBack;

--- a/Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in
@@ -24,7 +24,7 @@
 
 header: "PrepareBackingStoreBuffersData.h"
 
-[CustomHeader] struct WebKit::PrepareBackingStoreBuffersInputData {
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebKit::PrepareBackingStoreBuffersInputData {
     WebKit::BufferIdentifierSet bufferSet;
     bool supportsPartialRepaint;
     bool hasEmptyDirtyRegion;


### PR DESCRIPTION
#### 16aa19f9ac3198a965215c354e40b4da5a8b7fb5
<pre>
IPC spends time sending PrepareBuffersForDisplay as out of stream message
<a href="https://bugs.webkit.org/show_bug.cgi?id=258564">https://bugs.webkit.org/show_bug.cgi?id=258564</a>
rdar://problem/111438642

Reviewed by Simon Fraser.

Send PrepareBuffersForDisplay as stream message, it has only trivial
data parameters. The reply has MachSendRights, which cannot be
transferred through the stream.

Appears to improve MM images from 69 to 73 pts on iMac Pro.

* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/BufferIdentifierSet.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/PrepareBackingStoreBuffersData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/265579@main">https://commits.webkit.org/265579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea402cca0a71060a1ea26c29a6b7c9a860d413fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13685 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12344 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9565 "52 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13371 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9639 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17433 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10708 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13610 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9989 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2705 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->