### PR TITLE
html/browsers/browsing-the-web/read-media/cross-origin-video.html gives different results on different platforms

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Test cross origin load of media document in parts promise_test: Unhandled rejection with value: object "SecurityError: Blocked a frame with origin "http://localhost:8800" from accessing a cross-origin frame. Protocols, domains, and ports must match."
+PASS Test cross origin load of media document in parts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video.html
@@ -21,6 +21,10 @@ promise_test(async () => {
     + '/service-workers/service-worker/resources/fetch-access-control.py?'
     + 'VIDEO%26PartialContent';
 
+  let v = document.createElement("video");
+  if (v.canPlayType("video/ogv") == "")
+    frame.src += "%26mp4";
+
   document.body.appendChild(frame);
   await new Promise(resolve => frame.onload = resolve);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py
@@ -35,8 +35,13 @@ def main(request, response):
         return headers, body
 
     if b"VIDEO" in request.GET:
-        headers.append((b"Content-Type", b"video/webm"))
-        body = open(os.path.join(request.doc_root, u"media", u"movie_5.ogv"), "rb").read()
+        if b"mp4" in request.GET:
+          headers.append((b"Content-Type", b"video/mp4"))
+          body = open(os.path.join(request.doc_root, u"media", u"movie_5.mp4"), "rb").read()
+        else:
+          headers.append((b"Content-Type", b"video/ogg"))
+          body = open(os.path.join(request.doc_root, u"media", u"movie_5.ogv"), "rb").read()
+
         length = len(body)
         # If "PartialContent" is specified, the requestor wants to test range
         # requests. For the initial request, respond with "206 Partial Content"


### PR DESCRIPTION
#### 4b80e1fb9da84bd4763357aa590c48a20a85e9f9
<pre>
html/browsers/browsing-the-web/read-media/cross-origin-video.html gives different results on different platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=258689">https://bugs.webkit.org/show_bug.cgi?id=258689</a>
rdar://111070171

Reviewed by Jer Noble.

The test was using an ogv file but was serving a &quot;video/webm&quot; Content-Type header.
We don&apos;t support ogv and we only support webm on some platforms.

To address the issue, we now rely on video.canPlayType() to see if the browser can
play ogv. If it cannot, we request a mp4 video file instead.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resources/fetch-access-control.py:
(main):
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/265662@main">https://commits.webkit.org/265662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0eaf0cfc2f19d1a46579f58bf90bb1021998b00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11510 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10971 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13848 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13577 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17594 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13787 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->