### PR TITLE
Implement scrollbar-gutter on viewports

### DIFF
--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -124,6 +124,9 @@ public:
     void setVerticalScrollbarLock(bool lock = true) { m_verticalScrollbarLock = lock; }
     bool verticalScrollbarLock() const { return m_verticalScrollbarLock; }
 
+    int verticalScrollbarWidth(bool isHorizontalWritingMode = true) const;
+    int horizontalScrollbarHeight(bool isHorizontalWritingMode = true) const;
+
     void setScrollingModesLock(bool lock = true) { m_horizontalScrollbarLock = m_verticalScrollbarLock = lock; }
 
     WEBCORE_EXPORT virtual void setCanHaveScrollbars(bool);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -918,9 +918,18 @@ bool RenderBox::fixedElementLaysOutRelativeToFrame(const LocalFrameView& frameVi
 
 bool RenderBox::includeVerticalScrollbarSize() const
 {
-    return hasNonVisibleOverflow() && layer() && !layer()->hasOverlayScrollbars()
-        && (style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Auto
+    if (layer() && layer()->hasOverlayScrollbars())
+        return false;
+
+    if (hasNonVisibleOverflow()) {
+        return (style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Auto
             || (style().overflowY() == Overflow::Hidden && !style().scrollbarGutter().isAuto));
+    }
+
+    if (isDocumentElementRenderer())
+        return !style().scrollbarGutter().isAuto;
+
+    return false;
 }
 
 bool RenderBox::includeHorizontalScrollbarSize() const
@@ -935,6 +944,9 @@ int RenderBox::verticalScrollbarWidth() const
     auto* scrollableArea = layer() ? layer()->scrollableArea() : nullptr;
     if (!scrollableArea)
         return 0;
+
+    if (isDocumentElementRenderer())
+        return includeVerticalScrollbarSize() ? view().frameView().verticalScrollbarWidth(isHorizontalWritingMode()) : 0;
     return includeVerticalScrollbarSize() ? scrollableArea->verticalScrollbarWidth(IgnoreOverlayScrollbarSize, isHorizontalWritingMode()) : 0;
 }
 


### PR DESCRIPTION
#### ccc39c24b4b5347ea889059cd49bf4d7ac5ec2c1
<pre>
Implement scrollbar-gutter on viewports
<a href="https://bugs.webkit.org/show_bug.cgi?id=257606">https://bugs.webkit.org/show_bug.cgi?id=257606</a>

Reviewed by NOBODY (OOPS!).

Updates scrollbar gutter implementation to work for viewports.

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::documentScrollPositionRelativeToViewOrigin const):
(WebCore::ScrollView::verticalScrollbarWidth const):
(WebCore::ScrollView::horizontalScrollbarHeight const):
(WebCore::ScrollView::locationOfContents const):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::includeVerticalScrollbarSize const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccc39c24b4b5347ea889059cd49bf4d7ac5ec2c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/38876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/17807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/41221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/41407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/34529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/41183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/20653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/15156 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/32580 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-002.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-004.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/39449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/14979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/33711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/13025 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/12969 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/34629 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-002.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-004.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-007.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/42684 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/35276 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/34980 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-002.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-004.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-007.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/38805 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-002.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-004.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-007.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/13686 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/11285 "Found 7 new test failures: imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-002.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-004.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-005.html, imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-007.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html, imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html, workers/wasm-hashset.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/37030 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/15295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/14959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/14779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->