### PR TITLE
Bounds are not always correctly set when setting twice a MediaStream to a HTMLMediaElement

### DIFF
--- a/LayoutTests/fast/mediastream/video-srcObject-set-twice-expected.html
+++ b/LayoutTests/fast/mediastream/video-srcObject-set-twice-expected.html
@@ -1,0 +1,17 @@
+<div>
+<canvas id="canvas1" width=100 height=100></canvas>
+<canvas id="canvas2" width=100 height=100></canvas>
+<br>
+<canvas id="canvas3" width=100 height=100></canvas>
+</div>
+<script>
+const context1 = canvas1.getContext('2d');
+const context2 = canvas2.getContext('2d');
+const context3 = canvas3.getContext('2d');
+context1.fillStyle = "green";
+context1.fillRect(0, 0, 100, 100);
+context2.fillStyle = "green";
+context2.fillRect(0, 0, 100, 100);
+context3.fillStyle = "green";
+context3.fillRect(0, 0, 100, 100);
+</script>

--- a/LayoutTests/fast/mediastream/video-srcObject-set-twice.html
+++ b/LayoutTests/fast/mediastream/video-srcObject-set-twice.html
@@ -1,0 +1,37 @@
+<div>
+<canvas id="canvas1" width=100 height=100></canvas>
+<canvas id="canvas2" width=100 height=100></canvas>
+<br>
+<video id="video" width=100 height=100 autoplay playsinline></video>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+async function test()
+{
+     const context1 = canvas1.getContext('2d');
+     setInterval(() => {
+        context1.fillStyle = "green";
+        context1.fillRect(0, 0, 100, 100);
+    }, 100);
+    video.srcObject = canvas1.captureStream();
+    await video.play();
+    await new Promise(resolve => setTimeout(resolve, 500));
+    video.style.display = 'none';
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    video.style.display = 'block';
+    const context2 = canvas2.getContext('2d');
+    setInterval(() => {
+        context2.fillStyle = "green";
+        context2.fillRect(0, 0, 100, 100);
+    }, 100);
+    video.srcObject = canvas2.captureStream();
+    await video.play();
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+test();
+</script>

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -65,8 +65,7 @@ public:
 
     virtual void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) = 0;
 
-    virtual void updateAffineTransform(CGAffineTransform) = 0;
-    virtual void updateBoundsAndPosition(CGRect, VideoFrameRotation, std::optional<WTF::MachSendRight>&& = std::nullopt) = 0;
+    virtual void updateBoundsAndPosition(CGRect, std::optional<WTF::MachSendRight>&& = std::nullopt) = 0;
 
     virtual void flush() = 0;
     virtual void flushAndRemoveImage() = 0;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -29,6 +29,7 @@
 
 #include "FrameRateMonitor.h"
 #include "SampleBufferDisplayLayer.h"
+#include "VideoFrame.h"
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
@@ -52,8 +53,6 @@ public:
     LocalSampleBufferDisplayLayer(RetainPtr<AVSampleBufferDisplayLayer>&&, Client&);
     ~LocalSampleBufferDisplayLayer();
 
-    void enqueueBuffer(CVPixelBufferRef, MediaTime);
-
     // API used by WebAVSampleBufferStatusChangeListener
     void layerStatusDidChange();
     void layerErrorDidChange();
@@ -63,9 +62,7 @@ public:
 
     PlatformLayer* displayLayer();
 
-    enum class ShouldUpdateRootLayer : bool { No, Yes };
-    void updateRootLayerBoundsAndPosition(CGRect, VideoFrameRotation, ShouldUpdateRootLayer);
-    void updateRootLayerAffineTransform(CGAffineTransform);
+    void updateSampleLayerBoundsAndPosition(std::optional<CGRect>);
 
     // SampleBufferDisplayLayer.
     PlatformLayer* rootLayer() final;
@@ -76,9 +73,7 @@ public:
     bool didFail() const final;
 
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
-
-    void updateAffineTransform(CGAffineTransform)  final;
-    void updateBoundsAndPosition(CGRect, VideoFrameRotation, std::optional<WTF::MachSendRight>&&) final;
+    void updateBoundsAndPosition(CGRect, std::optional<WTF::MachSendRight>&&) final;
 
     void flush() final;
     void flushAndRemoveImage() final;
@@ -95,7 +90,6 @@ private:
     void removeOldVideoFramesFromPendingQueue();
     void addVideoFrameToPendingQueue(Ref<VideoFrame>&&);
     void requestNotificationWhenReadyForVideoData();
