### PR TITLE
[JSC] Use JSONValues for Bytecode Profiler output instead of JSC's JSON

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -928,6 +928,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     profiler/ProfilerCompilationKind.h
     profiler/ProfilerCompiledBytecode.h
     profiler/ProfilerDatabase.h
+    profiler/ProfilerDumper.h
     profiler/ProfilerEvent.h
     profiler/ProfilerExecutionCounter.h
     profiler/ProfilerJettisonReason.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1941,6 +1941,7 @@
 		E3BFA5D021E853A1009C0EBA /* DFGDesiredGlobalProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BFA5CD21E853A1009C0EBA /* DFGDesiredGlobalProperty.h */; };
 		E3BFD0BC1DAF808E0065DEA2 /* AccessCaseSnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BFD0BA1DAF807C0065DEA2 /* AccessCaseSnippetParams.h */; };
 		E3C091E929B07D4C00CD6D97 /* WasmBBQJIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FED5FA3329A0859C00798A7F /* WasmBBQJIT.cpp */; };
+		E3C0ECCA2A4C01E9002C9D2B /* ProfilerDumper.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C0ECC92A4C01E8002C9D2B /* ProfilerDumper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C295DD1ED2CBDA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C295DC1ED2CBAA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h */; };
 		E3C4131D289E08EA001150F8 /* SyntheticModuleRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C4131C289E08E5001150F8 /* SyntheticModuleRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C694B323026877006FBE42 /* WasmOSREntryData.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C694B123026873006FBE42 /* WasmOSREntryData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5469,6 +5470,7 @@
 		E3BFA5CD21E853A1009C0EBA /* DFGDesiredGlobalProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DFGDesiredGlobalProperty.h; path = dfg/DFGDesiredGlobalProperty.h; sourceTree = "<group>"; };
 		E3BFD0B91DAF807C0065DEA2 /* AccessCaseSnippetParams.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessCaseSnippetParams.cpp; sourceTree = "<group>"; };
 		E3BFD0BA1DAF807C0065DEA2 /* AccessCaseSnippetParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessCaseSnippetParams.h; sourceTree = "<group>"; };
+		E3C0ECC92A4C01E8002C9D2B /* ProfilerDumper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProfilerDumper.h; path = profiler/ProfilerDumper.h; sourceTree = "<group>"; };
 		E3C295DC1ED2CBAA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectPropertyChangeAdaptiveWatchpoint.h; sourceTree = "<group>"; };
 		E3C4131B289E08E5001150F8 /* SyntheticModuleRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SyntheticModuleRecord.cpp; sourceTree = "<group>"; };
 		E3C4131C289E08E5001150F8 /* SyntheticModuleRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyntheticModuleRecord.h; sourceTree = "<group>"; };
@@ -8829,6 +8831,7 @@
 				0FF7299B166AD347000F5BA3 /* ProfilerCompiledBytecode.h */,
 				0FF7299C166AD347000F5BA3 /* ProfilerDatabase.cpp */,
 				0FF7299D166AD347000F5BA3 /* ProfilerDatabase.h */,
+				E3C0ECC92A4C01E8002C9D2B /* ProfilerDumper.h */,
 				DC605B591CE26E9800593718 /* ProfilerEvent.cpp */,
 				DC605B5A1CE26E9800593718 /* ProfilerEvent.h */,
 				0FF7299E166AD347000F5BA3 /* ProfilerExecutionCounter.h */,
@@ -10961,6 +10964,7 @@
 				0FF729BB166AD360000F5BA3 /* ProfilerCompilationKind.h in Headers */,
 				0FF729BC166AD360000F5BA3 /* ProfilerCompiledBytecode.h in Headers */,
 				0FF729BD166AD360000F5BA3 /* ProfilerDatabase.h in Headers */,
+				E3C0ECCA2A4C01E9002C9D2B /* ProfilerDumper.h in Headers */,
 				DC605B5E1CE26EA200593718 /* ProfilerEvent.h in Headers */,
 				0FF729BE166AD360000F5BA3 /* ProfilerExecutionCounter.h in Headers */,
 				0F190CAD189D82F6000AE5F0 /* ProfilerJettisonReason.h in Headers */,

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -140,16 +140,11 @@ CString CodeBlock::sourceCodeForTools() const
 {
     if (codeType() != FunctionCode)
         return ownerExecutable()->source().toUTF8();
-    
-    SourceProvider* provider = source().provider();
+
     FunctionExecutable* executable = jsCast<FunctionExecutable*>(ownerExecutable());
-    UnlinkedFunctionExecutable* unlinked = executable->unlinkedExecutable();
-    unsigned unlinkedStartOffset = unlinked->startOffset();
-    unsigned linkedStartOffset = executable->source().startOffset();
-    int delta = linkedStartOffset - unlinkedStartOffset;
-    unsigned rangeStart = delta + unlinked->unlinkedFunctionStart();
-    unsigned rangeEnd = delta + unlinked->startOffset() + unlinked->sourceLength();
-    return provider->source().substring(rangeStart, rangeEnd - rangeStart).utf8();
+    return executable->source().provider()->getRange(
+        executable->functionStart(),
+        executable->parametersStartOffset() + executable->source().length()).utf8();
 }
 
 CString CodeBlock::sourceCodeOnOneLine() const

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
@@ -29,16 +29,16 @@
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
 #include "Opcode.h"
