### PR TITLE
[GTK] API test WebKit.OnDeviceChangeCrash is flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -241,9 +241,6 @@
             "WebKit.FocusedFrameAfterCrash": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}
             },
-            "WebKit.OnDeviceChangeCrash": {
-                "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/214805"}}
-            },
             "WebKit.PrivateBrowsingPushStateNoHistoryCallback": {
                 "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
             },

--- a/Tools/TestWebKitAPI/gtk/PlatformWebViewGtk.cpp
+++ b/Tools/TestWebKitAPI/gtk/PlatformWebViewGtk.cpp
@@ -57,6 +57,10 @@ PlatformWebView::PlatformWebView(WKPageRef relatedPage)
     WKPageConfigurationSetPageGroup(configuration.get(), WKPageGetPageGroup(relatedPage));
     WKPageConfigurationSetRelatedPage(configuration.get(), relatedPage);
 
+    auto relatedConfiguration = adoptWK(WKPageCopyPageConfiguration(relatedPage));
+    if (auto* preferences = WKPageConfigurationGetPreferences(relatedConfiguration.get()))
+        WKPageConfigurationSetPreferences(configuration.get(), preferences);
+
     initialize(configuration.get());
 }
 

--- a/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
+++ b/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
@@ -56,6 +56,10 @@ PlatformWebView::PlatformWebView(WKPageRef relatedPage)
     WKPageConfigurationSetPageGroup(configuration.get(), WKPageGetPageGroup(relatedPage));
     WKPageConfigurationSetRelatedPage(configuration.get(), relatedPage);
 
+    auto relatedConfiguration = adoptWK(WKPageCopyPageConfiguration(relatedPage));
+    if (auto* preferences = WKPageConfigurationGetPreferences(relatedConfiguration.get()))
+        WKPageConfigurationSetPreferences(configuration.get(), preferences);
+
     initialize(configuration.get());
 }
 


### PR DESCRIPTION
#### e289c4e0a33a89bbf768362c7ff336fe132a66df
<pre>
[GTK] API test WebKit.OnDeviceChangeCrash is flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=214805">https://bugs.webkit.org/show_bug.cgi?id=214805</a>

Reviewed by Philippe Normand.

When creating a `PlatformWebView` with a related &quot;WKPage&quot;, we need to
copy into the webview configuration not only the context and the page
group, but also the page preferenes.

* Tools/TestWebKitAPI/glib/TestExpectations.json:
* Tools/TestWebKitAPI/gtk/PlatformWebViewGtk.cpp:
(TestWebKitAPI::PlatformWebView::PlatformWebView):
* Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp:
(TestWebKitAPI::PlatformWebView::PlatformWebView):

Canonical link: <a href="https://commits.webkit.org/265577@main">https://commits.webkit.org/265577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02b28d8a28ff0546e74b7583147accfe358bfb04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12960 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13377 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10713 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13618 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9994 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2704 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->