### PR TITLE
Avoid evaluating layer backing store contents twice per update

### DIFF
--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -99,10 +99,9 @@ void RenderHTMLCanvas::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& pa
 
     canvasElement().setIsSnapshotting(paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting));
     CompositeOperator op = CompositeOperator::SourceOver;
-#if ENABLE(CSS_COMPOSITING)
     if (paintInfo.enclosingSelfPaintingLayer() && paintInfo.enclosingSelfPaintingLayer()->shouldPaintUsingCompositeCopy())
         op = CompositeOperator::Copy;
-#endif
+
     canvasElement().paint(context, replacedContentRect, op);
     canvasElement().setIsSnapshotting(false);
 }

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -88,7 +88,7 @@ public:
     void updateGeometry(const RenderLayer* compositingAncestor);
 
     // Update state the requires that descendant layers have been updated.
-    void updateAfterDescendants();
+    void updateAfterDescendants(bool reevaluateConfiguration);
 
     // Update contents and clipping structure.
     void updateDrawsContent();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1444,7 +1444,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
             if (auto* reflectionBacking = reflection->backing()) {
                 reflectionBacking->updateCompositedBounds();
                 reflectionBacking->updateGeometry(&layer);
-                reflectionBacking->updateAfterDescendants();
+                reflectionBacking->updateAfterDescendants(layerNeedsUpdate);
             }
         }
 
@@ -1537,7 +1537,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
         if (layer.hasCompositedScrollableOverflow())
             traversalState.overflowScrollLayers->append(&layer);
 
-        layerBacking->updateAfterDescendants();
+        layerBacking->updateAfterDescendants(layerNeedsUpdate);
     }
     
     layer.clearUpdateBackingOrHierarchyTraversalState();
@@ -2014,6 +2014,7 @@ bool RenderLayerCompositor::updateBacking(RenderLayer& layer, RequiresCompositin
     return layerChanged;
 }
 
+// Only used for reflection layers.
 bool RenderLayerCompositor::updateLayerCompositingState(RenderLayer& layer, const RenderLayer* compositingAncestor, RequiresCompositingData& queryData, BackingSharingState& backingSharingState)
 {
     bool layerChanged = updateBacking(layer, queryData, &backingSharingState);


### PR DESCRIPTION
#### 7f4d81cc368a03b8e402309bdd04fa0f5dcf6904
<pre>
Avoid evaluating layer backing store contents twice per update
<a href="https://bugs.webkit.org/show_bug.cgi?id=258579">https://bugs.webkit.org/show_bug.cgi?id=258579</a>
rdar://111397321

Reviewed by Alan Baradlay.

Profiling youtube pages shows that we spend a lot of time in the PaintedContentsInfo code, which
does a partial tree walk to determine if a compositing layer can be rendered as a simple color, or
has no contents. This is called from `updateDirectlyCompositedBoxDecorations()` which is called by
both RenderLayerBacking::updateConfiguration() and RenderLayerBacking::updateAfterDescendants(); the
latter call can give different results, since the result depends on the configuration of descendant
layers.

Fix this by moving all the code that leverages PaintedContentsInfo into updateAfterDescendants(), so
the contents evaluation is done only once; also guard it on a
m_owningLayer.needsCompositingConfigurationUpdate() check.

It&apos;s safe to move the code that calls setAppliesDeviceScale() and setShouldPaintUsingCompositeCopy()
here; those calls don&apos;t change the GraphicsLayer hierarchy (the intent of &quot;layerConfigChanged&quot;),
they only set state on a GraphicsLayer.

Also remove some #if ENABLE(CSS_COMPOSITING) checks; these were intended to surround code related to
CSS Compositing and Blending, not internal compositing changes.

Tested by existing tests, particularly compositing/backing/solid-color-with-paints-into-ancestor.html.

* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::paintReplaced):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
(WebCore::RenderLayerBacking::updateAfterDescendants):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):

Canonical link: <a href="https://commits.webkit.org/265587@main">https://commits.webkit.org/265587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6906cca4eb6d11f010765694e095d54fc0e5de9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13704 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13390 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17452 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10007 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->