+#include "ProfilerDumper.h"
 
 namespace JSC { namespace Profiler {
 
-JSValue Bytecode::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> Bytecode::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    result->putDirect(vm, vm.propertyNames->bytecodeIndex, jsNumber(m_bytecodeIndex));
-    result->putDirect(vm, vm.propertyNames->opcode, jsString(vm, String::fromUTF8(opcodeNames[m_opcodeID])));
-    result->putDirect(vm, vm.propertyNames->description, jsString(vm, String::fromUTF8(m_description)));
+    auto result = JSON::Object::create();
+    result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex);
+    result->setString(dumper.keys().m_opcode, String::fromUTF8(opcodeNames[m_opcodeID]));
+    result->setString(dumper.keys().m_description, String::fromUTF8(m_description));
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "JSCJSValue.h"
+#include <wtf/JSONValues.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -33,6 +34,8 @@ namespace JSC {
 enum OpcodeID : unsigned;
 
 namespace Profiler {
+
+class Dumper;
 
 class Bytecode {
 public:
@@ -52,7 +55,7 @@ public:
     OpcodeID opcodeID() const { return m_opcodeID; }
     const CString& description() const { return m_description; }
     
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
 private:
     unsigned m_bytecodeIndex;
     OpcodeID m_opcodeID;

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -73,25 +73,17 @@ const Bytecode& BytecodeSequence::forBytecodeIndex(unsigned bytecodeIndex) const
     return at(indexForBytecodeIndex(bytecodeIndex));
 }
 
-void BytecodeSequence::addSequenceProperties(JSGlobalObject* globalObject, JSObject* result) const
+void BytecodeSequence::addSequenceProperties(Dumper& dumper, JSON::Object& result) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSArray* header = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, void());
-    for (unsigned i = 0; i < m_header.size(); ++i) {
-        header->putDirectIndex(globalObject, i, jsString(vm, String::fromUTF8(m_header[i])));
-        RETURN_IF_EXCEPTION(scope, void());
-    }
-    result->putDirect(vm, vm.propertyNames->header, header);
-    
-    JSArray* sequence = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, void());
-    for (unsigned i = 0; i < m_sequence.size(); ++i) {
-        sequence->putDirectIndex(globalObject, i, m_sequence[i].toJS(globalObject));
-        RETURN_IF_EXCEPTION(scope, void());
-    }
-    result->putDirect(vm, vm.propertyNames->bytecode, sequence);
+    auto header = JSON::Array::create();
+    for (unsigned i = 0; i < m_header.size(); ++i)
+        header->pushString(String::fromUTF8(m_header[i]));
+    result.setValue(dumper.keys().m_header, WTFMove(header));
+
+    auto sequence = JSON::Array::create();
+    for (unsigned i = 0; i < m_sequence.size(); ++i)
+        sequence->pushValue(m_sequence[i].toJSON(dumper));
+    result.setValue(dumper.keys().m_bytecode, WTFMove(sequence));
 }
 
 } } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h
