### PR TITLE
Audio element control buttons are no longer circular after refreshing the page in visionOS

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -224,13 +224,13 @@ class Button extends LayoutItem
             height /= window.devicePixelRatio;
         }
 
-        if (this.image.width === width && this.image.height === height)
-            return;
-
         if (this.circular) {
             width = Math.max(width, height);
             height = width;
         }
+
+        if (this.image.width === width && this.image.height === height)
+            return;
 
         this.image.width = width;
         this.image.height = height;


### PR DESCRIPTION
#### cee3c7d1803a4e8ab72a2f4c8065e4d226b18c54
<pre>
Audio element control buttons are no longer circular after refreshing the page in visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=258739">https://bugs.webkit.org/show_bug.cgi?id=258739</a>
rdar://111523213

Reviewed by Jer Noble.

Fix the logic in `_updateImageMetrics` to possibly return early only after the final new width and
height are actually computed.

* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype._updateImageMetrics):
(Button):

Canonical link: <a href="https://commits.webkit.org/265665@main">https://commits.webkit.org/265665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d103695181a213bbd0f6fca3f649fa6079964b38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11037 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13644 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9890 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17648 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10239 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->