### PR TITLE
[WebXR] Pass depth texture in frame data

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -44,12 +44,52 @@ namespace WebCore {
 
 using GL = GraphicsContextGL;
 
+#if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
+static std::optional<GL::EGLImageAttachResult> createAndBindCompositorTexture(GL& gl, GCGLenum target, GCGLOwnedTexture& texture, GL::EGLImageSource source)
+{
+    texture.ensure(gl);
+    gl.bindTexture(target, texture);
+    gl.texParameteri(target, GL::TEXTURE_MAG_FILTER, GL::LINEAR);
+    gl.texParameteri(target, GL::TEXTURE_MIN_FILTER, GL::LINEAR);
+    gl.texParameteri(target, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
+    gl.texParameteri(target, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
+
+    auto attachResult = gl.createAndBindEGLImage(target, source);
+    if (!attachResult || !std::get<GCEGLImage>(*attachResult) || std::get<IntSize>(*attachResult).isEmpty()) {
+        texture.release(gl);
+        return std::nullopt;
+    }
+
+    return attachResult;
+}
+
+static std::optional<GL::EGLImageAttachResult> createAndBindCompositorBuffer(GL& gl, GCGLOwnedRenderbuffer& buffer, GL::EGLImageSource source)
+{
+    buffer.ensure(gl);
+    gl.bindRenderbuffer(GL::RENDERBUFFER, buffer);
+
+    auto attachResult = gl.createAndBindEGLImage(GL::RENDERBUFFER, source);
+    if (!attachResult || !std::get<GCEGLImage>(*attachResult) || std::get<IntSize>(*attachResult).isEmpty()) {
+        buffer.release(gl);
+        return std::nullopt;
+    }
+
+    return attachResult;
+}
+
+static GL::EGLImageSource makeEGLImageSource(const std::tuple<WTF::MachSendRight, bool>& imageSource)
+{
+    auto [imageHandle, isSharedTexture] = imageSource;
+    if (isSharedTexture)
+        return GL::EGLImageSourceMTLSharedTextureHandle { imageHandle };
+    return GL::EGLImageSourceIOSurfaceHandle { imageHandle };
+}
+#endif
+
 std::unique_ptr<WebXROpaqueFramebuffer> WebXROpaqueFramebuffer::create(PlatformXR::LayerHandle handle, WebGLRenderingContextBase& context, Attributes&& attributes, IntSize framebufferSize)
 {
     auto framebuffer = WebGLFramebuffer::createOpaque(context);
     auto opaque = std::unique_ptr<WebXROpaqueFramebuffer>(new WebXROpaqueFramebuffer(handle, WTFMove(framebuffer), context, WTFMove(attributes), framebufferSize));
-    if (!opaque->setupFramebuffer())
-        return nullptr;
     return opaque;
 }
 
@@ -66,9 +106,8 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
 {
     if (auto gl = m_context.graphicsContextGL()) {
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-        m_opaqueTexture.release(*gl);
+        m_colorTexture.release(*gl);
 #endif
-        m_stencilBuffer.release(*gl);
         m_depthStencilBuffer.release(*gl);
         m_multisampleColorBuffer.release(*gl);
         m_resolvedFBO.release(*gl);
@@ -77,9 +116,8 @@ WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer()
         // The GraphicsContextGL is gone, so disarm the GCGLOwned objects so
         // their destructors don't assert.
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-        m_opaqueTexture.leakObject();
+        m_colorTexture.release(*gl);
 #endif
-        m_stencilBuffer.leakObject();
         m_depthStencilBuffer.leakObject();
         m_multisampleColorBuffer.leakObject();
         m_resolvedFBO.leakObject();
@@ -92,20 +130,17 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
         return;
     auto& gl = *m_context.graphicsContextGL();
 
-#if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    IntSize bufferSize;
-#endif
     auto [textureTarget, textureTargetBinding] = gl.externalImageTextureBindingPoint();
 
     m_framebuffer->setOpaqueActive(true);
 
-    GCGLint boundFBO { 0 };
-    GCGLint boundTexture { 0 };
-    gl.getIntegerv(GL::FRAMEBUFFER_BINDING, std::span(&boundFBO, 1));
-    gl.getIntegerv(textureTargetBinding, std::span(&boundTexture, 1));
+    GCGLint boundFBO = gl.getInteger(GL::FRAMEBUFFER_BINDING);
+    GCGLint boundRenderbuffer = gl.getInteger(GL::RENDERBUFFER_BINDING);
+    GCGLint boundTexture = gl.getInteger(textureTargetBinding);
 
-    auto scopedBindings = makeScopeExit([&gl, boundFBO, boundTexture, textureTarget]() {
+    auto scopedBindings = makeScopeExit([=, &gl]() {
         gl.bindFramebuffer(GL::FRAMEBUFFER, boundFBO);
+        gl.bindRenderbuffer(GL::RENDERBUFFER, boundRenderbuffer);
         gl.bindTexture(textureTarget, boundTexture);
     });
 
@@ -118,32 +153,24 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
 
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
     // FIXME: This is temporary until Cocoa-specific platforms migrate to MTLTEXTURE_FOR_XR_LAYER_DATA.
-    auto colorTextureHandle = data.surface->createSendRight();
-    bool colorTextureIsShared = false;
+    auto colorTextureSource = makeEGLImageSource({ data.surface->createSendRight(), false });
+    auto depthStencilBufferSource = makeEGLImageSource({ { }, false });
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    // Tell the GraphicsContextGL to use the IOSurface as the backing store for m_opaqueTexture.
-    auto [colorTextureHandle, colorTextureIsShared] = data.colorTexture;
+    auto colorTextureSource = makeEGLImageSource(data.colorTexture);
+    auto depthStencilBufferSource = makeEGLImageSource(data.depthStencilBuffer);
 #endif
 
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    m_opaqueTexture.ensure(gl);
-    gl.bindTexture(textureTarget, m_opaqueTexture);
-    gl.texParameteri(textureTarget, GL::TEXTURE_MAG_FILTER, GL::LINEAR);
-    gl.texParameteri(textureTarget, GL::TEXTURE_MIN_FILTER, GL::LINEAR);
-    gl.texParameteri(textureTarget, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
-    gl.texParameteri(textureTarget, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
+    auto colorTextureAttachment = createAndBindCompositorTexture(gl, textureTarget, m_colorTexture, colorTextureSource);
+    auto depthStencilBufferAttachment = createAndBindCompositorBuffer(gl, m_depthStencilBuffer, depthStencilBufferSource);
 
-    auto colorTextureSource = (colorTextureIsShared) ? GL::EGLImageSource(GL::EGLImageSourceMTLSharedTextureHandle { colorTextureHandle }) : GL::EGLImageSource(GL::EGLImageSourceIOSurfaceHandle { colorTextureHandle });
-
-    auto colorTextureAttachment = gl.createAndBindEGLImage(textureTarget, colorTextureSource);
-    if (!colorTextureAttachment) {
-        m_opaqueTexture.release(gl);
+    if (!colorTextureAttachment)
         return;
-    }
 
-    std::tie(m_opaqueImage, bufferSize) = colorTextureAttachment.value();
-    if (bufferSize.isEmpty())
-        return;
+    IntSize bufferSize;
+    std::tie(m_colorImage, bufferSize) = colorTextureAttachment.value();
+    if (depthStencilBufferAttachment)
+        std::tie(m_depthStencilImage, std::ignore) = depthStencilBufferAttachment.value();
 
     // The drawing target can change size at any point during the session. If this happens, we need
     // to recreate the framebuffer.
@@ -158,14 +185,16 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     // is the resolved framebuffer we created in setupFramebuffer.
     if (m_multisampleColorBuffer)
         gl.bindFramebuffer(GL::FRAMEBUFFER, m_resolvedFBO);
-    gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, textureTarget, m_opaqueTexture, 0);
+    gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, textureTarget, m_colorTexture, 0);
+    if (m_depthStencilBuffer)
+        gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, m_depthStencilBuffer);
 
     // At this point the framebuffer should be "complete".
     ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
 #else
-    m_opaqueTexture = data.opaqueTexture;
+    m_colorTexture = data.opaqueTexture;
     if (!m_multisampleColorBuffer)
-        gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, m_opaqueTexture, 0);
+        gl.framebufferTexture2D(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, m_colorTexture, 0);
 #endif
 
 #if USE(MTLSHAREDEVENT_FOR_XR_FRAME_COMPLETION)
@@ -203,13 +232,17 @@ void WebXROpaqueFramebuffer::endFrame()
             gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, boundDrawFBO);
         });
 
+        GCGLbitfield buffers = GL::COLOR_BUFFER_BIT;
+        if (m_depthStencilBuffer)
+            buffers |= GL::DEPTH_BUFFER_BIT | GL::STENCIL_BUFFER_BIT;
+
         gl.bindFramebuffer(GL::READ_FRAMEBUFFER, m_framebuffer->object());
         gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, m_resolvedFBO);
-        gl.blitFramebufferANGLE(0, 0, width(), height(), 0, 0, width(), height(), GL::COLOR_BUFFER_BIT, GL::NEAREST);
+        gl.blitFramebufferANGLE(0, 0, width(), height(), 0, 0, width(), height(), buffers, GL::NEAREST);
     }
 
 #if USE(MTLSHAREDEVENT_FOR_XR_FRAME_COMPLETION)
