### PR TITLE
REGRESSION (265250@main): [ macOS ] fast/mediastream/device-change-event-2.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/mediastream/device-change-event-2.html
+++ b/LayoutTests/fast/mediastream/device-change-event-2.html
@@ -93,7 +93,6 @@
 
             testRunner.addMockMicrophoneDevice("id4", "microphone 3");
             testRunner.addMockMicrophoneDevice("id5", "microphone 4");
-            navigator.mediaDevices.ondevicechange = () => { };
         });
         assert_equals(eventCount, 1, "one event fired");
 
@@ -101,8 +100,6 @@
 
 
     promise_test(async (test) => {
-
-        navigator.mediaDevices.ondevicechange = () => { };
         await setup(test);
 
         await new Promise((resolve, reject) => {
@@ -137,8 +134,6 @@
     }, "'devicechange' event is not fired when the document doesn't has focus or permission to capture");
 
     promise_test(async (test) => {
-        navigator.mediaDevices.ondevicechange = () => { };
-
         await setup(test);
 
         await navigator.mediaDevices.getUserMedia({ audio:true, video:true })


### PR DESCRIPTION
#### e78625154d1d59b83d5a74a522c6ed52d8ae028b
<pre>
REGRESSION (265250@main): [ macOS ] fast/mediastream/device-change-event-2.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=258581">https://bugs.webkit.org/show_bug.cgi?id=258581</a>
&lt;rdar://111398769&gt;

Reviewed by Ryan Haddad.

Revert the test changes introduced in 265250@main. Making this test pass in GStreamer ports will
require additional changes anyway, so for now unbreak mac ports.

* LayoutTests/fast/mediastream/device-change-event-2.html:

Canonical link: <a href="https://commits.webkit.org/265575@main">https://commits.webkit.org/265575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deac99d562d0d0be6f0a571f07e6b9e9fd4f7119

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10716 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13308 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17376 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13552 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10757 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8841 "34 flakes 19 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2701 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14201 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->