### PR TITLE
Update buildSVGPathByteStreamFromString() to take a StringView

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2887,7 +2887,7 @@ svg/SVGPathParser.cpp
 svg/SVGPathSegListBuilder.cpp
 svg/SVGPathSegListSource.cpp
 svg/SVGPathStringBuilder.cpp
-svg/SVGPathStringSource.cpp
+svg/SVGPathStringViewSource.cpp
 svg/SVGPathTraversalStateBuilder.cpp
 svg/SVGPathUtilities.cpp
 svg/SVGPatternElement.cpp

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -6815,7 +6815,7 @@ static RefPtr<CSSPathValue> consumeBasicShapePath(CSSParserTokenRange& args)
         return nullptr;
 
     SVGPathByteStream byteStream;
-    if (!buildSVGPathByteStreamFromString(args.consumeIncludingWhitespace().value().toString(), byteStream, UnalteredParsing))
+    if (!buildSVGPathByteStreamFromString(args.consumeIncludingWhitespace().value(), byteStream, UnalteredParsing))
         return nullptr;
 
     return CSSPathValue::create(WTFMove(byteStream), rule);

--- a/Source/WebCore/html/canvas/Path2D.h
+++ b/Source/WebCore/html/canvas/Path2D.h
@@ -55,7 +55,7 @@ public:
         return create(path.path());
     }
 
-    static Ref<Path2D> create(const String& pathData)
+    static Ref<Path2D> create(StringView pathData)
     {
         return create(buildPathFromString(pathData));
     }

--- a/Source/WebCore/svg/SVGPathByteStream.h
+++ b/Source/WebCore/svg/SVGPathByteStream.h
@@ -50,7 +50,7 @@ public:
 
     SVGPathByteStream() { }
 
-    SVGPathByteStream(const String& string)
+    SVGPathByteStream(StringView string)
     {
         buildSVGPathByteStreamFromString(string, *this, UnalteredParsing);
     }

--- a/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
+++ b/Source/WebCore/svg/SVGPathByteStreamBuilder.cpp
@@ -22,7 +22,7 @@
 #include "SVGPathByteStreamBuilder.h"
 
 #include "SVGPathSeg.h"
-#include "SVGPathStringSource.h"
+#include "SVGPathStringViewSource.h"
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGPathSegList.h
+++ b/Source/WebCore/svg/SVGPathSegList.h
@@ -130,7 +130,7 @@ public:
         return m_pathByteStream;
     }
 
