### PR TITLE
Generated IPC serializers for base classes run conditions for all the derived classes

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -399,6 +399,7 @@ def encode_type(type):
                 result.append('        encoder << WTFMove(*subclass);')
             else:
                 result.append('        encoder << *subclass;')
+            result.append('        return;')
             result.append('    }')
         else:
             if type.rvalue and not type.serialize_with_function_calls:
@@ -614,6 +615,8 @@ def generate_impl(serialized_types, serialized_enums, headers):
             if not type.members_are_subclasses:
                 result = result + check_type_members(type, False)
             result = result + encode_type(type)
+            if type.members_are_subclasses:
+                result.append('    ASSERT_NOT_REACHED();')
             result.append('}')
         result.append('')
         if type.return_ref:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -654,19 +654,24 @@ void ArgumentCoder<WebCore::TimingFunction>::encode(Encoder& encoder, const WebC
     if (auto* subclass = dynamicDowncast<WebCore::LinearTimingFunction>(instance)) {
         encoder << WebCore_TimingFunction_Subclass::LinearTimingFunction;
         encoder << *subclass;
+        return;
     }
     if (auto* subclass = dynamicDowncast<WebCore::CubicBezierTimingFunction>(instance)) {
         encoder << WebCore_TimingFunction_Subclass::CubicBezierTimingFunction;
         encoder << *subclass;
+        return;
     }
     if (auto* subclass = dynamicDowncast<WebCore::StepsTimingFunction>(instance)) {
         encoder << WebCore_TimingFunction_Subclass::StepsTimingFunction;
         encoder << *subclass;
+        return;
     }
     if (auto* subclass = dynamicDowncast<WebCore::SpringTimingFunction>(instance)) {
         encoder << WebCore_TimingFunction_Subclass::SpringTimingFunction;
         encoder << *subclass;
+        return;
     }
+    ASSERT_NOT_REACHED();
 }
 
 std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunction>::decode(Decoder& decoder)
@@ -808,7 +813,9 @@ void ArgumentCoder<WebCore::MoveOnlyBaseClass>::encode(Encoder& encoder, WebCore
     if (auto* subclass = dynamicDowncast<WebCore::MoveOnlyDerivedClass>(instance)) {
         encoder << WebCore_MoveOnlyBaseClass_Subclass::MoveOnlyDerivedClass;
         encoder << WTFMove(*subclass);
+        return;
     }
+    ASSERT_NOT_REACHED();
 }
 
 std::optional<WebCore::MoveOnlyBaseClass> ArgumentCoder<WebCore::MoveOnlyBaseClass>::decode(Decoder& decoder)


### PR DESCRIPTION
#### f0d6209f8752f3d0d5dc6e8a178df13c84d16ad9
<pre>
Generated IPC serializers for base classes run conditions for all the derived classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=258609">https://bugs.webkit.org/show_bug.cgi?id=258609</a>
rdar://problem/111436035

Reviewed by Alex Christensen.

An instance cannot be of two types at the same time, so early out after
encoding the instance casted to the found subclass type.

* Source/WebKit/Scripts/generate-serializers.py:
(encode_type):
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebCore::TimingFunction&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyBaseClass&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/265711@main">https://commits.webkit.org/265711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7c707125d554ab9dc5789110b05854706382128

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10770 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13679 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13364 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/11397 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9633 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17425 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13602 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9982 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->