### PR TITLE
REGRESSION(262616@main): wpt/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Feature policy 'Payment' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute ';payment'.
+
+PASS permissions policy allow="payment" allows same-origin navigation in an iframe.
+PASS permissions policy allow="payment" disallows cross-origin navigation in an iframe.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<body>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+  <script src=/permissions-policy/resources/permissions-policy.js></script>
+  <script src=/common/get-host-info.sub.js></script>
+  <script>
+  'use strict';
+  var relative_path = '/permissions-policy/resources/permissions-policy-payment.html';
+  var base_src = '/permissions-policy/resources/redirect-on-load.html#';
+  var same_origin_src = base_src + relative_path;
+  var cross_origin_src = base_src + get_host_info().REMOTE_ORIGIN +
+    relative_path;
+  var header = 'permissions policy allow="payment"';
+
+  async_test(t => {
+    test_feature_availability(
+        'PaymentRequest()', t, same_origin_src,
+        expect_feature_available_default, 'payment');
+  }, header + ' allows same-origin navigation in an iframe.');
+
+  async_test(t => {
+    test_feature_availability(
+        'PaymentRequest()', t, cross_origin_src,
+        expect_feature_unavailable_default, 'payment');
+  }, header + ' disallows cross-origin navigation in an iframe.');
+
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment.html
@@ -1,0 +1,17 @@
+<script>
+'use strict';
+
+window.onload = function() {
+  var supportedInstruments = [ { supportedMethods: [ 'visa' ] } ];
+  var details = {
+      total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
+  };
+  let enabled = true;
+  try {
+    new PaymentRequest(supportedInstruments, details);
+  } catch (e) {
+    enabled = false;
+  }
+  parent.postMessage({ type: 'availability-result', enabled }, '*');
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js
@@ -24,11 +24,13 @@ function assert_permissions_policy_supported() {
 //      feature (https://w3c.github.io/webappsec-permissions-policy/#features).
 //      See examples at:
 //      https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
-//    allow_attribute: Optional argument, only used for testing fullscreen or
-//      payment: either "allowfullscreen" or "allowpaymentrequest" is passed.
+//    allow_attribute: Optional argument, only used for testing fullscreen
+//      by passing "allowfullscreen".
+//    is_promise_test: Optional argument, true if this call should return a
+//    promise. Used by test_feature_availability_with_post_message_result()
 function test_feature_availability(
     feature_description, test, src, expect_feature_available, feature_name,
-    allow_attribute) {
+    allow_attribute, is_promise_test = false) {
   let frame = document.createElement('iframe');
   frame.src = src;
 
@@ -40,16 +42,26 @@ function test_feature_availability(
     frame.setAttribute(allow_attribute, true);
   }
 
-  window.addEventListener('message', test.step_func(evt => {
+  function expectFeatureAvailable(evt) {
     if (evt.source === frame.contentWindow &&
         evt.data.type === 'availability-result') {
       expect_feature_available(evt.data, feature_description);
       document.body.removeChild(frame);
       test.done();
     }
-  }));
+  }
 
+  if (!is_promise_test) {
+    window.addEventListener('message', test.step_func(expectFeatureAvailable));
+    document.body.appendChild(frame);
+    return;
+  }
+
+  const promise = new Promise((resolve) => {
+                    window.addEventListener('message', resolve);
+                  }).then(expectFeatureAvailable);
   document.body.appendChild(frame);
+  return promise;
 }
 
 // Default helper functions to test a feature's availability:
@@ -76,7 +88,8 @@ function test_feature_availability_with_post_message_result(
   const test_result = ({ name, message }, feature_description) => {
     assert_equals(name, expected_result, message + '.');
   };
-  test_feature_availability(null, test, src, test_result, allow_attribute);
+  return test_feature_availability(
+      null, test, src, test_result, allow_attribute, undefined, true);
 }
 
 // If this page is intended to test the named feature (according to the URL),
@@ -163,9 +176,9 @@ function run_all_fp_tests_allow_self(
 
   // 2. Allowed in same-origin iframe.
   const same_origin_frame_pathname = same_origin_url(feature_name);
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, same_origin_frame_pathname, '#OK');
       },
       'Default "' + feature_name +
@@ -173,29 +186,29 @@ function run_all_fp_tests_allow_self(
 
   // 3. Blocked in cross-origin iframe.
   const cross_origin_frame_url = cross_origin_url(cross_origin, feature_name);
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, cross_origin_frame_url, error_name);
       },
       'Default "' + feature_name +
           '" permissions policy ["self"] disallows cross-origin iframes.');
 
   // 4. Allowed in cross-origin iframe with "allow" attribute.
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, cross_origin_frame_url, '#OK', feature_name);
       },
       'permissions policy "' + feature_name +
           '" can be enabled in cross-origin iframes using "allow" attribute.');
 
   // 5. Blocked in same-origin iframe with "allow" attribute set to 'none'.
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, same_origin_frame_pathname, error_name,
-            feature_name + " 'none'");
+            feature_name + ' \'none\'');
       },
       'permissions policy "' + feature_name +
           '" can be disabled in same-origin iframes using "allow" attribute.');
