### PR TITLE
[WPE][GTK] API test `WebKit.PrivateBrowsingPushStateNoHistoryCallback` is a timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp
@@ -32,6 +32,7 @@
 #include "Test.h"
 #include <WebKit/WKPreferencesRefPrivate.h>
 #include <WebKit/WKRetainPtr.h>
+#include <WebKit/WKWebsiteDataStoreConfigurationRef.h>
 #include <WebKit/WKWebsiteDataStoreRef.h>
 
 namespace TestWebKitAPI {
@@ -91,7 +92,10 @@ TEST(WebKit, PrivateBrowsingPushStateNoHistoryCallback)
 
     Util::run(&didSameDocumentNavigation);
 
-    WKPageConfigurationSetWebsiteDataStore(pageConfiguration.get(), WKWebsiteDataStoreGetDefaultDataStore());
+    WKRetainPtr<WKWebsiteDataStoreConfigurationRef> dataStoreConfiguration = adoptWK(WKWebsiteDataStoreConfigurationCreate());
+    WKRetainPtr<WKWebsiteDataStoreRef> dataStore = adoptWK(WKWebsiteDataStoreCreateWithConfiguration(dataStoreConfiguration.get()));
+    WKPageConfigurationSetWebsiteDataStore(pageConfiguration.get(), dataStore.get());
+
     PlatformWebView webView2(pageConfiguration.get());
 
     historyClient.didNavigateWithNavigationData = didNavigateWithNavigationData;

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -237,9 +237,6 @@
             "WebKit.FocusedFrameAfterCrash": {
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205336"}}
             },
-            "WebKit.PrivateBrowsingPushStateNoHistoryCallback": {
-                "expected": {"all": {"status": ["TIMEOUT"], "bug": "webkit.org/b/254002"}}
-            },
             "WebKit.GeolocationWatchMultiprocess": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/254002"}}
             },


### PR DESCRIPTION
#### 4fdb80d3008b30d5e6458c972763e57804e0b851
<pre>
[WPE][GTK] API test `WebKit.PrivateBrowsingPushStateNoHistoryCallback` is a timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=258721">https://bugs.webkit.org/show_bug.cgi?id=258721</a>

Reviewed by Michael Catanzaro.

`FrameLoader::HistoryController` won&apos;t update global history and notify
its client that it `didNavigateWithNavigationData()` when
`usesEphemeralSession()`.

On WPE and GTK `WKWebsiteDataStoreGetDefaultDataStore()` by default
creates a data store with an ephemeral session id.

To fix it, we must explicitly create and use a non-ephemeral data store.

* Tools/TestWebKitAPI/Tests/WebKit/PrivateBrowsingPushStateNoHistoryCallback.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265707@main">https://commits.webkit.org/265707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ada13ab55c9ccec4f90f72a44742bebd9c94d5d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10998 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13873 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11702 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13605 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17620 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13813 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9087 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10202 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2805 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->