### PR TITLE
REGRESSION (263995@main): preventDefault on wheel events can still result in page scrolling (fast/scrolling/mac/event-region-prevent-default-with-sublayer.html is a consistent failure)

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -52,6 +52,7 @@ public:
 
     virtual void willSendEventForDefaultHandling(const WebCore::PlatformWheelEvent&) { }
     virtual void waitForEventDefaultHandlingCompletion(const WebCore::PlatformWheelEvent&) { }
+    virtual void receivedEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, std::optional<WebCore::WheelScrollGestureState>) { };
     virtual WebCore::WheelEventHandlingResult handleWheelEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) { return WebCore::WheelEventHandlingResult::unhandled(); }
 
     RemoteScrollingCoordinatorProxy* scrollingCoordinatorProxy() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -280,6 +280,9 @@ void RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted(const PlatformW
 
     LOG_WITH_STREAM(WheelEvents, stream << "RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted " << wheelEvent << " - sending event to scrolling thread, node " << 0 << " gestureState " << gestureState);
 
+    if (auto scrollingTree = this->scrollingTree())
+        scrollingTree->receivedEventAfterDefaultHandling(wheelEvent, gestureState);
+
     ScrollingThread::dispatch([protectedThis = Ref { *this }, wheelEvent, scrollingNodeID, gestureState] {
         auto scrollingTree = protectedThis->scrollingTree();
         if (!scrollingTree)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -69,6 +69,8 @@ private:
     // "Default handling" here refers to sending the event to the web process for synchronous scrolling, and DOM event handling.
     void willSendEventForDefaultHandling(const WebCore::PlatformWheelEvent&) override;
     void waitForEventDefaultHandlingCompletion(const WebCore::PlatformWheelEvent&) override;
+    void receivedEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, std::optional<WebCore::WheelScrollGestureState>) override;
+
     WheelEventHandlingResult handleWheelEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3363,11 +3363,9 @@ void WebPageProxy::handleWheelEventReply(const WebWheelEvent& event, ScrollingNo
     MESSAGE_CHECK(m_process, wheelEventCoalescer().hasEventsBeingProcessed());
 
 #if ENABLE(ASYNC_SCROLLING) && PLATFORM(MAC)
-    if (nodeID) {
-        if (auto* scrollingCoordinatorProxy = this->scrollingCoordinatorProxy()) {
-            scrollingCoordinatorProxy->wheelEventHandlingCompleted(platform(event), nodeID, gestureState);
-            return;
-        }
+    if (auto* scrollingCoordinatorProxy = this->scrollingCoordinatorProxy()) {
+        scrollingCoordinatorProxy->wheelEventHandlingCompleted(platform(event), nodeID, gestureState);
+        return;
     }
 #else
     UNUSED_PARAM(event);


### PR DESCRIPTION
#### bdb0943f393055ad79b1a8cd7ba04515f82a7768
<pre>
REGRESSION (263995@main): preventDefault on wheel events can still result in page scrolling (fast/scrolling/mac/event-region-prevent-default-with-sublayer.html is a consistent failure)
<a href="https://bugs.webkit.org/show_bug.cgi?id=258741">https://bugs.webkit.org/show_bug.cgi?id=258741</a>
rdar://111420041

Reviewed by Tim Horton.

263995@main broke the &quot;only the first wheel event should be cancelable&quot; logic such that if the page
called preventDefault() on a wheel event, we&apos;d always time out the `m_waitingForBeganEventCondition`
condition, which results in us making a wheel event sequence that should be synchronous (i.e. page
can consume all events) into an async one (which can trigger scrolling).

This manifested as page scrolls in fast/scrolling/mac/event-region-prevent-default-with-sublayer.html.

There are two aspects to the fix. First, when we get back to `WebPageProxy::handleWheelEventReply()`
in the UI process with no nodeID (which means that the web process didn&apos;t use the event for main
thread scrolling for any node), we still call into the scrolling coordinator which calls into
`RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted()`. This flow eventually early
returns from `RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling()` if the nodeID is zero,
but this ensures that we always end up hitting WebPageProxy::wheelEventHandlingCompleted() which
is necessary.

Second, pull the code that notifies the m_waitingForBeganEventCondition into its own function that
is called on the main thread (previously we tried to notify the condition on the scrolling thread,
which was the waiting thread, which is why it always timed out).

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::receivedEventAfterDefaultHandling):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::receivedEventAfterDefaultHandling):
(WebKit::RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEventReply):

Canonical link: <a href="https://commits.webkit.org/265781@main">https://commits.webkit.org/265781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcdd4479f2b856ce51f47cd3b61f61be856ad2dc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13649 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9895 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17653 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10242 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2862 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->