### PR TITLE
[WebXR] Attach compositor image as renderbuffer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -92,16 +92,10 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
         return;
     auto& gl = *m_context.graphicsContextGL();
 
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA)
-    ASSERT(data.surface);
-    auto bufferSize = data.surface->size();
-
-    auto gCGL = static_cast<GraphicsContextGLCocoa*>(m_context.graphicsContextGL());
-    auto [textureTarget, textureTargetBinding] = gl.externalImageTextureBindingPoint();
-#else
-    GCGLenum textureTarget = GL::TEXTURE_2D;
-    GCGLenum textureTargetBinding = GL::TEXTURE_BINDING_2D;
+#if USE(WEBXR_USE_EGL_IMAGE)
+    IntSize bufferSize; // = data.surface->size();
 #endif
+    auto [textureTarget, textureTargetBinding] = gl.externalImageTextureBindingPoint();
 
     m_framebuffer->setOpaqueActive(true);
 
@@ -123,6 +117,15 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     // the textures/renderbuffers.
 
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
+    // FIXME: This is temporary until Cocoa-specific platforms migrate to MTLTEXTURE_FOR_XR_LAYER_DATA.
+    auto colorTextureHandle = data.surface->createSendRight();
+    bool colorTextureIsShared = false;
+#elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
+    // Tell the GraphicsContextGL to use the IOSurface as the backing store for m_opaqueTexture.
+    auto [colorTextureHandle, colorTextureIsShared] = data.colorTexture;
+#endif
+
+#if USE(WEBXR_USE_EGL_IMAGE)
     m_opaqueTexture.ensure(gl);
     gl.bindTexture(textureTarget, m_opaqueTexture);
     gl.texParameteri(textureTarget, GL::TEXTURE_MAG_FILTER, GL::LINEAR);
@@ -130,28 +133,15 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     gl.texParameteri(textureTarget, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
     gl.texParameteri(textureTarget, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
 
-    // Tell the GraphicsContextGL to use the IOSurface as the backing store for m_opaqueTexture.
-    if (data.isShared) {
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-        auto surfaceTextureAttachment = gCGL->createAndBindEGLImage(textureTarget, data.surface.get());
-        if (!surfaceTextureAttachment) {
-            m_opaqueTexture.release(gl);
-            return;
-        }
+    auto colorTextureSource = (colorTextureIsShared) ? GL::EGLImageSource(GL::EGLImageSourceMTLSharedTextureHandle { colorTextureHandle }) : GL::EGLImageSource(GL::EGLImageSourceIOSurfaceHandle { colorTextureHandle });
 
-        auto [textureHandle, textureSize] = surfaceTextureAttachment.value();
-        m_ioSurfaceTextureHandle = textureHandle;
-        bufferSize = textureSize;
-
-        m_ioSurfaceTextureHandleIsShared = true;
-#else
-        ASSERT_NOT_REACHED();
-#endif
-    } else {
-        m_ioSurfaceTextureHandle = gCGL->createPbufferAndAttachIOSurface(textureTarget, GraphicsContextGLCocoa::PbufferAttachmentUsage::Write, GL::BGRA, bufferSize.width(), bufferSize.height(), GL::UNSIGNED_BYTE, data.surface->surface(), 0);
-        m_ioSurfaceTextureHandleIsShared = false;
+    auto colorTextureAttachment = gl.createAndBindEGLImage(textureTarget, colorTextureSource);
+    if (!colorTextureAttachment) {
+        m_opaqueTexture.release(gl);
+        return;
     }
 
+    std::tie(m_opaqueImage, bufferSize) = colorTextureAttachment.value();
     if (bufferSize.isEmpty())
         return;
 
@@ -161,11 +151,6 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
         m_framebufferSize = bufferSize;
         if (!setupFramebuffer())
             return;
-    }
-
-    if (!m_ioSurfaceTextureHandle) {
-        m_opaqueTexture.release(gl);
-        return;
     }
 
     // Set up the framebuffer to use the texture that points to the IOSurface. If we're not multisampling,
@@ -241,20 +226,10 @@ void WebXROpaqueFramebuffer::endFrame()
 #endif
 
 
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA)
-    if (m_ioSurfaceTextureHandle) {
-        if (m_ioSurfaceTextureHandleIsShared) {
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-            gl.destroyEGLImage(m_ioSurfaceTextureHandle);
-#else
-            ASSERT_NOT_REACHED();
-#endif
-        } else {
-            auto gCGL = static_cast<GraphicsContextGLCocoa*>(&gl);
-            gCGL->destroyPbufferAndDetachIOSurface(m_ioSurfaceTextureHandle);
-        }
-        m_ioSurfaceTextureHandle = nullptr;
-        m_ioSurfaceTextureHandleIsShared = false;
+#if USE(WEBXR_USE_EGL_IMAGE)
+    if (m_opaqueImage) {
+        gl.destroyEGLImage(m_opaqueImage);
+        m_opaqueImage = nullptr;
     }
 #endif
 }
@@ -325,12 +300,7 @@ PlatformGLObject WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsCon
 
 PlatformGLObject WebXROpaqueFramebuffer::allocateColorStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
 {
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA) && !PLATFORM(IOS_FAMILY_SIMULATOR)
     constexpr auto colorFormat = GL::SRGB8_ALPHA8;
-#else
-    constexpr auto colorFormat = GL::RGBA8;
-#endif
-
     return allocateRenderbufferStorage(gl, samples, colorFormat, size);
 }
 

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -35,6 +35,10 @@
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 
+#if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
+#define USE_WEBXR_USE_EGL_IMAGE 1
+#endif
+
 namespace WebCore {
 
 class IntSize;
@@ -81,10 +85,10 @@ private:
     GCGLOwnedRenderbuffer m_stencilBuffer;
     GCGLOwnedRenderbuffer m_multisampleColorBuffer;
     GCGLOwnedFramebuffer m_resolvedFBO;
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA)
+
+#if USE(WEBXR_USE_EGL_IMAGE)
     GCGLOwnedTexture m_opaqueTexture;