-    if (std::get<0>(m_completionSyncEvent)) {
+    if (std::get<MachSendRight>(m_completionSyncEvent)) {
         auto completionSync = gl.createEGLSync(m_completionSyncEvent);
         ASSERT(completionSync);
         constexpr uint64_t kTimeout = 1'000'000'000; // 1 second
@@ -225,11 +258,14 @@ void WebXROpaqueFramebuffer::endFrame()
     gl.finish();
 #endif
 
-
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    if (m_opaqueImage) {
-        gl.destroyEGLImage(m_opaqueImage);
-        m_opaqueImage = nullptr;
+    if (m_colorImage) {
+        gl.destroyEGLImage(m_colorImage);
+        m_colorImage = nullptr;
+    }
+    if (m_depthStencilImage) {
+        gl.destroyEGLImage(m_depthStencilImage);
+        m_depthStencilImage = nullptr;
     }
 #endif
 }
@@ -241,12 +277,10 @@ bool WebXROpaqueFramebuffer::setupFramebuffer()
     auto& gl = *m_context.graphicsContextGL();
 
     // Restore bindings when exiting the function.
-    GCGLint boundFBO { 0 };
-    GCGLint boundRenderbuffer { 0 };
-    gl.getIntegerv(GL::FRAMEBUFFER_BINDING, std::span(&boundFBO, 1));
-    gl.getIntegerv(GL::RENDERBUFFER_BINDING, std::span(&boundRenderbuffer, 1));
+    GCGLint boundFBO = gl.getInteger(GL::FRAMEBUFFER_BINDING);
+    GCGLint boundRenderbuffer = gl.getInteger(GL::RENDERBUFFER_BINDING);
 
-    auto scopedBindings = makeScopeExit([&gl, boundFBO, boundRenderbuffer]() {
+    auto scopedBindings = makeScopeExit([=, &gl]() {
         gl.bindFramebuffer(GL::FRAMEBUFFER, boundFBO);
         gl.bindRenderbuffer(GL::RENDERBUFFER, boundRenderbuffer);
     });
@@ -273,16 +307,18 @@ bool WebXROpaqueFramebuffer::setupFramebuffer()
 
         auto colorBuffer = allocateColorStorage(gl, sampleCount, m_framebufferSize);
         bindColorBuffer(gl, colorBuffer);
-
         m_multisampleColorBuffer.adopt(gl, colorBuffer);
-    }
 
-    if (hasDepthOrStencil) {
-        auto [depthBuffer, stencilBuffer] = allocateDepthStencilStorage(gl, sampleCount, m_framebufferSize);
-        bindDepthStencilBuffer(gl, depthBuffer, stencilBuffer);
+        if (hasDepthOrStencil) {
+            auto depthStencilBuffer = allocateDepthStencilStorage(gl, sampleCount, m_framebufferSize);
+            bindDepthStencilBuffer(gl, depthStencilBuffer);
+            m_multisampleDepthStencilBuffer.adopt(gl, depthStencilBuffer);
+        }
+    } else if (hasDepthOrStencil && !m_depthStencilBuffer) {
+        auto depthStencilBuffer = allocateDepthStencilStorage(gl, sampleCount, m_framebufferSize);
+        bindDepthStencilBuffer(gl, depthStencilBuffer);
 
-        m_depthStencilBuffer.adopt(gl, depthBuffer);
-        m_stencilBuffer.adopt(gl, stencilBuffer != depthBuffer ? stencilBuffer : 0);
+        m_depthStencilBuffer.adopt(gl, depthStencilBuffer);
     }
 
     return gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE;
@@ -300,28 +336,12 @@ PlatformGLObject WebXROpaqueFramebuffer::allocateRenderbufferStorage(GraphicsCon
 
 PlatformGLObject WebXROpaqueFramebuffer::allocateColorStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
 {
-    constexpr auto colorFormat = GL::SRGB8_ALPHA8;
-    return allocateRenderbufferStorage(gl, samples, colorFormat, size);
+    return allocateRenderbufferStorage(gl, samples, GL::SRGB8_ALPHA8, size);
 }
 
-std::tuple<PlatformGLObject, PlatformGLObject> WebXROpaqueFramebuffer::allocateDepthStencilStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
+PlatformGLObject WebXROpaqueFramebuffer::allocateDepthStencilStorage(GraphicsContextGL& gl, GCGLsizei samples, IntSize size)
 {
-    PlatformGLObject depthBuffer = 0;
-    PlatformGLObject stencilBuffer = 0;
-
-    // FIXME: Does this need to be optional?
-    bool platformSupportsPackedDepthStencil = true;
-    if (platformSupportsPackedDepthStencil) {
-        depthBuffer = allocateRenderbufferStorage(gl, samples, GL::DEPTH24_STENCIL8, size);
-        stencilBuffer = depthBuffer;
-    } else {
-        if (m_attributes.stencil)
-            stencilBuffer = allocateRenderbufferStorage(gl, samples, GL::STENCIL_INDEX8, size);
-        if (m_attributes.depth)
-            depthBuffer = allocateRenderbufferStorage(gl, samples, GL::DEPTH_COMPONENT, size);
-    }
-
-    return std::make_tuple(depthBuffer, stencilBuffer);
+    return allocateRenderbufferStorage(gl, samples, GL::DEPTH24_STENCIL8, size);
 }
 
 void WebXROpaqueFramebuffer::bindColorBuffer(GraphicsContextGL& gl, PlatformGLObject colorBuffer)
@@ -329,17 +349,11 @@ void WebXROpaqueFramebuffer::bindColorBuffer(GraphicsContextGL& gl, PlatformGLOb
     gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::RENDERBUFFER, colorBuffer);
 }
 
-void WebXROpaqueFramebuffer::bindDepthStencilBuffer(GraphicsContextGL& gl, PlatformGLObject depthBuffer, PlatformGLObject stencilBuffer)
+void WebXROpaqueFramebuffer::bindDepthStencilBuffer(GraphicsContextGL& gl, PlatformGLObject depthStencilBuffer)
 {
-    if (depthBuffer == stencilBuffer && !m_context.isWebGL2()) {
-        ASSERT(m_attributes.stencil || m_attributes.depth);
-        gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, depthBuffer);
-    } else {
-        if (m_attributes.depth)
-            gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_ATTACHMENT, GL::RENDERBUFFER, depthBuffer);
-        if (m_attributes.stencil)
-            gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::STENCIL_ATTACHMENT, GL::RENDERBUFFER, stencilBuffer);
-    }
+    // NOTE: In WebGL2, GL::DEPTH_STENCIL_ATTACHMENT is an alias to set GL::DEPTH_ATTACHMENT and GL::STENCIL_ATTACHMENT, which is all we require.
+    ASSERT(m_attributes.stencil || m_attributes.depth);
+    gl.framebufferRenderbuffer(GL::FRAMEBUFFER, GL::DEPTH_STENCIL_ATTACHMENT, GL::RENDERBUFFER, depthStencilBuffer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -68,9 +68,9 @@ private:
     bool setupFramebuffer();
     PlatformGLObject allocateRenderbufferStorage(GraphicsContextGL&, GCGLsizei, GCGLenum, IntSize);
     PlatformGLObject allocateColorStorage(GraphicsContextGL&, GCGLsizei, IntSize);
-    std::tuple<PlatformGLObject, PlatformGLObject> allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, IntSize);
+    PlatformGLObject allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, IntSize);
     void bindColorBuffer(GraphicsContextGL&, PlatformGLObject);