@@ -36,6 +36,8 @@ class CodeBlock;
 
 namespace Profiler {
 
+class Dumper;
+
 class BytecodeSequence {
 public:
     BytecodeSequence(CodeBlock*);
@@ -49,7 +51,7 @@ public:
     const Bytecode& forBytecodeIndex(unsigned bytecodeIndex) const;
 
 protected:
-    void addSequenceProperties(JSGlobalObject*, JSObject*) const;
+    void addSequenceProperties(Dumper&, JSON::Object&) const;
     
 private:
     Vector<CString> m_header;

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
@@ -46,7 +46,7 @@ public:
 
     void dump(PrintStream&) const;
     
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
     
 private:
     size_t m_id;

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.h
@@ -47,6 +47,7 @@ namespace Profiler {
 
 class Bytecodes;
 class Database;
+class Dumper;
 
 // Represents the act of executing some bytecodes in some engine, and does
 // all of the counting for those executions.
@@ -78,7 +79,7 @@ public:
     UID uid() const { return m_uid; }
     
     void dump(PrintStream&) const;
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
     
 private:
     CompilationKind m_kind;

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
@@ -28,6 +28,7 @@
 
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
+#include "ProfilerDumper.h"
 
 namespace JSC { namespace Profiler {
 
@@ -41,14 +42,13 @@ CompiledBytecode::~CompiledBytecode()
 {
 }
 
-JSValue CompiledBytecode::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> CompiledBytecode::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    
-    result->putDirect(vm, vm.propertyNames->origin, m_origin.toJS(globalObject));
-    result->putDirect(vm, vm.propertyNames->description, jsString(vm, String::fromUTF8(m_description)));
-    
+    auto result = JSON::Object::create();
+
+    result->setValue(dumper.keys().m_origin, m_origin.toJSON(dumper));
+    result->setString(dumper.keys().m_description, String::fromUTF8(m_description));
+
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
@@ -40,9 +40,9 @@ public:
     
     const OriginStack& originStack() const { return m_origin; }
     const CString& description() const { return m_description; }
-    
-    JSValue toJS(JSGlobalObject*) const;
-    
+
+    Ref<JSON::Value> toJSON(Dumper&) const;
+
 private:
     OriginStack m_origin;
     CString m_description;

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.cpp
@@ -30,6 +30,7 @@
 #include "JSCInlines.h"
 #include "JSONObject.h"
 #include "ObjectConstructor.h"
+#include "ProfilerDumper.h"
 #include <wtf/FilePrintStream.h>
 
 namespace JSC { namespace Profiler {
@@ -94,69 +95,35 @@ void Database::addCompilation(CodeBlock* codeBlock, Ref<Compilation>&& compilati
     m_compilationMap.set(codeBlock, WTFMove(compilation));
 }
 
-JSValue Database::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> Database::toJSON() const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSObject* result = constructEmptyObject(globalObject);
-    
-    JSArray* bytecodes = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, { });
-    for (unsigned i = 0; i < m_bytecodes.size(); ++i) {
-        auto value = m_bytecodes[i].toJS(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        bytecodes->putDirectIndex(globalObject, i, value);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-    result->putDirect(vm, vm.propertyNames->bytecodes, bytecodes);
-    
-    JSArray* compilations = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, { });
-    for (unsigned i = 0; i < m_compilations.size(); ++i) {
-        auto value = m_compilations[i]->toJS(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        compilations->putDirectIndex(globalObject, i, value);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-    result->putDirect(vm, vm.propertyNames->compilations, compilations);
-    
-    JSArray* events = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, { });
-    for (unsigned i = 0; i < m_events.size(); ++i) {
-        auto value = m_events[i].toJS(globalObject);
-        RETURN_IF_EXCEPTION(scope, { });
-        events->putDirectIndex(globalObject, i, value);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-    result->putDirect(vm, vm.propertyNames->events, events);
-    
+    Dumper dumper(*this);
+    auto result = JSON::Object::create();
+
+    auto bytecodes = JSON::Array::create();
+    for (unsigned i = 0; i < m_bytecodes.size(); ++i)
+        bytecodes->pushValue(m_bytecodes[i].toJSON(dumper));
+    result->setValue(dumper.keys().m_bytecodes, WTFMove(bytecodes));
+
+    auto compilations = JSON::Array::create();
+    for (unsigned i = 0; i < m_compilations.size(); ++i)
+        compilations->pushValue(m_compilations[i]->toJSON(dumper));
+    result->setValue(dumper.keys().m_compilations, WTFMove(compilations));
+
+    auto events = JSON::Array::create();
+    for (unsigned i = 0; i < m_events.size(); ++i)
+        events->pushValue(m_events[i].toJSON(dumper));
+    result->setValue(dumper.keys().m_events, WTFMove(events));
+
     return result;
-}
-
-String Database::toJSON() const
-{
-    auto scope = DECLARE_THROW_SCOPE(m_vm);
-    JSGlobalObject* globalObject = JSGlobalObject::create(
-        m_vm, JSGlobalObject::createStructure(m_vm, jsNull()));
-
-    auto value = toJS(globalObject);
-    RETURN_IF_EXCEPTION(scope, String());
-    RELEASE_AND_RETURN(scope, JSONStringify(globalObject, value, 0));
 }
 
 bool Database::save(const char* filename) const
 {
-    auto scope = DECLARE_CATCH_SCOPE(m_vm);
     auto out = FilePrintStream::open(filename, "w");
     if (!out)
         return false;
-    
-    String data = toJSON();
-    if (UNLIKELY(scope.exception())) {
-        scope.clearException();
-        return false;
-    }
-    out->print(data);
+    out->print(toJSON().get());
     return true;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerDatabase.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDatabase.h
@@ -31,6 +31,7 @@
 #include "ProfilerEvent.h"
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
+#include <wtf/JSONValues.h>
 #include <wtf/Lock.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/SegmentedVector.h>
@@ -50,17 +51,10 @@ public:
     void notifyDestruction(CodeBlock*);
     
     void addCompilation(CodeBlock*, Ref<Compilation>&&);
-    
-    // Converts the database to a JavaScript object that is suitable for JSON stringification.
-    // Note that it's probably a good idea to use an CallFrame* associated with a global
-    // object that is "clean" - i.e. array and object prototypes haven't had strange things
-    // done to them. And yes, it should be appropriate to just use a globalExec here.
-    JS_EXPORT_PRIVATE JSValue toJS(JSGlobalObject*) const;
-    
-    // Converts the database to a JavaScript object using a private temporary global object,
-    // and then returns the JSON representation of that object.
-    JS_EXPORT_PRIVATE String toJSON() const;
-    
+
+    // Converts the database to a JSON object that is suitable for JSON stringification.
+    JS_EXPORT_PRIVATE Ref<JSON::Value> toJSON() const;
+
     // Saves the JSON representation (from toJSON()) to the given file. Returns false if the
     // save failed.
     JS_EXPORT_PRIVATE bool save(const char* filename) const;

--- a/Source/JavaScriptCore/profiler/ProfilerDumper.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDumper.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/PrintStream.h>
+#include <wtf/text/CString.h>
+
+namespace JSC { namespace Profiler {
+
+class Database;
+
+#define JSC_PROFILER_OBJECT_KEYS(macro) \
+    macro(bytecode) \
+    macro(bytecodeIndex) \
+    macro(bytecodes) \
+    macro(bytecodesID) \
+    macro(counters) \
+    macro(opcode) \
+    macro(description) \
+    macro(descriptions) \
+    macro(hash) \
+    macro(inferredName) \
+    macro(sourceCode) \
+    macro(instructionCount) \
+    macro(compilationKind) \
+    macro(compilationUID) \
+    macro(compilations) \
+    macro(profiledBytecodes) \
+    macro(origin) \
+    macro(osrExitSites) \
+    macro(osrExits) \
+    macro(executionCount) \
+    macro(exitKind) \
+    macro(numInlinedCalls) \
+    macro(numInlinedGetByIds) \
+    macro(numInlinedPutByIds) \
+    macro(additionalJettisonReason) \
+    macro(jettisonReason) \
+    macro(uid) \
+    macro(events) \
+    macro(summary) \
+    macro(isWatchpoint) \
+    macro(detail) \
+    macro(time) \
+    macro(id) \
+    macro(header) \
+    macro(count) \
+
+
+class Dumper {
+public:
+    class Keys {
+    public:
+#define JSC_DEFINE_PROFILER_OBJECT_KEY(key) String m_##key { #key ""_s };
+        JSC_PROFILER_OBJECT_KEYS(JSC_DEFINE_PROFILER_OBJECT_KEY)
+#undef JSC_DEFINE_PROFILER_OBJECT_KEY
+    };
+
+    Dumper(const Database& database)
+        : m_database(database)
+    {
+    }
+
+    const Database& database() const { return m_database; }
+    const Keys& keys() const { return m_keys; }
+
+private:
+    const Database& m_database;
+    Keys m_keys;
+};
+
+} } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
@@ -30,6 +30,7 @@
 #include "ObjectConstructor.h"
 #include "ProfilerBytecodes.h"
 #include "ProfilerCompilation.h"
+#include "ProfilerDumper.h"
 #include "ProfilerUID.h"
 
 namespace JSC { namespace Profiler {
@@ -44,19 +45,18 @@ void Event::dump(PrintStream& out) const
         out.print(" (", m_detail, ")");
 }
 
-JSValue Event::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> Event::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    
-    result->putDirect(vm, vm.propertyNames->time, jsNumber(m_time.secondsSinceEpoch().value()));
-    result->putDirect(vm, vm.propertyNames->bytecodesID, jsNumber(m_bytecodes->id()));
+    auto result = JSON::Object::create();
+
+    result->setDouble(dumper.keys().m_time, m_time.secondsSinceEpoch().value());
+    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
     if (m_compilation)
-        result->putDirect(vm, vm.propertyNames->compilationUID, m_compilation->uid().toJS(globalObject));
-    result->putDirect(vm, vm.propertyNames->summary, jsString(vm, String::fromUTF8(m_summary)));
+        result->setValue(dumper.keys().m_compilationUID, m_compilation->uid().toJSON(dumper));
+    result->setString(dumper.keys().m_summary, String::fromUTF8(m_summary));
     if (m_detail.length())
-        result->putDirect(vm, vm.propertyNames->detail, jsString(vm, String::fromUTF8(m_detail)));
-    
+        result->setString(dumper.keys().m_detail, String::fromUTF8(m_detail));
+
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.h
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.h
@@ -34,6 +34,7 @@ namespace JSC { namespace Profiler {
 
 class Bytecodes;
 class Compilation;
+class Dumper;
 
 class Event {
 public:
@@ -62,7 +63,7 @@ public:
     const CString& detail() const { return m_detail; }
     
     void dump(PrintStream&) const;
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
     
 private:
     WallTime m_time { };

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
@@ -28,7 +28,7 @@
 
 #include "JSGlobalObject.h"
 #include "ObjectConstructor.h"
-#include "JSCInlines.h"
+#include "ProfilerDumper.h"
 
 namespace JSC { namespace Profiler {
 
@@ -45,15 +45,14 @@ OSRExit::~OSRExit()
 {
 }
 
-JSValue OSRExit::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> OSRExit::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    result->putDirect(vm, vm.propertyNames->id, jsNumber(m_id));
-    result->putDirect(vm, vm.propertyNames->origin, m_origin.toJS(globalObject));
-    result->putDirect(vm, vm.propertyNames->exitKind, jsNontrivialString(vm, exitKindToString(m_exitKind)));
-    result->putDirect(vm, vm.propertyNames->isWatchpoint, jsBoolean(m_isWatchpoint));
-    result->putDirect(vm, vm.propertyNames->count, jsNumber(m_counter));
+    auto result = JSON::Object::create();
+    result->setDouble(dumper.keys().m_id, m_id);
+    result->setValue(dumper.keys().m_origin, m_origin.toJSON(dumper));
+    result->setString(dumper.keys().m_exitKind, exitKindToString(m_exitKind));
+    result->setBoolean(dumper.keys().m_isWatchpoint, !!m_isWatchpoint);
+    result->setDouble(dumper.keys().m_count, m_counter);
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
@@ -31,6 +31,9 @@
 
 namespace JSC { namespace Profiler {
 
+class Database;
+class Dumper;
+
 class OSRExit {
 public:
     OSRExit(unsigned id, const OriginStack&, ExitKind, bool isWatchpoint);
@@ -45,7 +48,7 @@ public:
     uint64_t count() const { return m_counter; }
     void incCount() { m_counter++; }
 
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
 
 private:
     OriginStack m_origin;

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.cpp
@@ -31,16 +31,11 @@
 
 namespace JSC { namespace Profiler {
 
-JSValue OSRExitSite::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> OSRExitSite::toJSON(Dumper&) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSArray* result = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, { });
-    for (unsigned i = 0; i < m_codeAddresses.size(); ++i) {
-        result->putDirectIndex(globalObject, i, jsString(vm, toString(RawPointer(m_codeAddresses[i].dataLocation()))));
-        RETURN_IF_EXCEPTION(scope, { });
-    }
+    auto result = JSON::Array::create();
+    for (unsigned i = 0; i < m_codeAddresses.size(); ++i)
+        result->pushString(toString(RawPointer(m_codeAddresses[i].dataLocation())));
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
@@ -31,6 +31,9 @@
 
 namespace JSC { namespace Profiler {
 
+class Database;
+class Dumper;
+
 class OSRExitSite {
 public:
     explicit OSRExitSite(const Vector<CodePtr<JSInternalPtrTag>>& codeAddresses)
@@ -40,7 +43,7 @@ public:
     
     const Vector<CodePtr<JSInternalPtrTag>>& codeAddress() const { return m_codeAddresses; }
     
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
 
 private:
     Vector<CodePtr<JSInternalPtrTag>> m_codeAddresses;

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.cpp
@@ -30,6 +30,7 @@
 #include "ObjectConstructor.h"
 #include "ProfilerBytecodes.h"
 #include "ProfilerDatabase.h"
+#include "ProfilerDumper.h"
 
 namespace JSC { namespace Profiler {
 
@@ -44,12 +45,11 @@ void Origin::dump(PrintStream& out) const
     out.print(*m_bytecodes, " ", m_bytecodeIndex);
 }
 
-JSValue Origin::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> Origin::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    result->putDirect(vm, vm.propertyNames->bytecodesID, jsNumber(m_bytecodes->id()));
-    result->putDirect(vm, vm.propertyNames->bytecodeIndex, jsNumber(m_bytecodeIndex.offset()));
+    auto result = JSON::Object::create();
+    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex.offset());
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOrigin.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOrigin.h
@@ -38,6 +38,7 @@ namespace Profiler {
 
 class Bytecodes;
 class Database;
+class Dumper;
 
 class Origin {
 public:
@@ -66,7 +67,7 @@ public:
     bool isHashTableDeletedValue() const;
     
     void dump(PrintStream&) const;
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
 
 private:
     Bytecodes* m_bytecodes;

--- a/Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp
@@ -97,18 +97,11 @@ void OriginStack::dump(PrintStream& out) const
     }
 }
 
-JSValue OriginStack::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> OriginStack::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSArray* result = constructEmptyArray(globalObject, nullptr);
-    RETURN_IF_EXCEPTION(scope, { });
-    
-    for (unsigned i = 0; i < m_stack.size(); ++i) {
-        result->putDirectIndex(globalObject, i, m_stack[i].toJS(globalObject));
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-    
+    auto result = JSON::Array::create();
+    for (unsigned i = 0; i < m_stack.size(); ++i)
+        result->pushValue(m_stack[i].toJSON(dumper));
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOriginStack.h
@@ -38,6 +38,7 @@ class CodeOrigin;
 namespace Profiler {
 
 class Database;
+class Dumper;
 
 class OriginStack {
 public:
@@ -65,7 +66,7 @@ public:
     bool isHashTableDeletedValue() const;
     
     void dump(PrintStream&) const;
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
     
 private:
     Vector<Origin, 1> m_stack;

--- a/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
@@ -28,6 +28,7 @@
 
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
+#include "ProfilerDumper.h"
 
 namespace JSC { namespace Profiler {
 
@@ -41,14 +42,11 @@ ProfiledBytecodes::~ProfiledBytecodes()
 {
 }
 
-JSValue ProfiledBytecodes::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> ProfiledBytecodes::toJSON(Dumper& dumper) const
 {
-    VM& vm = globalObject->vm();
-    JSObject* result = constructEmptyObject(globalObject);
-    
-    result->putDirect(vm, vm.propertyNames->bytecodesID, jsNumber(m_bytecodes->id()));
-    addSequenceProperties(globalObject, result);
-    
+    auto result = JSON::Object::create();
+    result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
+    addSequenceProperties(dumper, result.get());
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.h
+++ b/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.h
@@ -37,7 +37,7 @@ public:
     
     const Bytecodes* bytecodes() const { return m_bytecodes; }
     
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
 
 private:
     Bytecodes* m_bytecodes;

--- a/Source/JavaScriptCore/profiler/ProfilerUID.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerUID.cpp
@@ -48,9 +48,9 @@ void UID::dump(PrintStream& out) const
     out.print(m_uid);
 }
 
-JSValue UID::toJS(JSGlobalObject* globalObject) const
+Ref<JSON::Value> UID::toJSON(Dumper&) const
 {
-    return jsString(globalObject->vm(), toString(*this));
+    return JSON::Value::create(toString(*this));
 }
 
 } } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/profiler/ProfilerUID.h
+++ b/Source/JavaScriptCore/profiler/ProfilerUID.h
@@ -26,9 +26,13 @@
 #pragma once
 
 #include "JSCJSValue.h"
+#include <wtf/JSONValues.h>
 #include <wtf/PrintStream.h>
 
 namespace JSC { namespace Profiler {
+
+class Database;
+class Dumper;
 
 class UID {
 public:
@@ -77,7 +81,7 @@ public:
     }
     
     void dump(PrintStream&) const;
-    JSValue toJS(JSGlobalObject*) const;
+    Ref<JSON::Value> toJSON(Dumper&) const;
     
 private:
     uint64_t m_uid;

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -70,7 +70,6 @@
     macro(__lookupGetter__) \
     macro(__lookupSetter__) \
     macro(add) \
-    macro(additionalJettisonReason) \
     macro(anonymous) \
     macro(arguments) \
     macro(as) \
@@ -79,10 +78,6 @@
     macro(bind) \
     macro(byteLength) \
     macro(byteOffset) \
-    macro(bytecode) \
-    macro(bytecodeIndex) \
-    macro(bytecodes) \
-    macro(bytecodesID) \
     macro(calendar) \
     macro(callee) \
     macro(caller) \
@@ -91,14 +86,10 @@
     macro(clear) \
     macro(collation) \
     macro(column) \
-    macro(compilationKind) \
-    macro(compilationUID) \
-    macro(compilations) \
     macro(compile) \
     macro(configurable) \
     macro(constructor) \
     macro(count) \
-    macro(counters) \
     macro(dateStyle) \
     macro(day) \
     macro(days) \
@@ -107,7 +98,6 @@
     macro(defineProperty) \
     macro(deref) \
     macro(description) \
-    macro(descriptions) \
     macro(detail) \
     macro(displayName) \
     macro(done) \
@@ -117,10 +107,7 @@
     macro(eraYear) \
     macro(errors) \
     macro(eval) \
-    macro(events) \
     macro(exec) \
-    macro(executionCount) \
-    macro(exitKind) \
     macro(exports) \
     macro(fallback) \
     macro(flags) \
@@ -156,7 +143,6 @@
     macro(ignorePunctuation) \
     macro(index) \
     macro(indices) \
-    macro(inferredName) \
     macro(input) \
     macro(isoDay) \
     macro(isoHour) \
@@ -167,15 +153,12 @@
     macro(isoNanosecond) \
     macro(isoSecond) \
     macro(isoYear) \
-    macro(instructionCount) \
     macro(isArray) \
     macro(isEnabled) \
     macro(isPrototypeOf) \
     macro(isView) \
-    macro(isWatchpoint) \
     macro(isWellFormed) \
     macro(isWordLike) \
-    macro(jettisonReason) \
     macro(join) \
     macro(language) \
     macro(languageDisplay) \
@@ -212,22 +195,14 @@
     macro(nanosecondsDisplay) \
     macro(next) \
     macro(now) \
-    macro(numInlinedCalls) \
-    macro(numInlinedGetByIds) \
-    macro(numInlinedPutByIds) \
     macro(numberingSystem) \
     macro(numeric) \
     macro(of) \
-    macro(opcode) \
-    macro(origin) \
-    macro(osrExitSites) \
-    macro(osrExits) \
     macro(overflow) \
     macro(ownKeys) \
     macro(parse) \
     macro(parseInt) \
     macro(parseFloat) \
-    macro(profiledBytecodes) \
     macro(propertyIsEnumerable) \
     macro(prototype) \
     macro(raw) \
@@ -251,14 +226,12 @@
     macro(slice) \
     macro(smallestUnit) \
     macro(source) \
-    macro(sourceCode) \
     macro(sourceURL) \
     macro(stack) \
     macro(stackTraceLimit) \
     macro(sticky) \
     macro(style) \
     macro(subarray) \
-    macro(summary) \
     macro(target) \
     macro(test) \
     macro(then) \
@@ -278,7 +251,6 @@
     macro(trailingZeroDisplay) \
     macro(transfer) \
     macro(type) \
-    macro(uid) \
     macro(unicode) \
     macro(unicodeSets) \
     macro(unit) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -269,7 +269,9 @@ bool canUseWebAssemblyFastMemory();
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
+    v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \
     v(Bool, disassembleBaselineForProfiler, true, Normal, nullptr) \
+    v(Unsigned, abbreviateSourceCodeForProfiler, 0, Normal, nullptr) \
     \
     v(Bool, useArchitectureSpecificOptimizations, true, Normal, nullptr) \
     \

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -315,12 +315,14 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     if (UNLIKELY(Options::useProfiler())) {
         m_perBytecodeProfiler = makeUnique<Profiler::Database>(*this);
 
-        StringPrintStream pathOut;
-        const char* profilerPath = getenv("JSC_PROFILER_PATH");
-        if (profilerPath)
-            pathOut.print(profilerPath, "/");
-        pathOut.print("JSCProfile-", getCurrentProcessID(), "-", m_perBytecodeProfiler->databaseID(), ".json");
-        m_perBytecodeProfiler->registerToSaveAtExit(pathOut.toCString().data());
+        if (UNLIKELY(Options::dumpProfilerDataAtExit())) {
+            StringPrintStream pathOut;
+            const char* profilerPath = getenv("JSC_PROFILER_PATH");
+            if (profilerPath)
+                pathOut.print(profilerPath, "/");
+            pathOut.print("JSCProfile-", getCurrentProcessID(), "-", m_perBytecodeProfiler->databaseID(), ".json");
+            m_perBytecodeProfiler->registerToSaveAtExit(pathOut.toCString().data());
+        }
     }
 
     // Initialize this last, as a free way of asserting that VM initialization itself

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -33,6 +33,7 @@
 #include "config.h"
 #include <wtf/JSONValues.h>
 
+#include <wtf/CommaPrinter.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WTF {
@@ -457,13 +458,6 @@ RefPtr<JSON::Value> buildValue(const CodeUnit* start, const CodeUnit* end, const
     return result;
 }
 
-inline void appendDoubleQuotedString(StringBuilder& builder, StringView string)
-{
-    builder.append('"');
-    Value::escapeString(builder, string);
-    builder.append('"');
-}
-
 } // anonymous namespace
 
 Ref<Value> Value::null()
@@ -542,46 +536,6 @@ RefPtr<Value> Value::parseJSON(StringView json)
     return result;
 }
 
-void Value::escapeString(StringBuilder& builder, StringView string)
-{
-    for (UChar codeUnit : string.codeUnits()) {
-        switch (codeUnit) {
-        case '\b':
-            builder.append("\\b");
-            continue;
-        case '\f':
-            builder.append("\\f");
-            continue;
-        case '\n':
-            builder.append("\\n");
-            continue;
-        case '\r':
-            builder.append("\\r");
-            continue;
-        case '\t':
-            builder.append("\\t");
-            continue;
-        case '\\':
-            builder.append("\\\\");
-            continue;
-        case '"':
-            builder.append("\\\"");
-            continue;
-        }
-        // We escape < and > to prevent script execution.
-        if (codeUnit >= 32 && codeUnit < 127 && codeUnit != '<' && codeUnit != '>') {
-            builder.append(codeUnit);
-            continue;
-        }
-        // We could encode characters >= 127 as UTF-8 instead of \u escape sequences.
-        // We could handle surrogates here if callers wanted that; for now we just
-        // write them out as a \u sequence, so a surrogate pair appears as two of them.
-        builder.append("\\u",
-            upperNibbleToASCIIHexDigit(codeUnit >> 8), lowerNibbleToASCIIHexDigit(codeUnit >> 8),
-            upperNibbleToASCIIHexDigit(codeUnit), lowerNibbleToASCIIHexDigit(codeUnit));
-    }
-}
-
 String Value::toJSONString() const
 {
     StringBuilder result;
@@ -618,6 +572,57 @@ String Value::asString() const
     return m_value.string;
 }
 
+void Value::dump(PrintStream& out) const
+{
+    switch (m_type) {
+    case Type::Null:
+        out.print("null"_s);
+        break;
+    case Type::Boolean:
+        out.print(m_value.boolean ? "true"_s : "false"_s);
+        break;
+    case Type::String: {
+        StringBuilder builder;
+        builder.appendQuotedJSONString(m_value.string);
+        out.print(builder.toString());
+        break;
+    }
+    case Type::Double:
+    case Type::Integer: {
+        if (!std::isfinite(m_value.number))
+            out.print("null"_s);
+        else
+            out.print(makeString(m_value.number));
+        break;
+    }
+    case Type::Object: {
+        auto& object = *static_cast<const ObjectBase*>(this);
+        CommaPrinter comma(",");
+        out.print("{");
+        for (const auto& key : object.m_order) {
+            auto findResult = object.m_map.find(key);
+            ASSERT(findResult != object.m_map.end());
+            StringBuilder builder;
+            builder.appendQuotedJSONString(findResult->key);
+            out.print(comma, builder.toString(), ":", findResult->value.get());
+        }
+        out.print("}");
+        break;
+    }
+    case Type::Array: {
+        auto& array = *static_cast<const ArrayBase*>(this);
+        CommaPrinter comma(",");
+        out.print("[");
+        for (auto& value : array.m_map)
+            out.print(comma, value.get());
+        out.print("]");
+        break;
+    }
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
+
 void Value::writeJSON(StringBuilder& output) const
 {
     switch (m_type) {
@@ -631,7 +636,7 @@ void Value::writeJSON(StringBuilder& output) const
             output.append("false");
         break;
     case Type::String:
-        appendDoubleQuotedString(output, m_value.string);
+        output.appendQuotedJSONString(m_value.string);
         break;
     case Type::Double:
     case Type::Integer: {
@@ -748,7 +753,7 @@ void ObjectBase::writeJSON(StringBuilder& output) const
         ASSERT(findResult != m_map.end());
         if (i)
             output.append(',');
-        appendDoubleQuotedString(output, findResult->key);
+        output.appendQuotedJSONString(findResult->key);
         output.append(':');
         findResult->value->writeJSON(output);
     }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -38,6 +38,8 @@
 
 namespace WTF {
 
+class PrintStream;
+
 // Make sure compiled symbols contain the WTF namespace prefix, but
 // use a different inner namespace name so that JSON::Value is not ambigious.
 // Otherwise, the compiler would have both WTF::JSON::Value and JSON::Value
@@ -103,10 +105,11 @@ public:
     virtual RefPtr<Array> asArray();
 
     static RefPtr<Value> parseJSON(StringView);
-    static void escapeString(StringBuilder&, StringView);
 
     String toJSONString() const;
     virtual void writeJSON(StringBuilder& output) const;
+
+    void dump(PrintStream&) const;
 
     virtual size_t memoryCost() const;
 
@@ -163,6 +166,7 @@ private:
 
 class ObjectBase : public Value {
 private:
+    friend class Value;
     using DataStorage = HashMap<String, Ref<Value>>;
     using OrderStorage = Vector<String>;
 
@@ -257,6 +261,7 @@ public:
 
 class WTF_EXPORT_PRIVATE ArrayBase : public Value {
 private:
+    friend class Value;
     using DataStorage = Vector<Ref<Value>>;
 
 public:

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7521,7 +7521,7 @@ void WebPage::getBytecodeProfile(CompletionHandler<void(const String&)>&& callba
     if (LIKELY(!commonVM().m_perBytecodeProfiler))
         return callback({ });
 
-    String result = commonVM().m_perBytecodeProfiler->toJSON();
+    String result = commonVM().m_perBytecodeProfiler->toJSON()->toJSONString();
     ASSERT(result.length());
     callback(result);
 }


### PR DESCRIPTION
#### 9272021e237d560258752975dbe6219975cafac2
<pre>
[JSC] Use JSONValues for Bytecode Profiler output instead of JSC&apos;s JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=258606">https://bugs.webkit.org/show_bug.cgi?id=258606</a>
rdar://111435544

Reviewed by Keith Miller.

This prevents us from relying on JSC when dumping bytecode profiler result JSON,
so we do not need to create JSGlobalObject for that. Plus,

1. Add JSON::Value::dump so that we can dump content through PrintStream, which allows us to dump very large JSON in streaming fashion.
2. Add Options::abbreviateSourceCodeForProfiler to control included source string size. Some of script has massive size of source string,
   so we would like to limit the size included as a profiler output.
3. Add Options::dumpProfilerDataAtExit to avoid dumping profiler output twice when `-p` option is specified for JSC shell.
4. Fix CodeBlock::sourceCodeForTools() to align it to Function#toString.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/profiler/ProfilerBytecode.cpp:
(JSC::Profiler::Bytecode::toJSON const):
(JSC::Profiler::Bytecode::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerBytecode.h:
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp:
(JSC::Profiler::BytecodeSequence::addSequenceProperties const):
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.h:
* Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp:
(JSC::Profiler::Bytecodes::toJSON const):
(JSC::Profiler::Bytecodes::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerBytecodes.h:
* Source/JavaScriptCore/profiler/ProfilerCompilation.cpp:
(JSC::Profiler::Compilation::toJSON const):
(JSC::Profiler::Compilation::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerCompilation.h:
* Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp:
(JSC::Profiler::CompiledBytecode::toJSON const):
(JSC::Profiler::CompiledBytecode::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h:
* Source/JavaScriptCore/profiler/ProfilerDatabase.cpp:
(JSC::Profiler::Database::toJSON const):
(JSC::Profiler::Database::save const):
(JSC::Profiler::Database::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerDatabase.h:
* Source/JavaScriptCore/profiler/ProfilerDumper.h: Copied from Source/JavaScriptCore/profiler/ProfilerEvent.h.
(JSC::Profiler::Dumper::Dumper):
(JSC::Profiler::Dumper::database const):
(JSC::Profiler::Dumper::keys const):
* Source/JavaScriptCore/profiler/ProfilerEvent.cpp:
(JSC::Profiler::Event::toJSON const):
(JSC::Profiler::Event::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerEvent.h:
* Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp:
(JSC::Profiler::OSRExit::toJSON const):
(JSC::Profiler::OSRExit::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOSRExit.h:
* Source/JavaScriptCore/profiler/ProfilerOSRExitSite.cpp:
(JSC::Profiler::OSRExitSite::toJSON const):
(JSC::Profiler::OSRExitSite::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h:
* Source/JavaScriptCore/profiler/ProfilerOrigin.cpp:
(JSC::Profiler::Origin::toJSON const):
(JSC::Profiler::Origin::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOrigin.h:
* Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp:
(JSC::Profiler::OriginStack::toJSON const):
(JSC::Profiler::OriginStack::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerOriginStack.h:
* Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp:
(JSC::Profiler::ProfiledBytecodes::toJSON const):
(JSC::Profiler::ProfiledBytecodes::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.h:
* Source/JavaScriptCore/profiler/ProfilerUID.cpp:
(JSC::Profiler::UID::toJSON const):
(JSC::Profiler::UID::toJS const): Deleted.
* Source/JavaScriptCore/profiler/ProfilerUID.h:
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::dump const):
* Source/WTF/wtf/JSONValues.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getBytecodeProfile):

Canonical link: <a href="https://commits.webkit.org/265586@main">https://commits.webkit.org/265586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c01b1ccd043742fb52cc01052cf389cd3c7559ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11526 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12369 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13399 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/9627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10733 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13640 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10752 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/10845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11428 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10016 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3090 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14292 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1278 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/10700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2863 "Passed tests") | 
<!--EWS-Status-Bubble-End-->