@@ -246,9 +259,9 @@ function run_all_fp_tests_allow_all(
 
   // 2. Allowed in same-origin iframe.
   const same_origin_frame_pathname = same_origin_url(feature_name);
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, same_origin_frame_pathname, '#OK');
       },
       'Default "' + feature_name +
@@ -256,30 +269,29 @@ function run_all_fp_tests_allow_all(
 
   // 3. Allowed in cross-origin iframe.
   const cross_origin_frame_url = cross_origin_url(cross_origin, feature_name);
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, cross_origin_frame_url, '#OK');
       },
       'Default "' + feature_name +
           '" permissions policy ["*"] allows cross-origin iframes.');
 
   // 4. Blocked in cross-origin iframe with "allow" attribute set to 'none'.
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
-            t, cross_origin_frame_url, error_name,
-            feature_name + " 'none'");
+        return test_feature_availability_with_post_message_result(
+            t, cross_origin_frame_url, error_name, feature_name + ' \'none\'');
       },
       'permissions policy "' + feature_name +
           '" can be disabled in cross-origin iframes using "allow" attribute.');
 
   // 5. Blocked in same-origin iframe with "allow" attribute set to 'none'.
-  async_test(
+  promise_test(
       t => {
-        test_feature_availability_with_post_message_result(
+        return test_feature_availability_with_post_message_result(
             t, same_origin_frame_pathname, error_name,
-            feature_name + " 'none'");
+            feature_name + ' \'none\'');
       },
       'permissions policy "' + feature_name +
           '" can be disabled in same-origin iframes using "allow" attribute.');

--- a/LayoutTests/imported/w3c/web-platform-tests/permissions/resources/redirect-on-load.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions/resources/redirect-on-load.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<body>
+<script>
+// Automatically redirects the page to a new URL on load.
+// Load this document with a URL like:
+//     "permissions-policy/resources/redirect-on-load.html#https://www.example.com/"
+window.onload = function () {
+  document.location = document.location.hash.substring(1);
+}
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,5 +1,5 @@
-
+CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for iframe with origin 'https://127.0.0.1:9443' and allow attribute ';screen-wake-lock'.
 
 PASS Feature-Policy allow="screen-wake-lock" allows same-origin relocation
-FAIL Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation assert_false: navigator.wakeLock.request("screen") expected false got true
+PASS Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2400,6 +2400,7 @@ webgl/webgl-fail-remote-context-ipc-buffer-allocation-no-crash.html [ Skip ]
 
 # Payment Request
 imported/w3c/web-platform-tests/payment-request [ Skip ]
+imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html [ Skip ]
 
 # WebArchive
 webarchive [ WontFix ]

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/screen-wake-lock/wakelock-enabled-by-feature-policy-attribute-redirect-on-load.https.sub-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: Feature policy 'ScreenWakeLock' check failed for iframe with origin 'https://www1.web-platform.test:9443' and allow attribute ';screen-wake-lock'.
+
+PASS Feature-Policy allow="screen-wake-lock" allows same-origin relocation
+PASS Feature-Policy allow="screen-wake-lock" disallows cross-origin relocation
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -75,6 +75,9 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interfac
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-setsinkid.https.html [ Skip ]
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiocontext-interface/audiocontext-sinkid-state-change.https.html [ Skip ]
 
+# Payment request API is not supported on WK1.
+imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html [ Skip ]
+
 # No support for the Clear-Site-Data header in WebKit1.
 imported/w3c/web-platform-tests/clear-site-data [ Skip ]
 http/tests/clear-site-data [ Skip ]


### PR DESCRIPTION
#### 4be71d55e77b3a3c6216e19dc23db4504ad93bbc
<pre>
REGRESSION(262616@main): wpt/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=258217">https://bugs.webkit.org/show_bug.cgi?id=258217</a>
rdar://110907826

Reviewed by Ryosuke Niwa.

According to the specification [1]:
```
The allowlist for the features named in the attribute may be empty; in that
case, the default value for the allowlist is &apos;src&apos;, which represents the origin
of the URL in the iframe’s src attribute.
```

However, in FeaturePolicy&apos;s updateList(), we would set the AllowRule&apos;s type
to Type::All, which would be equivalent to having an allowlist of &apos;*&apos;.

To address the issue, we now get the iframe&apos;s src URL and compute its origin,
we then add this origin to the allowed list of origins. This implements
allowlist &apos;src&apos; behavior.

[1] <a href="https://www.w3.org/TR/permissions-policy/#iframe-allow-attribute">https://www.w3.org/TR/permissions-policy/#iframe-allow-attribute</a>

* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/payment-allowed-by-permissions-policy-attribute-redirect-on-load.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy-payment.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/permissions-policy/resources/permissions-policy.js:
(expectFeatureAvailable):
(test_feature_availability):
(test_feature_availability_with_post_message_result):
(run_all_fp_tests_allow_self):
* LayoutTests/imported/w3c/web-platform-tests/permissions/resources/redirect-on-load.html: Added.
Import WPT test coverage.

* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::updateList):
(WebCore::FeaturePolicy::parse):

Canonical link: <a href="https://commits.webkit.org/265641@main">https://commits.webkit.org/265641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f5ff8698cf53f89345cb15bbde1855585fcad10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13535 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17567 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10868 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13756 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9032 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2758 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->