-    void bindDepthStencilBuffer(GraphicsContextGL&, PlatformGLObject, PlatformGLObject);
+    void bindDepthStencilBuffer(GraphicsContextGL&, PlatformGLObject);
 
     PlatformXR::LayerHandle m_handle;
     Ref<WebGLFramebuffer> m_framebuffer;
@@ -78,14 +78,15 @@ private:
     Attributes m_attributes;
     IntSize m_framebufferSize;
     GCGLOwnedRenderbuffer m_depthStencilBuffer;
-    GCGLOwnedRenderbuffer m_stencilBuffer;
     GCGLOwnedRenderbuffer m_multisampleColorBuffer;
+    GCGLOwnedRenderbuffer m_multisampleDepthStencilBuffer;
     GCGLOwnedFramebuffer m_resolvedFBO;
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    GCGLOwnedTexture m_opaqueTexture;
-    GCEGLImage m_opaqueImage;
+    GCGLOwnedTexture m_colorTexture;
+    GCEGLImage m_colorImage { };
+    GCEGLImage m_depthStencilImage { };
 #else
-    PlatformGLObject m_opaqueTexture;
+    PlatformGLObject m_colorTexture;
 #endif
 #if USE(MTLSHAREDEVENT_FOR_XR_FRAME_COMPLETION)
     GraphicsContextGL::ExternalEGLSyncEvent m_completionSyncEvent;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -738,7 +738,10 @@ std::optional<GraphicsContextGL::EGLImageAttachResult> GraphicsContextGLCocoa::c
         return std::nullopt;
 
     // Tell the currently bound texture to use the EGLImage.
