### PR TITLE
[WebXR] Use MTLTexture to attach color IOSurface

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -81,10 +81,9 @@ private:
     GCGLOwnedRenderbuffer m_stencilBuffer;
     GCGLOwnedRenderbuffer m_multisampleColorBuffer;
     GCGLOwnedFramebuffer m_resolvedFBO;
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA)
+#if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
     GCGLOwnedTexture m_opaqueTexture;
-    void* m_ioSurfaceTextureHandle { nullptr };
-    bool m_ioSurfaceTextureHandleIsShared { false };
+    GCEGLImage m_opaqueImage;
 #else
     PlatformGLObject m_opaqueTexture;
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -69,10 +69,6 @@ public:
     void destroyPbufferAndDetachIOSurface(void* handle);
 
     std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, EGLImageSource) final;
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-    // Short-term support for in-process WebGL.
-    std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, IOSurface*);
-#endif
 
     RetainPtr<id> newSharedEventWithMachPort(mach_port_t);
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) final;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -406,7 +406,7 @@ bool GraphicsContextGLCocoa::platformInitialize()
         requiredExtensions.append("GL_EXT_texture_format_BGRA8888"_s);
     }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
-#if ENABLE(WEBXR) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if ENABLE(WEBXR)
     if (attributes.xrCompatible) {
         requiredExtensions.append("GL_OES_EGL_image"_s);
         requiredExtensions.append("GL_EXT_sRGB"_s);
@@ -683,85 +683,67 @@ void GraphicsContextGLCocoa::destroyPbufferAndDetachIOSurface(void* handle)
     WebCore::destroyPbufferAndDetachIOSurface(m_displayObj, handle);
 }
 
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-static std::optional<GraphicsContextGL::EGLImageAttachResult> createAndBindSharedTextureToExternalImage(GCGLDisplay platformDisplay, GCGLenum target, MTLSharedTextureHandle* handle)
+std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, EGLImageSource source)
 {
     EGLDeviceEXT eglDevice = EGL_NO_DEVICE_EXT;
-    if (!EGL_QueryDisplayAttribEXT(platformDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+    if (!EGL_QueryDisplayAttribEXT(platformDisplay(), EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
         return std::nullopt;
 
     id<MTLDevice> mtlDevice = nil;
     if (!EGL_QueryDeviceAttribEXT(eglDevice, EGL_METAL_DEVICE_ANGLE, reinterpret_cast<EGLAttrib*>(&mtlDevice)))
         return std::nullopt;
 
-    if (mtlDevice != [handle device]) {
-        LOG(WebGL, "MTLSharedTextureHandle does not have the same Metal device as platformDisplay in attachMTLTextureToExternalImage.");
-        return std::nullopt;
-    }
+    RetainPtr<id<MTLTexture>> texture = WTF::switchOn(WTFMove(source),
+    [&](EGLImageSourceIOSurfaceHandle&& ioSurface) -> RetainPtr<id> {
+        auto surface = IOSurface::createFromSendRight(WTFMove(ioSurface.handle));
+        if (!surface)
+            return { };
 
-    // Create a MTLTexture out of the MTLSharedTextureHandle.
-    auto texture = adoptNS([mtlDevice newSharedTextureWithHandle:handle]);
+        auto size = surface->size();
+        MTLTextureDescriptor *desc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm_sRGB width:size.width() height:size.height() mipmapped:NO];
+        [desc setUsage:MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget];
+
+        auto tex = adoptNS([mtlDevice newTextureWithDescriptor:desc iosurface:surface->surface() plane:0]);
+        return tex;
+    },
+    [&](EGLImageSourceMTLSharedTextureHandle&& sharedTexture) -> RetainPtr<id> {
+#if PLATFORM(IOS_FAMILY_SIMULATOR)
+        UNUSED_VARIABLE(sharedTexture);
+        ASSERT_NOT_REACHED();
+        return { };
+#else
+        auto handle = adoptNS([[MTLSharedTextureHandle alloc] initWithMachPort:sharedTexture.handle.sendRight()]);
+        if (!handle)
+            return { };
+
+        if (mtlDevice != [handle device]) {
+            LOG(WebGL, "MTLSharedTextureHandle does not have the same Metal device as platformDisplay.");
+            return { };
+        }
+
+        // Create a MTLTexture out of the MTLSharedTextureHandle.
+        RetainPtr<id> texture = adoptNS([mtlDevice newSharedTextureWithHandle:handle.get()]);
+        return texture;
+        // FIXME: Does the texture have the correct usage mode?
+#endif
+    });
+
     if (!texture)
         return std::nullopt;
 
-    GCGLuint textureWidth = [texture width];
-    GCGLuint textureHeight = [texture height];
-
-    // FIXME: Does the texture have the correct usage mode?
-
     // Create an EGLImage out of the MTLTexture
     constexpr EGLint emptyAttributes[] = { EGL_NONE };
-    auto eglImage = EGL_CreateImageKHR(platformDisplay, EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), emptyAttributes);
+    auto eglImage = EGL_CreateImageKHR(platformDisplay(), EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), emptyAttributes);
     if (!eglImage)
         return std::nullopt;
 
     // Tell the currently bound texture to use the EGLImage.
     GL_EGLImageTargetTexture2DOES(target, eglImage);
 
+    GCGLuint textureWidth = [texture width];
+    GCGLuint textureHeight = [texture height];
+
     return std::make_tuple(eglImage, IntSize(textureWidth, textureHeight));
-}
-
-std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, IOSurface* surface)
-{
-    auto handle = adoptNS([[MTLSharedTextureHandle alloc] initWithIOSurface:surface->surface() label:@"WebXR"]);
-    if (!handle)
-        return std::nullopt;
-
-    return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-}
-#endif
-
-std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, EGLImageSource source)
-{
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-    // MTLSharedTexture is unsupported on simulator
-    UNUSED_VARIABLE(target);
-    UNUSED_VARIABLE(source);
-
-    return std::nullopt;
-#else // !PLATFORM(IOS_FAMILY_SIMULATOR
-
-    RetainPtr<MTLSharedTextureHandle> handle;
-    return WTF::switchOn(WTFMove(source),
-        [&](EGLImageSourceIOSurfaceHandle&& ioSurface) -> std::optional<EGLImageAttachResult> {
-            auto surface = IOSurface::createFromSendRight(WTFMove(ioSurface.handle));
-            if (!surface)
-                return std::nullopt;
-
-            handle = adoptNS([[MTLSharedTextureHandle alloc] initWithIOSurface:surface->surface() label:@"WebXR"]);
-            if (!handle)
-                return std::nullopt;
-
-            return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-        },
-        [&](EGLImageSourceMTLSharedTextureHandle&& sharedTexture) -> std::optional<EGLImageAttachResult> {
-            handle = adoptNS([[MTLSharedTextureHandle alloc] initWithMachPort:sharedTexture.handle.sendRight()]);
-            if (!handle)
-                return std::nullopt;
-
-            return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-        });
-#endif
 }
 
 RetainPtr<id> GraphicsContextGLCocoa::newSharedEventWithMachPort(mach_port_t sharedEventSendRight)

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -158,6 +158,9 @@ void SimulatedXRDevice::frameTimerFired()
     for (auto& layer : m_layers) {
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
         data.layers.add(layer.key, FrameData::LayerData { .surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB()) });
