### PR TITLE
Revert unnecessary part of 265344@main

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -78,11 +78,8 @@ public:
         {
             Locker locker { m_lock };
             ASSERT_WITH_SECURITY_IMPLICATION(m_object);
-            auto tempRefCount = m_strongReferenceCount - 1;
-            if (LIKELY(tempRefCount)) {
-                m_strongReferenceCount = tempRefCount;
+            if (LIKELY(--m_strongReferenceCount))
                 return;
-            }
             object = static_cast<T*>(std::exchange(m_object, nullptr));
             if (!m_weakReferenceCount)
                 shouldDeleteControlBlock = true;


### PR DESCRIPTION
#### 883a699fc0cf1bdd0a2051ea9914f4ccfd137835
<pre>
Revert unnecessary part of 265344@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=258636">https://bugs.webkit.org/show_bug.cgi?id=258636</a>
rdar://111409234

Reviewed by Chris Dumez.

265344@main made it so we can make weak references during the destructor safely.
I also tried to do the same thing we do in RefCounted and ThreadSafeRefCounted
and make it so we can safely make strong references, however m_strongReferenceCount
is also used in weakDeref so it caused the control block to be leaked if there
are weak references when the destructor is called.  As a minimum risk fix,
revert that unneeded part of last week&apos;s PR.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):

Canonical link: <a href="https://commits.webkit.org/265598@main">https://commits.webkit.org/265598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c10b4ac92ad4655806c368a8112132f415ea22d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12999 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13727 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13418 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10287 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10751 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13657 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8941 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11445 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10034 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3093 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14308 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11768 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10717 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2866 "Passed tests") | 
<!--EWS-Status-Bubble-End-->