### PR TITLE
Serialize extension manifest as JSON data instead of NSDictionary

### DIFF
--- a/Source/WebKit/Shared/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.h
@@ -27,10 +27,8 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-OBJC_CLASS NSDictionary;
-
+#include "APIData.h"
 #include "WebExtensionContextIdentifier.h"
-#include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
 
 namespace WebKit {
@@ -38,13 +36,11 @@ namespace WebKit {
 struct WebExtensionContextParameters {
     WebExtensionContextIdentifier identifier;
 
-#if PLATFORM(COCOA)
     URL baseURL;
     String uniqueIdentifier;
-    RetainPtr<NSDictionary> manifest;
+    Ref<API::Data> manifestJSON;
     double manifestVersion;
     bool testingMode;
-#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/WebExtensionContextParameters.serialization.in
@@ -25,13 +25,11 @@
 struct WebKit::WebExtensionContextParameters {
     WebKit::WebExtensionContextIdentifier identifier;
 
-#if PLATFORM(COCOA)
     URL baseURL;
     String uniqueIdentifier;
-    RetainPtr<NSDictionary> manifest;
+    Ref<API::Data> manifestJSON;
     double manifestVersion;
     bool testingMode;
-#endif
 }
 
 #endif

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -32,6 +32,7 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#import "APIData.h"
 #import "CocoaHelpers.h"
 #import "FoundationSPI.h"
 #import "_WKWebExtensionInternal.h"
@@ -192,6 +193,11 @@ NSDictionary *WebExtension::manifest()
     // since that will need delegated to the app.
 
     return m_manifest.get();
+}
+
+Ref<API::Data> WebExtension::serializeManifest()
+{
+    return API::Data::createWithoutCopying([NSJSONSerialization dataWithJSONObject:manifest() options:0 error:nullptr]);
 }
 
 double WebExtension::manifestVersion()

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -57,6 +57,10 @@ OBJC_CLASS _WKWebExtensionMatchPattern;
 #include "_WKWebExtensionPermission.h"
 #endif
 
+namespace API {
+class Data;
+}
+
 namespace WebKit {
 
 class WebExtension : public API::ObjectImpl<API::Object::Type::WebExtension>, public CanMakeWeakPtr<WebExtension> {
@@ -138,6 +142,7 @@ public:
 
     bool manifestParsedSuccessfully();
     NSDictionary *manifest();
+    Ref<API::Data> serializeManifest();
 
     double manifestVersion();
     bool supportsManifestVersion(double version) { return manifestVersion() >= version; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -57,17 +57,14 @@ WebExtensionContext::WebExtensionContext()
 
 WebExtensionContextParameters WebExtensionContext::parameters() const
 {
-    WebExtensionContextParameters parameters;
-
-    parameters.identifier = identifier();
-
-    parameters.baseURL = baseURL();
-    parameters.uniqueIdentifier = uniqueIdentifier();
-    parameters.manifest = extension().manifest();
-    parameters.manifestVersion = extension().manifestVersion();
-    parameters.testingMode = inTestingMode();
-
-    return parameters;
+    return WebExtensionContextParameters {
+        identifier(),
+        baseURL(),
+        uniqueIdentifier(),
+        extension().serializeManifest(),
+        extension().manifestVersion(),
+        inTestingMode()
+    };
 }
 
 WeakHashSet<WebProcessProxy> WebExtensionContext::processes(WebExtensionEventListenerType type) const

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -33,6 +33,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #include "CocoaHelpers.h"
+#include "WKNSData.h"
 #include "WebExtensionAPINamespace.h"
 #include "WebExtensionAPIPermissions.h"
 #include "WebExtensionAPIWebNavigation.h"
@@ -139,6 +140,11 @@ void WebExtensionContextProxy::dispatchWebNavigationOnErrorOccurredEvent(WebPage
         auto& webNavigationObject = namespaceObject.webNavigation();
         webNavigationObject.onErrorOccurred().invokeListenersWithArgument(navigationDetails, frameURL);
     });
+}
+
+RetainPtr<NSDictionary> WebExtensionContextProxy::parseManifest(API::Data& json)
+{
+    return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:wrapper(json) options:0 error:nullptr]);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp
@@ -52,12 +52,12 @@ RefPtr<WebExtensionContextProxy> WebExtensionContextProxy::get(WebExtensionConte
     return webExtensionContextProxies().get(identifier).get();
 }
 
-Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(WebExtensionContextParameters parameters)
+Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExtensionContextParameters& parameters)
 {
     auto updateProperties = [&](WebExtensionContextProxy& context) {
         context.m_baseURL = parameters.baseURL;
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
-        context.m_manifest = parameters.manifest;
+        context.m_manifest = parseManifest(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
         context.m_testingMode = parameters.testingMode;
     };
@@ -72,7 +72,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(WebExtension
     return result.releaseNonNull();
 }
 
-WebExtensionContextProxy::WebExtensionContextProxy(WebExtensionContextParameters parameters)
+WebExtensionContextProxy::WebExtensionContextProxy(const WebExtensionContextParameters& parameters)
     : m_identifier(parameters.identifier)
 {
     ASSERT(!webExtensionContextProxies().contains(m_identifier));

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -37,6 +37,8 @@
 #include <wtf/Forward.h>
 #include <wtf/WeakHashSet.h>
 
+OBJC_CLASS NSDictionary;
+
 namespace WebKit {
 
 class WebExtensionAPINamespace;
@@ -49,7 +51,7 @@ class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProx
 
 public:
     static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
-    static Ref<WebExtensionContextProxy> getOrCreate(WebExtensionContextParameters);
+    static Ref<WebExtensionContextProxy> getOrCreate(const WebExtensionContextParameters&);
 
     ~WebExtensionContextProxy();
 
@@ -63,6 +65,7 @@ public:
     const String& uniqueIdentifier() const { return m_uniqueIdentifier; }
 
     NSDictionary *manifest() { return m_manifest.get(); }
+    static RetainPtr<NSDictionary> parseManifest(API::Data&);
 
     double manifestVersion() { return m_manifestVersion; }
     bool supportsManifestVersion(double version) { return manifestVersion() >= version; }
@@ -78,7 +81,7 @@ public:
     void enumerateContentScriptNamespaceObjects(const Function<void(WebExtensionAPINamespace&)>& function) { ASSERT(contentScriptWorld()); enumerateNamespaceObjects(function, *contentScriptWorld()); };
 
 private:
-    explicit WebExtensionContextProxy(WebExtensionContextParameters);
+    explicit WebExtensionContextProxy(const WebExtensionContextParameters&);
 
     // webNavigation support
     void dispatchWebNavigationOnBeforeNavigateEvent(WebPageProxyIdentifier, WebCore::FrameIdentifier, URL);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm
@@ -31,7 +31,15 @@
 
 namespace TestWebKitAPI {
 
-static auto *manifest = @{ @"manifest_version": @3, @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO } };
+static auto *manifest = @{
+    @"manifest_version": @3,
+    @"background": @{
+        @"scripts": @[ @"background.js" ],
+        @"type": @"module",
+        @"persistent": @NO
+    },
+    @"unused" : [NSNull null]
+};
 
 TEST(WKWebExtensionAPIRuntime, GetURL)
 {
@@ -103,8 +111,7 @@ TEST(WKWebExtensionAPIRuntime, Id)
 TEST(WKWebExtensionAPIRuntime, GetManifest)
 {
     auto *backgroundScript = Util::constructScript(@[
-        // FIXME: <https://webkit.org/b/248154> browser.runtime.getManifest() returns 1/0 instead true/false for background.persistent
-        @"browser.test.assertDeepEq(browser.runtime.getManifest(), { manifest_version: 3, background: { persistent: 0, scripts: [ 'background.js' ], type: 'module' } })",
+        @"browser.test.assertDeepEq(browser.runtime.getManifest(), { manifest_version: 3, background: { persistent: false, scripts: [ 'background.js' ], type: 'module' }, unused: null })",
 
         // Finish
         @"browser.test.notifyPass()"


### PR DESCRIPTION
#### b0f351a7aff3847fb1969a4c661ba546a695857f
<pre>
Serialize extension manifest as JSON data instead of NSDictionary
<a href="https://bugs.webkit.org/show_bug.cgi?id=258647">https://bugs.webkit.org/show_bug.cgi?id=258647</a>
rdar://111475992

Reviewed by Timothy Hatcher.

This allows us to handle null better.  It also handles true/false better instead of 1/0.

* Source/WebKit/Shared/WebExtensionContextParameters.h:
* Source/WebKit/Shared/WebExtensionContextParameters.serialization.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::serializeManifest):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::parseManifest):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.cpp:
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::WebExtensionContextProxy):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265607@main">https://commits.webkit.org/265607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e7614f6049a8cd092850ab7d031bfd194840316

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10834 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13753 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13446 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9709 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10317 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10471 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10887 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8960 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14333 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1284 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->