### PR TITLE
Regression: User-friendly name for the GPUProcess no longer gets set

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -298,6 +298,10 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 #if USE(OS_STATE)
     registerWithStateDumper("GPUProcess state"_s);
 #endif
+
+#if PLATFORM(COCOA)
+    platformInitializeGPUProcess(parameters);
+#endif
 }
 
 void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -177,6 +177,10 @@ private:
 #if PLATFORM(MAC)
     void displayConfigurationChanged(CGDirectDisplayID, CGDisplayChangeSummaryFlags);
     void setScreenProperties(const WebCore::ScreenProperties&);
+    void updateProcessName();
+#endif
+#if PLATFORM(COCOA)
+    void platformInitializeGPUProcess(GPUProcessCreationParameters&);
 #endif
 
 #if USE(OS_STATE)
@@ -232,6 +236,9 @@ private:
     WebCore::Timer m_idleExitTimer;
     std::unique_ptr<WebCore::NowPlayingManager> m_nowPlayingManager;
     String m_applicationVisibleName;
+#if PLATFORM(MAC)
+    String m_uiProcessName;
+#endif
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable std::unique_ptr<RemoteAudioSessionProxyManager> m_audioSessionManager;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -46,6 +46,7 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << useMockCaptureDevices;
 #if PLATFORM(MAC)
     encoder << microphoneSandboxExtensionHandle;
+    encoder << launchServicesExtensionHandle;
 #endif
 #endif
 #if HAVE(AVCONTENTKEYSPECIFIER)
@@ -87,6 +88,8 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
         return false;
 #if PLATFORM(MAC)
     if (!decoder.decode(result.microphoneSandboxExtensionHandle))
+        return false;
+    if (!decoder.decode(result.launchServicesExtensionHandle))
         return false;
 #endif
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -46,6 +46,7 @@ struct GPUProcessCreationParameters {
     bool useMockCaptureDevices { false };
 #if PLATFORM(MAC)
     SandboxExtension::Handle microphoneSandboxExtensionHandle;
+    SandboxExtension::Handle launchServicesExtensionHandle;
 #endif
 #endif
 #if HAVE(AVCONTENTKEYSPECIFIER)

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -62,11 +62,21 @@ void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
 
 void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
-#if !PLATFORM(MACCATALYST)
-    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)parameters.uiProcessName];
-    _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
+#if PLATFORM(MAC)
+    m_uiProcessName = parameters.uiProcessName;
 #endif
 }
+
+#if PLATFORM(MAC)
+void GPUProcess::updateProcessName()
+{
+#if !PLATFORM(MACCATALYST)
+    NSString *applicationName = [NSString stringWithFormat:WEB_UI_NSSTRING(@"%@ Graphics and Media", "visible name of the GPU process. The argument is the application name."), (NSString *)m_uiProcessName];
+    auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, _LSGetCurrentApplicationASN(), _kLSDisplayNameKey, (CFStringRef)applicationName, nullptr);
+    ASSERT_UNUSED(result, result == noErr);
+#endif
+}
+#endif
 
 void GPUProcess::initializeSandbox(const AuxiliaryProcessInitializationParameters& parameters, SandboxInitializationParameters& sandboxParameters)
 {

--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -799,8 +799,12 @@
         "com.apple.DiskArbitration.diskarbitrationd"
         "com.apple.ViewBridgeAuxiliary"
         "com.apple.audioanalyticsd"
-        "com.apple.coreservices.launchservicesd"
         "com.apple.windowserver.active"))
+
+(allow mach-lookup
+    (require-all
+        (extension "com.apple.webkit.extension.mach")
+        (global-name "com.apple.coreservices.launchservicesd")))
         
 (deny mach-lookup (with no-report)
     (global-name-prefix "com.apple.distributed_notifications"))

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -49,6 +49,10 @@ void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationP
     parameters.gpuToolsExtensionHandles = createGPUToolsSandboxExtensionHandlesIfNeeded();
     parameters.applicationVisibleName = applicationVisibleName();
     parameters.strictSecureDecodingForAllObjCEnabled = IPC::strictSecureDecodingForAllObjCEnabled();
+#if PLATFORM(MAC)
+    if (auto launchServicesExtensionHandle = SandboxExtension::createHandleForMachLookup("com.apple.coreservices.launchservicesd"_s, std::nullopt))
+        parameters.launchServicesExtensionHandle = WTFMove(*launchServicesExtensionHandle);
+#endif
 }
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)


### PR DESCRIPTION
#### 696d5ab56e5cb4a5a32408698deb2a9e63ff0cb4
<pre>
Regression: User-friendly name for the GPUProcess no longer gets set
<a href="https://bugs.webkit.org/show_bug.cgi?id=258600">https://bugs.webkit.org/show_bug.cgi?id=258600</a>

Reviewed by Per Arne Vollan and Brent Fulgham.

Access to launch services has been blocked by the GPUProcess&apos; sandbox. As a
result, the GPUProcess no longer gets a user-friendly name in Activity Monitor.

To address the issue, we now:
1. Have the UIProcess create a sandbox extension for launch services and send it
   to the GPUProcess to temporarily consume it during initialization
2. The GPUProcess, on initialization now consumes this extension
3. The GPUProcess checks in with Launch Services and sets the process name
4. The GPUProcess closes connections to launch services
5. The GPUProcess revokes the sandbox extension

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const):
(WebKit::GPUProcessCreationParameters::decode):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeProcessName):
(WebKit::GPUProcess::updateProcessName):
* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):

Canonical link: <a href="https://commits.webkit.org/265622@main">https://commits.webkit.org/265622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b1e80b53d1ba9f952988df6e9cba1389091b30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13076 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10881 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13790 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12464 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13496 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9756 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10827 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13725 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10106 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2741 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14379 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->