### PR TITLE
Silence ResizeObservers while backgrounding YouTube on iOS.

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8601,6 +8601,10 @@ void Document::setHasSkippedResizeObservations(bool skipped)
 
 void Document::updateResizeObservations(Page& page)
 {
+    if (quirks().shouldSilenceResizeObservers()) {
+        addConsoleMessage(MessageSource::Other, MessageLevel::Info, "ResizeObservers silenced due to: http://webkit.org/b/258597"_s);
+        return;
+    }
     if (!hasResizeObservers() && !m_resizeObserverForContainIntrinsicSize)
         return;
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -718,6 +718,26 @@ bool Quirks::shouldOmitHTMLDocumentSupportedPropertyNames()
 #endif
 }
 
+// rdar://110097836
+bool Quirks::shouldSilenceResizeObservers() const
+{
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    if (!needsQuirks())
+        return false;
+
+    // ResizeObservers are silenced on YouTube during the 'homing out' snapshout sequence to
+    // resolve rdar://109837319. This is due to a bug on the site that is causing unexpected
+    // content layout and can be removed when it is addressed.
+    auto* page = m_document->page();
+    if (!page || !page->isTakingSnapshotsForApplicationSuspension())
+        return false;
+
+    return RegistrableDomain(m_document->topDocument().url()) == "youtube.com"_s;
+#else
+    return false;
+#endif
+}
+
 bool Quirks::shouldSilenceWindowResizeEvents() const
 {
 #if PLATFORM(IOS) || PLATFORM(VISION)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -55,6 +55,7 @@ public:
     Quirks(Document&);
     ~Quirks();
 
+    bool shouldSilenceResizeObservers() const;
     bool shouldSilenceWindowResizeEvents() const;
     bool shouldSilenceMediaQueryListChangeEvents() const;
     bool shouldIgnoreInvalidSignal() const;


### PR DESCRIPTION
#### e54ba88232e1805a9027fa848a4b3f8db79aa42a
<pre>
Silence ResizeObservers while backgrounding YouTube on iOS.
rdar://109837319
<a href="https://bugs.webkit.org/show_bug.cgi?id=258588">https://bugs.webkit.org/show_bug.cgi?id=258588</a>

Reviewed by Brent Fulgham.

Currently, if you background and foreground Safari on iPad while on
YouTube, you will get a different page layout compared to what was
displayed before the backgrounding process. Since the viewport sizes are
the same one would expect there to be no difference in the page layout.
This is due to a ResizeObserver callback using requestAnimationFrame to
execute some logic to reinitalize the ResizeObserver, but the observer
is ultimately put into a bad state due to the quick viewport size
changed. By silencing ResizeObservers during this process we should not
trigger this behavior and reintroduce the expected page layout again.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateResizeObservations):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldSilenceResizeObservers const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/265603@main">https://commits.webkit.org/265603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4de017254592d5f5ad6fe7ef29660a92636982

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12399 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13428 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10297 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10454 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13677 "11 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10043 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2727 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->