### PR TITLE
GraphicsContextState returns it has inline changes when it does not have any change

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -46,7 +46,7 @@ GraphicsContextState GraphicsContextState::cloneForRecording() const
 
 bool GraphicsContextState::containsOnlyInlineChanges() const
 {
-    if (m_changeFlags != (m_changeFlags & basicChangeFlags))
+    if (m_changeFlags.isEmpty() || m_changeFlags != (m_changeFlags & basicChangeFlags))
         return false;
 
     if (m_changeFlags.contains(Change::StrokeBrush) && !m_strokeBrush.isInlineColor())
@@ -60,7 +60,7 @@ bool GraphicsContextState::containsOnlyInlineChanges() const
 
 bool GraphicsContextState::containsOnlyInlineStrokeChanges() const
 {
-    if (m_changeFlags != (m_changeFlags & strokeChangeFlags))
+    if (m_changeFlags.isEmpty() || m_changeFlags != (m_changeFlags & strokeChangeFlags))
         return false;
 
     if (m_changeFlags.contains(Change::StrokeBrush) && !m_strokeBrush.isInlineColor())


### PR DESCRIPTION
#### 3f9ec4370045aee58faa071ae21fa8dc6429ac3a
<pre>
GraphicsContextState returns it has inline changes when it does not have any change
<a href="https://bugs.webkit.org/show_bug.cgi?id=258673">https://bugs.webkit.org/show_bug.cgi?id=258673</a>
rdar://111513820

Reviewed by Wenson Hsieh.

containsOnlyInlineChanges() and containsOnlyInlineStrokeChanges() should return
false when the m_changeFlags is empty.

The condition `if (m_changeFlags != (m_changeFlags &amp; basicChangeFlags))` is
evaluated to false when m_changeFlags is empty.

* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::containsOnlyInlineChanges const):
(WebCore::GraphicsContextState::containsOnlyInlineStrokeChanges const):

Canonical link: <a href="https://commits.webkit.org/265627@main">https://commits.webkit.org/265627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1baadc345306f256e5eb1c8114c7a742081b792

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12465 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9683 "55 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13498 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17535 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13723 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9005 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10108 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2749 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->