### PR TITLE
[GStreamer][WebRTC] Improved statistics support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -70,24 +70,29 @@ static inline void fillRTCCodecStats(RTCStatsReport::CodecStats& stats, const Gs
         stats.payloadType = value;
     if (gst_structure_get_uint(structure, "clock-rate", &value))
         stats.clockRate = value;
+    if (gst_structure_get_uint(structure, "channels", &value))
+        stats.channels = value;
+
+    if (const char* sdpFmtpLine = gst_structure_get_string(structure, "sdp-fmtp-line"))
+        stats.sdpFmtpLine = String::fromLatin1(sdpFmtpLine);
+
+    if (const char* mimeType = gst_structure_get_string(structure, "mime-type"))
+        stats.mimeType = String::fromLatin1(mimeType);
 
     // FIXME:
-    // stats.mimeType =
-    // stats.channels =
-    // stats.sdpFmtpLine =
     // stats.implementation =
 }
 
-static inline void fillRemoteInboundRTPStreamStats(RTCStatsReport::RemoteInboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+static inline void fillReceivedRTPStreamStats(RTCStatsReport::ReceivedRtpStreamStats& stats, const GstStructure* structure)
 {
-    UNUSED_PARAM(additionalStats);
-    unsigned value;
-    if (gst_structure_get_uint(structure, "ssrc", &value))
-        stats.ssrc = value;
+    fillRTCRTPStreamStats(stats, structure);
 
-    double jitter;
-    if (gst_structure_get_double(structure, "jitter", &jitter))
-        stats.jitter = jitter;
+    GstStructure* rtpSourceStats;
+    gst_structure_get(structure, "gst-rtpsource-stats", GST_TYPE_STRUCTURE, &rtpSourceStats, nullptr);
+
+    uint64_t packetsReceived;
+    if (gst_structure_get_uint64(rtpSourceStats, "packets-received", &packetsReceived))
+        stats.packetsReceived = packetsReceived;
 
 #if GST_CHECK_VERSION(1, 22, 0)
     int64_t packetsLost;
@@ -98,6 +103,32 @@ static inline void fillRemoteInboundRTPStreamStats(RTCStatsReport::RemoteInbound
     if (gst_structure_get_uint(structure, "packets-lost", &packetsLost))
         stats.packetsLost = packetsLost;
 #endif
+
+    uint64_t value;
+    if (gst_structure_get_uint64(structure, "packets-repaired", &value))
+        stats.packetsRepaired = value;
+
+    double jitter;
+    if (gst_structure_get_double(structure, "jitter", &jitter))
+        stats.jitter = jitter;
+
+    // FIXME:
+    // stats.burstLossCount
+    // stats.burstDiscardCount
+    // stats.burstLossRate
+    // stats.burstDiscardRate
+    // stats.gapLossRate
+    // stats.gapDiscardRate
+    // stats.framesDropped
+    // stats.partialFramesLost
+    // stats.fullFramesLost
+}
+
+static inline void fillRemoteInboundRTPStreamStats(RTCStatsReport::RemoteInboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+{
+    fillReceivedRTPStreamStats(stats, structure);
+
+    UNUSED_PARAM(additionalStats);
 
     double roundTripTime;
     if (gst_structure_get_double(structure, "round-trip-time", &roundTripTime))
@@ -106,35 +137,22 @@ static inline void fillRemoteInboundRTPStreamStats(RTCStatsReport::RemoteInbound
     if (const char* localId = gst_structure_get_string(structure, "local-id"))
         stats.localId = String::fromLatin1(localId);
 
-    // FIXME: Fill remaining fields.
+    double fractionLost;
+    if (gst_structure_get_double(structure, "fraction-lost", &fractionLost))
+        stats.fractionLost = fractionLost;
+
+    // FIXME:
+    // stats.reportsReceived
+    // stats.roundTripTimeMeasurements
 }
 
 static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
 {
-    fillRTCRTPStreamStats(stats, structure);
+    fillReceivedRTPStreamStats(stats, structure);
 
     uint64_t value;
-    if (gst_structure_get_uint64(structure, "packets-received", &value))
-        stats.packetsReceived = value;
     if (gst_structure_get_uint64(structure, "bytes-received", &value))
         stats.bytesReceived = value;
-
-#if GST_CHECK_VERSION(1, 22, 0)
-    int64_t packetsLost;
-    if (gst_structure_get_int64(structure, "packets-lost", &packetsLost))
-        stats.packetsLost = packetsLost;
-#else
-    unsigned packetsLost;
-    if (gst_structure_get_uint(structure, "packets-lost", &packetsLost))
-        stats.packetsLost = packetsLost;
-#endif
-
-    double jitter;
-    if (gst_structure_get_double(structure, "jitter", &jitter))
-        stats.jitter = jitter;
-
-    if (gst_structure_get_uint64(structure, "packets-repaired", &value))
-        stats.packetsRepaired = value;
 
     if (gst_structure_get_uint64(structure, "packets-discarded", &value))
         stats.packetsDiscarded = value;
@@ -282,6 +300,10 @@ static inline void fillRTCCandidateStats(RTCStatsReport::IceCandidateStats& stat
     unsigned port;
     if (gst_structure_get_uint(structure, "port", &port))
         stats.port = port;
+
+    unsigned priority;
+    if (gst_structure_get_uint(structure, "priority", &priority))
+        stats.priority = priority;
 
     auto candidateType = String::fromLatin1(gst_structure_get_string(structure, "candidate-type"));
     stats.candidateType = iceCandidateType(candidateType);


### PR DESCRIPTION
#### 6372de17d30f735b2b6b09b478256d8e5e75d0c3
<pre>
[GStreamer][WebRTC] Improved statistics support
<a href="https://bugs.webkit.org/show_bug.cgi?id=258738">https://bugs.webkit.org/show_bug.cgi?id=258738</a>

Reviewed by Xabier Rodriguez-Calvar.

The codec stats are now spec compliant (implementation field is not). There&apos;s also a dedicated
function for filling ReceivedRtpStreamStats. RemoteInboundRtpStreamStats now account for
fractionLost infos. IceCandidateStats now account for priority infos.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillRTCCodecStats):
(WebCore::fillReceivedRTPStreamStats):
(WebCore::fillRemoteInboundRTPStreamStats):
(WebCore::fillInboundRTPStreamStats):
(WebCore::fillRTCCandidateStats):

Canonical link: <a href="https://commits.webkit.org/265752@main">https://commits.webkit.org/265752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8786f93e532ed032bb8dd6266fd24025448c270

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11779 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13642 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9889 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17649 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10962 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13843 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10237 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2839 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10917 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->