-    void setRootLayerBoundsAndPositions(CGRect, VideoFrameRotation);
 
 #if !RELEASE_LOG_DISABLED
     void onIrregularFrameRateNotification(MonotonicTime frameTime, MonotonicTime lastFrameTime);
@@ -107,6 +101,7 @@ private:
     RetainPtr<WebAVSampleBufferStatusChangeListener> m_statusChangeListener;
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     RetainPtr<AVSampleBufferDisplayLayer> m_sampleBufferDisplayLayerForQueue WTF_GUARDED_BY_CAPABILITY(workQueue());
+    bool m_isReconfiguring WTF_GUARDED_BY_CAPABILITY(workQueue()) { false };
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer WTF_GUARDED_BY_CAPABILITY(workQueue());
     MediaTime m_lastPresentationTime WTF_GUARDED_BY_CAPABILITY(workQueue());
     RetainPtr<PlatformLayer> m_rootLayer;
@@ -117,6 +112,9 @@ private:
     // Only accessed through m_processingQueue or if m_processingQueue is null.
     using PendingSampleQueue = Deque<Ref<VideoFrame>>;
     PendingSampleQueue m_pendingVideoFrameQueue;
+
+    WebCore::VideoFrameRotation m_videoFrameRotation { WebCore::VideoFrameRotation::None };
+    CGAffineTransform m_affineTransform { CGAffineTransformIdentity };
 
     bool m_paused { false };
     bool m_didFail { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -265,7 +265,6 @@ private:
     // Used on both main thread and sample thread.
     RefPtr<SampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     Lock m_sampleBufferDisplayLayerLock;
-    bool m_shouldUpdateDisplayLayer { true };
     // Written on main thread, read on sample thread.
     bool m_canEnqueueDisplayLayer { false };
     // Used on sample thread.

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -88,17 +88,12 @@ void RemoteSampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bo
     m_sampleBufferDisplayLayer->updateDisplayMode(hideDisplayLayer, hideRootLayer);
 }
 
-void RemoteSampleBufferDisplayLayer::updateAffineTransform(CGAffineTransform transform)
-{
-    m_sampleBufferDisplayLayer->updateRootLayerAffineTransform(transform);
-}
-
-void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation, std::optional<WTF::MachSendRight>&& fence)
+void RemoteSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std::optional<WTF::MachSendRight>&& fence)
 {
     if (fence && fence->sendRight())
         m_layerHostingContext->setFencePort(fence->sendRight());
 
-    m_sampleBufferDisplayLayer->updateRootLayerBoundsAndPosition(bounds, rotation, LocalSampleBufferDisplayLayer::ShouldUpdateRootLayer::Yes);
+    m_sampleBufferDisplayLayer->updateBoundsAndPosition(bounds, { });
 }
 
 void RemoteSampleBufferDisplayLayer::flush()
@@ -124,7 +119,7 @@ void RemoteSampleBufferDisplayLayer::pause()
 void RemoteSampleBufferDisplayLayer::enqueueVideoFrame(SharedVideoFrame&& frame)
 {
     if (auto videoFrame = m_sharedVideoFrameReader.read(WTFMove(frame)))
-        m_sampleBufferDisplayLayer->enqueueBuffer(videoFrame->pixelBuffer(), videoFrame->presentationTime());
+        m_sampleBufferDisplayLayer->enqueueVideoFrame(*videoFrame);
 }
 
 void RemoteSampleBufferDisplayLayer::clearVideoFrames()

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -71,8 +71,7 @@ private:
     void setLogIdentifier(String&&);
 #endif
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer);
-    void updateAffineTransform(CGAffineTransform);
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation, std::optional<WTF::MachSendRight>&&);
+    void updateBoundsAndPosition(CGRect, std::optional<WTF::MachSendRight>&&);
     void flush();
     void flushAndRemoveImage();
     void play();

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in
@@ -28,8 +28,7 @@ messages -> RemoteSampleBufferDisplayLayer NotRefCounted {
     SetLogIdentifier(String logIdentifier)
 #endif
     UpdateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
-    UpdateAffineTransform(CGAffineTransform transform)
-    UpdateBoundsAndPosition(CGRect bounds, WebCore::VideoFrame::Rotation rotation, std::optional<MachSendRight> fence)
+    UpdateBoundsAndPosition(CGRect bounds, std::optional<MachSendRight> fence)
     Flush()
     FlushAndRemoveImage()
     EnqueueVideoFrame(struct WebKit::SharedVideoFrame frame)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -96,14 +96,9 @@ void SampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bool hid
     m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateDisplayMode { hideDisplayLayer, hideRootLayer }, m_identifier);
 }
 
