### PR TITLE
Generated IPC serializers have tests for removed ReturnEarlyIfTrue feature

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -39,8 +39,8 @@
 #if ENABLE(TEST_FEATURE)
 #include "StructHeader.h"
 #endif
-#include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
+#include <Namespace/EmptyConstructorWithIf.h>
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
@@ -202,23 +202,19 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
 
 void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namespace::OtherClass& instance)
 {
-    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.isNull)>, bool>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, bool>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.dataDetectorResults)>, RetainPtr<NSArray>>);
     struct ShouldBeSameSizeAsOtherClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::OtherClass>, false> {
-        bool isNull;
         int a;
         bool b : 1;
         RetainPtr<NSArray> dataDetectorResults;
     };
     static_assert(sizeof(ShouldBeSameSizeAsOtherClass) == sizeof(Namespace::OtherClass));
     static_assert(MembersInCorrectOrder<0
-        , offsetof(Namespace::OtherClass, isNull)
         , offsetof(Namespace::OtherClass, a)
         , offsetof(Namespace::OtherClass, dataDetectorResults)
     >::value);
-    encoder << instance.isNull;
     encoder << instance.a;
     encoder << instance.b;
     encoder << instance.dataDetectorResults;
@@ -226,10 +222,6 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
 
 std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decode(Decoder& decoder)
 {
-    auto isNull = decoder.decode<bool>();
-    if (!isNull)
-        return std::nullopt;
-
     auto a = decoder.decode<int>();
     if (!a)
         return std::nullopt;
@@ -244,7 +236,6 @@ std::optional<Namespace::OtherClass> ArgumentCoder<Namespace::OtherClass>::decod
 
     return {
         Namespace::OtherClass {
-            WTFMove(*isNull),
             WTFMove(*a),
             WTFMove(*b),
             WTFMove(*dataDetectorResults)
@@ -312,17 +303,15 @@ std::optional<Namespace::EmptyConstructorStruct> ArgumentCoder<Namespace::EmptyC
 }
 
 
-void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder, const Namespace::EmptyConstructorNullable& instance)
+void ArgumentCoder<Namespace::EmptyConstructorWithIf>::encode(Encoder& encoder, const Namespace::EmptyConstructorWithIf& instance)
 {
-    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_isNull)>, bool>);
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_type)>, MemberType>);
 #endif
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_value)>, OtherMemberType>);
 #endif
-    struct ShouldBeSameSizeAsEmptyConstructorNullable : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::EmptyConstructorNullable>, false> {
-        bool m_isNull;
+    struct ShouldBeSameSizeAsEmptyConstructorWithIf : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::EmptyConstructorWithIf>, false> {
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
         MemberType m_type;
 #endif
@@ -330,17 +319,15 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
         OtherMemberType m_value;
 #endif
     };
-    static_assert(sizeof(ShouldBeSameSizeAsEmptyConstructorNullable) == sizeof(Namespace::EmptyConstructorNullable));
+    static_assert(sizeof(ShouldBeSameSizeAsEmptyConstructorWithIf) == sizeof(Namespace::EmptyConstructorWithIf));
     static_assert(MembersInCorrectOrder<0
-        , offsetof(Namespace::EmptyConstructorNullable, m_isNull)
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-        , offsetof(Namespace::EmptyConstructorNullable, m_type)
+        , offsetof(Namespace::EmptyConstructorWithIf, m_type)
 #endif
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
-        , offsetof(Namespace::EmptyConstructorNullable, m_value)
+        , offsetof(Namespace::EmptyConstructorWithIf, m_value)
 #endif
     >::value);
-    encoder << instance.m_isNull;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     encoder << instance.m_type;
 #endif
@@ -349,12 +336,8 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
 #endif
 }
 
