### PR TITLE
html/browsers/browsing-the-web/read-media/cross-origin-video.html is failing because it uses ogv

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test cross origin load of media document in parts promise_test: Unhandled rejection with value: object "SecurityError: Blocked a frame with origin "http://localhost:8800" from accessing a cross-origin frame. Protocols, domains, and ports must match."
+PASS Test cross origin load of media document in parts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py
@@ -35,8 +35,8 @@ def main(request, response):
         return headers, body
 
     if b"VIDEO" in request.GET:
-        headers.append((b"Content-Type", b"video/webm"))
-        body = open(os.path.join(request.doc_root, u"media", u"movie_5.ogv"), "rb").read()
+        headers.append((b"Content-Type", b"video/mp4"))
+        body = open(os.path.join(request.doc_root, u"media", u"A4.mp4"), "rb").read()
         length = len(body)
         # If "PartialContent" is specified, the requestor wants to test range
         # requests. For the initial request, respond with "206 Partial Content"

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
@@ -1,4 +1,0 @@
-
-
-FAIL Test cross origin load of media document in parts promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-


### PR DESCRIPTION
#### cad106efd2ef61b0f72d1f37e2f52f5bdc09471e
<pre>
html/browsers/browsing-the-web/read-media/cross-origin-video.html is failing because it uses ogv
<a href="https://bugs.webkit.org/show_bug.cgi?id=258689">https://bugs.webkit.org/show_bug.cgi?id=258689</a>
rdar://111070171

Reviewed by NOBODY (OOPS!).

The test was using an ogv file but was serving a &quot;video/webm&quot; Content-Type header.
Update the Content-Type header to &quot;video/ogg&quot; to match.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py:
(main):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt: Removed.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2313a01d47b1173f0d84f0cd16057944f35519a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10941 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13818 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13534 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10407 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17566 "21 flakes 96 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9031 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->