-void SampleBufferDisplayLayer::updateAffineTransform(CGAffineTransform transform)
+void SampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std::optional<WTF::MachSendRight>&& fence)
 {
-    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateAffineTransform { transform }, m_identifier);
-}
-
-void SampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, VideoFrame::Rotation rotation, std::optional<WTF::MachSendRight>&& fence)
-{
-    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateBoundsAndPosition { bounds, rotation, fence }, m_identifier);
+    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::UpdateBoundsAndPosition { bounds, fence }, m_identifier);
 }
 
 void SampleBufferDisplayLayer::flush()

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -67,8 +67,7 @@ private:
 #endif
     bool didFail() const final;
     void updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer) final;
-    void updateAffineTransform(CGAffineTransform) final;
-    void updateBoundsAndPosition(CGRect, WebCore::VideoFrameRotation, std::optional<WTF::MachSendRight>&&) final;
+    void updateBoundsAndPosition(CGRect, std::optional<WTF::MachSendRight>&&) final;
     void flush() final;
     void flushAndRemoveImage() final;
     void play() final;


### PR DESCRIPTION
#### 38b13961316ce40f4b73db47c5c97fba86459c3b
<pre>
Bounds are not always correctly set when setting twice a MediaStream to a HTMLMediaElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=258723">https://bugs.webkit.org/show_bug.cgi?id=258723</a>
rdar://110753228

Reviewed by Jer Noble.

After double layer hosting, we were relying on MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced to be called
so that the AVSampleBufferDisplayLayer bound would be set.

This works fine initially but not when resetting srcObject to a new MediaStream.
In that case, we create a new SampleBufferDisplayLayer but the bounds may not be correctly initialized.
We are making sure to initialize both root and AVSampleBufferDisplayLayer bounds and positions.

They might still not be correctly set due to rotation.
This patch is thus refactoring the code so that LocalSampleBufferDisplayLayer will handle rotation itself.
This is feasible since it receives VideoFrames.
We remove sending affine transforms updates from WebProcess to GPUProcess.
Instead, whenever we receive a VideoFrame in LocalSampleBufferDisplayLayer, we compute the affine transform to use.
If there is a need for a new affine transform, we update the bounds of the AVSampleBufferDisplayLayer, which triggers
creating a new one currently.
This simplifies things as now, only the AVSampleBufferDisplayLayer has to get an affine transform and switch width and height depending on frame rotation.

To reduce flicker, we introduce m_isReconfiguring which will ensure we do not enqueue new video frames to an AVSampleBufferDisplayLayer
that will be removed soon.

We are also using inline video size instead of presentation size if possible to reduce reflowing.
There are still some undesired flicker/reflowing happening when rotation changes since both the media element bounds may change and the rotation.
And these steps are not done at once.

* LayoutTests/fast/mediastream/video-srcObject-set-twice-expected.html: Added.
* LayoutTests/fast/mediastream/video-srcObject-set-twice.html: Added.
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::initialize):
(WebCore::LocalSampleBufferDisplayLayer::updateBoundsAndPosition):
(WebCore::LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition):
(WebCore::videoTransformationMatrix):
(WebCore::LocalSampleBufferDisplayLayer::enqueueVideoFrame):
(WebCore::LocalSampleBufferDisplayLayer::enqueueBufferInternal):
(WebCore::LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData):
(WebCore::LocalSampleBufferDisplayLayer::updateRootLayerAffineTransform): Deleted.
(WebCore::LocalSampleBufferDisplayLayer::updateAffineTransform): Deleted.
(WebCore::LocalSampleBufferDisplayLayer::setRootLayerBoundsAndPositions): Deleted.
(WebCore::LocalSampleBufferDisplayLayer::updateRootLayerBoundsAndPosition): Deleted.
(WebCore::LocalSampleBufferDisplayLayer::enqueueBuffer): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::enqueueVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::layersAreInitialized):
(WebCore::videoTransformationMatrix):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::rootLayerBoundsDidChange):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::setVideoInlineSizeFenced):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp:
(WebKit::RemoteSampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::RemoteSampleBufferDisplayLayer::enqueueVideoFrame):
(WebKit::RemoteSampleBufferDisplayLayer::updateAffineTransform): Deleted.
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.messages.in:
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::SampleBufferDisplayLayer::updateAffineTransform): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:

Canonical link: <a href="https://commits.webkit.org/265708@main">https://commits.webkit.org/265708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bc71181e329120c66c21933b432e410514de687

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11695 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14006 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17751 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->