### PR TITLE
Implement word-break: auto

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6549,3 +6549,6 @@ imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-
 webkit.org/b/257336 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic.html [ Pass Failure ]
 
 webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
+
+# Only some OSes have support for auto word breaking.
+imported/w3c/web-platform-tests/css/css-text/word-break/auto [ Pass Failure ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-invalid-expected.txt
@@ -1,5 +1,4 @@
 
-PASS e.style['word-break'] = "auto" should not set the property value
 PASS e.style['word-break'] = "normal keep-all" should not set the property value
 PASS e.style['word-break'] = "break-all break-all" should not set the property value
 PASS e.style['word-break'] = "normal break-word" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-invalid.html
@@ -11,7 +11,6 @@
 </head>
 <body>
 <script>
-test_invalid_value("word-break", "auto");
 test_invalid_value("word-break", "normal keep-all");
 test_invalid_value("word-break", "break-all break-all");
 test_invalid_value("word-break", "normal break-word");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-valid-expected.txt
@@ -1,4 +1,5 @@
 
+PASS e.style['word-break'] = "auto" should set the property value
 PASS e.style['word-break'] = "normal" should set the property value
 PASS e.style['word-break'] = "keep-all" should set the property value
 PASS e.style['word-break'] = "break-all" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/word-break-valid.html
@@ -11,6 +11,7 @@
 </head>
 <body>
 <script>
+test_valid_value("word-break", "auto");
 test_valid_value("word-break", "normal");
 test_valid_value("word-break", "keep-all");
 test_valid_value("word-break", "break-all");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-000-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-000-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>明日</span></div>
+<div class="ref"><span>明日</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-000.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-000.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">明日</span></div></div>
+<div class="ref"><span>明日</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-001-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>携帯</span></div>
+<div class="ref"><span>携帯</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-001.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">携帯</span></div></div>
+<div class="ref"><span>携帯</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-002-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>キラ</span></div>
+<div class="ref"><span>キラ</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-002.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">キラ</span></div></div>
+<div class="ref"><span>キラ</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-003-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>베트남에서</span></div>
+<div class="ref"><span>베트남에서</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-003.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">베트남에서</span></div></div>
+<div class="ref"><span>베트남에서</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-004-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>회전교차로에서</span></div>
+<div class="ref"><span>회전교차로에서</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-004.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">회전교차로에서</span></div></div>
+<div class="ref"><span>회전교차로에서</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-005-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: keep-all; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="ref"><span>Pro를</span></div>
+<div class="ref"><span>Pro를</span></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/word-break/auto/word-break-auto-005.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>word-break: auto</title>
+<meta name="assert" content="word-break: auto keeps phrases together.">
+<link rel='help' href='https://drafts.csswg.org/css-text-3/#word-break-property'>
+<link rel='match' href='reference/word-break-auto-ref-000.html'>
+<link rel='author' title='Myles C. Maxfield' href='mailto:mmaxfield@apple.com'>
+<style type='text/css'>
+.test { word-break: auto; }
+/* the CSS below is not part of the test */
+.test, .ref { border: 1px solid orange;  margin: 20px;  padding: 10px; width: 1ic; font: 36px/1 sans-serif; }
+.ref { word-break: keep-all; }
+</style>
+</head>
+<body>
+<div id='instructions'>Test passes if the two orange boxes are the same.</div>
+<div class="test"><div id="testdiv"><span id="testspan">Pro를</span></div></div>
+<div class="ref"><span>Pro를</span></div>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1435,6 +1435,21 @@ CSSWhiteSpaceLonghandsEnabled:
     WebCore:
       default: false
 
+CSSWordBreakAutoEnabled:
+  type: bool
+  status: testable
+  category: css
+  webcoreOnChange: setNeedsRecalcStyleInAllFrames
+  humanReadableName: "word-break: auto enabled"
+  humanReadableDescription: "Enables the auto value of the word-break CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 CacheAPIEnabled:
   type: bool

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1354,7 +1354,7 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef FOR_EACH
 
 #define TYPE WordBreak
-#define FOR_EACH(CASE) CASE(Normal) CASE(BreakAll) CASE(KeepAll) CASE(BreakWord)
+#define FOR_EACH(CASE) CASE(Normal) CASE(BreakAll) CASE(KeepAll) CASE(BreakWord) CASE(Auto)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6134,7 +6134,11 @@
                 "normal",
                 "break-all",
                 "keep-all",
-                "break-word"
+                "break-word",
+                {
+                    "settings-flag": "cssWordBreakAutoEnabled",
+                    "value": "auto"
+                }
             ],
             "codegen-properties": {
                 "aliases": [

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -103,6 +103,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #endif
     , cssTextUnderlinePositionLeftRightEnabled { document.settings().cssTextUnderlinePositionLeftRightEnabled() }
     , cssTextWrapNewValuesEnabled { document.settings().cssTextWrapNewValuesEnabled() }
+    , cssWordBreakAutoEnabled { document.settings().cssWordBreakAutoEnabled() }
     , propertySettings { CSSPropertySettings { document.settings() } }
 {
 }
@@ -141,6 +142,7 @@ bool operator==(const CSSParserContext& a, const CSSParserContext& b)
         && a.cssPaintingAPIEnabled == b.cssPaintingAPIEnabled
         && a.cssTextUnderlinePositionLeftRightEnabled == b.cssTextUnderlinePositionLeftRightEnabled
         && a.cssTextWrapNewValuesEnabled == b.cssTextWrapNewValuesEnabled
+        && a.cssWordBreakAutoEnabled == b.cssWordBreakAutoEnabled
         && a.propertySettings == b.propertySettings
     ;
 }
@@ -173,7 +175,8 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cssPaintingAPIEnabled                     << 21
         | context.cssTextUnderlinePositionLeftRightEnabled  << 22
         | context.cssTextWrapNewValuesEnabled               << 23
-        | (uint64_t)context.mode                            << 24; // This is multiple bits, so keep it last.
+        | context.cssWordBreakAutoEnabled                   << 24
+        | (uint64_t)context.mode                            << 25; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,6 +95,7 @@ struct CSSParserContext {
     bool cssPaintingAPIEnabled { false };
     bool cssTextUnderlinePositionLeftRightEnabled { false };
     bool cssTextWrapNewValuesEnabled { false };
+    bool cssWordBreakAutoEnabled { false };
 
     // Settings, those affecting properties.
     CSSPropertySettings propertySettings;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -638,7 +638,7 @@ void InlineItemsBuilder::handleTextContent(const InlineTextBox& inlineTextBox, I
     auto& style = inlineTextBox.style();
     auto shouldPreserveSpacesAndTabs = TextUtil::shouldPreserveSpacesAndTabs(inlineTextBox);
     auto shouldPreserveNewline = TextUtil::shouldPreserveNewline(inlineTextBox);
-    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { text, style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis() };
+    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { text, style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis(style.wordBreak()) };
     auto currentPosition = partialContentOffset.value_or(0lu);
     ASSERT(currentPosition <= contentLength);
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -114,7 +114,7 @@ static inline bool endsWithSoftWrapOpportunity(const InlineTextItem& currentText
         // The bidi boundary may or may not be the reason for splitting the inline text box content.
         // FIXME: We could add a "reason flag" to InlineTextItem to tell why the split happened.
         auto& style = currentTextItem.style();
-        auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { currentTextItem.inlineTextBox().content(), style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis() };
+        auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { currentTextItem.inlineTextBox().content(), style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis(style.wordBreak()) };
         auto softWrapOpportunityCandidate = nextInlineTextItem.start();
         return TextUtil::findNextBreakablePosition(lineBreakIteratorFactory, softWrapOpportunityCandidate, style) == softWrapOpportunityCandidate;
     }
@@ -129,7 +129,7 @@ static inline bool endsWithSoftWrapOpportunity(const InlineTextItem& currentText
         currentContent.convertTo16Bit();
     }
     auto& style = nextInlineTextItem.style();
-    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { currentContent, style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis() };
+    auto lineBreakIteratorFactory = CachedLineBreakIteratorFactory { currentContent, style.computedLocale(), TextUtil::lineBreakIteratorMode(style.lineBreak()), TextUtil::contentAnalysis(style.wordBreak()) };
     auto previousContentLength = previousContent.length();
     // FIXME: We should look into the entire uncommitted content for more text context.
     UChar lastCharacter = previousContentLength ? previousContent[previousContentLength - 1] : 0;

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -378,9 +378,17 @@ TextBreakIterator::LineMode::Behavior TextUtil::lineBreakIteratorMode(LineBreak 
     return TextBreakIterator::LineMode::Behavior::Default;
 }
 
-TextBreakIterator::ContentAnalysis TextUtil::contentAnalysis()
+TextBreakIterator::ContentAnalysis TextUtil::contentAnalysis(WordBreak wordBreak)
 {
-    // FIXME: Implement this.
+    switch (wordBreak) {
+    case WordBreak::Normal:
+    case WordBreak::BreakAll:
+    case WordBreak::KeepAll:
+    case WordBreak::BreakWord:
+        return TextBreakIterator::ContentAnalysis::Mechanical;
+    case WordBreak::Auto:
+        return TextBreakIterator::ContentAnalysis::Linguistic;
+    }
     return TextBreakIterator::ContentAnalysis::Mechanical;
 }
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -70,7 +70,7 @@ public:
 
     static unsigned findNextBreakablePosition(CachedLineBreakIteratorFactory&, unsigned startPosition, const RenderStyle&);
     static TextBreakIterator::LineMode::Behavior lineBreakIteratorMode(LineBreak);
-    static TextBreakIterator::ContentAnalysis contentAnalysis();
+    static TextBreakIterator::ContentAnalysis contentAnalysis(WordBreak);
 
     static bool shouldPreserveSpacesAndTabs(const Box&);
     static bool shouldPreserveNewline(const Box&);

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1039,9 +1039,17 @@ TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak lineB
     return TextBreakIterator::LineMode::Behavior::Default;
 }
 
-TextBreakIterator::ContentAnalysis mapWordBoundaryDetectionToContentAnalysis()
+TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak wordBreak)
 {
-    // FIXME: Implement this.
+    switch (wordBreak) {
+    case WordBreak::Normal:
+    case WordBreak::BreakAll:
+    case WordBreak::KeepAll:
+    case WordBreak::BreakWord:
+        return TextBreakIterator::ContentAnalysis::Mechanical;
+    case WordBreak::Auto:
+        return TextBreakIterator::ContentAnalysis::Linguistic;
+    }
     return TextBreakIterator::ContentAnalysis::Mechanical;
 }
 
@@ -1136,7 +1144,7 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, HashSet<const Fo
     auto& string = text();
     unsigned length = string.length();
     auto iteratorMode = mapLineBreakToIteratorMode(style.lineBreak());
-    auto contentAnalysis = mapWordBoundaryDetectionToContentAnalysis();
+    auto contentAnalysis = mapWordBreakToContentAnalysis(style.wordBreak());
     CachedLineBreakIteratorFactory lineBreakIteratorFactory(string, style.computedLocale(), iteratorMode, contentAnalysis);
     bool needsWordSpacing = false;
     bool ignoringSpaces = false;

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -33,7 +33,6 @@ namespace WebCore {
 class Font;
 class LegacyInlineTextBox;
 struct GlyphOverflow;
-class WordBoundaryDetection;
 struct WordTrailingSpace;
 
 namespace LayoutIntegration {
@@ -262,7 +261,7 @@ private:
 String applyTextTransform(const RenderStyle&, const String&, UChar previousCharacter);
 String capitalize(const String&, UChar previousCharacter);
 TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak);
-TextBreakIterator::ContentAnalysis mapWordBoundaryDetectionToContentAnalysis();
+TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak);
 
 inline UChar RenderText::characterAt(unsigned i) const
 {

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -701,7 +701,7 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements, bool
     bool keepAllWords = style.wordBreak() == WordBreak::KeepAll;
     float hyphenWidth = 0;
     auto iteratorMode = mapLineBreakToIteratorMode(m_blockStyle.lineBreak());
-    auto contentAnalysis = mapWordBoundaryDetectionToContentAnalysis();
+    auto contentAnalysis = mapWordBreakToContentAnalysis(m_blockStyle.wordBreak());
     bool canUseLineBreakShortcut = iteratorMode == TextBreakIterator::LineMode::Behavior::Default;
     bool isLineEmpty = m_lineInfo.isEmpty();
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1326,6 +1326,7 @@ TextStream& operator<<(TextStream& ts, WordBreak wordBreak)
     case WordBreak::BreakAll: ts << "break-all"; break;
     case WordBreak::KeepAll: ts << "keep-all"; break;
     case WordBreak::BreakWord: ts << "break-word"; break;
+    case WordBreak::Auto: ts << "auto"; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
@@ -536,7 +536,8 @@ enum class WordBreak : uint8_t {
     Normal,
     BreakAll,
     KeepAll,
-    BreakWord
+    BreakWord,
+    Auto
 };
 
 enum class OverflowWrap : uint8_t {

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -111,7 +111,7 @@ public:
     
     unsigned textSecurity : 2; // TextSecurity
     unsigned userModify : 2; // UserModify (editing)
-    unsigned wordBreak : 2; // WordBreak
+    unsigned wordBreak : 3; // WordBreak
     unsigned overflowWrap : 2; // OverflowWrap
     unsigned nbspMode : 1; // NBSPMode
     unsigned lineBreak : 3; // LineBreak


### PR DESCRIPTION
#### bd716947b5196a89ab2d9621075984389e2d4e50
<pre>
Implement word-break: auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=258668">https://bugs.webkit.org/show_bug.cgi?id=258668</a>
rdar://111507205

Reviewed by Tim Nguyen.

<a href="https://github.com/w3c/csswg-drafts/issues/7193#issuecomment-1611772475">https://github.com/w3c/csswg-drafts/issues/7193#issuecomment-1611772475</a> says:
&gt; RESOLVED: remove auto () from word-boundary-detection, add keyword to word-break
&gt; for this functionality

This patch implements word-break: auto and hooks it up to the CFStringTokenizer
infrastructure already implemented in 265059@main.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::endsWithSoftWrapOpportunity):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::contentAnalysis):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::mapWordBreakToContentAnalysis):
(WebCore::RenderText::computePreferredLogicalWidths):
(WebCore::mapWordBoundaryDetectionToContentAnalysis): Deleted.
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:

Canonical link: <a href="https://commits.webkit.org/265671@main">https://commits.webkit.org/265671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b3f8be148cdb5cc91c7c86860e4580d1b39f80b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13244 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13927 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13665 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10530 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9863 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13863 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11006 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9133 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11687 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10409 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14536 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12017 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10939 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2920 "Passed tests") | 
<!--EWS-Status-Bubble-End-->