### PR TITLE
[WPE] Implement `PlatformWebView` key press and button clicks simulation methods

### DIFF
--- a/Source/WebKit/Shared/API/c/wpe/WKEventWPE.cpp
+++ b/Source/WebKit/Shared/API/c/wpe/WKEventWPE.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKEventWPE.h"
+
+WKKeyboardEvent WKKeyboardEventMake(WKEventType type, WKInputType inputType, const char* text, uint32_t length, uint32_t keyCode, uint32_t hardwareKeyCode, uint32_t modifiers)
+{
+    WKKeyboardEvent keyboardEvent;
+    keyboardEvent.type = type;
+    keyboardEvent.keyCode = keyCode;
+    keyboardEvent.hardwareKeyCode = hardwareKeyCode;
+    keyboardEvent.modifiers = modifiers;
+
+    if (length > 0) {
+        keyboardEvent.text = text;
+        keyboardEvent.length = length;
+    } else {
+        keyboardEvent.text = nullptr;
+        keyboardEvent.length = 0;
+    }
+
+    return keyboardEvent;
+}
+
+WKMouseEvent WKMouseEventMake(WKEventType type, WKEventMouseButton button, WKPoint position, int32_t clickCount, uint32_t modifiers)
+{
+    WKMouseEvent mouseEvent;
+    mouseEvent.type = type;
+    mouseEvent.button = button;
+    mouseEvent.position = position;
+    mouseEvent.clickCount = clickCount;
+    mouseEvent.modifiers = modifiers;
+    return mouseEvent;
+}
+
+WKWheelEvent WKWheelEventMake(WKEventType type, WKPoint position, WKSize delta, WKSize wheelTicks, uint32_t modifiers)
+{
+    WKWheelEvent wheelEvent;
+    wheelEvent.type = type;
+    wheelEvent.position = position;
+    wheelEvent.delta = delta;
+    wheelEvent.wheelTicks = wheelTicks;
+    wheelEvent.modifiers = modifiers;
+    return wheelEvent;
+}

--- a/Source/WebKit/Shared/API/c/wpe/WKEventWPE.h
+++ b/Source/WebKit/Shared/API/c/wpe/WKEventWPE.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebKit/WKBase.h>
+#include <WebKit/WKEvent.h>
+#include <WebKit/WKGeometry.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    kWKEventNoType = -1,
+
+    // WebMouseEvent
+    kWKEventMouseDown,
+    kWKEventMouseUp,
+    kWKEventMouseMove,
+    kWKEventMouseForceChanged,
+    kWKEventMouseForceDown,
+    kWKEventMouseForceUp,
+
+    // WebWheelEvent
+    kWKEventWheel,
+
+    // WebKeyboardEvent
+    kWKEventKeyDown,
+    kWKEventKeyUp
+};
+typedef int32_t WKEventType;
+
+struct WKKeyboardEvent {
+    WKEventType type;
+    const char* text;
+    uint32_t length;
+    uint32_t keyCode;
+    uint32_t hardwareKeyCode;
+    uint32_t modifiers;
+};
+typedef struct WKKeyboardEvent WKKeyboardEvent;
+
+enum {
+    kWKInputTypeNormal,
+    kWKInputTypeSetComposition,
+    kWKInputTypeConfirmComposition,
+    kWKInputTypeCancelComposition,
+};
+typedef uint8_t WKInputType;
+
+struct WKMouseEvent {
+    WKEventType type;
+    WKEventMouseButton button;
+    WKPoint position;
+    int32_t clickCount;
+    uint32_t modifiers;
+};
+typedef struct WKMouseEvent WKMouseEvent;
+
+struct WKWheelEvent {
+    WKEventType type;
+    WKPoint position;
+    WKSize delta;
+    WKSize wheelTicks;
+    uint32_t modifiers;
+};
+typedef struct WKWheelEvent WKWheelEvent;
+
+WK_EXPORT WKKeyboardEvent WKKeyboardEventMake(WKEventType type, WKInputType inputType, const char* text, uint32_t length, uint32_t keyCode, uint32_t hardwareKeyCode, uint32_t modifiers);
+
+WK_EXPORT WKMouseEvent WKMouseEventMake(WKEventType type, WKEventMouseButton button, WKPoint position, int32_t clickCount, uint32_t modifiers);
+
+WK_EXPORT WKWheelEvent WKWheelEventMake(WKEventType type, WKPoint position, WKSize delta, WKSize wheelTicks, uint32_t modifiers);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -118,6 +118,9 @@ UIProcess/API/C/glib/WKContextConfigurationGlib.cpp
 UIProcess/API/C/glib/WKTextCheckerGLib.cpp
 
 UIProcess/API/C/wpe/WKView.cpp
+UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
+
+Shared/API/c/wpe/WKEventWPE.cpp
 
 UIProcess/API/glib/APIContentRuleListStoreGLib.cpp @no-unify
 UIProcess/API/glib/APISerializedScriptValueGLib.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
+++ b/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKPagePrivateWPE.h"
+
+#include "NativeWebKeyboardEvent.h"
+#include "NativeWebMouseEvent.h"
+#include "WKAPICast.h"
+#include "WebPageProxy.h"
+#include <wpe/wpe.h>
+
+void WKPageHandleKeyboardEvent(WKPageRef pageRef, WKKeyboardEvent event)
+{
+    using WebKit::NativeWebKeyboardEvent;
+
+    wpe_input_keyboard_event wpeEvent;
+    wpeEvent.time = 0;
+    wpeEvent.key_code = event.keyCode;
+    wpeEvent.hardware_key_code = event.hardwareKeyCode;
+    wpeEvent.modifiers = event.modifiers;
+    switch (event.type) {
+    case kWKEventKeyDown:
+        wpeEvent.pressed = true;
+        break;
+    case kWKEventKeyUp:
+        wpeEvent.pressed = false;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    NativeWebKeyboardEvent::HandledByInputMethod handledByInputMethod = NativeWebKeyboardEvent::HandledByInputMethod::No;
+    std::optional<Vector<WebCore::CompositionUnderline>> preeditUnderlines;
+    std::optional<WebKit::EditingRange> preeditSelectionRange;
+    WebKit::toImpl(pageRef)->handleKeyboardEvent(NativeWebKeyboardEvent(&wpeEvent, { event.text, event.length }, false, handledByInputMethod, WTFMove(preeditUnderlines), WTFMove(preeditSelectionRange)));
+}
+
+void WKPageHandleMouseEvent(WKPageRef pageRef, WKMouseEvent event)
+{
+    using WebKit::NativeWebMouseEvent;
+
+    wpe_input_pointer_event wpeEvent;
+
+    switch (event.type) {
+    case kWKEventMouseDown:
+        wpeEvent.type = wpe_input_pointer_event_type_button;
+        wpeEvent.state = 1;
+        break;
+    case kWKEventMouseUp:
+        wpeEvent.type = wpe_input_pointer_event_type_button;
+        wpeEvent.state = 0;
+        break;
+    case kWKEventMouseMove:
+        wpeEvent.type = wpe_input_pointer_event_type_motion;
+        wpeEvent.state = 0;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    switch (event.button) {
+    case kWKEventMouseButtonLeftButton:
+        wpeEvent.button = 1;
+        break;
+    case kWKEventMouseButtonMiddleButton:
+        wpeEvent.button = 3;
+        break;
+    case kWKEventMouseButtonRightButton:
+        wpeEvent.button = 2;
+        break;
+    case kWKEventMouseButtonNoButton:
+        wpeEvent.button = 0;
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    wpeEvent.time = 0;
+    wpeEvent.x = event.position.x;
+    wpeEvent.y = event.position.y;
+    wpeEvent.modifiers = event.modifiers;
+
+    const float deviceScaleFactor = 1;
+
+    WebKit::toImpl(pageRef)->handleMouseEvent(NativeWebMouseEvent(&wpeEvent, deviceScaleFactor));
+}

--- a/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.h
+++ b/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebKit/WKBase.h>
+#include <WebKit/WKEventWPE.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WK_EXPORT void WKPageHandleKeyboardEvent(WKPageRef, WKKeyboardEvent);
+WK_EXPORT void WKPageHandleMouseEvent(WKPageRef, WKMouseEvent);
+
+#ifdef __cplusplus
+}
+#endif

--- a/Tools/TestWebKitAPI/PlatformWebView.h
+++ b/Tools/TestWebKitAPI/PlatformWebView.h
@@ -89,7 +89,7 @@ public:
     void simulateAltKeyPress();
     void simulateRightClick(unsigned x, unsigned y);
     void simulateMouseMove(unsigned x, unsigned y, WKEventModifiers = 0);
-#if PLATFORM(MAC) || PLATFORM(PLAYSTATION)
+#if PLATFORM(MAC) || PLATFORM(PLAYSTATION) || PLATFORM(WPE)
     void simulateButtonClick(WKEventMouseButton, unsigned x, unsigned y, WKEventModifiers);
 #endif
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -213,8 +213,7 @@
         "subtests": {
             "WebKit.MouseMoveAfterCrash": {
                 "expected": {
-                    "gtk": {"status": ["CRASH", "PASS"], "bug": "webkit.org/b/85066"},
-                    "wpe": {"status": ["FAIL"]}
+                    "gtk": {"status": ["CRASH", "PASS"], "bug": "webkit.org/b/85066"}
                 }
             },
             "WebKit.NewFirstVisuallyNonEmptyLayoutForImages": {
@@ -234,9 +233,6 @@
             },
             "WebKit.TerminateTwice": {
                 "expected": {"gtk": {"status": ["SKIP"], "bug": "webkit.org/b/121970"}}
-            },
-            "WebKit.HitTestResultNodeHandle": {
-                "expected": {"wpe": {"status": ["TIMEOUT"]}}
             },
             "WebKit.FocusedFrameAfterCrash": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}

--- a/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
+++ b/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
@@ -27,6 +27,7 @@
 #include "PlatformWebView.h"
 
 #include <WPEToolingBackends/HeadlessViewBackend.h>
+#include <WebKit/WKPagePrivateWPE.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WKView.h>
 
@@ -86,22 +87,32 @@ void PlatformWebView::resizeTo(unsigned width, unsigned height)
 
 void PlatformWebView::simulateSpacebarKeyPress()
 {
-    // FIXME: implement this.
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
+    WKPageHandleKeyboardEvent(page(), WKKeyboardEventMake(kWKEventKeyDown, kWKInputTypeNormal, " ", 1, WPE_KEY_space, 0x0041, 0));
+    WKPageHandleKeyboardEvent(page(), WKKeyboardEventMake(kWKEventKeyUp, kWKInputTypeNormal, " ", 1, WPE_KEY_space, 0x0041, 0));
 }
 
 void PlatformWebView::simulateAltKeyPress()
 {
-    // FIXME: implement this.
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
+    WKPageHandleKeyboardEvent(page(), WKKeyboardEventMake(kWKEventKeyDown, kWKInputTypeNormal, nullptr, 0, WPE_KEY_Alt_L, 0x0040, 0));
+    WKPageHandleKeyboardEvent(page(), WKKeyboardEventMake(kWKEventKeyUp, kWKInputTypeNormal, nullptr, 0, WPE_KEY_Alt_L, 0x0040, 0));
 }
 
 void PlatformWebView::simulateRightClick(unsigned x, unsigned y)
 {
-    // FIXME: implement this.
+    simulateButtonClick(kWKEventMouseButtonRightButton, x, y, 0);
 }
 
-void PlatformWebView::simulateMouseMove(unsigned x, unsigned y, WKEventModifiers)
+void PlatformWebView::simulateButtonClick(WKEventMouseButton button, unsigned x, unsigned y, WKEventModifiers modifiers)
 {
-    // FIXME: implement this.
+    WKPageHandleMouseEvent(page(), WKMouseEventMake(kWKEventMouseDown, button, WKPointMake(x, y), 0, modifiers));
+    WKPageHandleMouseEvent(page(), WKMouseEventMake(kWKEventMouseUp, button, WKPointMake(x, y), 0, modifiers));
+}
+
+void PlatformWebView::simulateMouseMove(unsigned x, unsigned y, WKEventModifiers modifiers)
+{
+    WKPageHandleMouseEvent(page(), WKMouseEventMake(kWKEventMouseMove, kWKEventMouseButtonNoButton, WKPointMake(x, y), 0, modifiers));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### af208143c8139503872785ff9385e75ad0ed5411
<pre>
[WPE] Implement `PlatformWebView` key press and button clicks simulation methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=258665">https://bugs.webkit.org/show_bug.cgi?id=258665</a>

Reviewed by Miguel Gomez.

In fact, this is a copy of the Playstation port implementation with
some minor changes.

We are extending the `WKPage` API with a couple of functions that can
handle keyboard and mouse events.

These API events are then converted to `NativeWebKeyboardEvent` and
`NativeWebMouseEvent` respectively and sent to `WebPageProxy&apos; for handling.

* Source/WebKit/Shared/API/c/wpe/WKEventWPE.cpp: Added.
(WKKeyboardEventMake):
(WKMouseEventMake):
(WKWheelEventMake):
* Source/WebKit/Shared/API/c/wpe/WKEventWPE.h: Added.
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp: Added.
(WKPageHandleKeyboardEvent):
(WKPageHandleMouseEvent):
* Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.h: Added.
* Tools/TestWebKitAPI/PlatformWebView.h:
* Tools/TestWebKitAPI/glib/TestExpectations.json:
* Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp:
(TestWebKitAPI::PlatformWebView::simulateSpacebarKeyPress):
(TestWebKitAPI::PlatformWebView::simulateAltKeyPress):
(TestWebKitAPI::PlatformWebView::simulateRightClick):
(TestWebKitAPI::PlatformWebView::simulateButtonClick):
(TestWebKitAPI::PlatformWebView::simulateMouseMove):

Canonical link: <a href="https://commits.webkit.org/265620@main">https://commits.webkit.org/265620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5303e1c6483d4d3b23a67d96818d74c71997e929

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13486 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17527 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8993 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10096 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2739 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->