### PR TITLE
IPC::Connection::waitForAndDispatchImmediately() does not return Timeout on timeout

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -110,7 +110,7 @@ enum class Error : uint8_t {
     AttemptingToWaitOnClosedConnection,
     WaitingOnAlreadyDispatchedMessage,
     AttemptingToWaitInsideSyncMessageHandling,
-    SyncMessageInterrupedWait,
+    SyncMessageInterruptedWait,
     CantWaitForSyncReplies,
     FailedToEncodeMessageArguments,
     FailedToDecodeReplyArguments,


### PR DESCRIPTION
#### 08402919e3870f3788f6d936db3af4340b7f1c79
<pre>
IPC::Connection::waitForAndDispatchImmediately() does not return Timeout on timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=258621">https://bugs.webkit.org/show_bug.cgi?id=258621</a>
rdar://111448503

Reviewed by Simon Fraser.

Return IPC::Error::Timeout on
IPC::Connection::waitForAndDispatchImmediately() timeout.

Fix typo in IPC::Error::SyncMessageInterruptedWait. It was
...Interruped...

Fix incorrect error in hunk
        // Don&apos;t even start waiting if we have InterruptWaitingIfSyncMessageArrives and there&apos;s a sync message already in the queue.
        ....
            // We don&apos;t support having multiple clients waiting for messages.
            ASSERT(!m_waitingForMessage);
The assertion was a red herring and the intention of the error return
was to return early due to sync message being in the queue, not due to
multiple waiters. Multiple waiters are checked before.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForMessage):
(IPC::errorAsString):
* Source/WebKit/Platform/IPC/Connection.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/265590@main">https://commits.webkit.org/265590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/378146194c8aa5ad81fa5172d42df1cf98ba6ed9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13701 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9653 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10722 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13627 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10004 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2717 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->