### PR TITLE
Revert [265610@main] Regression: User-friendly name for the GPUProcess no longer gets set

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -298,10 +298,6 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 #if USE(OS_STATE)
     registerWithStateDumper("GPUProcess state"_s);
 #endif
-
-#if PLATFORM(COCOA)
-    platformInitializeGPUProcess(parameters);
-#endif
 }
 
 void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -177,10 +177,6 @@ private:
 #if PLATFORM(MAC)
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);
     void setScreenProperties(const WebCore::ScreenProperties&);
-    void updateProcessName();
-#endif
-#if PLATFORM(COCOA)
-    void platformInitializeGPUProcess(GPUProcessCreationParameters&);
 #endif
 
 #if USE(OS_STATE)
@@ -236,9 +232,6 @@ private:
     WebCore::Timer m_idleExitTimer;
     std::unique_ptr<WebCore::NowPlayingManager> m_nowPlayingManager;
     String m_applicationVisibleName;
-#if PLATFORM(MAC)
-    String m_uiProcessName;
-#endif
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable std::unique_ptr<RemoteAudioSessionProxyManager> m_audioSessionManager;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -46,7 +46,6 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << useMockCaptureDevices;
 #if PLATFORM(MAC)
     encoder << microphoneSandboxExtensionHandle;
-    encoder << launchServicesExtensionHandle;
 #endif
 #endif
 #if HAVE(AVCONTENTKEYSPECIFIER)
@@ -88,8 +87,6 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
         return false;
 #if PLATFORM(MAC)
     if (!decoder.decode(result.microphoneSandboxExtensionHandle))
-        return false;
-    if (!decoder.decode(result.launchServicesExtensionHandle))
         return false;
 #endif
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -46,7 +46,6 @@ struct GPUProcessCreationParameters {
     bool useMockCaptureDevices { false };
 #if PLATFORM(MAC)
     SandboxExtension::Handle microphoneSandboxExtensionHandle;
-    SandboxExtension::Handle launchServicesExtensionHandle;
 #endif
 #endif
 #if HAVE(AVCONTENTKEYSPECIFIER)

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -31,15 +31,10 @@
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
 
 #import "GPUConnectionToWebProcess.h"
-#import "GPUProcessCreationParameters.h"
 #import "Logging.h"
 #import "RemoteRenderingBackend.h"
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/RetainPtr.h>
-
-#if PLATFORM(MAC)
-#include <pal/spi/cocoa/LaunchServicesSPI.h>
-#endif
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
@@ -93,33 +88,6 @@ void GPUProcess::ensureAVCaptureServerConnection()
     }
 }
 #endif
-
-void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& parameters)
-{
-#if PLATFORM(MAC)
-    auto launchServicesExtension = SandboxExtension::create(WTFMove(parameters.launchServicesExtensionHandle));
-    if (launchServicesExtension) {
-        bool ok = launchServicesExtension->consume();
-        ASSERT_UNUSED(ok, ok);
-    }
-
-    // It is important to check in with launch services before setting the process name.
-    launchServicesCheckIn();
-
-    // Update process name while holding the Launch Services sandbox extension
-    updateProcessName();
-
-    // Close connection to launch services.
-#if HAVE(HAVE_LS_SERVER_CONNECTION_STATUS_RELEASE_NOTIFICATIONS_MASK)
-    _LSSetApplicationLaunchServicesServerConnectionStatus(kLSServerConnectionStatusDoNotConnectToServerMask | kLSServerConnectionStatusReleaseNotificationsMask, nullptr);
-#else
-    _LSSetApplicationLaunchServicesServerConnectionStatus(kLSServerConnectionStatusDoNotConnectToServerMask, nullptr);
-#endif
-
-    if (launchServicesExtension)
-        launchServicesExtension->revoke();
-#endif // PLATFORM(MAC)
-}
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -62,17 +62,9 @@ void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
 
 void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
-#if PLATFORM(MAC)
-    m_uiProcessName = parameters.uiProcessName;
-#endif
-}
-
-void GPUProcess::updateProcessName()
-{
 #if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)m_uiProcessName];
-    auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
-    ASSERT_UNUSED(result, result == noErr);
+    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)parameters.uiProcessName];
+    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -799,12 +799,8 @@
         "com.apple.DiskArbitration.diskarbitrationd"
         "com.apple.ViewBridgeAuxiliary"
         "com.apple.audioanalyticsd"
+        "com.apple.coreservices.launchservicesd"
         "com.apple.windowserver.active"))
-
-(allow mach-lookup
-    (require-all
-        (extension "com.apple.webkit.extension.mach")
-        (global-name "com.apple.coreservices.launchservicesd")))
         
 (deny mach-lookup (with no-report)
     (global-name-prefix "com.apple.distributed_notifications"))

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -49,10 +49,6 @@ void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationP
     parameters.gpuToolsExtensionHandles = createGPUToolsSandboxExtensionHandlesIfNeeded();
     parameters.applicationVisibleName = applicationVisibleName();
     parameters.strictSecureDecodingForAllObjCEnabled = IPC::strictSecureDecodingForAllObjCEnabled();
-#if PLATFORM(MAC)
-    if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))
-        parameters.launchServicesExtensionHandle = WTFMove(*launchServicesExtensionHandle);
-#endif
 }
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)


### PR DESCRIPTION
#### d42ba8c64e46430dacf3c77d4e3ae1ea840d44c4
<pre>
Revert [265610@main] Regression: User-friendly name for the GPUProcess no longer gets set
<a href="https://bugs.webkit.org/show_bug.cgi?id=258600">https://bugs.webkit.org/show_bug.cgi?id=258600</a>
Unreviewed revert
This reverts because it broke the build for the bots.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const):
(WebKit::GPUProcessCreationParameters::decode):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess): Deleted.
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeProcessName):
(WebKit::GPUProcess::updateProcessName): Deleted.
* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):

Canonical link: <a href="https://commits.webkit.org/265619@main">https://commits.webkit.org/265619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7dfa7dfd3731555e4599bf355b8d4c3aee95ab5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13075 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/10880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11616 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11593 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13495 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/10826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10930 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10105 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14378 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1287 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->