-    GL_EGLImageTargetTexture2DOES(target, eglImage);
+    if (target == RENDERBUFFER)
+        GL_EGLImageTargetRenderbufferStorageOES(RENDERBUFFER, eglImage);
+    else
+        GL_EGLImageTargetTexture2DOES(target, eglImage);
 
     GCGLuint textureWidth = [texture width];
     GCGLuint textureHeight = [texture height];

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -294,7 +294,8 @@ public:
             std::unique_ptr<WebCore::IOSurface> surface;
             bool isShared { false };
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-            std::tuple<MachSendRight, bool> colorTexture;
+            std::tuple<MachSendRight, bool> colorTexture = { { }, false };
+            std::tuple<MachSendRight, bool> depthStencilBuffer = { { }, false };
 #else
             PlatformGLObject opaqueTexture { 0 };
 #endif
@@ -585,6 +586,7 @@ void Device::FrameData::LayerData::encode(Encoder& encoder) const
     encoder << isShared;
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
     encoder << colorTexture;
+    encoder << depthStencilBuffer;
 #else
     encoder << opaqueTexture;
 #endif
@@ -606,6 +608,8 @@ std::optional<Device::FrameData::LayerData> Device::FrameData::LayerData::decode
         return std::nullopt;
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
     if (!decoder.decode(layerData.colorTexture))
