### PR TITLE
Selection should not set the cursor type to text over the explicitly set cursor type

### DIFF
--- a/LayoutTests/editing/caret/caret-type-for-user-select-none-expected.txt
+++ b/LayoutTests/editing/caret/caret-type-for-user-select-none-expected.txt
@@ -1,0 +1,11 @@
+Tests whether explicitly set caret style is retained on performing text selection
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Try selecting this text by dragging the cursor. Progress cursor should be displayed while doing so.
+PASS currentCursorType is "Progress"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/caret/caret-type-for-user-select-none.html
+++ b/LayoutTests/editing/caret/caret-type-for-user-select-none.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p id="description"></p>
+<div style="cursor:progress; border: 2px solid red;" id="test">Try selecting this text by dragging the cursor. Progress cursor should be displayed while doing so.</div>
+<div id="console"></div>
+<script src="../../resources/js-test.js"></script>
+<script>
+if (window.eventSender && window.internals) {
+    description('Tests whether explicitly set caret style is retained on performing text selection');
+    var div = document.getElementById("test");
+    div.focus();
+    var y = div.offsetTop + div.offsetHeight / 2;
+    function leapForwardAndMove(x) {
+        eventSender.leapForward(200);
+        eventSender.mouseMoveTo(div.offsetLeft + x, y);
+    }
+    eventSender.dragMode = false;
+    leapForwardAndMove(div.offsetLeft + 5, y);
+    eventSender.mouseDown();
+    leapForwardAndMove(10);
+    leapForwardAndMove(div.offsetWidth - 10);
+    var cursorInfo = window.internals.getCurrentCursorInfo(document);
+    var currentCursorType = cursorInfo.substring(cursorInfo.indexOf('=') + 1, cursorInfo.lastIndexOf(' '));
+    shouldBeEqualToString('currentCursorType', 'Progress');
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1081,6 +1081,7 @@ imported/w3c/web-platform-tests/shadow-dom/accesskey.tentative.html [ Skip ]
 
 # Tests that use EventSender's mouseMoveTo, mouseUp and mouseDown
 css3/viewport-percentage-lengths/vh-resize.html [ Skip ]
+editing/caret/caret-type-for-user-select-none.html [ Skip ]
 editing/pasteboard/can-read-in-dragstart-event.html [ Skip ]
 editing/pasteboard/cleanup-on-move.html [ Skip ]
 editing/pasteboard/copy-crash.html [ Skip ]

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1552,17 +1552,6 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
         }
     }
 
-    // During selection, use an I-beam regardless of the content beneath the cursor.
-    // If a drag may be starting or we're capturing mouse events for a particular node, don't treat this as a selection.
-    if (m_mousePressed
-        && mouseDownMayStartSelect()
-#if ENABLE(DRAG_SUPPORT)
-        && !m_mouseDownMayStartDrag
-#endif
-        && m_frame.selection().isCaretOrRange()
-        && !m_capturingMouseEventsElement)
-        return iBeam;
-
     switch (style ? style->cursor() : CursorType::Auto) {
     case CursorType::Auto: {
         if (ImageOverlay::isOverlayText(node.get())) {
@@ -1584,6 +1573,17 @@ std::optional<Cursor> EventHandler::selectCursor(const HitTestResult& result, bo
             if (inResizer)
                 return layerRenderer.shouldPlaceVerticalScrollbarOnLeft() ? southWestResizeCursor() : southEastResizeCursor();
         }
+
+        // During selection, use an I-beam regardless of the content beneath the cursor.
+        // If a drag may be starting or we're capturing mouse events for a particular node, don't treat this as a selection.
+        if (m_mousePressed
+            && mouseDownMayStartSelect()
+#if ENABLE(DRAG_SUPPORT)
+            && !m_mouseDownMayStartDrag
+#endif
+            && m_frame.selection().isCaretOrRange()
+            && !m_capturingMouseEventsElement)
+                return iBeam;
 
         if ((editable || (renderer && renderer->isText() && node->canStartSelection())) && !inResizer && !result.scrollbar())
             return iBeam;


### PR DESCRIPTION
#### 15042015b0c8ed72c5d6e8e226e117dcc8041d48
<pre>
Selection should not set the cursor type to text over the explicitly set cursor type

<a href="https://bugs.webkit.org/show_bug.cgi?id=258622">https://bugs.webkit.org/show_bug.cgi?id=258622</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/a5c471c481544403615780bce2845de58e37e341">https://chromium.googlesource.com/chromium/blink/+/a5c471c481544403615780bce2845de58e37e341</a>

When tried to select some text in an area that has style
cursor:default set, cursor type changes to text cursor ignoring
the cursor style that is explicitly set.

When the cursor style is explicitly set as default(or something else),
we should not change it to text cursor no matter what we are over
or what operation we are performing (be it hovering over the text
or selecting the text).

We change the cursor type to text during selection. But if there is
an explicit cursor style set then this explicitly set cursor style
should be given priority over the text style cursor during selection.

Currently if the area on which cursor:default is set is contenteditable,
in this particular case we do not change the cursor style to text on
selection. This should be the behavior irrespective of editability.

* Source/WebCore/page/EventHandler.cpp:
(EventHandler::selectCursor): As per commit message
* LayoutTests/editing/caret/caret-type-for-user-select-none.html: Add Test Case
* LayoutTests/editing/caret/caret-type-for-user-select-none-expected.txt: Add Test Case Expectation
* LayoutTests/platform/ios/TestExpectations: Add Platform Specific Expectation to Skip on iOS due to test leveraging &apos;eventSender&apos; mousedown and mouseMoveTo.

Canonical link: <a href="https://commits.webkit.org/265597@main">https://commits.webkit.org/265597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ac230c6841182fd447fad99373373f1319ac9bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12972 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13389 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17451 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13630 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2721 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->