### PR TITLE
REGRESSION: (264863@main) Fix regression in CSSCalcValue

### DIFF
--- a/LayoutTests/fast/css/css-calc-rem-no-children-crash-expected.txt
+++ b/LayoutTests/fast/css/css-calc-rem-no-children-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/css/css-calc-rem-no-children-crash.html
+++ b/LayoutTests/fast/css/css-calc-rem-no-children-crash.html
@@ -1,0 +1,13 @@
+<style>
+& { shape-outside: polygon(calc(var(--var9, --var7)) 1.2px, calc(var(--var3, --var0)) 0px, 0.6px 0px, 3px 2.5px, 0px 3.3px, 0lh 3.9px, 1.1px 3.9px, 1.2px 0px, 1.8px 2.4px, 2.1px 0px) border-box; }
+@property --var9 { syntax: "<custom-ident> | <length-percentage>+"; inherits: true; initial-value: 3.5px 0.1px calc(rem((0svh) + (0px), (2.4px)) + 1%); }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<html>
+    <body>
+        <p>PASS if no crash</p>
+    </body>
+</html>

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -237,7 +237,12 @@ static RefPtr<CSSCalcExpressionNode> createCSS(const CalcExpressionNode& node, c
             return CSSCalcOperationNode::createHypot(WTFMove(children));
         }
         case CalcOperator::Mod:
-        case CalcOperator::Rem:
+        case CalcOperator::Rem: {
+            auto children = createCSS(operationChildren, style);
+            if (children.size() != 2)
+                return nullptr;
+            return CSSCalcOperationNode::createStep(op, WTFMove(children));
+        }
         case CalcOperator::Round:
         case CalcOperator::Nearest:
         case CalcOperator::ToZero:


### PR DESCRIPTION
#### db8fe90cd4538413b18338e2308c9754c37fffe3
<pre>
REGRESSION: (264863@main) Fix regression in CSSCalcValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=258684">https://bugs.webkit.org/show_bug.cgi?id=258684</a>
rdar://111512503

Reviewed by Antti Koivisto.

This change fixes a regression introduced in rdar://109503971 where we
now create a step operation with no children. This makes sense for
CalcOperator::Round, but not for CalcOperator::Mod and CalcOperator::Rem

* LayoutTests/fast/css/css-calc-rem-no-children-crash-expected.txt: Added.
* LayoutTests/fast/css/css-calc-rem-no-children-crash.html: Added.
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):

Canonical link: <a href="https://commits.webkit.org/265667@main">https://commits.webkit.org/265667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56fc96201c61858557e5f33350004611183bdf98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12138 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13905 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13640 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17646 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13840 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->