### PR TITLE
Generated IPC serializers use deprecated stream input operator

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -418,8 +418,7 @@ def decode_type(type):
         result = result + decode_type(type.parent_class)
 
     if type.members_are_subclasses:
-        result.append('    std::optional<' + type.subclass_enum_name() + '> type;')
-        result.append('    decoder >> type;')
+        result.append('    auto type = decoder.decode<' + type.subclass_enum_name() + '>();')
         result.append('    if (!type)')
         result.append('        return std::nullopt;')
         result.append('')
@@ -439,8 +438,7 @@ def decode_type(type):
         elif member.is_subclass:
             result.append('    if (type == ' + type.subclass_enum_name() + "::" + member.name + ') {')
             typename = member.namespace + "::" + member.name
-            result.append('        std::optional<Ref<' + typename + '>> result;')
-            result.append('        decoder >> result;')
+            result.append('        auto result = decoder.decode<Ref<' + typename + '>>();')
             result.append('        if (!result)')
             result.append('            return std::nullopt;')
             result.append('        return WTFMove(*result);')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -676,38 +676,33 @@ void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebC
 
 std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
 {
-    std::optional<WebCore_TimingFunction_Subclass> type;
-    decoder >> type;
+    auto type = decoder.decode<WebCore_TimingFunction_Subclass>();
     if (!type)
         return std::nullopt;
 
     if (type == WebCore_TimingFunction_Subclass::LinearTimingFunction) {
-        std::optional<Ref<WebCore::LinearTimingFunction>> result;
-        decoder >> result;
+        auto result = decoder.decode<Ref<WebCore::LinearTimingFunction>>();
         if (!result)
             return std::nullopt;
         return WTFMove(*result);
     }
 
     if (type == WebCore_TimingFunction_Subclass::CubicBezierTimingFunction) {
-        std::optional<Ref<WebCore::CubicBezierTimingFunction>> result;
-        decoder >> result;
+        auto result = decoder.decode<Ref<WebCore::CubicBezierTimingFunction>>();
         if (!result)
             return std::nullopt;
         return WTFMove(*result);
     }
 
     if (type == WebCore_TimingFunction_Subclass::StepsTimingFunction) {
-        std::optional<Ref<WebCore::StepsTimingFunction>> result;
-        decoder >> result;
+        auto result = decoder.decode<Ref<WebCore::StepsTimingFunction>>();
         if (!result)
             return std::nullopt;
         return WTFMove(*result);
     }
 
     if (type == WebCore_TimingFunction_Subclass::SpringTimingFunction) {
-        std::optional<Ref<WebCore::SpringTimingFunction>> result;
-        decoder >> result;
+        auto result = decoder.decode<Ref<WebCore::SpringTimingFunction>>();
         if (!result)
             return std::nullopt;
         return WTFMove(*result);
@@ -820,14 +815,12 @@ void ArgumentCoder<WebCore::MoveOnlyBaseClass>::encode(Encoder& encoder, WebCore
 
 std::optional<WebCore::MoveOnlyBaseClass> ArgumentCoder<WebCore::MoveOnlyBaseClass>::decode(Decoder& decoder)
 {
-    std::optional<WebCore_MoveOnlyBaseClass_Subclass> type;
-    decoder >> type;
+    auto type = decoder.decode<WebCore_MoveOnlyBaseClass_Subclass>();
     if (!type)
         return std::nullopt;
 
     if (type == WebCore_MoveOnlyBaseClass_Subclass::MoveOnlyDerivedClass) {
-        std::optional<Ref<WebCore::MoveOnlyDerivedClass>> result;
-        decoder >> result;
+        auto result = decoder.decode<Ref<WebCore::MoveOnlyDerivedClass>>();
         if (!result)
             return std::nullopt;
         return WTFMove(*result);


### PR DESCRIPTION
#### de84aa87132c9e7825fae9f797ce581bf58df292
<pre>
Generated IPC serializers use deprecated stream input operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=258605">https://bugs.webkit.org/show_bug.cgi?id=258605</a>
rdar://problem/111435260

Reviewed by Alex Christensen.

Remove the &gt;&gt; use from the generated serializers so that the precedent
is removed, which might make it simpler to remove operator&gt;&gt;
implementation in the future.

Pattern is deprecated:
    std::optional&lt;T&gt; result;
    decoder &gt;&gt; result;

This is on the grounds of it requring default-constructible T.

For all types, we have to have support for:
    auto result = decoder.decode&lt;T&gt;();

Since we need latter anyway, we having the former is redundant.

* Source/WebKit/Scripts/generate-serializers.py:
(decode_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyBaseClass&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/265715@main">https://commits.webkit.org/265715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a81b25d41ed51541fe836800e498bd3819ade78a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13351 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14018 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13772 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/11804 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10003 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10361 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2813 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->