### PR TITLE
Fix non scrollable check for interaction regions

### DIFF
--- a/LayoutTests/interaction-region/hover-style-expected.txt
+++ b/LayoutTests/interaction-region/hover-style-expected.txt
@@ -15,7 +15,9 @@ not a button
         (interaction (0,0) width=100 height=100)
         (borderRadius 10.00),
         (interaction (0,100) width=108 height=108)
-        (borderRadius 0.00)])
+        (borderRadius 0.00),
+        (interaction (0,358) width=100 height=100)
+        (borderRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/hover-style.html
+++ b/LayoutTests/interaction-region/hover-style.html
@@ -8,11 +8,13 @@
         height: 100px;
     }
 
-    #button {
+    #button,
+    #button-overflow-hidden {
         background-color: green;
         border-radius: 10px;
     }
-    #button:hover {
+    #button:hover,
+    #button-overflow-hidden:hover {
         background-color: blue;
     }
     #button-negation {
@@ -30,6 +32,9 @@
         background: gray;
         overflow-y: scroll;
     }
+    #button-overflow-hidden {
+        overflow: hidden;
+    }
 </style>
 <body>
 <div id="button" onclick="click()"></div>
@@ -38,6 +43,7 @@
 <div id="scrollable" onclick="click()">
     <div></div>
 </div>
+<div id="button-overflow-hidden" onclick="click()"></div>
 
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -259,7 +259,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (!hasPointer) {
         // The hover check can be expensive (it may end up doing selector matching), so we only run it on some elements.
         bool hasVisibleBoxDecorations = renderer.hasVisibleBoxDecorations();
-        bool nonScrollable = !renderer.hasPotentiallyScrollableOverflow();
+        bool nonScrollable = !is<RenderBox>(renderer) || (!downcast<RenderBox>(renderer).hasScrollableOverflowX() && !downcast<RenderBox>(renderer).hasScrollableOverflowY());
         if (hasVisibleBoxDecorations && nonScrollable)
             detectedHoverRules = elementMatchesHoverRules(*matchedElement);
     }


### PR DESCRIPTION
#### d3747cf8f4f7dc3aa651c926793c7e0e5fbca6d6
<pre>
Fix non scrollable check for interaction regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=258582">https://bugs.webkit.org/show_bug.cgi?id=258582</a>
rdar://110652649

Reviewed by Simon Fraser.

overflow: hidden containers can be scrolled programatically, but from the user perspective, they are not scrollable.

* LayoutTests/interaction-region/hover-style-expected.txt:
* LayoutTests/interaction-region/hover-style.html:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):

Canonical link: <a href="https://commits.webkit.org/265648@main">https://commits.webkit.org/265648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbfd75f8788c70748ae20027881de9d22672c584

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12559 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13599 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10471 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13805 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9080 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2762 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->