### PR TITLE
[GStreamer][WebCodecs] Rebaseline after 265616@main

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1125,9 +1125,6 @@ imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?v
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
-# Needs rebasing
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.html [ Pass Failure ]
-imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker.html [ Pass Failure ]
 
 # Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -1,0 +1,16 @@
+
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Emtpy codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Unrecognized codec
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
+PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
+PASS VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters
+FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
+FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}
+


### PR DESCRIPTION
#### e8ac547a12a92c5e13dfc5d38816922295beb1a7
<pre>
[GStreamer][WebCodecs] Rebaseline after 265616@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=258678">https://bugs.webkit.org/show_bug.cgi?id=258678</a>

Reviewed by Xabier Rodriguez-Calvar.

Add basic sanity checks on width and height values of the encoder configuration. This also makes the
&quot;Too strenuous accelerated encoding parameters&quot; test pass on our platform, so add baselines accordingly.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt: Added.
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSetEncoder):

Canonical link: <a href="https://commits.webkit.org/265649@main">https://commits.webkit.org/265649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920d282b0481413b27135b007fac1cda6ba9b1d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13510 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17545 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13733 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10937 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9008 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10112 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2763 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->