### PR TITLE
TestIPC.StreamMessageTest.SendAsyncReplyCancel fails in ASAN builds

### DIFF
--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -212,10 +212,10 @@ public:
 
 TEST_F(StreamConnectionTest, OpenConnections)
 {
-    auto cleanup = localReferenceBarrier();
     auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
     ASSERT_TRUE(clientConnection);
     auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle));
+    auto cleanup = localReferenceBarrier();
     MockMessageReceiver mockClientReceiver;
     clientConnection->open(mockClientReceiver);
     serverQueue().dispatch([this, serverConnection] {
@@ -229,10 +229,10 @@ TEST_F(StreamConnectionTest, OpenConnections)
 
 TEST_F(StreamConnectionTest, InvalidateUnopened)
 {
-    auto cleanup = localReferenceBarrier();
     auto [clientConnection, serverConnectionHandle] = IPC::StreamClientConnection::create(defaultBufferSizeLog2);
     ASSERT_TRUE(clientConnection);
     auto serverConnection = IPC::StreamServerConnection::create(WTFMove(serverConnectionHandle));
+    auto cleanup = localReferenceBarrier();
     serverQueue().dispatch([this, serverConnection] {
         assertIsCurrent(serverQueue());
         serverConnection->invalidate();
@@ -390,9 +390,9 @@ TEST_P(StreamMessageTest, SendAsyncReplyCancel)
         // Skip if not all messages fit to the buffer.
         return;
     }
-    auto cleanup = localReferenceBarrier();
-    std::atomic<bool> waiting;
+    std::atomic<bool> waiting = false;
     BinarySemaphore workQueueWait;
+    auto cleanup = localReferenceBarrier();
     serverQueue().dispatch([&] {
         waiting = true;
         workQueueWait.wait();


### PR DESCRIPTION
#### 2c7aad7e72e9b1c12b444fb99251b11f7a70d790
<pre>
TestIPC.StreamMessageTest.SendAsyncReplyCancel fails in ASAN builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=258717">https://bugs.webkit.org/show_bug.cgi?id=258717</a>
rdar://111558108

Reviewed by Simon Fraser.

Fix the failure in the test implementation. The local variable
`workQueueWait` would be destroyed before local reference barrier
`cleanup` would ensure that no pending work is in the server work queue.

The local reference barriers should be constructed after the locals
being protected.

* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/265710@main">https://commits.webkit.org/265710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e9c1b13aae0ceac9c02ff4661db626c46828a84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13596 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17614 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13806 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9081 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10193 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2807 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10871 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->