### PR TITLE
Occasional crashes under WebWheelEventCoalescer::takeOldestEventBeingProcessed()

### DIFF
--- a/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.cpp
@@ -155,9 +155,11 @@ bool WebWheelEventCoalescer::shouldDispatchEvent(const NativeWebWheelEvent& even
     return true;
 }
 
-NativeWebWheelEvent WebWheelEventCoalescer::takeOldestEventBeingProcessed()
+std::optional<NativeWebWheelEvent> WebWheelEventCoalescer::takeOldestEventBeingProcessed()
 {
-    ASSERT(hasEventsBeingProcessed());
+    if (m_eventsBeingProcessed.isEmpty())
+        return { };
+
     auto oldestSequence = m_eventsBeingProcessed.takeFirst();
     return oldestSequence->last();
 }

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -38,7 +38,7 @@ public:
     bool shouldDispatchEvent(const NativeWebWheelEvent&);
     std::optional<WebWheelEvent> nextEventToDispatch();
 
-    NativeWebWheelEvent takeOldestEventBeingProcessed();
+    std::optional<NativeWebWheelEvent> takeOldestEventBeingProcessed();
 
     bool hasEventsBeingProcessed() const { return !m_eventsBeingProcessed.isEmpty(); }
     

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3373,11 +3373,14 @@ void WebPageProxy::wheelEventHandlingCompleted(bool wasHandled)
 {
     auto oldestProcessedEvent = wheelEventCoalescer().takeOldestEventBeingProcessed();
 
-    LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::wheelEventHandlingCompleted - finished handling " << platform(oldestProcessedEvent) << " handled " << wasHandled);
+    if (oldestProcessedEvent)
+        LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::wheelEventHandlingCompleted - finished handling " << platform(*oldestProcessedEvent) << " handled " << wasHandled);
+    else
+        LOG_WITH_STREAM(WheelEvents, stream << "WebPageProxy::wheelEventHandlingCompleted - no event, handled " << wasHandled);
 
-    if (!wasHandled) {
-        m_uiClient->didNotHandleWheelEvent(this, oldestProcessedEvent);
-        pageClient().wheelEventWasNotHandledByWebCore(oldestProcessedEvent);
+    if (oldestProcessedEvent && !wasHandled) {
+        m_uiClient->didNotHandleWheelEvent(this, *oldestProcessedEvent);
+        pageClient().wheelEventWasNotHandledByWebCore(*oldestProcessedEvent);
     }
 
     if (auto eventToSend = wheelEventCoalescer().nextEventToDispatch()) {


### PR DESCRIPTION
#### c09328b452c7f838fe5e15bf1137c34d69c93e2a
<pre>
Occasional crashes under WebWheelEventCoalescer::takeOldestEventBeingProcessed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258653">https://bugs.webkit.org/show_bug.cgi?id=258653</a>
rdar://111271905

Reviewed by Jer Noble.

Crash data suggest that we can reach WebWheelEventCoalescer::takeOldestEventBeingProcessed() with
m_eventsBeingProcessed being empty. We get here after one or more trips to the web process for wheel
event handling, so it&apos;s possible there&apos;s some code path where we can get here with an empty m_eventsBeingProcessed,
but I have not figured out how, so do a defensive fix of returning a std::optional&lt;NativeWebWheelEvent&gt;.

* Source/WebKit/Shared/WebWheelEventCoalescer.cpp:
(WebKit::WebWheelEventCoalescer::takeOldestEventBeingProcessed):
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::wheelEventHandlingCompleted):

Canonical link: <a href="https://commits.webkit.org/265625@main">https://commits.webkit.org/265625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52b15b9685f926ff11b2bc45947644187a640652

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10851 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13466 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9725 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17510 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13699 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8974 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10077 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2745 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->