-std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::EmptyConstructorNullable>::decode(Decoder& decoder)
+std::optional<Namespace::EmptyConstructorWithIf> ArgumentCoder<Namespace::EmptyConstructorWithIf>::decode(Decoder& decoder)
 {
-    auto m_isNull = decoder.decode<bool>();
-    if (!m_isNull)
-        return std::nullopt;
-
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     auto m_type = decoder.decode<MemberType>();
     if (!m_type)
@@ -367,8 +350,7 @@ std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::Empt
         return std::nullopt;
 #endif
 
-    Namespace::EmptyConstructorNullable result;
-    result.m_isNull = WTFMove(*m_isNull);
+    Namespace::EmptyConstructorWithIf result;
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     result.m_type = WTFMove(*m_type);
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -43,7 +43,7 @@ namespace Namespace::Subnamespace { struct StructName; }
 #endif
 namespace Namespace { class ReturnRefClass; }
 namespace Namespace { struct EmptyConstructorStruct; }
-namespace Namespace { class EmptyConstructorNullable; }
+namespace Namespace { class EmptyConstructorWithIf; }
 class WithoutNamespace;
 class WithoutNamespaceWithAttributes;
 namespace WebCore { class InheritsFrom; }
@@ -88,9 +88,9 @@ template<> struct ArgumentCoder<Namespace::EmptyConstructorStruct> {
     static std::optional<Namespace::EmptyConstructorStruct> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<Namespace::EmptyConstructorNullable> {
-    static void encode(Encoder&, const Namespace::EmptyConstructorNullable&);
-    static std::optional<Namespace::EmptyConstructorNullable> decode(Decoder&);
+template<> struct ArgumentCoder<Namespace::EmptyConstructorWithIf> {
+    static void encode(Encoder&, const Namespace::EmptyConstructorWithIf&);
+    static std::optional<Namespace::EmptyConstructorWithIf> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WithoutNamespace> {

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -39,8 +39,8 @@
 #if ENABLE(TEST_FEATURE)
 #include "StructHeader.h"
 #endif
-#include <Namespace/EmptyConstructorNullable.h>
 #include <Namespace/EmptyConstructorStruct.h>
+#include <Namespace/EmptyConstructorWithIf.h>
 #include <Namespace/ReturnRefClass.h>
 #include <WebCore/FloatBoxExtent.h>
 #include <WebCore/InheritanceGrandchild.h>
@@ -72,9 +72,6 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "Namespace::OtherClass"_s, {
             {
-                "bool"_s,
-                "isNull"_s
-            }, {
                 "int"_s,
                 "a"_s
             }, {
@@ -106,11 +103,8 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "m_double"_s
             }
         } },
-        { "Namespace::EmptyConstructorNullable"_s, {
+        { "Namespace::EmptyConstructorWithIf"_s, {
             {
-                "bool"_s,
-                "m_isNull"_s
-            }, {
                 "MemberType"_s,
                 "m_type"_s
             }, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -14,7 +14,6 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
 #endif
 
 [Nested] class Namespace::OtherClass {
-    [ReturnEarlyIfTrue] bool isNull
     int a
     [BitField] bool b
     [SecureCodingAllowed=[NSArray.class, PAL::getDDScannerResultClass()]] RetainPtr<NSArray> dataDetectorResults;
@@ -31,8 +30,7 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
     double m_double;
 }
 
-[LegacyPopulateFromEmptyConstructor] class Namespace::EmptyConstructorNullable {
-    [ReturnEarlyIfTrue] bool m_isNull;
+[LegacyPopulateFromEmptyConstructor] class Namespace::EmptyConstructorWithIf {
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     MemberType m_type;
     OtherMemberType m_value;


### PR DESCRIPTION
#### b8729a500b8298a70d9b3ea3d516bac7a5bc31e6
<pre>
Generated IPC serializers have tests for removed ReturnEarlyIfTrue feature
<a href="https://bugs.webkit.org/show_bug.cgi?id=258611">https://bugs.webkit.org/show_bug.cgi?id=258611</a>
rdar://problem/111436405

Reviewed by Alex Christensen.

Remove the tests.

* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::OtherClass&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorWithIf&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorWithIf&gt;::decode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::decode): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:

Canonical link: <a href="https://commits.webkit.org/265709@main">https://commits.webkit.org/265709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d611ad373c29d3605a7225282d9b1e3636c7300

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13681 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12339 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9568 "3 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13366 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/11399 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9634 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17426 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9984 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2808 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->