### PR TITLE
Make ReplaceSelectionCommand not to attempt to modify uneditable list element

### DIFF
--- a/LayoutTests/editing/execCommand/insert-list-into-list-crash-expected.txt
+++ b/LayoutTests/editing/execCommand/insert-list-into-list-crash-expected.txt
@@ -1,0 +1,5 @@
+bar
+foo
+
+PASS insert-list-into-list-crash
+

--- a/LayoutTests/editing/execCommand/insert-list-into-list-crash.html
+++ b/LayoutTests/editing/execCommand/insert-list-into-list-crash.html
@@ -1,0 +1,17 @@
+
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<div>
+<ul>
+<li id="sample" contenteditable>foo</li>
+</ul>
+</div>
+<div id="log"></div>
+<script>
+test(function() {
+    var sample = document.getElementById('sample');
+    window.getSelection().collapse(sample.firstChild, 0);
+    document.execCommand('insertHTML', false, '<ul><li>bar</li></ul>');
+});
+</script>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1316,7 +1316,7 @@ void ReplaceSelectionCommand::doApply()
 
     RefPtr blockStart { enclosingBlock(insertionPos.deprecatedNode()) };
     bool isInsertingIntoList = (isListHTMLElement(refNode.get()) || (isLegacyAppleStyleSpan(refNode.get()) && isListHTMLElement(refNode->firstChild())))
-    && blockStart && blockStart->renderer()->isListItem();
+    && blockStart && blockStart->renderer()->isListItem() && blockStart->parentNode()->hasEditableStyle();
     if (isInsertingIntoList)
         refNode = insertAsListItems(downcast<HTMLElement>(*refNode), blockStart.get(), insertionPos, insertedNodes);
     else if (isEditablePosition(insertionPos)) {


### PR DESCRIPTION
#### 09159fc78c97383b8a3a6531a99ae68f53c0d94f
<pre>
Make ReplaceSelectionCommand not to attempt to modify uneditable list element

<a href="https://bugs.webkit.org/show_bug.cgi?id=258736">https://bugs.webkit.org/show_bug.cgi?id=258736</a>

Reviewed by Ryosuke Niwa.

This aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/835ae14aec4cdc54e151eaf583fa51a12460e276">https://chromium.googlesource.com/chromium/src.git/+/835ae14aec4cdc54e151eaf583fa51a12460e276</a>

This patch makes &apos;ReplaceSelectionCommand&apos; not to attempt to modify uneditable
list element, when replaced range inside list element, e.g. UL and OL element,
and replacing fragment contains list item within list element.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(ReplaceSelectionCommand::doApply): Add condition for &apos;editable&apos; style
* LayoutTests/editing/execCommand/insert-list-into-list-crash.html: Add Test Case
* LayoutTests/editing/execCommand/insert-list-into-list-crash-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/265663@main">https://commits.webkit.org/265663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4826f905e6d2b9a347ff0b8eab1861939003097f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13899 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13635 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17643 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11053 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9110 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2777 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->