-    bool parse(const String& value)
+    bool parse(StringView value)
     {
         pathByteStreamWillChange();
         return buildSVGPathByteStreamFromString(value, m_pathByteStream, UnalteredParsing);

--- a/Source/WebCore/svg/SVGPathStringViewSource.cpp
+++ b/Source/WebCore/svg/SVGPathStringViewSource.cpp
@@ -19,32 +19,31 @@
  */
 
 #include "config.h"
-#include "SVGPathStringSource.h"
+#include "SVGPathStringViewSource.h"
 
 #include "SVGParserUtilities.h"
 
 namespace WebCore {
 
-SVGPathStringSource::SVGPathStringSource(const String& string)
-    : m_string(string)
-    , m_is8BitSource(string.is8Bit())
+SVGPathStringViewSource::SVGPathStringViewSource(StringView view)
+    : m_is8BitSource(view.is8Bit())
 {
-    ASSERT(!string.isEmpty());
+    ASSERT(!view.isEmpty());
 
     if (m_is8BitSource)
-        m_buffer8 = { string.characters8(), string.length() };
+        m_buffer8 = { view.characters8(), view.length() };
     else
-        m_buffer16 = { string.characters16(), string.length() };
+        m_buffer16 = { view.characters16(), view.length() };
 }
 
-bool SVGPathStringSource::hasMoreData() const
+bool SVGPathStringViewSource::hasMoreData() const
 {
     if (m_is8BitSource)
         return m_buffer8.hasCharactersRemaining();
     return m_buffer16.hasCharactersRemaining();
 }
 
-bool SVGPathStringSource::moveToNextToken()
+bool SVGPathStringViewSource::moveToNextToken()
 {
     if (m_is8BitSource)
         return skipOptionalSVGSpaces(m_buffer8);
@@ -66,7 +65,7 @@ template <typename CharacterType> static std::optional<SVGPathSegType> nextComma
     return std::nullopt;
 }
 
-SVGPathSegType SVGPathStringSource::nextCommand(SVGPathSegType previousCommand)
+SVGPathSegType SVGPathStringViewSource::nextCommand(SVGPathSegType previousCommand)
 {
     if (m_is8BitSource) {
         if (auto nextCommand = nextCommandHelper(m_buffer8, previousCommand))
@@ -79,14 +78,14 @@ SVGPathSegType SVGPathStringSource::nextCommand(SVGPathSegType previousCommand)
     return *parseSVGSegmentType();
 }
 
-template<typename F> decltype(auto) SVGPathStringSource::parse(F&& functor)
+template<typename F> decltype(auto) SVGPathStringViewSource::parse(F&& functor)
 {
     if (m_is8BitSource)
         return functor(m_buffer8);
     return functor(m_buffer16);
 }
 
-std::optional<SVGPathSegType> SVGPathStringSource::parseSVGSegmentType()
+std::optional<SVGPathSegType> SVGPathStringViewSource::parseSVGSegmentType()
 {
     return parse([](auto& buffer) -> SVGPathSegType {
         auto character = *buffer;
@@ -137,7 +136,7 @@ std::optional<SVGPathSegType> SVGPathStringSource::parseSVGSegmentType()
     });
 }
 
-std::optional<SVGPathSource::MoveToSegment> SVGPathStringSource::parseMoveToSegment()
+std::optional<SVGPathSource::MoveToSegment> SVGPathStringViewSource::parseMoveToSegment()
 {
     return parse([](auto& buffer) -> std::optional<MoveToSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -150,7 +149,7 @@ std::optional<SVGPathSource::MoveToSegment> SVGPathStringSource::parseMoveToSegm
     });
 }
 
-std::optional<SVGPathSource::LineToSegment> SVGPathStringSource::parseLineToSegment()
+std::optional<SVGPathSource::LineToSegment> SVGPathStringViewSource::parseLineToSegment()
 {
     return parse([](auto& buffer) -> std::optional<LineToSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -163,7 +162,7 @@ std::optional<SVGPathSource::LineToSegment> SVGPathStringSource::parseLineToSegm
     });
 }
 
-std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringSource::parseLineToHorizontalSegment()
+std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringViewSource::parseLineToHorizontalSegment()
 {
     return parse([](auto& buffer) -> std::optional<LineToHorizontalSegment> {
         auto x = parseNumber(buffer);
@@ -176,7 +175,7 @@ std::optional<SVGPathSource::LineToHorizontalSegment> SVGPathStringSource::parse
     });
 }
 
-std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringSource::parseLineToVerticalSegment()
+std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringViewSource::parseLineToVerticalSegment()
 {
     return parse([](auto& buffer) -> std::optional<LineToVerticalSegment> {
         auto y = parseNumber(buffer);
@@ -189,7 +188,7 @@ std::optional<SVGPathSource::LineToVerticalSegment> SVGPathStringSource::parseLi
     });
 }
 
-std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringSource::parseCurveToCubicSegment()
+std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringViewSource::parseCurveToCubicSegment()
 {
     return parse([](auto& buffer) -> std::optional<CurveToCubicSegment> {
         auto point1 = parseFloatPoint(buffer);
@@ -212,7 +211,7 @@ std::optional<SVGPathSource::CurveToCubicSegment> SVGPathStringSource::parseCurv
     });
 }
 
-std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringSource::parseCurveToCubicSmoothSegment()
+std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringViewSource::parseCurveToCubicSmoothSegment()
 {
     return parse([](auto& buffer) -> std::optional<CurveToCubicSmoothSegment> {
         auto point2 = parseFloatPoint(buffer);
@@ -230,7 +229,7 @@ std::optional<SVGPathSource::CurveToCubicSmoothSegment> SVGPathStringSource::par
     });
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringSource::parseCurveToQuadraticSegment()
+std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringViewSource::parseCurveToQuadraticSegment()
 {
     return parse([](auto& buffer) -> std::optional<CurveToQuadraticSegment> {
         auto point1 = parseFloatPoint(buffer);
@@ -248,7 +247,7 @@ std::optional<SVGPathSource::CurveToQuadraticSegment> SVGPathStringSource::parse
     });
 }
 
-std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringSource::parseCurveToQuadraticSmoothSegment()
+std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringViewSource::parseCurveToQuadraticSmoothSegment()
 {
     return parse([](auto& buffer) -> std::optional<CurveToQuadraticSmoothSegment> {
         auto targetPoint = parseFloatPoint(buffer);
@@ -261,7 +260,7 @@ std::optional<SVGPathSource::CurveToQuadraticSmoothSegment> SVGPathStringSource:
     });
 }
 
-std::optional<SVGPathSource::ArcToSegment> SVGPathStringSource::parseArcToSegment()
+std::optional<SVGPathSource::ArcToSegment> SVGPathStringViewSource::parseArcToSegment()
 {
     return parse([](auto& buffer) -> std::optional<ArcToSegment> {
         auto rx = parseNumber(buffer);

--- a/Source/WebCore/svg/SVGPathStringViewSource.h
+++ b/Source/WebCore/svg/SVGPathStringViewSource.h
@@ -26,9 +26,9 @@
 
 namespace WebCore {
 
-class SVGPathStringSource final : public SVGPathSource {
+class SVGPathStringViewSource final : public SVGPathSource {
 public:
-    explicit SVGPathStringSource(const String&);
+    explicit SVGPathStringViewSource(StringView);
 
 private:
     bool hasMoreData() const final;
@@ -48,9 +48,7 @@ private:
 
     template<typename Function> decltype(auto) parse(Function&&);
 
-    String m_string;
     bool m_is8BitSource;
-
     union {
         StringParsingBuffer<LChar> m_buffer8;
         StringParsingBuffer<UChar> m_buffer16;

--- a/Source/WebCore/svg/SVGPathUtilities.cpp
+++ b/Source/WebCore/svg/SVGPathUtilities.cpp
@@ -35,19 +35,19 @@
 #include "SVGPathSegListBuilder.h"
 #include "SVGPathSegListSource.h"
 #include "SVGPathStringBuilder.h"
-#include "SVGPathStringSource.h"
+#include "SVGPathStringViewSource.h"
 #include "SVGPathTraversalStateBuilder.h"
 
 namespace WebCore {
 
-Path buildPathFromString(const String& d)
+Path buildPathFromString(StringView d)
 {
     if (d.isEmpty())
         return { };
 
     Path path;
     SVGPathBuilder builder(path);
-    SVGPathStringSource source(d);
+    SVGPathStringViewSource source(d);
     SVGPathParser::parse(source, builder);
     return path;
 }
@@ -122,13 +122,13 @@ bool buildStringFromByteStream(const SVGPathByteStream& stream, String& result, 
     return SVGPathParser::parseToString(source, result, parsingMode, checkForInitialMoveTo);
 }
 
-bool buildSVGPathByteStreamFromString(const String& d, SVGPathByteStream& result, PathParsingMode parsingMode)
+bool buildSVGPathByteStreamFromString(StringView d, SVGPathByteStream& result, PathParsingMode parsingMode)
 {
     result.clear();
     if (d.isEmpty())
         return true;
 
-    SVGPathStringSource source(d);
+    SVGPathStringViewSource source(d);
     return SVGPathParser::parseToByteStream(source, result, parsingMode);
 }
 

--- a/Source/WebCore/svg/SVGPathUtilities.h
+++ b/Source/WebCore/svg/SVGPathUtilities.h
@@ -35,12 +35,12 @@ class SVGPathSegList;
 String buildStringFromPath(const Path&);
 
 // String/SVGPathByteStream -> Path
-Path buildPathFromString(const String&);
+Path buildPathFromString(StringView);
 Path buildPathFromByteStream(const SVGPathByteStream&);
 
 // SVGPathSegList/String -> SVGPathByteStream
 bool buildSVGPathByteStreamFromSVGPathSegList(const SVGPathSegList&, SVGPathByteStream& result, PathParsingMode, bool checkForInitialMoveTo = true);
-bool buildSVGPathByteStreamFromString(const String&, SVGPathByteStream&, PathParsingMode);
+bool buildSVGPathByteStreamFromString(StringView, SVGPathByteStream&, PathParsingMode);
 
 // SVGPathByteStream -> String
 bool buildStringFromByteStream(const SVGPathByteStream&, String&, PathParsingMode, bool checkForInitialMoveTo = true);

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -37,7 +37,7 @@
 #include "SVGHKernElement.h"
 #include "SVGMissingGlyphElement.h"
 #include "SVGPathParser.h"
-#include "SVGPathStringSource.h"
+#include "SVGPathStringViewSource.h"
 #include "SVGVKernElement.h"
 #include <wtf/Vector.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -1257,7 +1257,7 @@ Vector<char> SVGToOTFFontConverter::transcodeGlyphPaths(float width, const SVGEl
         horizontalOriginY = scaleUnitsPerEm(m_fontFaceElement->horizontalOriginY());
 
     CFFBuilder builder(result, width, FloatPoint(horizontalOriginX, horizontalOriginY), static_cast<float>(s_outputUnitsPerEm) / m_inputUnitsPerEm);
-    SVGPathStringSource source(dAttribute);
+    SVGPathStringViewSource source(dAttribute);
 
     ok = SVGPathParser::parse(source, builder);
     if (!ok)


### PR DESCRIPTION
#### 6326fffd83e206cd952ba5ef2634e0c3ce5118f0
<pre>
Update buildSVGPathByteStreamFromString() to take a StringView
<a href="https://bugs.webkit.org/show_bug.cgi?id=258589">https://bugs.webkit.org/show_bug.cgi?id=258589</a>

Reviewed by Ryosuke Niwa.

Update buildSVGPathByteStreamFromString() to take a StringView to avoid
constructing Strings in some cases. A StringView is sufficient for parsing.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeBasicShapePath):
* Source/WebCore/html/canvas/Path2D.h:
* Source/WebCore/svg/SVGPathByteStream.h:
(WebCore::SVGPathByteStream::SVGPathByteStream):
* Source/WebCore/svg/SVGPathByteStreamBuilder.cpp:
* Source/WebCore/svg/SVGPathSegList.h:
* Source/WebCore/svg/SVGPathStringViewSource.cpp: Renamed from Source/WebCore/svg/SVGPathStringSource.cpp.
(WebCore::SVGPathStringViewSource::SVGPathStringViewSource):
(WebCore::SVGPathStringViewSource::hasMoreData const):
(WebCore::SVGPathStringViewSource::moveToNextToken):
(WebCore::nextCommandHelper):
(WebCore::SVGPathStringViewSource::nextCommand):
(WebCore::SVGPathStringViewSource::parse):
(WebCore::SVGPathStringViewSource::parseSVGSegmentType):
(WebCore::SVGPathStringViewSource::parseMoveToSegment):
(WebCore::SVGPathStringViewSource::parseLineToSegment):
(WebCore::SVGPathStringViewSource::parseLineToHorizontalSegment):
(WebCore::SVGPathStringViewSource::parseLineToVerticalSegment):
(WebCore::SVGPathStringViewSource::parseCurveToCubicSegment):
(WebCore::SVGPathStringViewSource::parseCurveToCubicSmoothSegment):
(WebCore::SVGPathStringViewSource::parseCurveToQuadraticSegment):
(WebCore::SVGPathStringViewSource::parseCurveToQuadraticSmoothSegment):
(WebCore::SVGPathStringViewSource::parseArcToSegment):
* Source/WebCore/svg/SVGPathStringViewSource.h: Renamed from Source/WebCore/svg/SVGPathStringSource.h.
* Source/WebCore/svg/SVGPathUtilities.cpp:
(WebCore::buildPathFromString):
(WebCore::buildSVGPathByteStreamFromString):
* Source/WebCore/svg/SVGPathUtilities.h:
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::transcodeGlyphPaths const):

Canonical link: <a href="https://commits.webkit.org/265573@main">https://commits.webkit.org/265573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c6741ce483297ef510d1c1618a893e5f4c21ae6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13312 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17383 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9939 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2698 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->