### PR TITLE
REGRESSION(265569@main): All path segments should be coded by StreamConnectionEncoder

### DIFF
--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -112,7 +112,6 @@ struct PathArcTo {
 
     bool operator==(const PathArcTo&) const = default;
 
-    FloatPoint calculateEndPoint(const FloatPoint& currentPoint) const;
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
 
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
@@ -220,12 +219,11 @@ struct PathRoundedRect {
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathRoundedRect&);
 
-template<typename DataType1, typename DataType2>
-struct PathDataComposite {
-    DataType1 data1;
-    DataType2 data2;
+struct PathDataLine {
+    FloatPoint start;
+    FloatPoint end;
 
-    bool operator==(const PathDataComposite&) const = default;
+    bool operator==(const PathDataLine&) const = default;
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
 
@@ -236,18 +234,62 @@ struct PathDataComposite {
     void applyElements(const PathElementApplier&) const;
 };
 
-template<typename DataType1, typename DataType2>
-inline WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataComposite<DataType1, DataType2>& data)
-{
-    ts << data.data1;
-    ts << ", ";
-    ts << data.data2;
-    return ts;
-}
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataLine&);
 
-using PathDataLine        = PathDataComposite<PathMoveTo, PathLineTo>;
-using PathDataQuadCurve   = PathDataComposite<PathMoveTo, PathQuadCurveTo>;
-using PathDataBezierCurve = PathDataComposite<PathMoveTo, PathBezierCurveTo>;
-using PathDataArc         = PathDataComposite<PathMoveTo, PathArcTo>;
+struct PathDataQuadCurve {
+    FloatPoint start;
+    FloatPoint controlPoint;
+    FloatPoint endPoint;
+
+    bool operator==(const PathDataQuadCurve&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void addToImpl(PathImpl&) const;
+    void applyElements(const PathElementApplier&) const;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataQuadCurve&);
+
+struct PathDataBezierCurve {
+    FloatPoint start;
+    FloatPoint controlPoint1;
+    FloatPoint controlPoint2;
+    FloatPoint endPoint;
+
+    bool operator==(const PathDataBezierCurve&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void addToImpl(PathImpl&) const;
+    void applyElements(const PathElementApplier&) const;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataBezierCurve&);
+
+struct PathDataArc {
+    FloatPoint start;
+    FloatPoint controlPoint1;
+    FloatPoint controlPoint2;
+    float radius;
+
+    bool operator==(const PathDataArc&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void addToImpl(PathImpl&) const;
+    [[noreturn]] void applyElements(const PathElementApplier&) const { RELEASE_ASSERT_NOT_REACHED(); }
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -70,8 +70,7 @@ public:
     FloatRect boundingRect() const final;
 
 private:
-    template<typename DataType1, typename DataType2>
-    bool mergeIntoComposite(const DataType2&);
+    const PathMoveTo* lastIfMoveTo() const;
 
     bool isPathStream() const final { return true; }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -810,7 +810,7 @@ void GraphicsContextCG::strokePath(const Path& path)
 
 #if USE(CG_CONTEXT_STROKE_LINE_SEGMENTS_WHEN_STROKING_PATH)
     if (auto line = path.singleDataLine()) {
-        CGPoint cgPoints[2] { line->data1.point, line->data2.point };
+        CGPoint cgPoints[2] { line->start, line->end };
         CGContextStrokeLineSegments(context, cgPoints, 2);
         return;
     }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -1252,8 +1252,8 @@ public:
 
 #if ENABLE(INLINE_PATH_DATA)
     StrokeLine(const PathDataLine& line)
-        : m_start(line.data1.point)
-        , m_end(line.data2.point)
+        : m_start(line.start)
+        , m_end(line.end)
     {
     }
 #endif

--- a/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
@@ -92,6 +92,35 @@ header: <WebCore/PathSegmentData.h>
     WebCore::PathRoundedRect::Strategy strategy;
 };
 
+header: <WebCore/PathSegmentData.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataLine {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint end;
+};
+
+header: <WebCore/PathSegmentData.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataQuadCurve {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint controlPoint;
+    WebCore::FloatPoint endPoint;
+};
+
+header: <WebCore/PathSegmentData.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataBezierCurve {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint controlPoint1;
+    WebCore::FloatPoint controlPoint2;
+    WebCore::FloatPoint endPoint;
+};
+
+header: <WebCore/PathSegmentData.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathDataArc {
+    WebCore::FloatPoint start;
+    WebCore::FloatPoint controlPoint1;
+    WebCore::FloatPoint controlPoint2;
+    float radius;
+};
+
 header: <WebCore/PathSegment.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::PathSegment {
     WebCore::PathSegment::Data data();

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -86,8 +86,8 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
 #endif
     StrokeRect(WebCore::FloatRect rect, float lineWidth)
 #if ENABLE(INLINE_PATH_DATA)
-    StrokeLine(WebCore::PathDataLine line) StreamBatched
-    StrokeLineWithColorAndThickness(WebCore::PathDataLine line, WebCore::DisplayList::SetInlineStrokeColor color, float thickness) StreamBatched
+    StrokeLine(struct WebCore::PathDataLine line) StreamBatched
+    StrokeLineWithColorAndThickness(struct WebCore::PathDataLine line, WebCore::DisplayList::SetInlineStrokeColor color, float thickness) StreamBatched
     StrokeArc(struct WebCore::PathArc arc) StreamBatched
     StrokeQuadCurve(struct WebCore::PathDataQuadCurve curve) StreamBatched
     StrokeBezierCurve(struct WebCore::PathDataBezierCurve curve) StreamBatched

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -457,30 +457,6 @@ template<> struct ArgumentCoder<WebCore::Filter> {
     static std::optional<Ref<WebCore::Filter>> decode(Decoder&);
 };
 
-template<typename DataType1, typename DataType2>
-struct ArgumentCoder<WebCore::PathDataComposite<DataType1, DataType2>> {
-    template<typename Encoder>
-    static void encode(Encoder& encoder, const WebCore::PathDataComposite<DataType1, DataType2>& data)
-    {
-        encoder << data.data1;
-        encoder << data.data2;
-    }
-    static std::optional<WebCore::PathDataComposite<DataType1, DataType2>> decode(Decoder& decoder)
-    {
-        std::optional<DataType1> data1;
-        decoder >> data1;
-        if (!data1)
-            return std::nullopt;
-
-        std::optional<DataType2> data2;
-        decoder >> data2;
-        if (!data2)
-            return std::nullopt;
-
-        return WebCore::PathDataComposite<DataType1, DataType2> { *data1, *data2 };
-    }
-};
-
 template<> struct ArgumentCoder<WebCore::Path> {
     template<typename Encoder>
     static void encode(Encoder&, const WebCore::Path&);

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp
@@ -74,7 +74,7 @@ TEST(DisplayListTests, AppendItems)
         list.append<FillRectWithGradient>(FloatRect { 1., 1., 10., 10. }, gradient);
         list.append<SetInlineFillColor>(Color::red);
 #if ENABLE(INLINE_PATH_DATA)
-        list.append<StrokeLine>(PathDataLine { { { 0., 0. } }, { { 10., 15. } } });
+        list.append<StrokeLine>(PathDataLine { { 0., 0. }, { 10., 15. } });
 #endif
     }
 


### PR DESCRIPTION
#### 7dc4e7c7d38b1bc12aa3b7ba168e23699bc5fe6e
<pre>
REGRESSION(265569@main): All path segments should be coded by StreamConnectionEncoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=258734">https://bugs.webkit.org/show_bug.cgi?id=258734</a>
rdar://111570644

Reviewed by Wenson Hsieh.

Detemplatize the composite path segments. Add StreamConnectionEncoder as additional
encoder for these structures. This should recover part of the CanvasLines regression
which was caused by 265569@main.

* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::calculateArcToEndPoint):
(WebCore::PathArcTo::calculateEndPoint const):
(WebCore::PathArcTo::extendBoundingRect const):
(WebCore::PathDataLine::calculateEndPoint const):
(WebCore::PathDataLine::extendFastBoundingRect const):
(WebCore::PathDataLine::extendBoundingRect const):
(WebCore::PathDataLine::addToImpl const):
(WebCore::PathDataLine::applyElements const):
(WebCore::operator&lt;&lt;):
(WebCore::PathDataQuadCurve::calculateEndPoint const):
(WebCore::PathDataQuadCurve::extendFastBoundingRect const):
(WebCore::PathDataQuadCurve::extendBoundingRect const):
(WebCore::PathDataQuadCurve::addToImpl const):
(WebCore::PathDataQuadCurve::applyElements const):
(WebCore::PathDataBezierCurve::calculateEndPoint const):
(WebCore::PathDataBezierCurve::extendFastBoundingRect const):
(WebCore::PathDataBezierCurve::extendBoundingRect const):
(WebCore::PathDataBezierCurve::addToImpl const):
(WebCore::PathDataBezierCurve::applyElements const):
(WebCore::PathDataArc::calculateEndPoint const):
(WebCore::PathDataArc::extendFastBoundingRect const):
(WebCore::PathDataArc::extendBoundingRect const):
(WebCore::PathDataArc::addToImpl const):
(WebCore::DataType2&gt;::calculateEndPoint const): Deleted.
(WebCore::DataType2&gt;::extendFastBoundingRect const): Deleted.
(WebCore::DataType2&gt;::extendBoundingRect const): Deleted.
(WebCore::DataType2&gt;::addToImpl const): Deleted.
(WebCore::DataType2&gt;::applyElements const): Deleted.
* Source/WebCore/platform/graphics/PathSegmentData.h:
(WebCore::PathDataArc::applyElements const):
(WebCore::operator&lt;&lt;): Deleted.
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::lastIfMoveTo const):
(WebCore::PathStream::addLineTo):
(WebCore::PathStream::addQuadCurveTo):
(WebCore::PathStream::addBezierCurveTo):
(WebCore::PathStream::addArcTo):
(WebCore::PathStream::mergeIntoComposite): Deleted.
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::strokePath):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::StrokeLine::StrokeLine):
* Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
(): Deleted.
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265680@main">https://commits.webkit.org/265680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0770be012af738eb5f3620e3e90e9d009dd0774

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11032 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10505 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17645 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10958 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13839 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9112 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10234 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->