### PR TITLE
[webkitscmpy] Ignore ChangeLogs in commit classification

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.2',
+    version='6.6.3',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 2)
+version = Version(6, 6, 3)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py
@@ -128,7 +128,7 @@ class CommitClassifier(object):
                 continue
 
             if klass.paths and paths_for.value and not all([
-                any([c.match(path) for c in klass.paths]) for path in paths_for.value
+                any([c.match(path) for c in klass.paths]) for path in paths_for.value if not path.endswith('ChangeLog')
             ]):
                 continue
             return klass


### PR DESCRIPTION
#### 45692d913fa0f9dd60c208ac98c44503cb914fdb
<pre>
[webkitscmpy] Ignore ChangeLogs in commit classification
<a href="https://bugs.webkit.org/show_bug.cgi?id=258576">https://bugs.webkit.org/show_bug.cgi?id=258576</a>
rdar://111393202

Reviewed by Aakash Jain.

ChangeLogs may mean that historic commits are mis-classified. Our classifiers
should exclude ChangeLogs to avoid these mis-classifications.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit_classifier.py:
(CommitClassifier.classify): Ignore ChangeLogs.

Canonical link: <a href="https://commits.webkit.org/266110@main">https://commits.webkit.org/266110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55f5018ca105add94476ffe54207be5c9eae0350

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/12912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/13236 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/13566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/14650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12324 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/12980 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/15740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/13258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/14650 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/13078 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/15740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/13566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15100 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/13005 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/15740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/13566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/15100 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/15740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/13566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15100 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12310 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/13258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/12800 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/11572 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/13566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15890 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1467 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12151 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->