-    void* m_ioSurfaceTextureHandle { nullptr };
-    bool m_ioSurfaceTextureHandleIsShared { false };
+    GCEGLImage m_opaqueImage;
 #else
     PlatformGLObject m_opaqueTexture;
 #endif

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -87,8 +87,8 @@ private:
     GCGLOwnedFramebuffer m_resolvedFBO;
 
 #if USE(WEBXR_USE_EGL_IMAGE)
-    GCGLOwnedTexture m_opaqueTexture;
-    GCEGLImage m_opaqueImage;
+    GCGLOwnedRenderbuffer m_colorBuffer;
+    GCEGLImage m_colorImage { };
 #else
     PlatformGLObject m_opaqueTexture;
 #endif

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -69,10 +69,6 @@ public:
     void destroyPbufferAndDetachIOSurface(void* handle);
 
     std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, EGLImageSource) final;
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-    // Short-term support for in-process WebGL.
-    std::optional<EGLImageAttachResult> createAndBindEGLImage(GCGLenum, IOSurface*);
-#endif
 
     RetainPtr<id> newSharedEventWithMachPort(mach_port_t);
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) final;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -738,7 +738,10 @@ std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::c
         return std::nullopt;
 
     // Tell the currently bound texture to use the EGLImage.
-    GL_EGLImageTargetTexture2DOES(target, eglImage);
+    if (target == RENDERBUFFER)
+        GL_EGLImageTargetRenderbufferStorageOES(target, eglImage);
+    else
+        GL_EGLImageTargetTexture2DOES(target, eglImage);
 
     GCGLuint textureWidth = [texture.get() width];
     GCGLuint textureHeight = [texture.get() height];

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -406,7 +406,7 @@ bool GraphicsContextGLCocoa::platformInitialize()
         requiredExtensions.append("GL_EXT_texture_format_BGRA8888"_s);
     }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
-#if ENABLE(WEBXR) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if ENABLE(WEBXR)
     if (attributes.xrCompatible) {
         requiredExtensions.append("GL_OES_EGL_image"_s);
         requiredExtensions.append("GL_EXT_sRGB"_s);
@@ -683,85 +683,67 @@ void GraphicsContextGLCocoa::destroyPbufferAndDetachIOSurface(void* handle)
     WebCore::destroyPbufferAndDetachIOSurface(m_displayObj, handle);
 }
 
