### PR TITLE
[CSS Container Queries] Container units in container query should evaluate against ancestor container

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-dynamic-expected.txt
@@ -1,4 +1,4 @@
 Test
 
-FAIL Query with container-relative units are responsive to changes assert_equals: expected "true" but got ""
+PASS Query with container-relative units are responsive to changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt
@@ -1,22 +1,22 @@
 Test1
 Test1
 
-FAIL cqw unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqh unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqi unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqb unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqmin unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqmax unit resolves against appropriate container assert_equals: expected "true" but got ""
-FAIL cqw unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqh unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqi unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqb unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqmin unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqmax unit resolves against appropriate container (vertical writing-mode on subject) assert_equals: expected "true" but got ""
-FAIL cqw unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
-FAIL cqh unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+PASS cqw unit resolves against appropriate container
+PASS cqh unit resolves against appropriate container
+PASS cqi unit resolves against appropriate container
+PASS cqb unit resolves against appropriate container
+PASS cqmin unit resolves against appropriate container
+PASS cqmax unit resolves against appropriate container
+PASS cqw unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqh unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqi unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqb unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqmin unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqmax unit resolves against appropriate container (vertical writing-mode on subject)
+PASS cqw unit resolves against appropriate container (vertical writing-mode on container)
+PASS cqh unit resolves against appropriate container (vertical writing-mode on container)
 FAIL cqi unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
 FAIL cqb unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
-FAIL cqmin unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
-FAIL cqmax unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+PASS cqmin unit resolves against appropriate container (vertical writing-mode on container)
+PASS cqmax unit resolves against appropriate container (vertical writing-mode on container)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-fallback-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Use small viewport size as fallback assert_equals: expected "rgb(0, 0, 255)" but got "rgb(0, 128, 0)"
+FAIL Use small viewport size as fallback assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 255)"
 

--- a/Source/WebCore/style/ContainerQueryEvaluator.cpp
+++ b/Source/WebCore/style/ContainerQueryEvaluator.cpp
@@ -78,7 +78,7 @@ auto ContainerQueryEvaluator::featureEvaluationContextForQuery(const CQ::Contain
 
     return MQ::FeatureEvaluationContext {
         m_element->document(),
-        CSSToLengthConversionData { renderer.style(), m_element->document().documentElement()->renderStyle(), nullptr, &renderer.view() },
+        CSSToLengthConversionData { renderer.style(), m_element->document().documentElement()->renderStyle(), nullptr, &renderer.view(), container },
         &renderer
     };
 }


### PR DESCRIPTION
#### fe4a838ddc27d979c45b3db9e7418285a3c9bdde
<pre>
[CSS Container Queries] Container units in container query should evaluate against ancestor container
<a href="https://bugs.webkit.org/show_bug.cgi?id=258617">https://bugs.webkit.org/show_bug.cgi?id=258617</a>
rdar://111446508

Reviewed by Tim Nguyen.

Currently they are always resolved against the small viewport size.

<a href="https://drafts.csswg.org/css-contain-3/#container-lengths">https://drafts.csswg.org/css-contain-3/#container-lengths</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-fallback-expected.txt:
* Source/WebCore/style/ContainerQueryEvaluator.cpp:
(WebCore::Style::ContainerQueryEvaluator::featureEvaluationContextForQuery const):

Pass the container itself to CSSToLengthConversionData as the element for container unit resolution.

Canonical link: <a href="https://commits.webkit.org/265583@main">https://commits.webkit.org/265583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513bb0ace67fbe101583c321ee471d5e2ac5c002

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13381 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17443 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10716 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13622 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10828 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9998 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2711 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->