### PR TITLE
[JSC] Use std::popcount instead of __builtin_popcount and __builtin_popcountll

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -55,6 +55,7 @@
 #include "WasmOps.h"
 #include "WasmThunks.h"
 #include "WasmTypeDefinition.h"
+#include <bit>
 #include <wtf/Assertions.h>
 #include <wtf/Compiler.h>
 #include <wtf/HashFunctions.h>
@@ -6044,7 +6045,7 @@ public:
     {
         EMIT_UNARY(
             "I32Popcnt", TypeKind::I32,
-            BLOCK(Value::fromI32(__builtin_popcount(operand.asI32()))),
+            BLOCK(Value::fromI32(std::popcount(static_cast<uint32_t>(operand.asI32())))),
             BLOCK(
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation32(operandLocation.asGPR(), resultLocation.asGPR(), wasmScratchFPR);
@@ -6068,7 +6069,7 @@ public:
     {
         EMIT_UNARY(
             "I64Popcnt", TypeKind::I64,
-            BLOCK(Value::fromI64(__builtin_popcountll(operand.asI64()))),
+            BLOCK(Value::fromI64(std::popcount(static_cast<uint64_t>(operand.asI64())))),
             BLOCK(
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation64(operandLocation.asGPR(), resultLocation.asGPR(), wasmScratchFPR);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -55,6 +55,7 @@
 #include "WasmOSREntryPlan.h"
 #include "WasmOperationsInlines.h"
 #include "WasmWorklist.h"
+#include <bit>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DataLog.h>
 #include <wtf/Locker.h>
@@ -757,12 +758,12 @@ JSC_DEFINE_JIT_OPERATION(operationWasmWriteBarrierSlowPath, void, (JSCell* cell,
 
 JSC_DEFINE_JIT_OPERATION(operationPopcount32, uint32_t, (int32_t value))
 {
-    return __builtin_popcount(value);
+    return std::popcount(static_cast<uint32_t>(value));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationPopcount64, uint64_t, (int64_t value))
 {
-    return __builtin_popcountll(value);
+    return std::popcount(static_cast<uint64_t>(value));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGrowMemory, int32_t, (Instance* instance, int32_t delta))

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -49,6 +49,7 @@
 #include "WasmTypeDefinitionInlines.h"
 #include "WasmWorklist.h"
 #include "WebAssemblyFunction.h"
+#include <bit>
 
 namespace JSC { namespace LLInt {
 
@@ -1184,13 +1185,13 @@ extern "C" UGPRPair slow_path_wasm_throw_exception(CallFrame* callFrame, const W
 
 extern "C" UGPRPair slow_path_wasm_popcount(const WasmInstruction* pc, uint32_t x)
 {
-    void* result = bitwise_cast<void*>(static_cast<size_t>(__builtin_popcount(x)));
+    void* result = bitwise_cast<void*>(static_cast<size_t>(std::popcount(x)));
     WASM_RETURN_TWO(pc, result);
 }
 
 extern "C" UGPRPair slow_path_wasm_popcountll(const WasmInstruction* pc, uint64_t x)
 {
-    void* result = bitwise_cast<void*>(static_cast<size_t>(__builtin_popcountll(x)));
+    void* result = bitwise_cast<void*>(static_cast<size_t>(std::popcount(x)));
     WASM_RETURN_TWO(pc, result);
 }
 


### PR DESCRIPTION
#### 4e7fe413ab40496e17623f5679b3e21cda074f1f
<pre>
[JSC] Use std::popcount instead of __builtin_popcount and __builtin_popcountll
<a href="https://bugs.webkit.org/show_bug.cgi?id=258557">https://bugs.webkit.org/show_bug.cgi?id=258557</a>

Reviewed by Ross Kirsling.

__builtin_popcount and __builtin_popcountll are builtin functions
provided by GCC and Clang. However MSVC doesn&apos;t provide them so they
don&apos;t compile with MSVC.

This patch replaces the builtin functions with portable std::popcount
defined in C++ STL. The function is available in all major C++ standard
library implementations (libstdc++, libc++, MSVC STL).

* libc++: <a href="https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/libcxx/include/bit#L192">https://github.com/llvm/llvm-project/blob/llvmorg-14.0.6/libcxx/include/bit#L192</a>
* libstdc++: <a href="https://github.com/gcc-mirror/gcc/blob/releases/gcc-9.5.0/libstdc%2B%2B-v3/include/std/bit#L169">https://github.com/gcc-mirror/gcc/blob/releases/gcc-9.5.0/libstdc%2B%2B-v3/include/std/bit#L169</a>
* MSVC STL: <a href="https://github.com/microsoft/STL/blob/40640c6df9754ea031f8df7c720b89714d19df97/stl/inc/__msvc_bit_utils.hpp#L396">https://github.com/microsoft/STL/blob/40640c6df9754ea031f8df7c720b89714d19df97/stl/inc/__msvc_bit_utils.hpp#L396</a>

It is confirmed that all implementations are optimized to use the
compiler-specific intrinsics.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJIT::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::slow_path_wasm_popcount):
(JSC::LLInt::slow_path_wasm_popcountll):

Canonical link: <a href="https://commits.webkit.org/265651@main">https://commits.webkit.org/265651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a651444831ca095d1e049298445ed55d11317203

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10990 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13864 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13597 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17610 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13802 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/10941 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9078 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11619 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10194 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3137 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14469 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/11949 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10872 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2909 "Passed tests") | 
<!--EWS-Status-Bubble-End-->