+        return std::nullopt;
+    if (!decoder.decode(layerData.depthStencilBuffer))
         return std::nullopt;
 #else
     if (!decoder.decode(layerData.opaqueTexture))


### PR DESCRIPTION
#### 9e2a90f480f252eeee098ab7bd5648432342d153
<pre>
[WebXR] Pass depth texture in frame data
<a href="https://bugs.webkit.org/show_bug.cgi?id=258661">https://bugs.webkit.org/show_bug.cgi?id=258661</a>
rdar://111501806

Reviewed by Dean Jackson.

Render to compositor provided depth-stencil buffers.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::createAndBindCompositorTexture):
(WebCore::createAndBindCompositorBuffer):
(WebCore::makeEGLImageSource):
(WebCore::WebXROpaqueFramebuffer::create):
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
(WebCore::WebXROpaqueFramebuffer::startFrame):
(WebCore::WebXROpaqueFramebuffer::endFrame):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):
(WebCore::WebXROpaqueFramebuffer::allocateDepthStencilStorage):
(WebCore::WebXROpaqueFramebuffer::bindDepthStencilBuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::createAndBindEGLImage):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::FrameData::LayerData::encode const):
(PlatformXR::Device::FrameData::LayerData::decode):

Canonical link: <a href="https://commits.webkit.org/266053@main">https://commits.webkit.org/266053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfb68e6aefd19161a856de2fc91bb6e4038504a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14675 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14656 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18398 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14660 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11191 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->