### PR TITLE
[CSS Container Queries] Use element writing mode for unit resolution

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt
@@ -15,8 +15,8 @@ PASS cqmin unit resolves against appropriate container (vertical writing-mode on
 PASS cqmax unit resolves against appropriate container (vertical writing-mode on subject)
 PASS cqw unit resolves against appropriate container (vertical writing-mode on container)
 PASS cqh unit resolves against appropriate container (vertical writing-mode on container)
-FAIL cqi unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
-FAIL cqb unit resolves against appropriate container (vertical writing-mode on container) assert_equals: expected "true" but got ""
+PASS cqi unit resolves against appropriate container (vertical writing-mode on container)
+PASS cqb unit resolves against appropriate container (vertical writing-mode on container)
 PASS cqmin unit resolves against appropriate container (vertical writing-mode on container)
 PASS cqmax unit resolves against appropriate container (vertical writing-mode on container)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-selection-expected.txt
@@ -1,5 +1,5 @@
 Test
 
 PASS Container units select the proper container
-FAIL Units respond to the writing-mode of the element assert_equals: expected "40px" but got "30px"
+PASS Units respond to the writing-mode of the element
 


### PR DESCRIPTION
#### b4d32d728a61a0786b99f30af82b3d4c92422afd
<pre>
[CSS Container Queries] Use element writing mode for unit resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=258722">https://bugs.webkit.org/show_bug.cgi?id=258722</a>
rdar://111565488

Reviewed by Simon Fraser.

Correct handling for vertical writing mode per <a href="https://github.com/w3c/csswg-drafts/issues/6873">https://github.com/w3c/csswg-drafts/issues/6873</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-in-at-container-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-selection-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):

Resolve logical to to physical axis based on the element writing mode.
Also explicitly fall back to small viewport units to guarantee consistency.

Canonical link: <a href="https://commits.webkit.org/265654@main">https://commits.webkit.org/265654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8654810fba057348c60a6f4622f1b0f0dcedddbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13886 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12578 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13618 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17631 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13824 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9098 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10213 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2771 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->