-#if !PLATFORM(IOS_FAMILY_SIMULATOR)
-static std::optional<GraphicsContextGL::EGLImageAttachResult> createAndBindSharedTextureToExternalImage(GCGLDisplay platformDisplay, GCGLenum target, MTLSharedTextureHandle* handle)
+std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, EGLImageSource source)
 {
     EGLDeviceEXT eglDevice = EGL_NO_DEVICE_EXT;
-    if (!EGL_QueryDisplayAttribEXT(platformDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
+    if (!EGL_QueryDisplayAttribEXT(platformDisplay(), EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice)))
         return std::nullopt;
 
     id<MTLDevice> mtlDevice = nil;
     if (!EGL_QueryDeviceAttribEXT(eglDevice, EGL_METAL_DEVICE_ANGLE, reinterpret_cast<EGLAttrib*>(&mtlDevice)))
         return std::nullopt;
 
-    if (mtlDevice != [handle device]) {
-        LOG(WebGL, "MTLSharedTextureHandle does not have the same Metal device as platformDisplay in attachMTLTextureToExternalImage.");
-        return std::nullopt;
-    }
+    RetainPtr<id<MTLTexture>> texture = WTF::switchOn(WTFMove(source),
+    [&](EGLImageSourceIOSurfaceHandle&& ioSurface) -> RetainPtr<id> {
+        auto surface = IOSurface::createFromSendRight(WTFMove(ioSurface.handle));
+        if (!surface)
+            return { };
 
-    // Create a MTLTexture out of the MTLSharedTextureHandle.
-    auto texture = adoptNS([mtlDevice newSharedTextureWithHandle:handle]);
+        auto size = surface->size();
+        MTLTextureDescriptor *desc = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm_sRGB width:size.width() height:size.height() mipmapped:NO];
+        [desc setUsage:MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget];
+
+        auto tex = adoptNS([mtlDevice newTextureWithDescriptor:desc iosurface:surface->surface() plane:0]);
+        return tex;
+    },
+    [&](EGLImageSourceMTLSharedTextureHandle&& sharedTexture) -> RetainPtr<id> {
+#if PLATFORM(IOS_FAMILY_SIMULATOR)
+        UNUSED_VARIABLE(sharedTexture);
+        ASSERT_NOT_REACHED();
+        return { };
+#else
+        auto handle = adoptNS([[MTLSharedTextureHandle alloc] initWithMachPort:sharedTexture.handle.sendRight()]);
+        if (!handle)
+            return { };
+
+        if (mtlDevice != [handle device]) {
+            LOG(WebGL, "MTLSharedTextureHandle does not have the same Metal device as platformDisplay.");
+            return { };
+        }
+
+        // Create a MTLTexture out of the MTLSharedTextureHandle.
+        RetainPtr<id> texture = adoptNS([mtlDevice newSharedTextureWithHandle:handle.get()]);
+        return texture;
+        // FIXME: Does the texture have the correct usage mode?
+#endif
+    });
+
     if (!texture)
         return std::nullopt;
 
-    GCGLuint textureWidth = [texture width];
-    GCGLuint textureHeight = [texture height];
-
-    // FIXME: Does the texture have the correct usage mode?
-
     // Create an EGLImage out of the MTLTexture
     constexpr EGLint emptyAttributes[] = { EGL_NONE };
-    auto eglImage = EGL_CreateImageKHR(platformDisplay, EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), emptyAttributes);
+    auto eglImage = EGL_CreateImageKHR(platformDisplay(), EGL_NO_CONTEXT, EGL_METAL_TEXTURE_ANGLE, reinterpret_cast<EGLClientBuffer>(texture.get()), emptyAttributes);
     if (!eglImage)
         return std::nullopt;
 
     // Tell the currently bound texture to use the EGLImage.
     GL_EGLImageTargetTexture2DOES(target, eglImage);
 
+    GCGLuint textureWidth = [texture.get() width];
+    GCGLuint textureHeight = [texture.get() height];
+
     return std::make_tuple(eglImage, IntSize(textureWidth, textureHeight));
