### PR TITLE
Safari video playback and Youtube app playback using Movie tuning route when it should be using General tuning route

### DIFF
--- a/LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt
+++ b/LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt
@@ -14,6 +14,6 @@ RUN(video.muted = false)
 RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.categoryAtMostRecentPlayback(video) == 'MediaPlayback') OK
-EXPECTED (internals.modeAtMostRecentPlayback(video) == 'MoviePlayback') OK
+EXPECTED (internals.modeAtMostRecentPlayback(video) == 'Default') OK
 END OF TEST
 

--- a/LayoutTests/media/audio-session-category-at-most-recent-playback.html
+++ b/LayoutTests/media/audio-session-category-at-most-recent-playback.html
@@ -33,7 +33,7 @@
         await waitFor(video, 'playing');
         await sleepFor(500);
         testExpected('internals.categoryAtMostRecentPlayback(video)', 'MediaPlayback');
-        testExpected('internals.modeAtMostRecentPlayback(video)', 'MoviePlayback');
+        testExpected('internals.modeAtMostRecentPlayback(video)', 'Default');
 
         endTest();
     });

--- a/LayoutTests/media/video-audio-session-mode-expected.txt
+++ b/LayoutTests/media/video-audio-session-mode-expected.txt
@@ -23,13 +23,13 @@ RUN(video.muted = false)
 EVENT(volumechange)
 
 EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
-EXPECTED (internals.audioSessionMode() == 'MoviePlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
 EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
 
 ** Mute the element, check again after 500ms.
 RUN(video.pause())
 RUN(video.muted = true)
-EXPECTED (internals.audioSessionCategory() == 'MoviePlayback'), OBSERVED 'MediaPlayback' FAIL
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
 EXPECTED (internals.audioSessionMode() == 'Default') OK
 EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
 

--- a/LayoutTests/media/video-audio-session-mode.html
+++ b/LayoutTests/media/video-audio-session-mode.html
@@ -44,14 +44,14 @@
             runWithKeyDown(() => { run('video.muted = false') });
             await waitFor(video, 'volumechange');
             await waitForCategory('MediaPlayback', 1, '');
-            testExpected('internals.audioSessionMode()', 'MoviePlayback');
+            testExpected('internals.audioSessionMode()', 'Default');
             testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
 
             consoleWrite('<br>** Mute the element, check again after 500ms.');
             run('video.pause()');
             runWithKeyDown(() => { run('video.muted = true') });
             await sleepFor(500);
-            testExpected('internals.audioSessionCategory()', 'MoviePlayback');
+            testExpected('internals.audioSessionCategory()', 'MediaPlayback');
             testExpected('internals.audioSessionMode()', 'Default');
             testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -191,7 +191,11 @@ void MediaSessionManagerCocoa::updateSessionState()
         mode = AudioSession::Mode::VideoChat;
     } else if (hasAudibleVideoMediaType) {
         category = AudioSession::CategoryType::MediaPlayback;
+#if PLATFORM(VISION)
+        // visionOS AudioSessions are designed more like a headphone experience,
+        // and thus use a different mode.
         mode = AudioSession::Mode::MoviePlayback;
+#endif
     } else if (hasAudibleAudioOrVideoMediaType)
         category = AudioSession::CategoryType::MediaPlayback;
     else if (webAudioCount)


### PR DESCRIPTION
#### 40b644b3f1961d26cf352fabbba261a3f5181419
<pre>
Safari video playback and Youtube app playback using Movie tuning route when it should be using General tuning route
<a href="https://bugs.webkit.org/show_bug.cgi?id=258629">https://bugs.webkit.org/show_bug.cgi?id=258629</a>
rdar://110648685

Reviewed by Jer Noble.

We unilaterally changed the AudioSession Category for playback in
a previous commit. It turns out this should only be for visionOS,
which has an experience that is more like wearing headphones.

Use the default category for iOS, and only the MoviePlayback category
for visionOS.

* LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt:
* LayoutTests/media/audio-session-category-at-most-recent-playback.html:
* LayoutTests/media/video-audio-session-mode-expected.txt:
* LayoutTests/media/video-audio-session-mode.html:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):

Canonical link: <a href="https://commits.webkit.org/265592@main">https://commits.webkit.org/265592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/097384cd6302c9cf0f528c2b6862048dc8302017

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11536 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13720 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12379 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13409 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10280 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13647 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2718 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->