### PR TITLE
[CSS] Update Full Size Kana map to Unicode 15.0

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2996,7 +2996,6 @@ webkit.org/b/195275 imported/w3c/web-platform-tests/css/css-text/text-transform/
 webkit.org/b/195275 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-shaping-001.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-upperlower-016.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-upperlower-044.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-full-size-kana-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-upperlower-106.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/text-transform/math/text-transform-math-auto-001.html [ ImageOnlyFailure ]
 webkit.org/b/214290 imported/w3c/web-platform-tests/css/css-text/text-transform/math/text-transform-math-auto-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css/text-transform-full-size-kana-expected.html
+++ b/LayoutTests/fast/css/text-transform-full-size-kana-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: Unicode 15 kana and text-transform: full-size-kana</title>
+<style>
+</style>
+
+<div>&#x3042;&#x30F3;&#x1BBBB;</div>

--- a/LayoutTests/fast/css/text-transform-full-size-kana.html
+++ b/LayoutTests/fast/css/text-transform-full-size-kana.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: Unicode 15 kana and text-transform: full-size-kana</title>
+<style>
+div {
+  text-transform: full-size-kana
+}
+</style>
+
+<div>&#x3041;&#x1B167;&#x1BBBB;</div>

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1481,7 +1481,7 @@ UChar RenderText::previousCharacter() const
 static String convertToFullSizeKana(const String& string)
 {
     // https://www.w3.org/TR/css-text-3/#small-kana
-    static constexpr std::pair<UChar, UChar> kanasMap[] = {
+    static constexpr std::pair<UChar32, UChar> kanasMap[] = {
         { 0x3041, 0x3042 },
         { 0x3043, 0x3044 },
         { 0x3045, 0x3046 },
@@ -1530,19 +1530,35 @@ static String convertToFullSizeKana(const String& string)
         { 0xFF6C, 0xFF94 },
         { 0xFF6D, 0xFF95 },
         { 0xFF6E, 0xFF96 },
-        { 0xFF6F, 0xFF82 }
+        { 0xFF6F, 0xFF82 },
+        { 0x1B132, 0x3053 },
+        { 0x1B150, 0x3090 },
+        { 0x1B151, 0x3091 },
+        { 0x1B152, 0x3092 },
+        { 0x1B155, 0x30B3 },
+        { 0x1B164, 0x30F0 },
+        { 0x1B165, 0x30F1 },
+        { 0x1B166, 0x30F2 },
+        { 0x1B167, 0x30F3 }
     };
-    static constexpr auto sortedMap = SortedArrayMap { kanasMap };
+
+    static constexpr SortedArrayMap sortedMap { kanasMap };
 
     StringBuilder result;
-    auto codeUnits = StringView { string }.codeUnits();
-    for (const auto character : codeUnits) {
-        if (auto found = sortedMap.tryGet(character))
+    auto codePoints = StringView { string }.codePoints();
+    bool hasChanged = false;
+    for (auto character : codePoints) {
+        if (auto found = sortedMap.tryGet(character)) {
             result.append(*found);
-        else
-            result.append(character);
+            hasChanged = true;
+        } else
+            result.appendCharacter(character);
     }
-    return result == string ? string : result.toString();
+
+    if (hasChanged)
+        return result.toString();
+
+    return string;
 }
 
 String applyTextTransform(const RenderStyle& style, const String& text, UChar previousCharacter)


### PR DESCRIPTION
#### f40b35978cf406e1d82902dcb8106232fe0cf32a
<pre>
[CSS] Update Full Size Kana map to Unicode 15.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=258671">https://bugs.webkit.org/show_bug.cgi?id=258671</a>
<a href="https://rdar.apple.com/111508663">rdar://111508663</a>

Reviewed by Darin Adler.

The table has been updated in the CSS Text specification:
<a href="https://github.com/w3c/csswg-drafts/commit/9110c78e787ac8e8f85825dd0e37d0736943cdc5">https://github.com/w3c/csswg-drafts/commit/9110c78e787ac8e8f85825dd0e37d0736943cdc5</a>

The code now use code points (because some of the mapped code points
are represented by more than one code unit).
The code is careful about correctly cutting the unnecessary high level bits
for code points which are effectively represented which a single UTF-16 code unit.

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/text-transform-full-size-kana-expected.html: Added.
* LayoutTests/fast/css/text-transform-full-size-kana.html: Added.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::convertToFullSizeKana):

Canonical link: <a href="https://commits.webkit.org/271276@main">https://commits.webkit.org/271276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a391781cd94b9e6b8571757e70052a34180680

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/27875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/6514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/29147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/30406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/25442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/28369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/8490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/3908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/25213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/28141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/5270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/23929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/4544 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/4730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/24944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/31094 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/25477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/25387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/30932 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/4739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/2894 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/28795 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/6260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/24687 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/6692 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/5185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/5207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->