### PR TITLE
Implement text-wrap balance via binary search

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2893,8 +2893,6 @@ webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/pre
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg-break-transformation-018.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/seg-break-transformation-019.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/tab-bidi-001.html [ ImageOnlyFailure ]
-webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-002.html [ ImageOnlyFailure ]
-webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-text-indent-001.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-005.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-006.html [ ImageOnlyFailure ]
 webkit.org/b/257049 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-ideographic-space-008.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1674,8 +1674,6 @@ webkit.org/b/245727 [ Monterey ] imported/w3c/web-platform-tests/notifications/i
 
 webkit.org/b/248734 media/video-inaccurate-duration-ended.html [ Crash ]
 
-webkit.org/b/257154 [ Debug ] imported/w3c/web-platform-tests/css/css-text/white-space/text-wrap-balance-line-clamp-001.html [ Skip ]
-
 webkit.org/b/254778 [ Ventura Debug arm64 ] fast/images/avif-image-decoding.html [ Pass Crash ]
 
 webkit.org/b/255407 [ Monterey x86_64 ] imported/w3c/web-platform-tests/html/semantics/popovers/light-dismiss-event-ordering.html [ Pass Failure ]

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -75,6 +75,8 @@ private:
 
     InlineLayoutUnit computedIntrinsicWidthForConstraint(IntrinsicWidthMode) const;
 
+    std::optional<LayoutUnit> computeTextWrapBalanceWidthConstraint(const InlineItems&, const ConstraintsForInlineContent&, const InlineLayoutState&);
+
     void collectContentIfNeeded();
     InlineRect createDisplayContentForLine(size_t lineIndex, const LineBuilder::LayoutResult&, const ConstraintsForInlineContent&, const InlineLayoutState&, InlineDisplay::Content&);
     void resetGeometryForClampedContent(const InlineItemRange& needsDisplayContentRange, const LineBuilder::SuspendedFloatList& suspendedFloats, LayoutPoint topleft);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
@@ -46,12 +46,16 @@ public:
 
     LayoutUnit nestedListMarkerOffset(const ElementBox& listMarkerBox) const { return m_nestedListMarkerOffsets.get(&listMarkerBox); }
 
+    void setHorizontalConstraintOverride(std::optional<LayoutUnit> horizontalConstraintOverride) { m_horizontalConstraintOverride = horizontalConstraintOverride; }
+    std::optional<LayoutUnit> horizontalConstraintOverride() const { return m_horizontalConstraintOverride; }
+
 private:
     BlockLayoutState& m_parentBlockLayoutState;
     InlineLayoutUnit m_clearGapBeforeFirstLine { 0.f };
     InlineLayoutUnit m_clearGapAfterLastLine { 0.f };
     // FIXME: This is required by the integaration codepath.
     HashMap<const ElementBox*, LayoutUnit> m_nestedListMarkerOffsets;
+    std::optional<LayoutUnit> m_horizontalConstraintOverride { std::nullopt };
 };
 
 inline InlineLayoutState::InlineLayoutState(BlockLayoutState& parentBlockLayoutState, HashMap<const ElementBox*, LayoutUnit>&& nestedListMarkerOffsets)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1156,7 +1156,13 @@ LineBuilder::Result LineBuilder::handleInlineContent(InlineContentBreaker& inlin
 
     // While the floats are not considered to be on the line, they make the line contentful for line breaking.
     auto [adjustedLineForCandidateContent, candidateContentIsConstrainedByFloat] = lineBoxForCandidateInlineContent(lineCandidate);
-    auto availableWidthForCandidateContent = availableWidth(inlineContent, m_line, adjustedLineForCandidateContent.width());
+
+    // Alter the available width for content appropriately when horizontal constraint override exists
+    // e.g. text-wrap: balance is enabled
+    auto widthOverride = m_inlineLayoutState.horizontalConstraintOverride();
+    auto availableTotalWidthForContent = widthOverride ? InlineLayoutUnit { widthOverride.value() } - m_lineMarginStart : adjustedLineForCandidateContent.width();
+
+    auto availableWidthForCandidateContent = availableWidth(inlineContent, m_line, availableTotalWidthForContent);
     auto lineIsConsideredContentful = m_line.hasContentOrListMarker() || m_lineIsConstrainedByFloat || candidateContentIsConstrainedByFloat;
     auto lineStatus = InlineContentBreaker::LineStatus {
         m_line.contentLogicalRight(),

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -502,6 +502,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
         // Single mutation only atm.
         return true;
     }
+    if (renderer.style().textWrap() == TextWrap::Balance)
+        return true;
 
     auto rootHasNonSupportedRenderer = [&] {
         for (auto* sibling = rootBlockContainer.firstChild(); sibling; sibling = sibling->nextSibling()) {


### PR DESCRIPTION
#### 20edffd2441b762e882ed4603a980de9665e3bcd
<pre>
Implement text-wrap balance via binary search
<a href="https://bugs.webkit.org/show_bug.cgi?id=249840">https://bugs.webkit.org/show_bug.cgi?id=249840</a>
rdar://problem/103663513

Reviewed by NOBODY (OOPS!).

This patch implements `text-wrap: balance` in IFC. It currently uses a
binary search to find the minimum width constraint for line boxes that
preserves the number of lines used in normal wrapping behavior. This
approach does accomodate floats (or other types of intrusive content
such as initial-letter). Currently, `text-wrap: balance` is not
implemented in legacy line layout.

There is no line limit imposed on this implementation, although
performance is roughly an order of magnitude slower than non-balanced
line layout. Given a fixed containing width, the time complexity of this
algorithm is linear with respect to the number of inline items.

* LayoutTests/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.cpp:
(WebCore::Layout::InlineFormattingContext::layoutInFlowAndFloatContent):
(WebCore::Layout::InlineFormattingContext::computeTextWrapBalanceWidthConstraint):
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
* Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h:
(WebCore::Layout::InlineLayoutState::setHorizontalConstraintOverride):
(WebCore::Layout::InlineLayoutState::horizontalConstraintOverride const):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleInlineContent):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutPathAfterChangeFor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20edffd2441b762e882ed4603a980de9665e3bcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14865 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14903 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18589 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11993 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->