### PR TITLE
[WebVTT] Modernize VTTCue

### DIFF
--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <type_traits>
 
 namespace WTF {
@@ -33,6 +34,20 @@ template<typename> struct EnumTraits;
 template<typename> struct EnumTraitsForPersistence;
 
 template<typename E, E...> struct EnumValues;
+
+template<typename E, E... values>
+struct EnumValues {
+    static constexpr E max = std::max({ values... });
+    static constexpr E min = std::min({ values... });
+    static constexpr size_t count = sizeof...(values);
+
+    template <typename Callable>
+    static void forEach(Callable&& c)
+    {
+        for (auto value : { values... })
+            c(value);
+    }
+};
 
 template<typename T, typename E> struct EnumValueChecker;
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -48,13 +48,24 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
     height: calc(100% - var(--inline-controls-bar-height) - var(--inline-controls-inside-margin));
 }
 
+/* https://w3c.github.io/webvtt/#applying-css-properties
+   7.4. Applying CSS properties to WebVTT Node Objects */
+
 video::cue {
     background-color: rgba(0, 0, 0, 0.8);
+    overflow: visible;
 }
 
 video::-webkit-media-text-track-display {
     position: absolute;
-    overflow: hidden;
+    unicode-bidi: plaintext;
+    overflow: visible;
+    writing-mode: writing-mode;
+    overflow-wrap: break-word;
+    white-space: pre-line;
+}
+
+video::-webkit-media-text-track-display {
     white-space: pre-wrap;
     box-sizing: border-box;
     font: 22px sans-serif; /* Keep in sync with `DEFAULTCAPTIONFONTSIZE`. */

--- a/Source/WebCore/html/track/InbandGenericTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.cpp
@@ -107,11 +107,11 @@ void InbandGenericTextTrack::updateCueFromCueData(TextTrackCueGeneric& cue, Inba
         cue.setHighlightColor(inbandCue.highlightColor());
 
     if (inbandCue.align() == GenericCueData::Alignment::Start)
-        cue.setAlign("start"_s);
+        cue.setAlign(VTTCue::AlignSetting::Start);
     else if (inbandCue.align() == GenericCueData::Alignment::Middle)
-        cue.setAlign("middle"_s);
+        cue.setAlign(VTTCue::AlignSetting::Center);
     else if (inbandCue.align() == GenericCueData::Alignment::End)
-        cue.setAlign("end"_s);
+        cue.setAlign(VTTCue::AlignSetting::End);
     cue.setSnapToLines(false);
 
     cue.didChange();

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -453,7 +453,7 @@ bool TextTrackCue::isRenderable() const
     return m_cueNode && m_cueNode->firstChild();
 }
 
-RefPtr<TextTrackCueBox> TextTrackCue::getDisplayTree(const IntSize&, int)
+RefPtr<TextTrackCueBox> TextTrackCue::getDisplayTree()
 {
     if (m_displayTree && !m_displayTreeNeedsUpdate)
         return m_displayTree;
@@ -473,7 +473,7 @@ void TextTrackCue::removeDisplayTree()
     m_displayTree->remove();
 }
 
-void TextTrackCue::setFontSize(int fontSize, const IntSize&, bool important)
+void TextTrackCue::setFontSize(int fontSize, bool important)
 {
     if (fontSize == m_fontSize && important == m_fontSizeIsImportant)
         return;

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -51,7 +51,7 @@ public:
     static Ref<TextTrackCueBox> create(Document&, TextTrackCue&);
 
     TextTrackCue* getCue() const;
-    virtual void applyCSSProperties(const IntSize&) { }
+    virtual void applyCSSProperties() { }
 
 protected:
     void initialize();
@@ -109,7 +109,7 @@ public:
     void willChange();
     virtual void didChange();
 
-    virtual RefPtr<TextTrackCueBox> getDisplayTree(const IntSize& videoSize, int fontSize);
+    virtual RefPtr<TextTrackCueBox> getDisplayTree();
     virtual void removeDisplayTree();
 
     virtual RefPtr<DocumentFragment> getCueAsHTML();
@@ -121,7 +121,7 @@ public:
     using RefCounted::deref;
 
     virtual void recalculateStyles() { m_displayTreeNeedsUpdate = true; }
-    virtual void setFontSize(int fontSize, const IntSize& videoSize, bool important);
+    virtual void setFontSize(int fontSize, bool important);
     virtual void updateDisplayTree(const MediaTime&) { }
 
     unsigned cueIndex() const;

--- a/Source/WebCore/html/track/TextTrackCueGeneric.cpp
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.cpp
@@ -53,7 +53,7 @@ class TextTrackCueGenericBoxElement final : public VTTCueBox {
 public:
     static Ref<TextTrackCueGenericBoxElement> create(Document&, TextTrackCueGeneric&);
     
-    void applyCSSProperties(const IntSize&) override;
+    void applyCSSProperties() override;
     
 private:
     TextTrackCueGenericBoxElement(Document&, VTTCue&);
@@ -71,7 +71,7 @@ TextTrackCueGenericBoxElement::TextTrackCueGenericBoxElement(Document& document,
 {
 }
 
-void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
+void TextTrackCueGenericBoxElement::applyCSSProperties()
 {
     RefPtr<TextTrackCueGeneric> cue = static_cast<TextTrackCueGeneric*>(getCue());
     if (!cue)
@@ -94,7 +94,7 @@ void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
         setInlineStyleProperty(CSSPropertyLeft, static_cast<float>(textPosition), CSSUnitType::CSS_PERCENTAGE);
         setInlineStyleProperty(CSSPropertyTop, static_cast<float>(linePosition), CSSUnitType::CSS_PERCENTAGE);
 
-        double authorFontSize = videoSize.height() * cue->baseFontSizeRelativeToVideoHeight() / 100.0;
+        double authorFontSize = cue->baseFontSizeRelativeToVideoHeight();
         if (!authorFontSize)
             authorFontSize = DEFAULTCAPTIONFONTSIZE;
 
@@ -103,7 +103,7 @@ void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
 
         double multiplier = fontSizeFromCaptionUserPrefs() / authorFontSize;
         double newCueSize = std::min(size * multiplier, 100.0);
-        if (cue->getWritingDirection() == VTTCue::Horizontal) {
+        if (cue->vertical() == VTTCue::DirectionSetting::Horizontal) {
             setInlineStyleProperty(CSSPropertyWidth, newCueSize, CSSUnitType::CSS_PERCENTAGE);
             if ((alignment == CSSValueMiddle || alignment == CSSValueCenter) && multiplier != 1.0)
                 setInlineStyleProperty(CSSPropertyLeft, static_cast<double>(textPosition - (newCueSize - cue->getCSSSize()) / 2), CSSUnitType::CSS_PERCENTAGE);
@@ -121,7 +121,7 @@ void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
     else if (alignment == CSSValueStart || alignment == CSSValueLeft)
         maxSize = 100.0 - textPosition;
 
-    if (cue->getWritingDirection() == VTTCue::Horizontal) {
+    if (cue->vertical() == VTTCue::DirectionSetting::Horizontal) {
         setInlineStyleProperty(CSSPropertyMinWidth, "min-content"_s);
         setInlineStyleProperty(CSSPropertyMaxWidth, maxSize, CSSUnitType::CSS_PERCENTAGE);
     } else {
@@ -134,17 +134,17 @@ void TextTrackCueGenericBoxElement::applyCSSProperties(const IntSize& videoSize)
     if (cue->highlightColor().isValid())
         cueElement->setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForHTML(cue->highlightColor()));
 
-    if (cue->getWritingDirection() == VTTCue::Horizontal)
+    if (cue->vertical() == VTTCue::DirectionSetting::Horizontal)
         setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
     else
         setInlineStyleProperty(CSSPropertyWidth, CSSValueAuto);
 
     if (cue->baseFontSizeRelativeToVideoHeight())
-        cue->setFontSize(cue->baseFontSizeRelativeToVideoHeight(), videoSize, false);
+        cue->setFontSize(cue->baseFontSizeRelativeToVideoHeight(), false);
 
-    if (cue->getAlignment() == VTTCue::Center)
+    if (cue->align() == VTTCue::AlignSetting::Center)
         setInlineStyleProperty(CSSPropertyTextAlign, CSSValueCenter);
-    else if (cue->getAlignment() == VTTCue::End)
+    else if (cue->align() == VTTCue::AlignSetting::End)
         setInlineStyleProperty(CSSPropertyTextAlign, CSSValueEnd);
     else
         setInlineStyleProperty(CSSPropertyTextAlign, CSSValueStart);
@@ -179,14 +179,6 @@ RefPtr<VTTCueBox> TextTrackCueGeneric::createDisplayTree()
     return nullptr;
 }
 
-ExceptionOr<void> TextTrackCueGeneric::setLine(const LineAndPositionSetting& line)
-{
-    auto result = VTTCue::setLine(line);
-    if (!result.hasException())
-        m_useDefaultPosition = false;
-    return result;
-}
-
 ExceptionOr<void> TextTrackCueGeneric::setPosition(const LineAndPositionSetting& position)
 {
     auto result = VTTCue::setPosition(position);
@@ -195,21 +187,18 @@ ExceptionOr<void> TextTrackCueGeneric::setPosition(const LineAndPositionSetting&
     return result;
 }
 
-void TextTrackCueGeneric::setFontSize(int fontSize, const IntSize& videoSize, bool important)
+void TextTrackCueGeneric::setFontSize(int fontSize, bool important)
 {
     if (!fontSize)
         return;
     
     if (important || !hasDisplayTree() || !baseFontSizeRelativeToVideoHeight()) {
-        VTTCue::setFontSize(fontSize, videoSize, important);
+        VTTCue::setFontSize(fontSize, important);
         return;
     }
 
-    double size = videoSize.height() * baseFontSizeRelativeToVideoHeight() / 100;
-    if (fontSizeMultiplier())
-        size *= fontSizeMultiplier() / 100;
     if (auto* displayTree = displayTreeInternal())
-        displayTree->setInlineStyleProperty(CSSPropertyFontSize, lround(size), CSSUnitType::CSS_PX);
+        displayTree->setInlineStyleProperty(CSSPropertyFontSize, fontSize, CSSUnitType::CSS_CQH);
 }
 
 bool TextTrackCueGeneric::cueContentsMatch(const TextTrackCue& otherTextTrackCue) const

--- a/Source/WebCore/html/track/TextTrackCueGeneric.h
+++ b/Source/WebCore/html/track/TextTrackCueGeneric.h
@@ -38,7 +38,6 @@ class TextTrackCueGeneric final : public VTTCue {
 public:
     WEBCORE_EXPORT static Ref<TextTrackCueGeneric> create(ScriptExecutionContext&, const MediaTime& start, const MediaTime& end, const String& content);
 
-    ExceptionOr<void> setLine(const LineAndPositionSetting&) final;
     ExceptionOr<void> setPosition(const LineAndPositionSetting&) final;
 
     bool useDefaultPosition() const { return m_useDefaultPosition; }
@@ -61,7 +60,7 @@ public:
     const Color& highlightColor() const { return m_highlightColor; }
     void setHighlightColor(const Color& color) { m_highlightColor = color; }
 
-    void setFontSize(int, const IntSize&, bool important) final;
+    void setFontSize(int, bool important) final;
 
 private:
     TextTrackCueGeneric(Document&, const MediaTime& start, const MediaTime& end, const String&);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -36,6 +36,7 @@
 
 #include "CSSPropertyNames.h"
 #include "CSSValueKeywords.h"
+#include "CSSValuePool.h"
 #include "CommonAtomStrings.h"
 #include "DocumentFragment.h"
 #include "ElementInlines.h"
@@ -43,6 +44,7 @@
 #include "HTMLDivElement.h"
 #include "HTMLSpanElement.h"
 #include "HTMLStyleElement.h"
+#include "JSVTTCue.h"
 #include "Logging.h"
 #include "NodeTraversal.h"
 #include "RenderVTTCue.h"
@@ -74,12 +76,12 @@ constexpr double DEFAULTCAPTIONFONTSIZEPERCENTAGE = 5;
 static const CSSValueID displayWritingModeMap[] = {
     CSSValueHorizontalTb, CSSValueVerticalRl, CSSValueVerticalLr
 };
-static_assert(std::size(displayWritingModeMap) == VTTCue::NumberOfWritingDirections, "displayWritingModeMap has wrong size");
+static_assert(std::size(displayWritingModeMap) == static_cast<size_t>(WTF::EnumTraits<VTTCue::DirectionSetting>::values::max) + 1, "displayWritingModeMap has wrong size");
 
 static const CSSValueID displayAlignmentMap[] = {
     CSSValueStart, CSSValueCenter, CSSValueEnd, CSSValueLeft, CSSValueRight
 };
-static_assert(std::size(displayAlignmentMap) == VTTCue::NumberOfAlignments, "displayAlignmentMap has wrong size");
+static_assert(std::size(displayAlignmentMap) == static_cast<size_t>(WTF::EnumTraits<VTTCue::AlignSetting>::values::max) + 1, "displayAlignmentMap has wrong size");
 
 static const String& startKeyword()
 {
@@ -109,11 +111,6 @@ static const String& rightKeyword()
 {
     static NeverDestroyed<const String> right(MAKE_STATIC_STRING_IMPL("right"));
     return right;
-}
-
-static const String& horizontalKeyword()
-{
-    return emptyString();
 }
 
 static const String& verticalGrowingLeftKeyword()
@@ -154,7 +151,7 @@ VTTCueBox::VTTCueBox(Document& document, VTTCue& cue)
 {
 }
 
-void VTTCueBox::applyCSSProperties(const IntSize& videoSize)
+void VTTCueBox::applyCSSProperties()
 {
     auto textTrackCue = getCue();
     ASSERT(!textTrackCue || is<VTTCue>(textTrackCue));
@@ -163,85 +160,85 @@ void VTTCueBox::applyCSSProperties(const IntSize& videoSize)
 
     Ref cue = downcast<VTTCue>(*textTrackCue);
 
-    // FIXME: Apply all the initial CSS positioning properties. http://wkb.ug/79916
-    if (!cue->regionId().isEmpty()) {
-        setInlineStyleProperty(CSSPropertyPosition, CSSValueRelative);
-        return;
-    }
+    // https://w3c.github.io/webvtt/#applying-css-properties
+    // 7.4. Applying CSS properties to WebVTT Node Objects
 
-    // 3.5.1 On the (root) List of WebVTT Node Objects:
+    // When following the rules for updating the display of WebVTT text tracks,
+    // user agents must set properties of WebVTT Node Objects at the CSS user
+    // agent cascade layer as defined in this section. [CSS22]
+
+    // Initialize the (root) list of WebVTT Node Objects with the following CSS settings:
+    // NOTE: The following settings are initialized by text-tracks.css:
 
     // the 'position' property must be set to 'absolute'
-    setInlineStyleProperty(CSSPropertyPosition, CSSValueAbsolute);
-
-    //  the 'unicode-bidi' property must be set to 'plaintext'
-    setInlineStyleProperty(CSSPropertyUnicodeBidi, CSSValuePlaintext);
-
-    // the 'direction' property must be set to direction
-    setInlineStyleProperty(CSSPropertyDirection, cue->getCSSWritingDirection());
-
+    // the 'unicode-bidi' property must be set to 'plaintext'
     // the 'writing-mode' property must be set to writing-mode
-    setInlineStyleProperty(CSSPropertyWritingMode, cue->getCSSWritingMode(), false);
+    // the overflow-wrap property must be set to break-word
+    // the text-wrap property must be set to balance [CSS-TEXT-4]
+    // The color property on the (root) list of WebVTT Node Objects must be set
+    // to rgba(255,255,255,1). [CSS3-COLOR]
+    // The background shorthand property on the WebVTT cue background box and
+    // on WebVTT Ruby Text Objects must be set to rgba(0,0,0,0.8). [CSS3-COLOR]
+    // The white-space property on the (root) list of WebVTT Node Objects must
+    // be set to pre-line. [CSS22]
 
-    auto& position = cue->getCSSPosition();
+    // NOTE: For 'top' and 'left', see step 25. in 7.2, Processing Cue Settings:
+    //   Let left be x-position vw and top be y-position vh.
+    // Use 'cqh' and 'cqw' rather than 'vh' and 'vw' here, as the video viewport
+    // is not a true viewport, but it is a container, so they serve the same purpose.
 
-    // the 'top' property must be set to top,
-    if (position.second)
-        setInlineStyleProperty(CSSPropertyTop, *position.second, CSSUnitType::CSS_PERCENTAGE);
+    // the 'top' property must be set to top
+    std::visit(WTF::makeVisitor([&] (double top) {
+        setInlineStyleProperty(CSSPropertyTop, top, CSSUnitType::CSS_CQH);
+    }, [&] (auto) {
+        setInlineStyleProperty(CSSPropertyTop, CSSValueAuto);
+    }), cue->top());
 
     // the 'left' property must be set to left
-    if (cue->vertical() == horizontalKeyword() && position.first)
-        setInlineStyleProperty(CSSPropertyLeft, *position.first, CSSUnitType::CSS_PERCENTAGE);
-    else if (cue->vertical() == verticalGrowingRightKeyword()) {
-        // FIXME: Why use calc to do the math instead of doing the subtraction here?
-        setInlineStyleProperty(CSSPropertyLeft, makeString("calc(-", videoSize.width(), "px - ", cue->getCSSSize(), "px)"));
-    }
+    std::visit(WTF::makeVisitor([&] (double left) {
+        setInlineStyleProperty(CSSPropertyLeft, left, CSSUnitType::CSS_CQW);
+    }, [&] (auto) {
+        setInlineStyleProperty(CSSPropertyLeft, CSSValueAuto);
+    }), cue->left());
 
-    double authorFontSize = std::min(videoSize.width(), videoSize.height()) * DEFAULTCAPTIONFONTSIZEPERCENTAGE / 100.0;
-    double multiplier = 1.0;
-    if (authorFontSize)
-        multiplier = m_fontSizeFromCaptionUserPrefs / authorFontSize;
+    // NOTE: For 'width' and 'height', see step 8. in 7.2, Processing Cue Settings:
+    //   If the WebVTT cue writing direction is horizontal, then let width be size
+    //   vw and height be auto. Otherwise, let width be auto and height be size vh.
+    // Use 'cqh' and 'cqw' rather than 'vh' and 'vw' here, as the video viewport
+    // is not a true viewport, but it is a container, so they serve the same purpose.
 
-    double textPosition = cue->calculateComputedTextPosition();
-    double maxSize = 100.0;
-    CSSValueID alignment = cue->getCSSAlignment();
-    if (alignment == CSSValueEnd || alignment == CSSValueRight)
-        maxSize = textPosition;
-    else if (alignment == CSSValueStart || alignment == CSSValueLeft)
-        maxSize = 100.0 - textPosition;
-
-    double newCueSize = std::min(cue->getCSSSize() * multiplier, 100.0);
-    // the 'width' property must be set to width, and the 'height' property  must be set to height
-    if (cue->vertical() == horizontalKeyword()) {
-        setInlineStyleProperty(CSSPropertyWidth, newCueSize, CSSUnitType::CSS_PERCENTAGE);
-        setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
-        setInlineStyleProperty(CSSPropertyMinWidth, "min-content"_s);
-        setInlineStyleProperty(CSSPropertyMaxWidth, maxSize, CSSUnitType::CSS_PERCENTAGE);
-        if ((alignment == CSSValueMiddle || alignment == CSSValueCenter) && multiplier != 1.0 && position.first)
-            setInlineStyleProperty(CSSPropertyLeft, static_cast<double>(*position.first - (newCueSize - cue->getCSSSize()) / 2), CSSUnitType::CSS_PERCENTAGE);
-    } else {
+    // the 'width' property must be set to width
+    std::visit(WTF::makeVisitor([&] (double width) {
+        setInlineStyleProperty(CSSPropertyWidth, width, CSSUnitType::CSS_CQW);
+    }, [&] (auto) {
         setInlineStyleProperty(CSSPropertyWidth, CSSValueAuto);
-        setInlineStyleProperty(CSSPropertyHeight, newCueSize, CSSUnitType::CSS_PERCENTAGE);
-        setInlineStyleProperty(CSSPropertyMinHeight, "min-content"_s);
-        setInlineStyleProperty(CSSPropertyMaxHeight, maxSize, CSSUnitType::CSS_PERCENTAGE);
-        if ((alignment == CSSValueMiddle || alignment == CSSValueCenter) && multiplier != 1.0 && position.second)
-            setInlineStyleProperty(CSSPropertyTop, static_cast<double>(*position.second - (newCueSize - cue->getCSSSize()) / 2), CSSUnitType::CSS_PERCENTAGE);
-    }
+    }), cue->width());
+
+    // the 'height' property must be set to height
+    std::visit(WTF::makeVisitor([&] (double height) {
+        setInlineStyleProperty(CSSPropertyHeight, height, CSSUnitType::CSS_CQW);
+    }, [&] (auto) {
+        setInlineStyleProperty(CSSPropertyHeight, CSSValueAuto);
+    }), cue->height());
 
     // The 'text-align' property on the (root) List of WebVTT Node Objects must
     // be set to the value in the second cell of the row of the table below
-    // whose first cell is the value of the corresponding cue's text track cue
+    // whose first cell is the value of the corresponding cue's WebVTT cue text
     // alignment:
     setInlineStyleProperty(CSSPropertyTextAlign, cue->getCSSAlignment());
-    
+
+    // The font shorthand property on the (root) list of WebVTT Node Objects
+    // must be set to 5vh sans-serif. [CSS-VALUES]
+    // NOTE: We use 'cqh' rather than 'vh' as the video element is not a proper viewport.
+    setInlineStyleProperty(CSSPropertyFontSize, cue->fontSize(), CSSUnitType::CSS_CQH, cue->fontSizeIsImportant());
+
     if (!cue->snapToLines()) {
         setInlineStyleProperty(CSSPropertyWhiteSpaceCollapse, CSSValuePreserve);
         setInlineStyleProperty(CSSPropertyTextWrap, CSSValueNowrap);
     }
 
     // Make sure shadow or stroke is not clipped.
-    setInlineStyleProperty(CSSPropertyOverflow, CSSValueVisible);
-    cue->element().setInlineStyleProperty(CSSPropertyOverflow, CSSValueVisible);
+    // NOTE: Set in text-tracks.css
 }
 
 RenderPtr<RenderElement> VTTCueBox::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
@@ -268,16 +265,19 @@ Ref<VTTCue> VTTCue::create(Document& document, const WebVTTCueData& data)
 VTTCue::VTTCue(Document& document, const MediaTime& start, const MediaTime& end, String&& content)
     : TextTrackCue(document, start, end)
     , m_content(WTFMove(content))
+    , m_cueHighlightBox(HTMLSpanElement::create(spanTag, document))
+    , m_cueBackdropBox(HTMLDivElement::create(document))
     , m_originalStartTime(MediaTime::zeroTime())
+    , m_snapToLines(true)
+    , m_displayTreeShouldChange(true)
+    , m_notifyRegion(true)
 {
-    initialize(document);
 }
 
 VTTCue::VTTCue(Document& document, const WebVTTCueData& cueData)
-    : TextTrackCue(document, MediaTime::zeroTime(), MediaTime::zeroTime())
-    , m_originalStartTime(cueData.originalStartTime())
+    : VTTCue(document, MediaTime::zeroTime(), MediaTime::zeroTime(), { })
 {
-    initialize(document);
+    m_originalStartTime = cueData.originalStartTime();
     setText(cueData.content());
     setStartTime(cueData.startTime());
     setEndTime(cueData.endTime());
@@ -287,15 +287,6 @@ VTTCue::VTTCue(Document& document, const WebVTTCueData& cueData)
 
 VTTCue::~VTTCue()
 {
-}
-
-void VTTCue::initialize(Document& document)
-{
-    m_cueBackdropBox = HTMLDivElement::create(document);
-    m_cueHighlightBox = HTMLSpanElement::create(spanTag, document);
-    m_snapToLines = true;
-    m_displayTreeShouldChange = true;
-    m_notifyRegion = true;
 }
 
 RefPtr<VTTCueBox> VTTCue::createDisplayTree()
@@ -318,47 +309,20 @@ void VTTCue::didChange()
     m_displayTreeShouldChange = true;
 }
 
-const String& VTTCue::vertical() const
-{
-    switch (m_writingDirection) {
-    case Horizontal: 
-        return horizontalKeyword();
-    case VerticalGrowingLeft:
-        return verticalGrowingLeftKeyword();
-    case VerticalGrowingRight:
-        return verticalGrowingRightKeyword();
-    default:
-        ASSERT_NOT_REACHED();
-        return emptyString();
-    }
-}
-
-ExceptionOr<void> VTTCue::setVertical(const String& value)
+void VTTCue::setVertical(DirectionSetting direction)
 {
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#dom-texttrackcue-vertical
     // On setting, the text track cue writing direction must be set to the value given 
     // in the first cell of the row in the table above whose second cell is a 
     // case-sensitive match for the new value, if any. If none of the values match, then
     // the user agent must instead throw a SyntaxError exception.
-    
-    WritingDirection direction = m_writingDirection;
-    if (value == horizontalKeyword())
-        direction = Horizontal;
-    else if (value == verticalGrowingLeftKeyword())
-        direction = VerticalGrowingLeft;
-    else if (value == verticalGrowingRightKeyword())
-        direction = VerticalGrowingRight;
-    else
-        return { };
 
     if (direction == m_writingDirection)
-        return { };
+        return;
 
     willChange();
     m_writingDirection = direction;
     didChange();
-
-    return { };
 }
 
 void VTTCue::setSnapToLines(bool value)
@@ -379,7 +343,7 @@ VTTCue::LineAndPositionSetting VTTCue::line() const
     return *m_linePosition;
 }
 
-ExceptionOr<void> VTTCue::setLine(const LineAndPositionSetting& position)
+void VTTCue::setLine(const LineAndPositionSetting& position)
 {
     std::optional<double> linePosition;
 
@@ -387,55 +351,26 @@ ExceptionOr<void> VTTCue::setLine(const LineAndPositionSetting& position)
         linePosition = std::get<double>(position);
 
     if (m_linePosition == linePosition)
-        return { };
+        return;
 
     willChange();
     m_linePosition = linePosition;
     m_computedLinePosition = calculateComputedLinePosition();
     didChange();
-
-    return { };
 }
 
-const String& VTTCue::lineAlign() const
+void VTTCue::setLineAlign(LineAlignSetting lineAlignment)
 {
-    switch (m_lineAlignment) {
-    case LignAlignmentStart:
-        return startKeyword();
-    case LignAlignmentCenter:
-        return centerKeyword();
-    case LignAlignmentEnd:
-        return endKeyword();
-    default:
-        ASSERT_NOT_REACHED();
-        return emptyString();
-    }
-}
-
-ExceptionOr<void> VTTCue::setLineAlign(const String& value)
-{
-    CueLignAlignment lineAlignment;
-    if (value == startKeyword())
-        lineAlignment = LignAlignmentStart;
-    else if (value == centerKeyword())
-        lineAlignment = LignAlignmentCenter;
-    else if (value == endKeyword())
-        lineAlignment = LignAlignmentEnd;
-    else
-        return { };
-
     if (lineAlignment == m_lineAlignment)
-        return { };
+        return;
 
     willChange();
     m_lineAlignment = lineAlignment;
     didChange();
-
-    return { };
 }
 
 
-VTTCue::LineAndPositionSetting VTTCue::position() const
+auto VTTCue::position() const -> LineAndPositionSetting
 {
     if (m_textPosition)
         return *m_textPosition;
@@ -468,45 +403,14 @@ ExceptionOr<void> VTTCue::setPosition(const LineAndPositionSetting& position)
     return { };
 }
 
-const String& VTTCue::positionAlign() const
+void VTTCue::setPositionAlign(PositionAlignSetting positionAlignment)
 {
-    switch (m_positionAlignment) {
-    case PositionAlignmentLignLeft:
-        return lineLeftKeyword();
-    case PositionAlignmentLignCenter:
-        return centerKeyword();
-    case PositionAlignmentLignRight:
-        return lineRightKeyword();
-    case PositionAlignmentLignAuto:
-        return autoAtom();
-    default:
-        ASSERT_NOT_REACHED();
-        return emptyString();
-    }
-}
-
-ExceptionOr<void> VTTCue::setPositionAlign(const String& value)
-{
-    CuePositionAlignment positionAlignment;
-    if (value == lineLeftKeyword())
-        positionAlignment = PositionAlignmentLignLeft;
-    else if (value == centerKeyword())
-        positionAlignment = PositionAlignmentLignCenter;
-    else if (value == lineRightKeyword())
-        positionAlignment = PositionAlignmentLignRight;
-    else if (value == autoAtom())
-        positionAlignment = PositionAlignmentLignAuto;
-    else
-        return { };
-
     if (positionAlignment == m_positionAlignment)
-        return { };
+        return;
 
     willChange();
     m_positionAlignment = positionAlignment;
     didChange();
-
-    return { };
 }
 
 ExceptionOr<void> VTTCue::setSize(int size)
@@ -528,55 +432,20 @@ ExceptionOr<void> VTTCue::setSize(int size)
     return { };
 }
 
-const String& VTTCue::align() const
-{
-    switch (m_cueAlignment) {
-    case Start:
-        return startKeyword();
-    case Center:
-        return centerKeyword();
-    case End:
-        return endKeyword();
-    case Left:
-        return leftKeyword();
-    case Right:
-        return rightKeyword();
-    default:
-        ASSERT_NOT_REACHED();
-        return emptyString();
-    }
-}
-
-ExceptionOr<void> VTTCue::setAlign(const String& value)
+void VTTCue::setAlign(AlignSetting alignment)
 {
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#dom-texttrackcue-align
     // On setting, the text track cue alignment must be set to the value given in the 
     // first cell of the row in the table above whose second cell is a case-sensitive
     // match for the new value, if any. If none of the values match, then the user
     // agent must instead throw a SyntaxError exception.
-    
-    CueAlignment alignment;
-    if (value == startKeyword())
-        alignment = Start;
-    else if (value == centerKeyword())
-        alignment = Center;
-    else if (value == endKeyword())
-        alignment = End;
-    else if (value == leftKeyword())
-        alignment = Left;
-    else if (value == rightKeyword())
-        alignment = Right;
-    else
-        return { };
 
     if (alignment == m_cueAlignment)
-        return { };
+        return;
 
     willChange();
     m_cueAlignment = alignment;
     didChange();
-
-    return { };
 }
     
 void VTTCue::setText(const String& text)
@@ -706,35 +575,48 @@ const String& VTTCue::regionId()
 int VTTCue::calculateComputedLinePosition() const
 {
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-computed-line-position
+    // A WebVTT cue has a computed line whose value is that returned by the following
+    // algorithm, which is defined in terms of the other aspects of the cue:
 
-    // If the text track cue line position is numeric, then that is the text
-    // track cue computed line position.
+    // 1. If the line is numeric, the WebVTT cue snap-to-lines flag of the WebVTT
+    // cue is false, and the line is negative or greater than 100, then return 100
+    // and abort these steps.
+    // (Although the WebVTT parser will not set the line to a number outside the
+    // range 0..100 and also set the WebVTT cue snap-to-lines flag to false, this
+    // can happen when using the DOM API’s snapToLines and line attributes.)
+    if (m_snapToLines && m_linePosition && (*m_linePosition < 0 && *m_linePosition > 100))
+        return 100;
+
+    // 2. If the line is numeric, return the value of the WebVTT cue line and abort
+    // these steps. (Either the WebVTT cue snap-to-lines flag is true, so any value,
+    // not just those in the range 0..100, is valid, or the value is in the range 0..100
+    // and is thus valid regardless of the value of that flag.)
     if (m_linePosition)
         return *m_linePosition;
 
-    // If the text track cue snap-to-lines flag of the text track cue is not
-    // set, the text track cue computed line position is the value 100;
+    // 3. If the WebVTT cue snap-to-lines flag of the WebVTT cue is false, return the value
+    // 100 and abort these steps. (The line is the special value auto.)
     if (!m_snapToLines)
         return 100;
 
-    // Otherwise, it is the value returned by the following algorithm:
-
-    // If cue is not associated with a text track, return -1 and abort these
-    // steps.
+    // 4. Let cue be the WebVTT cue.
+    // 5. If cue is not in a list of cues of a text track, or if that text track is not in
+    // the list of text tracks of a media element, return −1 and abort these steps.
     if (!track())
         return -1;
 
-    // Let n be the number of text tracks whose text track mode is showing or
-    // showing by default and that are in the media element's list of text
-    // tracks before track.
+    // 6. Let track be the text track whose list of cues the cue is in.
+    // 7. Let n be the number of text tracks whose text track mode is showing and that are
+    // in the media element’s list of text tracks before track.
     int n = track()->trackIndexRelativeToRenderedTracks();
 
-    // Increment n by one.
+    // 8. Increment n by one.
     n++;
 
-    // Negate n.
+    // 9. Negate n.
     n = -n;
 
+    // 10. Return n.
     return n;
 }
 
@@ -798,103 +680,168 @@ double VTTCue::calculateComputedTextPosition() const
         return *m_textPosition;
     
     switch (m_cueAlignment) {
-    case Start:
-    case Left:
+    case AlignSetting::Start:
+    case AlignSetting::Left:
         // 2. If the cue text alignment is start or left, return 0 and abort these
         // steps.
         return 0;
-    case End:
-    case Right:
+    case AlignSetting::End:
+    case AlignSetting::Right:
         // 3. If the cue text alignment is end or right, return 100 and abort these
         // steps.
         return 100;
-    case Center:
+    case AlignSetting::Center:
         // 4. If the cue text alignment is center, return 50 and abort these steps.
         return 50;
-    default:
-        ASSERT_NOT_REACHED();
-        return 0;
     }
+
+    // NOTE: The following is required for GCC, which will otherwise warn about
+    // 'control reaches end of non-void function'.
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+auto VTTCue::calculateComputedPositionAlignment() const -> PositionAlignSetting
+{
+    // https://w3c.github.io/webvtt/#cue-computed-position-alignment
+    // A WebVTT cue has a computed position alignment whose value is that returned by
+    // the following algorithm, which is defined in terms of other aspects of the cue:
+
+    // 1. If the WebVTT cue position alignment is not auto, then return the
+    //    value of the WebVTT cue position alignment and abort these steps.
+    if (m_positionAlignment != PositionAlignSetting::Auto)
+        return m_positionAlignment;
+
+    switch (m_cueAlignment) {
+    case AlignSetting::Left:
+        // 2. If the WebVTT cue text alignment is left, return line-left and abort these steps.
+        return PositionAlignSetting::LineLeft;
+    case AlignSetting::Right:
+        // 3. If the WebVTT cue text alignment is right, return line-right and abort these steps.
+        return PositionAlignSetting::LineRight;
+    case AlignSetting::Start:
+        // 4. If the WebVTT cue text alignment is start, return line-left if the base direction
+        //    of the cue text is left-to-right, line-right otherwise.
+        return m_displayDirection == CSSValueLtr ? PositionAlignSetting::LineLeft : PositionAlignSetting::LineRight;
+    case AlignSetting::End:
+        // 5. If the WebVTT cue text alignment is end, return line-right if the base direction
+        //    of the cue text is left-to-right, line-left otherwise.
+        return m_displayDirection == CSSValueLtr ? PositionAlignSetting::LineRight : PositionAlignSetting::LineLeft;
+    case AlignSetting::Center:
+        // 6. Otherwise, return center.
+        return PositionAlignSetting::Center;
+    }
+
+    // NOTE: The following is required for GCC, which will otherwise warn about
+    // 'control reaches end of non-void function'.
+    ASSERT_NOT_REACHED();
+    return PositionAlignSetting::Center;
+}
+
+double VTTCue::calculateMaximumSize() const
+{
+    // 7.2. Processing cue settings
+    // 7.2.2 Determine the value of maximum size for cue as per the appropriate rules from
+    // the following list:
+
+    double maxSize = 0;
+    auto computedPosition = calculateComputedTextPosition();
+    auto positionAlignment = calculateComputedPositionAlignment();
+
+    if (positionAlignment == PositionAlignSetting::LineLeft) {
+        // If the computed position alignment is line-left
+        // Let maximum size be the computed position subtracted from 100.
+        maxSize = 100.0 - computedPosition;
+    } else if (positionAlignment == PositionAlignSetting::LineRight) {
+        // If the computed position alignment is line-right
+        // Let maximum size be the computed position.
+        maxSize = computedPosition;
+    } else if (positionAlignment == PositionAlignSetting::Center && computedPosition <= 50) {
+        // If the computed position alignment is center, and the computed position is less than or equal to 50
+        // Let maximum size be the computed position multiplied by two.
+        maxSize = 2 * computedPosition;
+        // If the computed position alignment is center, and the computed position is greater than 50
+    } else if (positionAlignment == PositionAlignSetting::Center && computedPosition > 50) {
+        // Let maximum size be the result of subtracting computed position from 100 and then multiplying the result by two.
+        maxSize = 2 * (100.0 - computedPosition);
+    } else
+        ASSERT_NOT_REACHED();
+
+    return maxSize;
 }
 
 void VTTCue::calculateDisplayParameters()
 {
-    // Steps 10.2, 10.3
+    // https://w3c.github.io/webvtt/#processing-cue-settings
+    // Steps 7.2.1-25
     determineTextDirection();
 
-    // 10.4 If the text track cue writing direction is horizontal, then let
-    // block-flow be 'tb'. Otherwise, if the text track cue writing direction is
-    // vertical growing left, then let block-flow be 'lr'. Otherwise, the text
-    // track cue writing direction is vertical growing right; let block-flow be
-    // 'rl'.
+    // 1. If the WebVTT cue writing direction is horizontal, then let writing-mode be
+    // "horizontal-tb". Otherwise, if the WebVTT cue writing direction is vertical growing
+    // left, then let writing-mode be "vertical-rl". Otherwise, the WebVTT cue writing direction
+    // is vertical growing right; let writing-mode be "vertical-lr".
 
     // The above step is done through the writing direction static map.
 
-    // 10.5 Determine the value of maximum size for cue as per the appropriate
+    // 2. Determine the value of maximum size for cue as per the appropriate
     // rules from the following list:
-    double computedTextPosition = calculateComputedTextPosition();
-    int maximumSize = computedTextPosition;
-    if ((m_writingDirection == Horizontal && m_cueAlignment == Start && m_displayDirection == CSSValueLtr)
-        || (m_writingDirection == Horizontal && m_cueAlignment == End && m_displayDirection == CSSValueRtl)
-        || (m_writingDirection == Horizontal && m_cueAlignment == Left)
-        || (m_writingDirection == VerticalGrowingLeft && (m_cueAlignment == Start || m_cueAlignment == Left))
-        || (m_writingDirection == VerticalGrowingRight && (m_cueAlignment == Start || m_cueAlignment == Left))) {
-        maximumSize = 100 - computedTextPosition;
-    } else if ((m_writingDirection == Horizontal && m_cueAlignment == End && m_displayDirection == CSSValueLtr)
-        || (m_writingDirection == Horizontal && m_cueAlignment == Start && m_displayDirection == CSSValueRtl)
-        || (m_writingDirection == Horizontal && m_cueAlignment == Right)
-        || (m_writingDirection == VerticalGrowingLeft && (m_cueAlignment == End || m_cueAlignment == Right))
-        || (m_writingDirection == VerticalGrowingRight && (m_cueAlignment == End || m_cueAlignment == Right))) {
-        maximumSize = computedTextPosition;
-    } else if (m_cueAlignment == Center) {
-        maximumSize = computedTextPosition <= 50 ? computedTextPosition : (100 - computedTextPosition);
-        maximumSize = maximumSize * 2;
-    } else
-        ASSERT_NOT_REACHED();
+    // NOTE: Defined in calculateMaximumSize()
+    double maximumSize = calculateMaximumSize();
 
-    // 10.6 If the text track cue size is less than maximum size, then let size
-    // be text track cue size. Otherwise, let size be maximum size.
+    // 7. If the WebVTT cue size is less than maximum size, then let size be WebVTT cue size.
+    // Otherwise, let size be maximum size.
     m_displaySize = std::min(m_cueSize, maximumSize);
 
-    // FIXME: Understand why step 10.7 is missing (just a copy/paste error?)
-    // Could be done within a spec implementation check - http://crbug.com/301580
+    // 8. If the WebVTT cue writing direction is horizontal, then let width be size vw and height
+    // be auto. Otherwise, let width be auto and height be size vh.
+    if (m_writingDirection == DirectionSetting::Horizontal) {
+        m_width = m_displaySize;
+        m_height = Auto;
+    } else {
+        m_width = Auto;
+        m_height = m_displaySize;
+    }
 
-    // 10.8 Determine the value of x-position or y-position for cue as per the
+    double computedTextPosition = calculateComputedTextPosition();
+    auto computedPositionAlignment = calculateComputedPositionAlignment();
+
+    // 9. Determine the value of x-position or y-position for cue as per the
     // appropriate rules from the following list:
-    if (m_writingDirection == Horizontal) {
-        switch (m_cueAlignment) {
-        case Start:
-            if (m_displayDirection == CSSValueLtr)
-                m_displayPosition.first = computedTextPosition;
-            else
-                m_displayPosition.first = 100 - computedTextPosition - m_displaySize;
+    if (m_writingDirection == DirectionSetting::Horizontal) {
+        switch (computedPositionAlignment) {
+        case PositionAlignSetting::LineLeft:
+            // Let x-position be the computed position.
+            m_displayPosition.first = computedTextPosition;
             break;
-        case End:
-            if (m_displayDirection == CSSValueRtl)
-                m_displayPosition.first = 100 - computedTextPosition;
-            else
-                m_displayPosition.first = computedTextPosition - m_displaySize;
+        case PositionAlignSetting::Center:
+            // Let x-position be the computed position minus half of size.
+            m_displayPosition.first = computedTextPosition - m_displaySize / 2;
             break;
-        case Left:
-            if (m_displayDirection == CSSValueLtr)
-                m_displayPosition.first = computedTextPosition;
-            else
-                m_displayPosition.first = 100 - computedTextPosition;
+        case PositionAlignSetting::LineRight:
+            // Let x-position be the computed position minus size.
+            m_displayPosition.first = computedTextPosition - m_displaySize;
             break;
-        case Right:
-            if (m_displayDirection == CSSValueLtr)
-                m_displayPosition.first = computedTextPosition - m_displaySize;
-            else
-                m_displayPosition.first = 100 - computedTextPosition - m_displaySize;
-            break;
-        case Center:
-            if (m_displayDirection == CSSValueLtr)
-                m_displayPosition.first = computedTextPosition - m_displaySize / 2;
-            else
-                m_displayPosition.first = 100 - computedTextPosition - m_displaySize / 2;
-            break;
-        case NumberOfAlignments:
+        case PositionAlignSetting::Auto:
             ASSERT_NOT_REACHED();
+            break;
+        }
+    } else if (m_writingDirection == DirectionSetting::VerticalGrowingLeft || m_writingDirection == DirectionSetting::VerticalGrowingRight) {
+        switch (computedPositionAlignment) {
+        case PositionAlignSetting::LineLeft:
+            // Let y-position be the computed position.
+            m_displayPosition.second = computedTextPosition;
+            break;
+        case PositionAlignSetting::Center:
+            // Let y-position be the computed position minus half of size.
+            m_displayPosition.second = computedTextPosition - m_displaySize / 2;
+            break;
+        case PositionAlignSetting::LineRight:
+            // Let y-position be the computed position minus size.
+            m_displayPosition.second = computedTextPosition - m_displaySize;
+            break;
+        case PositionAlignSetting::Auto:
+            ASSERT_NOT_REACHED();
+            break;
         }
     }
 
@@ -902,23 +849,82 @@ void VTTCue::calculateDisplayParameters()
     // is defined in terms of the other aspects of the cue.
     m_computedLinePosition = calculateComputedLinePosition();
 
-    // 10.9 Determine the value of whichever of x-position or y-position is not
+    // 10. Determine the value of whichever of x-position or y-position is not
     // yet calculated for cue as per the appropriate rules from the following
     // list:
-    if (m_snapToLines && !m_displayPosition.second && m_writingDirection == Horizontal)
-        m_displayPosition.second = 0;
+    if (!m_snapToLines) {
+        if (m_writingDirection == DirectionSetting::Horizontal) {
+            // Let y-position be the computed line.
+            m_displayPosition.second = *m_computedLinePosition;
+        } else if (m_writingDirection == DirectionSetting::VerticalGrowingLeft || m_writingDirection == DirectionSetting::VerticalGrowingRight) {
+            // Let x-position be the computed line.
+            m_displayPosition.first = *m_computedLinePosition;
+        }
+    } else {
+        if (m_writingDirection == DirectionSetting::Horizontal) {
+            // Let y-position 0.
+            m_displayPosition.second = 0;
+        } else if (m_writingDirection == DirectionSetting::VerticalGrowingLeft || m_writingDirection == DirectionSetting::VerticalGrowingRight) {
+            // Let x-position 0.
+            m_displayPosition.first = 0;
+        }
+    }
 
-    if (!m_snapToLines && !m_displayPosition.second && m_writingDirection == Horizontal)
-        m_displayPosition.second = *m_computedLinePosition;
-
-    if (m_snapToLines && !m_displayPosition.first
-        && (m_writingDirection == VerticalGrowingLeft || m_writingDirection == VerticalGrowingRight))
-        m_displayPosition.first = 0;
-
-    if (!m_snapToLines && (m_writingDirection == VerticalGrowingLeft || m_writingDirection == VerticalGrowingRight))
-        m_displayPosition.first = *m_computedLinePosition;
+    // 25. Let left be x-position vw and top be y-position vh.
+    ASSERT(m_displayPosition.first);
+    ASSERT(m_displayPosition.second);
+    m_left = m_displayPosition.first.value_or(0);
+    m_top = m_displayPosition.second.value_or(0);
 }
-    
+
+void VTTCue::obtainCSSBoxes()
+{
+    // https://w3c.github.io/webvtt/#obtaining-css-boxes
+    // 7.3 Obtaining CSS Boxes
+    // When the processing algorithm above requires that the user agent obtain a set of
+    // CSS boxes 'boxes', then apply the terms of the CSS specifications to nodes within
+    // the following constraints:
+    RefPtr displayTree = displayTreeInternal();
+    if (!displayTree)
+        return;
+
+    displayTree->removeChildren();
+
+    // The document tree is the tree of WebVTT Node Objects rooted at nodes.
+
+    // The children of the nodes must be wrapped in an anonymous box whose
+    // 'display' property has the value 'inline'. This is the WebVTT cue
+    // background box.
+
+    // Note: This is contained by default in m_cueHighlightBox.
+    m_cueHighlightBox->setPseudo(ShadowPseudoIds::cue());
+
+    m_cueBackdropBox->setPseudo(ShadowPseudoIds::webkitMediaTextTrackDisplayBackdrop());
+    m_cueBackdropBox->appendChild(m_cueHighlightBox);
+    displayTree->appendChild(m_cueBackdropBox);
+
+    // FIXME(BUG 79916): Runs of children of WebVTT Ruby Objects that are not
+    // WebVTT Ruby Text Objects must be wrapped in anonymous boxes whose
+    // 'display' property has the value 'ruby-base'.
+
+    displayTree->applyCSSProperties();
+
+    if (displayTree->document().page()) {
+        auto cssString = displayTree->document().page()->captionUserPreferencesStyleSheet();
+        auto style = HTMLStyleElement::create(HTMLNames::styleTag, displayTree->document(), false);
+        style->setTextContent(WTFMove(cssString));
+        displayTree->appendChild(WTFMove(style));
+    }
+
+    if (const auto& styleSheets = track()->styleSheets()) {
+        for (const auto& cssString : *styleSheets) {
+            auto style = HTMLStyleElement::create(HTMLNames::styleTag, displayTree->document(), false);
+            style->setTextContent(String { cssString });
+            displayTree->appendChild(WTFMove(style));
+        }
+    }
+}
+
 void VTTCue::markFutureAndPastNodes(ContainerNode* root, const MediaTime& previousTimestamp, const MediaTime& movieTime)
 {
     static NeverDestroyed<const String> timestampTag(MAKE_STATIC_STRING_IMPL("timestamp"));
@@ -957,7 +963,7 @@ void VTTCue::updateDisplayTree(const MediaTime& movieTime)
         return;
 
     // Mutating the VTT contents is safe because it's never exposed to author scripts.
-    ScriptDisallowedScope::EventAllowedScope allowedScopeForCueHighlightBox(*m_cueHighlightBox);
+    ScriptDisallowedScope::EventAllowedScope allowedScopeForCueHighlightBox(m_cueHighlightBox);
 
     // Clear the contents of the set.
     m_cueHighlightBox->removeChildren();
@@ -973,7 +979,7 @@ void VTTCue::updateDisplayTree(const MediaTime& movieTime)
     m_cueHighlightBox->appendChild(*referenceTree);
 }
 
-RefPtr<TextTrackCueBox> VTTCue::getDisplayTree(const IntSize& videoSize, int fontSize)
+RefPtr<TextTrackCueBox> VTTCue::getDisplayTree()
 {
     ASSERT(track());
 
@@ -981,61 +987,16 @@ RefPtr<TextTrackCueBox> VTTCue::getDisplayTree(const IntSize& videoSize, int fon
     if (!displayTree || !m_displayTreeShouldChange || !track() || !track()->isRendered())
         return displayTree;
 
-    // 10.1 - 10.10
+    // https://w3c.github.io/webvtt/#processing-cue-settings
+    // 7.2. Processing cue settings
+    // Steps 1-25:
     calculateDisplayParameters();
 
-    // 10.11. Apply the terms of the CSS specifications to nodes within the
-    // following constraints, thus obtaining a set of CSS boxes positioned
-    // relative to an initial containing block:
-    displayTree->removeChildren();
+    // 26. Obtain a set of CSS boxes boxes positioned relative to an initial containing block.
+    obtainCSSBoxes();
 
-    // The document tree is the tree of WebVTT Node Objects rooted at nodes.
-
-    // The children of the nodes must be wrapped in an anonymous box whose
-    // 'display' property has the value 'inline'. This is the WebVTT cue
-    // background box.
-
-    // Note: This is contained by default in m_cueHighlightBox.
-    m_cueHighlightBox->setPseudo(ShadowPseudoIds::cue());
-
-    m_cueBackdropBox->setPseudo(ShadowPseudoIds::webkitMediaTextTrackDisplayBackdrop());
-    m_cueBackdropBox->appendChild(*m_cueHighlightBox);
-    displayTree->appendChild(*m_cueBackdropBox);
-
-    // FIXME(BUG 79916): Runs of children of WebVTT Ruby Objects that are not
-    // WebVTT Ruby Text Objects must be wrapped in anonymous boxes whose
-    // 'display' property has the value 'ruby-base'.
-
-    displayTree->setFontSizeFromCaptionUserPrefs(fontSize);
-    displayTree->applyCSSProperties(videoSize);
-
-    if (displayTree->document().page()) {
-        auto cssString = displayTree->document().page()->captionUserPreferencesStyleSheet();
-        auto style = HTMLStyleElement::create(HTMLNames::styleTag, displayTree->document(), false);
-        style->setTextContent(WTFMove(cssString));
-        displayTree->appendChild(WTFMove(style));
-    }
-
-    const auto& styleSheets = track()->styleSheets();
-    if (styleSheets) {
-        for (const auto& cssString : *styleSheets) {
-            auto style = HTMLStyleElement::create(HTMLNames::styleTag, displayTree->document(), false);
-            style->setTextContent(String { cssString });
-            displayTree->appendChild(WTFMove(style));
-        }
-    }
-
-    if (m_fontSize)
-        displayTree->setInlineStyleProperty(CSSPropertyFontSize, m_fontSize, CSSUnitType::CSS_PX, m_fontSizeIsImportant);
-
-    m_displayTreeShouldChange = false;
-
-    if (m_region)
-        m_region->cueStyleChanged();
-
-    // 10.15. Let cue's text track cue display state have the CSS boxes in
-    // boxes.
-    return displayTree;
+    // Steps 27-31 performed by RenderVTTCue.
+    return displayTreeInternal();
 }
 
 void VTTCue::removeDisplayTree()
@@ -1066,28 +1027,28 @@ std::pair<double, double> VTTCue::getPositionCoordinates() const
     auto textPosition = calculateComputedTextPosition();
     auto computedLinePosition = m_computedLinePosition ? *m_computedLinePosition : calculateComputedLinePosition();
     
-    if (m_writingDirection == Horizontal && m_displayDirection == CSSValueLtr) {
+    if (m_writingDirection == DirectionSetting::Horizontal && m_displayDirection == CSSValueLtr) {
         coordinates.first = textPosition;
         coordinates.second = computedLinePosition;
 
         return coordinates;
     }
 
-    if (m_writingDirection == Horizontal && m_displayDirection == CSSValueRtl) {
+    if (m_writingDirection == DirectionSetting::Horizontal && m_displayDirection == CSSValueRtl) {
         coordinates.first = 100 - textPosition;
         coordinates.second = computedLinePosition;
 
         return coordinates;
     }
 
-    if (m_writingDirection == VerticalGrowingLeft) {
+    if (m_writingDirection == DirectionSetting::VerticalGrowingLeft) {
         coordinates.first = 100 - *m_computedLinePosition;
         coordinates.second = textPosition;
 
         return coordinates;
     }
 
-    if (m_writingDirection == VerticalGrowingRight) {
+    if (m_writingDirection == DirectionSetting::VerticalGrowingRight) {
         coordinates.first = computedLinePosition;
         coordinates.second = textPosition;
 
@@ -1153,15 +1114,15 @@ void VTTCue::setCueSettings(const String& inputString)
         switch (name) {
         case Vertical: {
             // If name is a case-sensitive match for "vertical"
-            // 1. If value is a case-sensitive match for the string "rl", then let cue's text track cue writing direction 
+            // 1. If value is a case-sensitive match for the string "rl", then let cue's text track cue writing direction
             //    be vertical growing left.
             if (input.scanRun(valueRun, verticalGrowingLeftKeyword()))
-                m_writingDirection = VerticalGrowingLeft;
-            
-            // 2. Otherwise, if value is a case-sensitive match for the string "lr", then let cue's text track cue writing 
+                m_writingDirection = DirectionSetting::VerticalGrowingLeft;
+
+            // 2. Otherwise, if value is a case-sensitive match for the string "lr", then let cue's text track cue writing
             //    direction be vertical growing right.
             else if (input.scanRun(valueRun, verticalGrowingRightKeyword()))
-                m_writingDirection = VerticalGrowingRight;
+                m_writingDirection = DirectionSetting::VerticalGrowingRight;
 
             else
                 LOG(Media, "VTTCue::setCueSettings, invalid Vertical");
@@ -1179,18 +1140,18 @@ void VTTCue::setCueSettings(const String& inputString)
                 if (!input.scanFloat(linePosition, &isNegative))
                     break;
 
-                CueLignAlignment alignment { LignAlignmentStart };
+                LineAlignSetting alignment { LineAlignSetting::Start };
                 bool isPercentage = input.scan('%');
                 if (!input.isAt(valueRun.end())) {
                     if (!input.scan(','))
                         break;
 
                     if (input.scan(startKeyword().characters8(), startKeyword().length()))
-                        alignment = LignAlignmentStart;
+                        alignment = LineAlignSetting::Start;
                     else if (input.scan(centerKeyword().characters8(), centerKeyword().length()))
-                        alignment = LignAlignmentCenter;
+                        alignment = LineAlignSetting::Center;
                     else if (input.scan(endKeyword().characters8(), endKeyword().length()))
-                        alignment = LignAlignmentEnd;
+                        alignment = LineAlignSetting::End;
                     else {
                         LOG(Media, "VTTCue::setCueSettings, invalid line setting alignment");
                         break;
@@ -1240,7 +1201,7 @@ void VTTCue::setCueSettings(const String& inputString)
         }
         case Position: {
             float position;
-            CuePositionAlignment alignment { PositionAlignmentLignAuto };
+            PositionAlignSetting alignment { PositionAlignSetting::Auto };
 
             auto parsePosition = [] (VTTScanner& input, auto end, float& position, auto& alignment) -> bool {
                 // 1. a position value consisting of: a WebVTT percentage.
@@ -1259,11 +1220,11 @@ void VTTCue::setCueSettings(const String& inputString)
 
                 // 2.2 One of the following strings: "line-left", "center", "line-right"
                 if (input.scan(lineLeftKeyword().characters8(), lineLeftKeyword().length()))
-                    alignment = PositionAlignmentLignLeft;
+                    alignment = PositionAlignSetting::LineLeft;
                 else if (input.scan(centerKeyword().characters8(), centerKeyword().length()))
-                    alignment = PositionAlignmentLignCenter;
+                    alignment = PositionAlignSetting::Center;
                 else if (input.scan(lineRightKeyword().characters8(), lineRightKeyword().length()))
-                    alignment = PositionAlignmentLignRight;
+                    alignment = PositionAlignSetting::LineRight;
                 else {
                     LOG(Media, "VTTCue::setCueSettings, invalid Position setting alignment");
                     return false;
@@ -1290,23 +1251,23 @@ void VTTCue::setCueSettings(const String& inputString)
         case Align: {
             // 1. If value is a case-sensitive match for the string "start", then let cue's text track cue alignment be start alignment.
             if (input.scanRun(valueRun, startKeyword()))
-                m_cueAlignment = Start;
+                m_cueAlignment = AlignSetting::Start;
 
             // 2. If value is a case-sensitive match for the string "center", then let cue's text track cue alignment be center alignment.
             else if (input.scanRun(valueRun, centerKeyword()))
-                m_cueAlignment = Center;
+                m_cueAlignment = AlignSetting::Center;
 
             // 3. If value is a case-sensitive match for the string "end", then let cue's text track cue alignment be end alignment.
             else if (input.scanRun(valueRun, endKeyword()))
-                m_cueAlignment = End;
+                m_cueAlignment = AlignSetting::End;
 
             // 4. If value is a case-sensitive match for the string "left", then let cue's text track cue alignment be left alignment.
             else if (input.scanRun(valueRun, leftKeyword()))
-                m_cueAlignment = Left;
+                m_cueAlignment = AlignSetting::Left;
 
             // 5. If value is a case-sensitive match for the string "right", then let cue's text track cue alignment be right alignment.
             else if (input.scanRun(valueRun, rightKeyword()))
-                m_cueAlignment = Right;
+                m_cueAlignment = AlignSetting::Right;
 
             else
                 LOG(Media, "VTTCue::setCueSettings, invalid Align");
@@ -1329,7 +1290,7 @@ void VTTCue::setCueSettings(const String& inputString)
 
 CSSValueID VTTCue::getCSSAlignment() const
 {
-    return displayAlignmentMap[m_cueAlignment];
+    return displayAlignmentMap[static_cast<size_t>(m_cueAlignment)];
 }
 
 CSSValueID VTTCue::getCSSWritingDirection() const
@@ -1339,7 +1300,7 @@ CSSValueID VTTCue::getCSSWritingDirection() const
 
 CSSValueID VTTCue::getCSSWritingMode() const
 {
-    return displayWritingModeMap[m_writingDirection];
+    return displayWritingModeMap[static_cast<size_t>(m_writingDirection)];
 }
 
 int VTTCue::getCSSSize() const
@@ -1359,7 +1320,7 @@ bool VTTCue::cueContentsMatch(const TextTrackCue& otherTextTrackCue) const
         && align() == other.align();
 }
 
-void VTTCue::setFontSize(int fontSize, const IntSize&, bool important)
+void VTTCue::setFontSize(int fontSize, bool important)
 {
     if (fontSize == m_fontSize && important == m_fontSizeIsImportant)
         return;
@@ -1374,7 +1335,7 @@ void VTTCue::toJSON(JSON::Object& object) const
     TextTrackCue::toJSON(object);
 
     object.setString("text"_s, text());
-    object.setString("vertical"_s, vertical());
+    object.setString("vertical"_s, convertEnumerationToString(vertical()));
     object.setBoolean("snapToLines"_s, snapToLines());
     if (m_linePosition)
         object.setDouble("line"_s, *m_linePosition);
@@ -1385,7 +1346,7 @@ void VTTCue::toJSON(JSON::Object& object) const
     else
         object.setString("position"_s, autoAtom());
     object.setInteger("size"_s, m_cueSize);
-    object.setString("align"_s, align());
+    object.setString("align"_s, convertEnumerationToString(align()));
 }
 
 #if ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebCore/html/track/VTTCue.idl
+++ b/Source/WebCore/html/track/VTTCue.idl
@@ -26,6 +26,11 @@
 enum AutoKeyword { "auto" };
 typedef (double or AutoKeyword) LineAndPositionSetting;
 
+enum DirectionSetting { "" /* horizontal */, "rl", "lr" };
+enum LineAlignSetting { "start", "center", "end" };
+enum PositionAlignSetting { "line-left", "center", "line-right", "auto" };
+enum AlignSetting { "start", "center", "end", "left", "right" };
+
 [
     Conditional=VIDEO,
     ExportMacro=WEBCORE_EXPORT,
@@ -35,14 +40,14 @@ typedef (double or AutoKeyword) LineAndPositionSetting;
 ] interface VTTCue : TextTrackCue {
     [CallWith=CurrentDocument] constructor(double startTime, double endTime, DOMString text);
 
-    attribute DOMString vertical;
+    attribute DirectionSetting vertical;
     attribute boolean snapToLines;
     attribute LineAndPositionSetting line;
-    attribute DOMString lineAlign;
+    attribute LineAlignSetting lineAlign;
     attribute LineAndPositionSetting position;
-    attribute DOMString positionAlign;
+    attribute PositionAlignSetting positionAlign;
     attribute double size;
-    attribute DOMString align;
+    attribute AlignSetting align;
     attribute DOMString text;
     DocumentFragment getCueAsHTML();
 

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -86,7 +86,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     // 1. Horizontal: Let step be the height of the first line box in boxes.
     //    Vertical: Let step be the width of the first line box in boxes.
     auto firstInlineBoxSize = firstInlineBox->visualRectIgnoringBlockDirection().size();
-    step = m_cue->getWritingDirection() == VTTCue::Horizontal ? firstInlineBoxSize.height() : firstInlineBoxSize.width();
+    step = m_cue->vertical() == VTTCue::DirectionSetting::Horizontal ? firstInlineBoxSize.height() : firstInlineBoxSize.width();
 
     // Note: the previous rules in initializeLayoutParameters() only account for
     // the height of the line boxes contained within the cue, and not the cue's height
@@ -111,7 +111,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     int linePosition = m_cue->calculateComputedLinePosition();
 
     // 4. Vertical Growing Left: Add one to line position then negate it.
-    if (m_cue->getWritingDirection() == VTTCue::VerticalGrowingLeft)
+    if (m_cue->vertical() == VTTCue::DirectionSetting::VerticalGrowingLeft)
         linePosition = -(linePosition + 1);
 
     // 5. Let position be the result of multiplying step and line position.
@@ -119,7 +119,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
 
     // 6. Vertical Growing Left: Decrease position by the width of the
     // bounding box of the boxes in boxes, then increase position by step.
-    if (m_cue->getWritingDirection() == VTTCue::VerticalGrowingLeft) {
+    if (m_cue->vertical() == VTTCue::DirectionSetting::VerticalGrowingLeft) {
         position -= width();
         position += step;
     }
@@ -128,7 +128,7 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
     if (linePosition < 0) {
         // Horizontal / Vertical: ... then increase position by the
         // height / width of the video's rendering area ...
-        position += m_cue->getWritingDirection() == VTTCue::Horizontal ? containingBlock()->height() : containingBlock()->width();
+        position += m_cue->vertical() == VTTCue::DirectionSetting::Horizontal ? containingBlock()->height() : containingBlock()->width();
 
         // ... and negate step.
         step = -step;
@@ -140,12 +140,13 @@ bool RenderVTTCue::initializeLayoutParameters(LayoutUnit& step, LayoutUnit& posi
 void RenderVTTCue::placeBoxInDefaultPosition(LayoutUnit position, bool& switched)
 {
     // 8. Move all boxes in boxes ...
-    if (m_cue->getWritingDirection() == VTTCue::Horizontal)
+    if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal) {
         // Horizontal: ... down by the distance given by position
         setY(y() + position);
-    else
+    } else {
         // Vertical: ... right by the distance given by position
         setX(x() + position);
+    }
 
     // 9. Default: Remember the position of all the boxes in boxes as their
     // default position.
@@ -188,7 +189,7 @@ RenderVTTCue* RenderVTTCue::overlappingObjectForRect(const IntRect& rect) const
 {
     for (RenderObject* sibling = previousSibling(); sibling; sibling = sibling->previousSibling()) {
         auto* previousCue = downcast<RenderVTTCue>(sibling);
-        if (!previousCue)
+        if (!previousCue || !previousCue->firstChild())
             continue;
 
         if (rect.intersects(previousCue->backdropBox().absoluteBoundingBoxRect()))
@@ -212,7 +213,7 @@ bool RenderVTTCue::shouldSwitchDirection(const InlineIterator::InlineBox& firstI
     // boxes is now below the bottom of the video's rendering area, jump
     // to the step labeled switch direction.
     LayoutUnit parentHeight = containingBlock()->height();
-    if (m_cue->getWritingDirection() == VTTCue::Horizontal && ((step < 0 && top < 0) || (step > 0 && bottom > parentHeight)))
+    if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal && ((step < 0 && top < 0) || (step > 0 && bottom > parentHeight)))
         return true;
 
     // 12. Vertical: If step is negative and the left edge of the first line
@@ -221,7 +222,7 @@ bool RenderVTTCue::shouldSwitchDirection(const InlineIterator::InlineBox& firstI
     // first line box in boxes is now to the right of the right edge of
     // the video's rendering area, jump to the step labeled switch direction.
     LayoutUnit parentWidth = containingBlock()->width();
-    if (m_cue->getWritingDirection() != VTTCue::Horizontal && ((step < 0 && left < 0) || (step > 0 && right > parentWidth)))
+    if (m_cue->vertical() != VTTCue::DirectionSetting::Horizontal && ((step < 0 && left < 0) || (step > 0 && right > parentWidth)))
         return true;
 
     return false;
@@ -232,7 +233,7 @@ void RenderVTTCue::moveBoxesByStep(LayoutUnit step)
     // 13. Horizontal: Move all the boxes in boxes down by the distance
     // given by step. (If step is negative, then this will actually
     // result in an upwards movement of the boxes in absolute terms.)
-    if (m_cue->getWritingDirection() == VTTCue::Horizontal)
+    if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
         setY(y() + step);
 
     // 13. Vertical: Move all the boxes in boxes right by the distance
@@ -307,7 +308,7 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
 
     // Move the box up, looking for a non-overlapping position:
     while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
-        if (m_cue->getWritingDirection() == VTTCue::Horizontal)
+        if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
             destRect.setY(cue->backdropBox().absoluteBoundingBoxRect().y() - destRect.height());
         else
             destRect.setX(cue->backdropBox().absoluteBoundingBoxRect().x() - destRect.width());
@@ -323,7 +324,7 @@ bool RenderVTTCue::findNonOverlappingPosition(int& newX, int& newY) const
 
     // Move the box down, looking for a non-overlapping position:
     while (RenderVTTCue* cue = overlappingObjectForRect(destRect)) {
-        if (m_cue->getWritingDirection() == VTTCue::Horizontal)
+        if (m_cue->vertical() == VTTCue::DirectionSetting::Horizontal)
             destRect.setY(cue->backdropBox().absoluteBoundingBoxRect().maxY());
         else
             destRect.setX(cue->backdropBox().absoluteBoundingBoxRect().maxX());
@@ -343,6 +344,10 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
     LayoutUnit step;
     LayoutUnit position;
     if (!initializeLayoutParameters(step, position))
+        return;
+
+    ASSERT(firstChild());
+    if (!firstChild())
         return;
 
     bool switched;
@@ -373,6 +378,8 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
 void RenderVTTCue::repositionGenericCue()
 {
     ASSERT(firstChild());
+    if (!firstChild())
+        return;
 
     auto firstInlineBox = InlineIterator::firstInlineBoxFor(cueBox());
     if (downcast<TextTrackCueGeneric>(*m_cue).useDefaultPosition() && firstInlineBox) {
@@ -386,12 +393,54 @@ void RenderVTTCue::repositionGenericCue()
 
 void RenderVTTCue::repositionCueSnapToLinesNotSet()
 {
-    // 3. If none of the boxes in boxes would overlap any of the boxes in output, and all the boxes in
+    if (!firstChild())
+        return;
+
+    // https://w3c.github.io/webvtt/#processing-cue-settings
+    // 7.2.28 Adjust the positions of boxes according to the appropriate steps from the following list:
+
+    // ↳ If cue’s WebVTT cue snap-to-lines flag is false
+    // 1. Let bounding box be the bounding box of the boxes in boxes.
+    auto boundingBox = backdropBox().absoluteBoundingBoxRect();
+
+    // 2. Run the appropriate steps from the following list:
+    switch (m_cue->vertical()) {
+    case VTTCue::DirectionSetting::Horizontal:
+        // ↳ If the WebVTT cue writing direction is horizontal
+        if (m_cue->lineAlign() == VTTCue::LineAlignSetting::Center) {
+            // ↳ If the WebVTT cue line alignment is center alignment
+            // Move all the boxes in boxes up by half of the height of bounding box.
+            setY(y() - boundingBox.height() / 2);
+        } else if (m_cue->lineAlign() == VTTCue::LineAlignSetting::End) {
+            // ↳ If the WebVTT cue line alignment is end alignment
+            // Move all the boxes in boxes up by the height of bounding box.
+            setY(y() - boundingBox.height());
+        }
+        break;
+    case VTTCue::DirectionSetting::VerticalGrowingLeft:
+    case VTTCue::DirectionSetting::VerticalGrowingRight:
+        // ↳ If the WebVTT cue writing direction is vertical growing left or
+        // vertical growing right
+        if (m_cue->lineAlign() == VTTCue::LineAlignSetting::Center) {
+            // ↳ If the WebVTT cue line alignment is center alignment
+            // Move all the boxes in boxes left by half of the width of bounding box.
+            setX(x() - boundingBox.width() / 2);
+        } else if (m_cue->lineAlign() == VTTCue::LineAlignSetting::End) {
+            // ↳ If the WebVTT cue line alignment is end alignment
+            // Move all the boxes in boxes left by the width of bounding box.
+            setX(x() - boundingBox.width());
+        }
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+
+    // 9. If none of the boxes in boxes would overlap any of the boxes in output, and all the boxes in
     // output are within the video's rendering area, then jump to the step labeled done positioning below.
     if (!isOutside() && !isOverlapping())
         return;
 
-    // 4. If there is a position to which the boxes in boxes can be moved while maintaining the relative
+    // 10. If there is a position to which the boxes in boxes can be moved while maintaining the relative
     // positions of the boxes in boxes to each other such that none of the boxes in boxes would overlap
     // any of the boxes in output, and all the boxes in output would be within the video's rendering area,
     // then move the boxes in boxes to the closest such position to their current position, and then jump
@@ -401,11 +450,13 @@ void RenderVTTCue::repositionCueSnapToLinesNotSet()
     moveIfNecessaryToKeepWithinContainer();
     int x = 0;
     int y = 0;
-    if (!findNonOverlappingPosition(x, y))
-        return;
+    if (findNonOverlappingPosition(x, y)) {
+        setX(x);
+        setY(y);
+    }
 
-    setX(x);
-    setY(y);
+    // 11. Otherwise, jump to the step labeled done positioning below. (The
+    // boxes will unfortunately overlap.)
 }
 
 RenderBlockFlow& RenderVTTCue::backdropBox() const

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <wtf/Deque.h>
 #include <wtf/EnumTraits.h>
 
 enum class TestEnum {
@@ -46,6 +47,22 @@ TEST(WTF_EnumTraits, IsValidEnum)
     EXPECT_TRUE(isValidEnum<TestEnum>(0));
     EXPECT_FALSE(isValidEnum<TestEnum>(-1));
     EXPECT_FALSE(isValidEnum<TestEnum>(3));
+}
+
+TEST(WTF_EnumTraits, ValuesTraits)
+{
+    EXPECT_EQ(WTF::EnumTraits<TestEnum>::values::max, TestEnum::C);
+    EXPECT_EQ(WTF::EnumTraits<TestEnum>::values::min, TestEnum::A);
+    EXPECT_EQ(WTF::EnumTraits<TestEnum>::values::count, 3UL);
+    EXPECT_NE(WTF::EnumTraits<TestEnum>::values::max, TestEnum::A);
+    EXPECT_NE(WTF::EnumTraits<TestEnum>::values::min, TestEnum::C);
+    EXPECT_NE(WTF::EnumTraits<TestEnum>::values::count, 4UL);
+
+    Deque<TestEnum> expectedValues = { TestEnum::A, TestEnum::B, TestEnum::C };
+    WTF::EnumTraits<TestEnum>::values::forEach([&] (auto value) {
+        EXPECT_EQ(value, expectedValues.takeFirst());
+    });
+    EXPECT_EQ(expectedValues.size(), 0UL);
 }
 
 }


### PR DESCRIPTION
#### 687a6e6a1e60b9f64c6892feee42156e959508d8
<pre>
[WebVTT] Modernize VTTCue
<a href="https://bugs.webkit.org/show_bug.cgi?id=258578">https://bugs.webkit.org/show_bug.cgi?id=258578</a>
rdar://111393504

Reviewed by Eric Carlson.

VTTCue has a number of stylistic and functional implementation details that
are held over from its original implementation in 2014, and could benefit from
being brought up to a more modern set of practices and language features used
in other parts of WebKit.

The bindings generator now supports IDL-defined enumerations, and automatically
converts between them and C++ defined enumerations, so there is no need to
have string checks exist in VTTCue for properties that take those enumerations.

C++ enumerations should have the same type name as IDL enumerations, and values
for those enumerations should be equivalent as well (after converting to
CamelCase from snake-case). Those enumerations should therefore be `enum class`.

The existing enumerations included sentinel values for static checks of the
enumerations&apos; sizes. Add support in EnumTraits for calculating the minimum,
maximum, and count of values at compile time, making sentinal values unnecessary.

The WebVTT specification now defines heights and font sizes in terms of &apos;vh&apos; and
&apos;vw&apos;, which are percentages of the video viewport height and width, respectively.
Now that WebKit supports these CSS units (as well as &apos;cqh&apos; and &apos;cqw&apos;, which are
the equivalent units for percentage of container height and width), it is no
longer necessary to pass the layout size of the video element into the VTTCue
(and its subclasses) to calculate the CSS values of cue properties.

The WebVTT specification added more default CSS properties which need to be set
on the resulting elements, so those are added here too.

Add support for lineAlign and positionAlign properties in layout, where those
properties were already parsed and exposed though DOM APIs.

* Source/WTF/wtf/EnumTraits.h:
(WTF::EnumValues::std::max):
(WTF::EnumValues::std::min):
(WTF::EnumValues::forEach):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateDisplay):
(WebCore::MediaControlTextTrackContainerElement::processActiveVTTCue):
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
* Source/WebCore/html/track/InbandGenericTextTrack.cpp:
(WebCore::InbandGenericTextTrack::updateCueFromCueData):
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::getDisplayTree):
(WebCore::TextTrackCue::setFontSize):
* Source/WebCore/html/track/TextTrackCue.h:
(WebCore::TextTrackCueBox::applyCSSProperties):
* Source/WebCore/html/track/TextTrackCueGeneric.cpp:
(WebCore::TextTrackCueGenericBoxElement::applyCSSProperties):
(WebCore::TextTrackCueGeneric::setFontSize):
(WebCore::TextTrackCueGeneric::setLine): Deleted.
* Source/WebCore/html/track/TextTrackCueGeneric.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties):
(WebCore::VTTCue::VTTCue):
(WebCore::VTTCue::setVertical):
(WebCore::VTTCue::setLine):
(WebCore::VTTCue::setLineAlign):
(WebCore::VTTCue::position const):
(WebCore::VTTCue::setPositionAlign):
(WebCore::VTTCue::setAlign):
(WebCore::VTTCue::calculateComputedLinePosition const):
(WebCore::VTTCue::calculateComputedTextPosition const):
(WebCore::VTTCue::calculateComputedPositionAlignment const):
(WebCore::VTTCue::calculateMaximumSize const):
(WebCore::VTTCue::calculateDisplayParameters):
(WebCore::VTTCue::obtainCSSBoxes):
(WebCore::VTTCue::updateDisplayTree):
(WebCore::VTTCue::getDisplayTree):
(WebCore::VTTCue::getPositionCoordinates const):
(WebCore::VTTCue::setCueSettings):
(WebCore::VTTCue::getCSSAlignment const):
(WebCore::VTTCue::getCSSWritingMode const):
(WebCore::VTTCue::setFontSize):
(WebCore::VTTCue::toJSON const):
(WebCore::horizontalKeyword): Deleted.
(WebCore::VTTCue::initialize): Deleted.
(WebCore::VTTCue::vertical const): Deleted.
(WebCore::VTTCue::lineAlign const): Deleted.
(WebCore::VTTCue::positionAlign const): Deleted.
(WebCore::VTTCue::align const): Deleted.
* Source/WebCore/html/track/VTTCue.h:
(WebCore::VTTCue::vertical const):
(WebCore::VTTCue::lineAlign const):
(WebCore::VTTCue::positionAlign const):
(WebCore::VTTCue::align const):
(WebCore::VTTCue::element const):
(WebCore::VTTCue::backdrop const):
(WebCore::VTTCue::fontSize const):
(WebCore::VTTCue::fontSizeIsImportant const):
(WebCore::VTTCue::left const):
(WebCore::VTTCue::top const):
(WebCore::VTTCue::width const):
(WebCore::VTTCue::height const):
(WebCore::VTTCue::getWritingDirection const): Deleted.
(WebCore::VTTCue::getAlignment const): Deleted.
* Source/WebCore/html/track/VTTCue.idl:
* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::initializeLayoutParameters):
(WebCore::RenderVTTCue::placeBoxInDefaultPosition):
(WebCore::RenderVTTCue::overlappingObjectForRect const):
(WebCore::RenderVTTCue::shouldSwitchDirection const):
(WebCore::RenderVTTCue::moveBoxesByStep):
(WebCore::RenderVTTCue::findNonOverlappingPosition const):
(WebCore::RenderVTTCue::repositionCueSnapToLinesSet):
(WebCore::RenderVTTCue::repositionGenericCue):
(WebCore::RenderVTTCue::repositionCueSnapToLinesNotSet):
* Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265596@main">https://commits.webkit.org/265596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c325006ff5c829238a0218017b578de353fe9dae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11346 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13708 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11487 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12366 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13393 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17457 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9621 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10730 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13636 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10746 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8921 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11422 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10010 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3088 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14286 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11743 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10694 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2861 "Passed tests") | 
<!--EWS-Status-Bubble-End-->