### PR TITLE
[ watchOS ] Crash in PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include "HTMLMediaElementEnums.h"
+#include "PlaybackSessionModel.h"
+
+OBJC_CLASS AVPlayerViewController;
+OBJC_CLASS UIView;
+
+namespace WebCore {
+
+class FloatRect;
+class FloatSize;
+
+class NullPlaybackSessionInterface final
+    : public PlaybackSessionModelClient
+    , public RefCounted<NullPlaybackSessionInterface> {
+public:
+    static Ref<NullPlaybackSessionInterface> create(PlaybackSessionModel& model)
+    {
+        return adoptRef(*new NullPlaybackSessionInterface(model));
+    }
+
+    PlaybackSessionModel* playbackSessionModel() const { return m_model.get(); }
+
+    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
+    void enterFullscreen() { }
+    bool exitFullscreen(const FloatRect&) { return false; }
+    void cleanupFullscreen() { }
+    void invalidate() { }
+    void requestHideAndExitFullscreen() { }
+    void preparedToReturnToInline(bool visible, const FloatRect& inlineRect) { }
+    void preparedToExitFullscreen() { }
+    void setHasVideoContentLayer(bool) { }
+    void setInlineRect(const FloatRect&, bool) { }
+    void preparedToReturnToStandby() { }
+    bool mayAutomaticallyShowVideoPictureInPicture() const { return false; }
+    void applicationDidBecomeActive() { }
+    void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool) { }
+    bool pictureInPictureWasStartedWhenEnteringBackground() const { return false; }
+    AVPlayerViewController *avPlayerViewController() const { return nullptr; }
+
+private:
+    NullPlaybackSessionInterface(PlaybackSessionModel& model)
+        : m_model(model)
+    {
+    }
+
+    void durationChanged(double) final { }
+    void currentTimeChanged(double, double) final { }
+    void bufferedTimeChanged(double) final { }
+    void rateChanged(OptionSet<PlaybackSessionModel::PlaybackState>, double, double) final { }
+    void seekableRangesChanged(const TimeRanges&, double, double) final { }
+    void canPlayFastReverseChanged(bool) final { }
+    void audioMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void legibleMediaSelectionOptionsChanged(const Vector<MediaSelectionOption>&, uint64_t) final { }
+    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
+    void wirelessVideoPlaybackDisabledChanged(bool) final { }
+    void mutedChanged(bool) final { }
+    void volumeChanged(double) final { }
+    void modelDestroyed() final { }
+
+    WeakPtr<PlaybackSessionModel> m_model;
+};
+
+}
+
+#endif

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#include "NullPlaybackSessionInterface.h"
+#include "VideoFullscreenCaptions.h"
+#include "VideoFullscreenModel.h"
+
+namespace WebCore {
+
+class NullVideoFullscreenInterface final
+    : public VideoFullscreenModelClient
+    , public PlaybackSessionModelClient
+    , public VideoFullscreenCaptions
+    , public RefCounted<NullVideoFullscreenInterface> {
+public:
+    static Ref<NullVideoFullscreenInterface> create(NullPlaybackSessionInterface& playbackSessionInterface)
+    {
+        return adoptRef(*new NullVideoFullscreenInterface(playbackSessionInterface));
+    }
+
+    virtual ~NullVideoFullscreenInterface() = default;
+    NullPlaybackSessionInterface& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
+    PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
+
+    void setVideoFullscreenModel(VideoFullscreenModel* model) { m_videoFullscreenModel = model; }
+    void setupFullscreen(UIView&, const FloatRect&, const FloatSize&, UIView*, HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) { }
+    void enterFullscreen() { }
+    bool exitFullscreen(const FloatRect& finalRect) { return false; }
+    void cleanupFullscreen() { }
+    void invalidate() { }
+    void requestHideAndExitFullscreen() { }
+    void preparedToReturnToInline(bool visible, const FloatRect& inlineRect) { }
+    void preparedToExitFullscreen() { }
+    void setHasVideoContentLayer(bool) { }
+    void setInlineRect(const FloatRect&, bool visible) { }
+    void preparedToReturnToStandby() { }
+    bool mayAutomaticallyShowVideoPictureInPicture() const { return false; }
+    void applicationDidBecomeActive() { }
+    void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool) { }
+    HTMLMediaElementEnums::VideoFullscreenMode mode() const { return HTMLMediaElementEnums::VideoFullscreenModeNone; }
+    bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
+    bool pictureInPictureWasStartedWhenEnteringBackground() const { return false; }
+    AVPlayerViewController *avPlayerViewController() const { return nullptr; }
+    bool isPlayingVideoInEnhancedFullscreen() const { return false; }
+    std::optional<MediaPlayerIdentifier> playerIdentifier() const { return std::nullopt; }
+    bool changingStandbyOnly() { return false; }
+
+    // VideoFullscreenModelClient
+    void hasVideoChanged(bool) final { }
+    void videoDimensionsChanged(const FloatSize&) final { }
+    void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final { }
+
+    // PlaybackSessionModelClient
+    void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
+
+private:
+    NullVideoFullscreenInterface(NullPlaybackSessionInterface& playbackSessionInterface)
+        : m_playbackSessionInterface(playbackSessionInterface)
+    {
+    }
+
+    Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
+    ThreadSafeWeakPtr<VideoFullscreenModel> m_videoFullscreenModel;
+};
+
+}
+
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -38,13 +38,17 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(WATCHOS)
+#include <WebCore/NullPlaybackSessionInterface.h>
+#elif PLATFORM(IOS_FAMILY)
 #include <WebCore/PlaybackSessionInterfaceAVKit.h>
 #else
 #include <WebCore/PlaybackSessionInterfaceMac.h>
 #endif
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(WATCHOS)
+typedef WebCore::NullPlaybackSessionInterface PlatformPlaybackSessionInterface;
+#elif PLATFORM(IOS_FAMILY)
 typedef WebCore::PlaybackSessionInterfaceAVKit PlatformPlaybackSessionInterface;
 #else
 typedef WebCore::PlaybackSessionInterfaceMac PlatformPlaybackSessionInterface;

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -43,7 +43,10 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(WATCHOS)
+#include <WebCore/NullVideoFullscreenInterface.h>
+typedef WebCore::NullVideoFullscreenInterface PlatformVideoFullscreenInterface;
+#elif PLATFORM(IOS_FAMILY)
 #include <WebCore/VideoFullscreenInterfaceAVKit.h>
 typedef WebCore::VideoFullscreenInterfaceAVKit PlatformVideoFullscreenInterface;
 #else


### PR DESCRIPTION
#### cecd69451d07f0ab7eb2fbba3661ef19fa085072
<pre>
[ watchOS ] Crash in PlaybackSessionInterfaceAVKit::PlaybackSessionInterfaceAVKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=258750">https://bugs.webkit.org/show_bug.cgi?id=258750</a>
rdar://110387309

Reviewed by Andy Estes and Eric Carlson.

Video playback on watchOS is disabled, but somehow pages are getting far enough along
in video playback to cause a PlaybackSessionInterfaceAVKit to be instantiated. Due to
differences in the implementation of AVKit on watchOS from iOS, our technique of creating
a WebAVPlayerController causes an unimplemented selector exception.

Since we shouldn&apos;t be playing any video on watchOS anyway, just add empty implementations
of VideoFullscreenInterface and PlaybackSessionInterface for use there.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h: Added.
* Source/WebCore/platform/graphics/cocoa/NullVideoFullscreenInterface.h: Added.
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/265674@main">https://commits.webkit.org/265674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dad37536b82b7ce9f5d16862d23df7c4d1bf9fcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13246 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13928 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12617 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13667 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10531 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13865 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9134 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10260 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2788 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->