### PR TITLE
GPU process startup does not have release logging

### DIFF
--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -125,6 +125,7 @@ RefPtr<GPUProcessConnection> GPUProcessConnection::create(IPC::Connection& paren
     if (parentConnection.ignoreInvalidMessageForTesting())
         instance->connection().setIgnoreInvalidMessageForTesting();
 #endif
+    RELEASE_LOG(Process, "GPUProcessConnection::create - %p", instance.ptr());
     return instance;
 }
 
@@ -166,6 +167,7 @@ void GPUProcessConnection::invalidate()
 
 void GPUProcessConnection::didClose(IPC::Connection&)
 {
+    RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::didClose", this);
     auto protector = Ref { *this };
     WebProcess::singleton().gpuProcessConnectionClosed(*this);
 
@@ -292,10 +294,12 @@ bool GPUProcessConnection::dispatchSyncMessage(IPC::Connection& connection, IPC:
 void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>&& info)
 {
     if (!info) {
+        RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::didInitialize - failed", this);
         invalidate();
         return;
     }
     m_hasInitialized = true;
+    RELEASE_LOG(Process, "%p - GPUProcessConnection::didInitialize", this);
 
 #if ENABLE(VP9) && USE(LIBWEBRTC) && PLATFORM(COCOA)
     WebProcess::singleton().libWebRTCCodecs().setVP9VTBSupport(info->hasVP9HardwareDecoder);
@@ -308,6 +312,7 @@ bool GPUProcessConnection::waitForDidInitialize()
     if (!m_hasInitialized) {
         auto result = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
         if (result != IPC::Error::NoError) {
+            RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result));
             invalidate();
             return false;
         }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1330,14 +1330,14 @@ GPUProcessConnection& WebProcess::ensureGPUProcessConnection()
     // If we've lost our connection to the GPU process (e.g. it crashed) try to re-establish it.
     if (!m_gpuProcessConnection) {
         m_gpuProcessConnection = GPUProcessConnection::create(*parentProcessConnection());
-
+        if (!m_gpuProcessConnection)
+            CRASH();
         for (auto& page : m_pageMap.values()) {
             // If page is null, then it is currently being constructed.
             if (page)
                 page->gpuProcessConnectionDidBecomeAvailable(*m_gpuProcessConnection);
         }
     }
-    
     return *m_gpuProcessConnection;
 }
 


### PR DESCRIPTION
#### 8cdb27dae2a958f4ad5ff00f4900a7c235835247
<pre>
GPU process startup does not have release logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=258659">https://bugs.webkit.org/show_bug.cgi?id=258659</a>
rdar://111501591

Reviewed by Simon Fraser.

Add WebContent process logging to establishing GPU process connection.

Common message timeout root cause might be that the UI process does not
forward the connection to GPU process.

* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::create):
(WebKit::GPUProcessConnection::didClose):
(WebKit::GPUProcessConnection::didInitialize):
(WebKit::GPUProcessConnection::waitForDidInitialize):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureGPUProcessConnection):

Canonical link: <a href="https://commits.webkit.org/265644@main">https://commits.webkit.org/265644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7a368a82e2b8d2aa91bb418b08484284b601d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10869 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13780 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13484 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9744 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17525 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13714 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->