+#elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
+        auto surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB());
+        data.layers.add(layer.key, FrameData::LayerData { .colorTexture = std::make_tuple(surface->createSendRight(), false) });
 #else
         data.layers.add(layer.key, FrameData::LayerData { .opaqueTexture = layer.value });
 #endif


### PR DESCRIPTION
#### d41c610090b07554b2266f6d56435c8612c987b4
<pre>
[WebXR] Use MTLTexture to attach color IOSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=258598">https://bugs.webkit.org/show_bug.cgi?id=258598</a>
rdar://problem/111426880

Reviewed by Kimmo Kinnunen.

There are two paths in WebXROpaqueFramebuffer for attaching compositor provided
IOSurface for rendering: 1) Via MTLSharedTexture, and 2) Via pbuffer.

Since it&apos;s possible to create a MTLTexture from an IOSurface and plane index,
switch away from using pbuffer to reduce the number of code paths.

This patch introduces USE(MTLTEXTURE_FOR_XR_LAYER_DATA) to aid the transition of
platform specific WebXR systems. Once those systems are updated,
USE(IOSURFACE_FOR_XR_LAYER_DATA) will be removed.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::platformInitialize):
(WebCore::GraphicsContextGLCocoa::createAndBindEGLImage):
(WebCore::createAndBindSharedTextureToExternalImage): Deleted.
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::FrameData::LayerData::encode const):
(PlatformXR::Device::FrameData::LayerData::decode):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):

Canonical link: <a href="https://commits.webkit.org/265606@main">https://commits.webkit.org/265606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e740e59f3448aeae3f353f14234fac8cae0c8b42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13448 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10319 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13682 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10889 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10062 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2725 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10744 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->