### PR TITLE
[JSC] Add assertions to collect more data for ValueProfile

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -411,7 +411,8 @@ public:
 
     ValueProfile& valueProfileForBytecodeIndex(BytecodeIndex);
     SpeculatedType valueProfilePredictionForBytecodeIndex(const ConcurrentJSLocker&, BytecodeIndex);
-
+    template<bool enableCorruptionCheck, typename Functor, typename FunctorWithCorruptionCheck> void forEachValueProfileHelper(const Functor&, const FunctorWithCorruptionCheck&);
+    template<typename Functor, typename FunctorWithCorruptionCheck> void forEachValueProfileWithCorruptionCheck(const Functor&, const FunctorWithCorruptionCheck&);
     template<typename Functor> void forEachValueProfile(const Functor&);
     template<typename Functor> void forEachArrayAllocationProfile(const Functor&);
     template<typename Functor> void forEachObjectAllocationProfile(const Functor&);

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -390,7 +390,7 @@ void UnlinkedCodeBlock::allocateSharedProfiles(unsigned numBinaryArithProfiles, 
         if (m_metadata->hasMetadata()) {
 #define COUNT(__op) \
             numberOfValueProfiles += m_metadata->numEntries<__op>();
-            FOR_EACH_OPCODE_WITH_VALUE_PROFILE(COUNT)
+            FOR_EACH_OPCODE_WITH_VALUE_PROFILE(COUNT) // <- here, not this one
 #undef COUNT
             numberOfValueProfiles += m_metadata->numEntries<OpIteratorOpen>() * 3;
             numberOfValueProfiles += m_metadata->numEntries<OpIteratorNext>() * 3;

--- a/Source/JavaScriptCore/bytecode/ValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/ValueProfile.h
@@ -145,6 +145,11 @@ struct ValueProfileBase {
         return m_prediction;
     }
 
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=258889.
+    // This should only be used for code for tracking ValueProfile corruption.
+    // Remove this when the issue is fixed.
+    EncodedJSValue bucketForInspection(unsigned i) { return m_buckets[i]; }
+
     EncodedJSValue m_buckets[totalNumberOfBuckets];
 
     SpeculatedType m_prediction { SpecNone };

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -696,10 +696,16 @@ void Heap::finalizeUnconditionalFinalizers()
 
     finalizeMarkedUnconditionalFinalizers<SymbolTable>(symbolTableSpace, collectionScope);
 
-    forEachCodeBlockSpace(
-        [&] (auto& space) {
-            this->finalizeMarkedUnconditionalFinalizers<CodeBlock>(space.set, collectionScope);
-        });
+    {
+#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
+        SetForScope valueProfileDiagAnalysisScope(vm.enableCorruptionCheck, true);
+#endif
+        forEachCodeBlockSpace(
+            [&] (auto& space) {
+                this->finalizeMarkedUnconditionalFinalizers<CodeBlock>(space.set, collectionScope);
+            });
+    }
+
     if (collectionScope == CollectionScope::Full) {
         finalizeMarkedUnconditionalFinalizers<Structure>(structureSpace, collectionScope);
         finalizeMarkedUnconditionalFinalizers<BrandedStructure>(brandedStructureSpace, collectionScope);

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2390,7 +2390,9 @@ JSC_DEFINE_JIT_OPERATION(operationTryOSREnterAtCatchAndValueProfile, UGPRPair, (
     auto bytecode = codeBlock->instructions().at(bytecodeIndex)->as<OpCatch>();
     auto& metadata = bytecode.metadata(codeBlock);
     metadata.m_buffer->forEach([&] (ValueProfileAndVirtualRegister& profile) {
-        profile.m_buckets[0] = JSValue::encode(callFrame->uncheckedR(profile.m_operand).jsValue());
+        JSValue value = callFrame->uncheckedR(profile.m_operand).jsValue();
+        vm.checkForValueProfileCorruptionIfNeeded(value);
+        profile.m_buckets[0] = JSValue::encode(value);
     });
 
     return encodeResult(nullptr, nullptr);

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -142,6 +142,7 @@ namespace JSC {
     PROFILE_VALUE_IN(value__, m_profile)
 
 #define PROFILE_VALUE_IN(value, profileName) do { \
+        vm.checkForValueProfileCorruptionIfNeeded(value); \
         bytecode.metadata(codeBlock).profileName.m_buckets[0] = JSValue::encode(value); \
     } while (false)
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -475,6 +475,24 @@ VM::~VM()
 #endif
 }
 
+std::tuple<bool, void*, void*> VM::detectValueProfileCorruption(JSValue value)
+{
+    JSCell* cell = value.asCell();
+
+    auto* structure = cell->structureID().tryDecode();
+    Structure* cellStructureStructure = structure->structure();
+    Structure* vmStructureStructure = this->structureStructure.get();
+    bool hasValidStructureStructure = cellStructureStructure == vmStructureStructure;
+
+    return { hasValidStructureStructure, (void*)cellStructureStructure, (void*)cellStructureStructure };
+}
+
+void VM::checkForValueProfileCorruption(JSValue value)
+{
+    auto [hasValidStructureStructure, cellStructureStructure, vmStructureStructure] = detectValueProfileCorruption(value);
+    RELEASE_ASSERT(hasValidStructureStructure, cellStructureStructure, vmStructureStructure);
+}
+
 void VM::primitiveGigacageDisabledCallback(void* argument)
 {
     static_cast<VM*>(argument)->primitiveGigacageDisabled();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1069,6 +1069,15 @@ private:
 
 public:
     bool didEnterVM { false };
+
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=258889.
+    // The 5 lines of code below is used for tracking ValueProfile corruption.
+    // Remove them when the issue is fixed.
+    bool needsValueProfileCorruptionCheck(JSValue);
+    std::tuple<bool, void*, void*> detectValueProfileCorruption(JSValue);
+    void checkForValueProfileCorruption(JSValue);
+    void checkForValueProfileCorruptionIfNeeded(JSValue);
+    bool enableCorruptionCheck { false };
 private:
     bool m_failNextNewCodeBlock { false };
     bool m_globalConstRedeclarationShouldThrow { true };

--- a/Source/JavaScriptCore/runtime/VMInlines.h
+++ b/Source/JavaScriptCore/runtime/VMInlines.h
@@ -108,4 +108,18 @@ inline void VM::forEachDebugger(const Func& callback)
         callback(*debugger);
 }
 
+inline bool VM::needsValueProfileCorruptionCheck(JSValue value)
+{
+    return value && value.isCell() && !value.isString();
+}
+
+inline void VM::checkForValueProfileCorruptionIfNeeded(JSValue value)
+{
+    UNUSED_VARIABLE(value);
+#if ENABLE(STRUCTURE_ID_WITH_SHIFT)
+    if (needsValueProfileCorruptionCheck(value))
+        checkForValueProfileCorruption(value);
+#endif
+}
+
 } // namespace JSC


### PR DESCRIPTION
#### fd901770c379a65ac93ccf87b07c6daf84374f43
<pre>
[JSC] Add assertions to collect more data for ValueProfile
<a href="https://bugs.webkit.org/show_bug.cgi?id=258702">https://bugs.webkit.org/show_bug.cgi?id=258702</a>
rdar://110385053

There are crashes in JSC::CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness.
So far all hints implies that the encoded JSValue in ValueProfile might be corrupted.
This patch add additional assertions without impacting performance to gather more information
for diagnostic analysis.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finalizeUnconditionally):
(JSC::CodeBlock::updateAllNonLazyValueProfilePredictionsAndCountLiveness):
(JSC::CodeBlock::updateAllNonLazyValueProfilePredictions):
(JSC::CodeBlock::updateAllPredictions):
(JSC::CodeBlock::dumpValueProfiles):
* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/JavaScriptCore/bytecode/CodeBlockInlines.h:
(JSC::CodeBlock::forEachValueProfile):
* Source/JavaScriptCore/bytecode/ValueProfile.h:
(JSC::ValueProfileBase::bucket):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalizeMarkedUnconditionalFinalizers):
(JSC::Heap::finalizeUnconditionalFinalizers):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/tools/HeapVerifier.cpp:
(JSC::HeapVerifier::validateJSCell):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd901770c379a65ac93ccf87b07c6daf84374f43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14272 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14143 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10880 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18008 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10162 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14210 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11339 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11520 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9486 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12066 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10734 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3224 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15059 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12403 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11380 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2990 "Passed tests") | 
<!--EWS-Status-Bubble-End-->