### PR TITLE
[popover] Make togglePopover throw more exceptions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover-expected.txt
@@ -1,4 +1,5 @@
 
 PASS togglePopover should toggle the popover and return true or false as specified.
 PASS togglePopover's return value should reflect what the end state is, not just the force parameter.
+PASS togglePopover should throw an exception when there is no popover attribute.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover.html
@@ -44,4 +44,34 @@ test(() => {
   // but every way to prevent that from hiding the popover also throws an
   // exception, so the return value is not testable.
 }, `togglePopover's return value should reflect what the end state is, not just the force parameter.`);
+
+	
+test(() => {
+  const popover = document.createElement('div');
+  document.body.appendChild(popover);
+
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(),
+    'togglePopover() should throw an exception when the element has no popover attribute.');
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(true),
+    'togglePopover(true) should throw an exception when the element has no popover attribute.');
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(false),
+    'togglePopover(false) should throw an exception when the element has no popover attribute.');
+
+  popover.setAttribute('popover', 'auto');
+  popover.remove();
+
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(),
+    'togglePopover() should throw an exception when the element is disconnected.');
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(true),
+    'togglePopover(true) should throw an exception when the element is disconnected.');
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(false),
+    'togglePopover(false) should throw an exception when the element is disconnected.');
+
+  document.body.appendChild(popover);
+  // togglePopover(false) should not throw just because the popover is already hidden.
+  popover.togglePopover(false);
+  popover.showPopover();
+  // togglePopover(true) should not throw just because the popover is already showing.
+  popover.togglePopover(true);
+}, 'togglePopover should throw an exception when there is no popover attribute.');
 </script>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1489,6 +1489,10 @@ ExceptionOr<bool> HTMLElement::togglePopover(std::optional<bool> force)
         auto returnValue = showPopover();
         if (returnValue.hasException())
             return returnValue.releaseException();
+    } else {
+        auto check = checkPopoverValidity(*this, popoverData() ? popoverData()->visibilityState() : PopoverVisibilityState::Showing);
+        if (check.hasException())
+            return check.releaseException();
     }
     return isPopoverShowing();
 }


### PR DESCRIPTION
#### 348e2c980bf9d8cb0be366d0423fad4ce952b127
<pre>
[popover] Make togglePopover throw more exceptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=258574">https://bugs.webkit.org/show_bug.cgi?id=258574</a>

Reviewed by Tim Nguyen.

Throw exceptions in togglePopover in case of a disconnected node or the popover
attribute not being set anymore, see <a href="https://github.com/whatwg/html/issues/8999.">https://github.com/whatwg/html/issues/8999.</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/togglePopover.html:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::togglePopover):

Canonical link: <a href="https://commits.webkit.org/265589@main">https://commits.webkit.org/265589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae96b1a84cb1bd0acc9bc20029c813382709bed1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11762 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10700 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13614 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12265 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13278 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17355 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8828 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->