### PR TITLE
Update color-span-inside-editable tests for redesigned text cursor

### DIFF
--- a/LayoutTests/editing/caret/color-span-inside-editable-background-expected.html
+++ b/LayoutTests/editing/caret/color-span-inside-editable-background-expected.html
@@ -1,4 +1,4 @@
-This test makes sure that carets in content editable divs with a background color specified remain black even if there is a span inside them with a foreground color specified.
+This test makes sure that carets in content editable divs with a background color specified remain as default even if there is a span inside them with a foreground color specified.
 <div style="width: 505px; height: 505px; overflow: hidden;">
 <div style="width: 50px; height: 500px; background-color: red"></div>
 </div>

--- a/LayoutTests/editing/caret/color-span-inside-editable-background.html
+++ b/LayoutTests/editing/caret/color-span-inside-editable-background.html
@@ -1,4 +1,4 @@
-This test makes sure that carets in content editable divs with a background color specified remain black even if there is a span inside them with a foreground color specified.
+This test makes sure that carets in content editable divs with a background color specified remain as default even if there is a span inside them with a foreground color specified.
 <div style="width: 505px; height: 505px; overflow: hidden;">
 <div id="edit" contenteditable="true" style="background: #fff; -webkit-transform-origin: left top; -webkit-transform: scale(50, 50); outline: none; font-family: Ahem; font-size: 10px;"><span id="spn" style="color: red;">&nbsp;&nbsp;</span></div>
 </div>

--- a/LayoutTests/editing/caret/color-span-inside-editable-expected.html
+++ b/LayoutTests/editing/caret/color-span-inside-editable-expected.html
@@ -1,4 +1,4 @@
-This test makes sure that carets in content editable divs remain black even if there is a span inside them with a foreground color specified.
+This test makes sure that carets in content editable divs remain as default if there is a span inside them with a foreground color specified.
 <div style="width: 505px; height: 505px; overflow: hidden;">
 <div style="width: 50px; height: 500px; background-color: red"></div>
 </div>

--- a/LayoutTests/editing/caret/color-span-inside-editable.html
+++ b/LayoutTests/editing/caret/color-span-inside-editable.html
@@ -1,4 +1,4 @@
-This test makes sure that carets in content editable divs remain black even if there is a span inside them with a foreground color specified.
+This test makes sure that carets in content editable divs remain as default if there is a span inside them with a foreground color specified.
 <div style="width: 505px; height: 505px; overflow: hidden;">
 <div id="edit" contenteditable="true" style="-webkit-transform-origin: left top; -webkit-transform: scale(50, 50); outline: none; font-family: Ahem; font-size: 10px;"><span id="spn" style="color: red;">&nbsp;&nbsp;</span></div>
 </div>


### PR DESCRIPTION
#### b78da69ee5d73ce851b17712af9f3a74aa786a18
<pre>
Update color-span-inside-editable tests for redesigned text cursor
<a href="https://bugs.webkit.org/show_bug.cgi?id=258679">https://bugs.webkit.org/show_bug.cgi?id=258679</a>
rdar://111079967

Reviewed by Tim Nguyen.

This is a preparation for the redesigned cursor update. For now the tests are just updating the description.

* LayoutTests/editing/caret/color-span-inside-editable-background-expected.html:
* LayoutTests/editing/caret/color-span-inside-editable-background.html:
* LayoutTests/editing/caret/color-span-inside-editable-expected.html:
* LayoutTests/editing/caret/color-span-inside-editable.html:

Canonical link: <a href="https://commits.webkit.org/265630@main">https://commits.webkit.org/265630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e3984436127d5aa12021e76a0402121f2745b46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10945 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13820 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12502 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13538 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9794 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10865 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13757 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10143 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/10295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2750 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10826 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->