### PR TITLE
REGRESSION (260897@main): Occasional crash when right clicking an image

### DIFF
--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -55,9 +55,13 @@ Vector<Ref<WebContextMenuItem>> WebContextMenuProxy::proposedItems() const
 void WebContextMenuProxy::show()
 {
     ASSERT(m_context.webHitTestResultData());
-    
+
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
     m_contextMenuListener = WebContextMenuListenerProxy::create(*this);
-    page()->contextMenuClient().getContextMenuFromProposedMenu(*page(), proposedItems(), *m_contextMenuListener, m_context.webHitTestResultData().value(), page()->process().transformHandlesToObjects(m_userData.object()).get());
+    page->contextMenuClient().getContextMenuFromProposedMenu(*page, proposedItems(), *m_contextMenuListener, m_context.webHitTestResultData().value(), page->process().transformHandlesToObjects(m_userData.object()).get());
 }
 
 void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& items)

--- a/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm
@@ -468,6 +468,28 @@ TEST(ContextMenuTests, ContextMenuElementInfoContainsQRCodePayloadStringSVGPageZ
     EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
 }
 
+TEST(ContextMenuTests, ContextMenuElementInfoWithQRCodeDetectionCrash)
+{
+    auto createWebView = [] {
+        auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [configuration _setContextMenuQRCodeDetectionEnabled:YES];
+        auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 600, 600) configuration:configuration.get()]);
+        [webView synchronouslyLoadHTMLString:@"<img src='qr-code.png'></img>"];
+        return webView;
+    };
+
+    @autoreleasepool {
+        auto webView = createWebView();
+        [webView rightClickAtPoint:CGPointMake(300, 300)];
+        [webView waitForNextPresentationUpdate];
+        [webView removeFromSuperview];
+    }
+
+    auto webView = createWebView();
+    _WKContextMenuElementInfo *elementInfo = [webView rightClickAtPointAndWaitForContextMenu:NSMakePoint(300, 300)];
+    EXPECT_WK_STREQ(elementInfo.qrCodePayloadString, "https://www.webkit.org");
+}
+
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
 TEST(ContextMenuTests, ContextMenuElementInfoHasEntireImage)


### PR DESCRIPTION
#### 16e3d68d600a2b0236681d13820e9ec5d33b9901
<pre>
REGRESSION (260897@main): Occasional crash when right clicking an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=258599">https://bugs.webkit.org/show_bug.cgi?id=258599</a>
rdar://110708014

Reviewed by Wenson Hsieh.

260897@main introduced additional asynchronicity when generating context menu
information, to perform QR code detection. Consequently, it is possible for
the `WebPageProxy` to be destroyed prior to finishing detection. Add a
null-check for `WebContextMenuProxy::page` to avoid crashes in this scenario.

* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
(WebKit::WebContextMenuProxy::show):
* Tools/TestWebKitAPI/Tests/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265582@main">https://commits.webkit.org/265582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0f0f98b70c96d412f184fdc20e6fa3973d9aaa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12937 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13670 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12329 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13352 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17417 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10382 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13594 "10 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8883 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9972 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2710 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->