### PR TITLE
[LibWebRTC] Enable AVX2 extensions only if host supports AVX2

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -1780,7 +1780,7 @@ if (WTF_CPU_X86_64 OR WTF_CPU_X86)
     )
 endif()
 
-if (WTF_CPU_X86_64)
+if (WTF_CPU_X86_64 AND WTF_CPU_HAS_AVX2)
     list(APPEND webrtc_SOURCES
         Source/webrtc/common_audio/fir_filter_avx2.cc
         Source/webrtc/common_audio/resampler/sinc_resampler_avx2.cc
@@ -1791,7 +1791,8 @@ if (WTF_CPU_X86_64)
         Source/webrtc/modules/audio_processing/aec3/vector_math_avx2.cc
         Source/webrtc/modules/audio_processing/agc2/rnn_vad/vector_math_avx2.cc
     )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -mno-avx512f")
+    add_definitions(-DWEBRTC_ENABLE_AVX2)
 endif()
 
 if (WTF_CPU_ARM64)

--- a/Source/cmake/DetectAVX2.cmake
+++ b/Source/cmake/DetectAVX2.cmake
@@ -1,0 +1,69 @@
+#################################
+# Check for the presence of AVX2.
+#
+# Once done, this will define:
+# - AVX2_SUPPORT_FOUND - the system supports (at least) AVX2.
+#
+# Copyright (c) 2023, Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#   * Neither the name of the copyright holders nor the names of its contributors
+#     may be used to endorse or promote products derived from this software without
+#     specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+# WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(AVX2_SUPPORT_FOUND FALSE)
+
+macro(CHECK_FOR_AVX2)
+    include(CheckCXXSourceRuns)
+
+    set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
+
+    if (COMPILER_IS_GCC_OR_CLANG)
+        set(CMAKE_REQUIRED_FLAGS -mavx2)
+    endif ()
+
+    if (MSVC AND CMAKE_CL_64)
+        set(CMAKE_REQUIRED_FLAGS /arch:AVX2)
+    endif ()
+
+    check_cxx_source_runs("
+        #include <immintrin.h>
+        int main()
+        {
+          volatile __m256i a, b;
+          a = _mm256_set1_epi8 (1);
+          b = _mm256_add_epi8 (a,a);
+          return 0;
+        }"
+        HAVE_AVX2_EXTENSIONS)
+
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_SAVE})
+
+    if (COMPILER_IS_GCC_OR_CLANG OR (MSVC AND CMAKE_CL_64))
+        if (HAVE_AVX2_EXTENSIONS)
+            set(AVX2_SUPPORT_FOUND TRUE)
+        endif ()
+    endif ()
+
+endmacro(CHECK_FOR_AVX2)
+
+CHECK_FOR_AVX2()

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -124,6 +124,13 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
         set(WTF_CPU_UNKNOWN 1)
     endif ()
 
+    if (WTF_CPU_X86_64 AND NOT CMAKE_CROSSCOMPILING)
+        include(DetectAVX2)
+        if (AVX2_SUPPORT_FOUND)
+            set(WTF_CPU_HAS_AVX2 1)
+        endif ()
+    endif ()
+
     # -----------------------------------------------------------------------------
     # Determine the operating system
     # -----------------------------------------------------------------------------


### PR DESCRIPTION
#### d95cad7579b54950ac97ad0f0c19d1c29aeef489
<pre>
[LibWebRTC] Enable AVX2 extensions only if host supports AVX2
<a href="https://bugs.webkit.org/show_bug.cgi?id=258708">https://bugs.webkit.org/show_bug.cgi?id=258708</a>

Reviewed by Philippe Normand.

Include specialized AVX2 files in LibWebRTC only if the host supports
AVX2 extensions. Also, when AVX2 is enabled, avoid building using AVX512
extensions even if the host has support for it since it may result into
compatibility issues (binary built on host with AVX512 support but
executed in host without AVX512 support will result into a crash).

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/cmake/DetectAVX2.cmake: Added.
* Source/cmake/WebKitCommon.cmake:

Canonical link: <a href="https://commits.webkit.org/265646@main">https://commits.webkit.org/265646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eb1562e521c67a6b719de3f8c7f94d3d9bdf8b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13156 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10972 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13578 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17595 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13788 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10923 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9062 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11602 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10176 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14451 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11930 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10855 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2901 "Passed tests") | 
<!--EWS-Status-Bubble-End-->