-}
-
-std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, IOSurface* surface)
-{
-    auto handle = adoptNS([[MTLSharedTextureHandle alloc] initWithIOSurface:surface->surface() label:@"WebXR"]);
-    if (!handle)
-        return std::nullopt;
-
-    return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-}
-#endif
-
-std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::createAndBindEGLImage(GCGLenum target, EGLImageSource source)
-{
-#if PLATFORM(IOS_FAMILY_SIMULATOR)
-    // MTLSharedTexture is unsupported on simulator
-    UNUSED_VARIABLE(target);
-    UNUSED_VARIABLE(source);
-
-    return std::nullopt;
-#else // !PLATFORM(IOS_FAMILY_SIMULATOR
-
-    RetainPtr<MTLSharedTextureHandle> handle;
-    return WTF::switchOn(WTFMove(source),
-        [&](EGLImageSourceIOSurfaceHandle&& ioSurface) -> std::optional<EGLImageAttachResult> {
-            auto surface = IOSurface::createFromSendRight(WTFMove(ioSurface.handle));
-            if (!surface)
-                return std::nullopt;
-
-            handle = adoptNS([[MTLSharedTextureHandle alloc] initWithIOSurface:surface->surface() label:@"WebXR"]);
-            if (!handle)
-                return std::nullopt;
-
-            return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-        },
-        [&](EGLImageSourceMTLSharedTextureHandle&& sharedTexture) -> std::optional<EGLImageAttachResult> {
-            handle = adoptNS([[MTLSharedTextureHandle alloc] initWithMachPort:sharedTexture.handle.sendRight()]);
-            if (!handle)
-                return std::nullopt;
-
-            return createAndBindSharedTextureToExternalImage(platformDisplay(), target, handle.get());
-        });
-#endif
 }
 
 RetainPtr<id> GraphicsContextGLCocoa::newSharedEventWithMachPort(mach_port_t sharedEventSendRight)

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -158,6 +158,9 @@ void SimulatedXRDevice::frameTimerFired()
     for (auto& layer : m_layers) {
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
         data.layers.add(layer.key, FrameData::LayerData { .surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB()) });
+#elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
+        auto surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB());
+        data.layers.add(layer.key, FrameData::LayerData { .colorTexture = std::make_tuple(surface->createSendRight(), false) });
 #else
         data.layers.add(layer.key, FrameData::LayerData { .opaqueTexture = layer.value });
 #endif


### PR DESCRIPTION
#### 957b37f0bf1efbf1a57aa6b20f78deed698e702e
<pre>
[WebXR] Attach compositor image as renderbuffer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=258612">https://bugs.webkit.org/show_bug.cgi?id=258612</a>
rdar://111437061

Reviewed by NOBODY (OOPS!).

A small refactoring to attach compositor images via GL_RENDERBUFFER instead of
GL_TEXTURE_2D/GL_TEXTURE_RECTANGLE_ARB.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createAndBindEGLImage):
</pre>
----------------------------------------------------------------------
#### a943057678b3ac4b3111db4df2947589ed332944
<pre>
[WebXR] Use MTLTexture to attach color IOSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=258598">https://bugs.webkit.org/show_bug.cgi?id=258598</a>
rdar://problem/111426880

Reviewed by NOBODY (OOPS!).

There are two paths in WebXROpaqueFramebuffer for attaching compositor provided
IOSurface for rendering: 1) Via MTLSharedTexture, and 2) Via pbuffer.

Since it&apos;s possible to create a MTLTexture from an IOSurface and plane index,
switch away from using pbuffer to reduce the number of code paths.

This patch introduces USE(MTLTEXTURE_FOR_XR_LAYER_DATA) to aid the transition of
platform specific WebXR systems. Once those systems are updated,
USE(IOSURFACE_FOR_XR_LAYER_DATA) will be removed.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::platformInitialize):
(WebCore::GraphicsContextGLCocoa::createAndBindEGLImage):
(WebCore::createAndBindSharedTextureToExternalImage): Deleted.
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::FrameData::LayerData::encode const):
(PlatformXR::Device::FrameData::LayerData::decode):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/957b37f0bf1efbf1a57aa6b20f78deed698e702e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12951 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13683 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11462 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12340 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13367 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13604 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8895 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9985 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->