### PR TITLE
Resync WPT webcodecs tests up to 4c14ced

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Test the Opus DTX flag works. promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: AudioEncoder"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js
@@ -1,0 +1,98 @@
+// META: global=window
+// META: script=/webcodecs/utils.js
+
+function make_silent_audio_data(timestamp, channels, sampleRate, frames) {
+  let data = new Float32Array(frames*channels);
+
+  return new AudioData({
+    timestamp: timestamp,
+    data: data,
+    numberOfChannels: channels,
+    numberOfFrames: frames,
+    sampleRate: sampleRate,
+    format: "f32-planar",
+  });
+}
+
+// The Opus DTX flag (discontinuous transmission) reduces the encoding bitrate
+// for silence. This test ensures the DTX flag is working properly by encoding
+// almost 10s of silence and comparing the bitrate with and without the flag.
+promise_test(async t => {
+  let sample_rate = 48000;
+  let total_duration_s = 10;
+  let data_count = 100;
+  let normal_outputs = [];
+  let dtx_outputs = [];
+
+  let normal_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      normal_outputs.push(chunk);
+    }
+  });
+
+  let dtx_encoder = new AudioEncoder({
+    error: e => {
+      assert_unreached('error: ' + e);
+    },
+    output: chunk => {
+      dtx_outputs.push(chunk);
+    }
+  });
+
+  let config = {
+    codec: 'opus',
+    sampleRate: sample_rate,
+    numberOfChannels: 2,
+    bitrate: 256000,  // 256kbit
+  };
+
+  let normal_config = {...config, opus: {usedtx: false}};
+  let dtx_config = {...config, opus: {usedtx: true}};
+
+  let normal_config_support = await AudioEncoder.isConfigSupported(normal_config);
+  assert_implements_optional(normal_config_support.supported, "Opus not supported");
+
+  let dtx_config_support = await AudioEncoder.isConfigSupported(dtx_config);
+  assert_implements_optional(dtx_config_support.supported, "Opus DTX not supported");
+
+  // Configure one encoder with and one without the DTX flag
+  normal_encoder.configure(normal_config);
+  dtx_encoder.configure(dtx_config);
+
+  let timestamp_us = 0;
+  let data_duration_s = total_duration_s / data_count;
+  let data_length = data_duration_s * config.sampleRate;
+  for (let i = 0; i < data_count; i++) {
+    let data;
+
+    if (i == 0 || i == (data_count - 1)) {
+      // Send real data for the first and last 100ms.
+      data = make_audio_data(
+          timestamp_us, config.numberOfChannels, config.sampleRate,
+          data_length);
+
+    } else {
+      // Send silence for the rest of the 10s.
+      data = make_silent_audio_data(
+          timestamp_us, config.numberOfChannels, config.sampleRate,
+          data_length);
+    }
+
+    normal_encoder.encode(data);
+    dtx_encoder.encode(data);
+    data.close();
+
+    timestamp_us += data_duration_s * 1_000_000;
+  }
+
+  await Promise.all([normal_encoder.flush(), dtx_encoder.flush()])
+
+  normal_encoder.close();
+  dtx_encoder.close();
+
+  // We expect a significant reduction in the number of packets, over ~10s of silence.
+  assert_less_than(dtx_outputs.length, (normal_outputs.length / 2));
+}, 'Test the Opus DTX flag works.');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -1,9 +1,13 @@
 
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large assert_unreached: Should have rejected: undefined Reached unreachable code
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters assert_false: expected false got true
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js
@@ -19,6 +19,54 @@ const invalidConfigs = [
     },
   },
   {
+    comment: 'Width is 0',
+    config: {
+      codec: 'vp8',
+      width: 0,
+      height: 480,
+    },
+  },
+  {
+    comment: 'Height is 0',
+    config: {
+      codec: 'vp8',
+      width: 640,
+      height: 0,
+    },
+  },
+  {
+    comment: 'displayWidth is 0',
+    config: {
+      codec: 'vp8',
+      displayWidth: 0,
+      width: 640,
+      height: 480,
+    },
+  },
+  {
+    comment: 'displayHeight is 0',
+    config: {
+      codec: 'vp8',
+      width: 640,
+      displayHeight: 0,
+      height: 480,
+    },
+  }
+];
+
+invalidConfigs.forEach(entry => {
+  promise_test(t => {
+    return promise_rejects_js(t, TypeError, VideoEncoder.isConfigSupported(entry.config));
+  }, 'Test that VideoEncoder.isConfigSupported() rejects invalid config:' + entry.comment);
+});
+
+
+const validButUnsupportedConfigs = [
+  {
+    comment: 'Invalid scalability mode',
+    config: {codec: 'vp8', width: 640, height: 480, scalabilityMode: 'ABC'}
+  },
+  {
     comment: 'Width is too large',
     config: {
       codec: 'vp8',
@@ -34,20 +82,6 @@ const invalidConfigs = [
       height: 1000000,
     },
   },
-  {
-    comment: 'Invalid scalability mode',
-    config: {codec: 'vp8', width: 640, height: 480, scalabilityMode: 'ABC'}
-  }
-];
-
-invalidConfigs.forEach(entry => {
-  promise_test(t => {
-    return promise_rejects_js(t, TypeError, VideoEncoder.isConfigSupported(entry.config));
-  }, 'Test that VideoEncoder.isConfigSupported() rejects invalid config:' + entry.comment);
-});
-
-
-const validButUnsupportedConfigs = [
   {
     comment: 'Too strenuous accelerated encoding parameters',
     config: {

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -1,9 +1,13 @@
 
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is too large assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is too large assert_unreached: Should have rejected: undefined Reached unreachable code
-PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Invalid scalability mode
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters assert_false: expected false got true
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt
@@ -7,8 +7,6 @@ PASS Test successful reset() and re-confiugre()
 PASS Test successful encode() after re-configure().
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
-FAIL Verify encoding closed frames throws. assert_throws_dom: function "() => {
-    encoder.encode(frame);
-  }" threw object "TypeError: VideoFrame is detached" that is not a DOMException OperationError: property "code" is equal to undefined, expected 0
+PASS Verify encoding closed frames throws.
 PASS Encode video with negative timestamp
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js
@@ -295,7 +295,7 @@ promise_test(async t => {
 
   encoder.configure(defaultConfig);
 
-  assert_throws_dom("OperationError", () => {
+  assert_throws_js(TypeError, () => {
     encoder.encode(frame);
   });
 }, 'Verify encoding closed frames throws.');

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt
@@ -7,8 +7,6 @@ PASS Test successful reset() and re-confiugre()
 PASS Test successful encode() after re-configure().
 PASS Verify closed VideoEncoder operations
 PASS Verify unconfigured VideoEncoder operations
-FAIL Verify encoding closed frames throws. assert_throws_dom: function "() => {
-    encoder.encode(frame);
-  }" threw object "TypeError: VideoFrame is detached" that is not a DOMException OperationError: property "code" is equal to undefined, expected 0
+PASS Verify encoding closed frames throws.
 PASS Encode video with negative timestamp
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js
@@ -133,6 +133,22 @@ function view(buffer, {offset, size}) {
   return new Uint8Array(buffer, offset, size);
 }
 
+async function checkImplements() {
+  // Don't run any tests if the codec is not supported.
+  assert_equals("function", typeof VideoDecoder.isConfigSupported);
+  let supported = false;
+  try {
+    // TODO(sandersd): To properly support H.264 in AVC format, this should
+    // include the `description`. For now this test assumes that H.264 Annex B
+    // support is the same as H.264 AVC support.
+    const support =
+        await VideoDecoder.isConfigSupported({codec: CONFIG.codec});
+    supported = support.supported;
+  } catch (e) {
+  }
+  assert_implements_optional(supported, CONFIG.codec + ' unsupported');
+}
+
 let CONFIG = null;
 let CHUNK_DATA = null;
 let CHUNKS = null;
@@ -144,20 +160,6 @@ promise_setup(async () => {
     '?h264_avc': H264_AVC_DATA,
     '?h264_annexb': H264_ANNEXB_DATA
   }[location.search];
-
-  // Don't run any tests if the codec is not supported.
-  assert_equals("function", typeof VideoDecoder.isConfigSupported);
-  let supported = false;
-  try {
-    // TODO(sandersd): To properly support H.264 in AVC format, this should
-    // include the `description`. For now this test assumes that H.264 Annex B
-    // support is the same as H.264 AVC support.
-    const support =
-        await VideoDecoder.isConfigSupported({codec: data.config.codec});
-    supported = support.supported;
-  } catch (e) {
-  }
-  assert_implements_optional(supported, data.config.codec + ' unsupported');
 
   // Fetch the media data and prepare buffers.
   const response = await fetch(data.src);
@@ -176,11 +178,13 @@ promise_setup(async () => {
 });
 
 promise_test(async t => {
+  await checkImplements();
   const support = await VideoDecoder.isConfigSupported(CONFIG);
   assert_true(support.supported, 'supported');
 }, 'Test isConfigSupported()');
 
 promise_test(async t => {
+  await checkImplements();
   // TODO(sandersd): Create a 1080p `description` for H.264 in AVC format.
   // This version is testing only the H.264 Annex B path.
   const config = {
@@ -196,6 +200,7 @@ promise_test(async t => {
 }, 'Test isConfigSupported() with 1080p crop');
 
 promise_test(async t => {
+  await checkImplements();
   // Define a valid config that includes a hypothetical `futureConfigFeature`,
   // which is not yet recognized by the User Agent.
   const config = {
@@ -233,6 +238,7 @@ promise_test(async t => {
 }, 'Test that isConfigSupported() returns a parsed configuration');
 
 promise_test(async t => {
+  await checkImplements();
   async function test(t, config, description) {
     await promise_rejects_js(
         t, TypeError, VideoDecoder.isConfigSupported(config), description);
@@ -247,12 +253,14 @@ promise_test(async t => {
 }, 'Test invalid configs');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   decoder.configure(CONFIG);
   assert_equals(decoder.state, 'configured', 'state');
 }, 'Test configure()');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -271,6 +279,7 @@ promise_test(async t => {
 }, 'Decode a key frame');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -281,6 +290,7 @@ promise_test(async t => {
 }, 'Decode a non key frame first fails');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
   decoder.configure(CONFIG);
@@ -323,6 +333,7 @@ promise_test(async t => {
 }, 'Verify reset() suppresses outputs');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   assert_equals(decoder.state, 'unconfigured');
 
@@ -334,6 +345,7 @@ promise_test(async t => {
 }, 'Test unconfigured VideoDecoder operations');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
   decoder.close();
   assert_equals(decoder.state, 'closed');
@@ -347,6 +359,7 @@ promise_test(async t => {
 }, 'Test closed VideoDecoder operations');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
 
   let errors = 0;
@@ -367,6 +380,7 @@ promise_test(async t => {
 
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
 
   let errors = 0;
@@ -391,6 +405,7 @@ promise_test(async t => {
 }, 'Decode corrupt frame');
 
 promise_test(async t => {
+  await checkImplements();
   const decoder = createVideoDecoder(t);
 
   decoder.configure(CONFIG);
@@ -406,6 +421,7 @@ promise_test(async t => {
 }, 'Close while decoding corrupt frame');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -427,6 +443,7 @@ promise_test(async t => {
 }, 'Test decoding after flush');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -446,6 +463,7 @@ promise_test(async t => {
 }, 'Test decoding a with negative timestamp');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -473,6 +491,7 @@ promise_test(async t => {
 }, 'Test reset during flush');
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   const decoder = createVideoDecoder(t, callbacks);
 
@@ -490,6 +509,7 @@ promise_test(async t => {
 
 
 promise_test(async t => {
+  await checkImplements();
   const callbacks = {};
   callbacks.output = frame => { frame.close(); };
   const decoder = createVideoDecoder(t, callbacks);

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.js
@@ -100,13 +100,17 @@ promise_test(async t => {
     return;
 
   let video = document.createElement('video');
-  video.src = 'av1.mp4';
+  video.src = 'vp9.mp4';
   video.autoplay = true;
   video.controls = false;
   video.muted = false;
   document.body.appendChild(video);
 
   const loadVideo = new Promise((resolve) => {
+    if (video.requestVideoFrameCallback) {
+      video.requestVideoFrameCallback(resolve);
+      return;
+    }
     video.onloadeddata = () => resolve();
   });
   await loadVideo;

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
@@ -208,11 +208,11 @@ function createVideoFrame(ts) {
   });
 }
 
-function canSerializeVideoFrame(target, vf, transfer) {
+function canSerializeVideoFrame(target, vf) {
   return canPostVideoFrame(target, vf, false);
 };
 
-function canTransferVideoFrame(target, vf, transfer) {
+function canTransferVideoFrame(target, vf) {
   return canPostVideoFrame(target, vf, true);
 };
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.crossOriginIsolated.https.any.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-decoder.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.js

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1125,6 +1125,9 @@ imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?v
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
+# Needs rebasing
+imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker.html [ Pass Failure ]
 
 # Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt
@@ -1,4 +1,6 @@
 
+Harness Error (TIMEOUT), message = null
+
 PASS Test we can construct a VideoFrame.
 FAIL Test closed VideoFrame. null is not an object (evaluating 'frame.colorSpace.primaries')
 PASS Test we can construct a VideoFrame with a negative timestamp.
@@ -7,7 +9,7 @@ PASS Test that timestamp is required when constructing VideoFrame from Offscreen
 PASS Test that timestamp is NOT required when constructing VideoFrame from another VideoFrame
 PASS Test we can construct an odd-sized VideoFrame.
 PASS Test constructing w/ unusable image argument throws: HAVE_NOTHING <video>.
-PASS Test we can construct a VideoFrame from a <video>.
+TIMEOUT Test we can construct a VideoFrame from a <video>. Test timed out
 PASS Test constructing w/ unusable image argument throws: emtpy Canvas.
 PASS Test constructing w/ unusable image argument throws: closed ImageBitmap.
 PASS Test constructing w/ unusable image argument throws: closed VideoFrame.


### PR DESCRIPTION
#### aec46acb2936291b4bfda85b4134cc09dc350a83
<pre>
Resync WPT webcodecs tests up to 4c14ced
<a href="https://bugs.webkit.org/show_bug.cgi?id=258614">https://bugs.webkit.org/show_bug.cgi?id=258614</a>
rdar://111440403

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-codec-specific.https.any.js: Added.
(make_silent_audio_data):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/w3c-import.log:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.any-expected.txt.

Canonical link: <a href="https://commits.webkit.org/265616@main">https://commits.webkit.org/265616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acb99eb9563858e16da873bab22845628c26a673

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10790 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13698 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17445 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13624 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8910 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2736 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14278 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->