### PR TITLE
Revert gardening changes 265171@main and 265172@main after fix in 265656@main

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3686,9 +3686,6 @@ webkit.org/b/240929 [ Debug ]  resize-observer/resize-observer-with-zoom.html [ 
 
 webkit.org/b/241253 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
-# webkit.org/b/258095 [ iOS, macOS ]  media/track/video-track-add-remove.html  is a flaky crash.
-[ Debug ] media/track/video-track-add-remove.html [ Pass Crash ]
-
 # These tests have different results on iOS
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment.html
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -195,12 +195,6 @@ fast/mediastream/RTCPeerConnection-stats.html [ Skip ]
 media/track/track-user-stylesheet.html [ Pass Crash ]
 media/track/track-webvtt-snap-to-lines-inline-style.html [ Pass Crash ]
 
-# webkit.org/b/258097  [ iOS, macOS Debug ] media/track/video-track-alternate-groups.html is a flaky crash.
-[ Debug ] media/track/video-track-alternate-groups.html [ Pass Crash ]
-
-# webkit.org/b/258095 [ iOS, macOS ]  media/track/video-track-add-remove.html  is a flaky crash.
-[ Debug ] media/track/video-track-add-remove.html [ Pass Crash ]
-
 # webkit.org/b/258184 [ macOS ] 2x media/track/ tests are flaky crashes. 
 [ Debug ] media/track/track-webvtt-no-snap-to-lines-overlap.html [ Pass Crash ]
 [ Debug ] media/track/track-webvtt-snap-to-lines-left-right.html [ Pass Crash ]


### PR DESCRIPTION
#### b0d43f67764c4857903c3e79800664eff4aa95b6
<pre>
Revert gardening changes 265171@main and 265172@main after fix in 265656@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=258742">https://bugs.webkit.org/show_bug.cgi?id=258742</a>

Unreviewed gardening after addressing issue causing these tests to fail flakily.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/265668@main">https://commits.webkit.org/265668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c049b9b81374963f10172292c3fea05e1095c27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13232 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11044 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13914 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11750 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13653 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10522 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17657 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10971 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13852 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2784 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14524 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->