### PR TITLE
Small cleanup on BMPImageReader.cpp

### DIFF
--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Google Inc. All rights reserved.
+ * Copyright (c) 2008-2015 Google Inc. All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -44,7 +44,6 @@ BMPImageReader::BMPImageReader(ScalableImageDecoder* parent, size_t decodedAndHe
     , m_isTopDown(false)
     , m_needToProcessBitmasks(false)
     , m_needToProcessColorTable(false)
-    , m_tableSizeInBytes(0)
     , m_seenNonZeroAlphaPixel(false)
     , m_seenZeroAlphaPixel(false)
     , m_andMaskState(usesAndMask ? NotYetDecoded : None)
@@ -59,8 +58,9 @@ bool BMPImageReader::decodeBMP(bool onlySize)
     if (!m_infoHeader.biSize && !readInfoHeaderSize())
         return false;
 
+    const size_t headerEnd = m_headerOffset + m_infoHeader.biSize;
     // Read and process info header.
-    if ((m_decodedOffset < (m_headerOffset + m_infoHeader.biSize)) && !processInfoHeader())
+    if ((m_decodedOffset < headerEnd) && !processInfoHeader())
         return false;
 
     // processInfoHeader() set the size, so if that's all we needed, we're done.
@@ -134,7 +134,8 @@ bool BMPImageReader::readInfoHeaderSize()
     // Don't allow the header to overflow (which would be harmless here, but
     // problematic or at least confusing in other places), or to overrun the
     // image data.
-    if (((m_headerOffset + m_infoHeader.biSize) < m_headerOffset) || (m_imgDataOffset && (m_imgDataOffset < (m_headerOffset + m_infoHeader.biSize))))
+    const size_t headerEnd = m_headerOffset + m_infoHeader.biSize;
+    if ((headerEnd < m_headerOffset) || (m_imgDataOffset && (m_imgDataOffset < headerEnd)))
         return m_parent->setFailed();
 
     // See if this is a header size we understand:
@@ -392,12 +393,14 @@ bool BMPImageReader::processBitmasks()
         // we read the info header.
 
         // Fail if we don't have enough file space for the bitmasks.
-        static const size_t SIZEOF_BITMASKS = 12;
-        if (((m_headerOffset + m_infoHeader.biSize + SIZEOF_BITMASKS) < (m_headerOffset + m_infoHeader.biSize)) || (m_imgDataOffset && (m_imgDataOffset < (m_headerOffset + m_infoHeader.biSize + SIZEOF_BITMASKS))))
+        const size_t headerEnd = m_headerOffset + m_infoHeader.biSize;
+        static constexpr size_t bitmasksSize = 12;
+        const size_t bitmasksEnd = headerEnd + bitmasksSize;
+        if ((bitmasksEnd < headerEnd) || (m_imgDataOffset && (m_imgDataOffset < bitmasksEnd)))
             return m_parent->setFailed();
 
         // Read bitmasks.
-        if ((m_data->size() - m_decodedOffset) < SIZEOF_BITMASKS)
+        if ((m_data->size() - m_decodedOffset) < bitmasksSize)
             return false;
         m_bitMasks[0] = readUint32(0);
         m_bitMasks[1] = readUint32(4);
@@ -405,7 +408,7 @@ bool BMPImageReader::processBitmasks()
         // No alpha in anything other than Windows V4+.
         m_bitMasks[3] = 0;
 
-        m_decodedOffset += SIZEOF_BITMASKS;
+        m_decodedOffset += bitmasksSize;
     }
 
     // We've now decoded all the non-image data we care about.  Skip anything
@@ -462,14 +465,15 @@ bool BMPImageReader::processBitmasks()
 
 bool BMPImageReader::processColorTable()
 {
-    m_tableSizeInBytes = m_infoHeader.biClrUsed * (m_isOS21x ? 3 : 4);
-
     // Fail if we don't have enough file space for the color table.
-    if (((m_headerOffset + m_infoHeader.biSize + m_tableSizeInBytes) < (m_headerOffset + m_infoHeader.biSize)) || (m_imgDataOffset && (m_imgDataOffset < (m_headerOffset + m_infoHeader.biSize + m_tableSizeInBytes))))
+    const size_t headerEnd = m_headerOffset + m_infoHeader.biSize;
+    const size_t tableSizeInBytes = m_infoHeader.biClrUsed * (m_isOS21x ? 3 : 4);
+    const size_t tableEnd = headerEnd + tableSizeInBytes;
+    if ((tableEnd < headerEnd) || (m_imgDataOffset && (m_imgDataOffset < tableEnd)))
         return m_parent->setFailed();
 
     // Read color table.
-    if ((m_decodedOffset > m_data->size()) || ((m_data->size() - m_decodedOffset) < m_tableSizeInBytes))
+    if ((m_decodedOffset > m_data->size()) || ((m_data->size() - m_decodedOffset) < tableSizeInBytes))
         return false;
     m_colorTable.resize(m_infoHeader.biClrUsed);
     for (size_t i = 0; i < m_infoHeader.biClrUsed; ++i) {

--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, Google Inc. All rights reserved.
+ * Copyright (c) 2008-2015 Google Inc. All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -325,7 +325,6 @@ private:
     int m_bitShiftsLeft[4];
 
     // The color palette, for paletted formats.
-    size_t m_tableSizeInBytes;
     Vector<RGBTriple> m_colorTable;
 
     // The coordinate to which we've decoded the image.


### PR DESCRIPTION
#### d156132fce2fe3a0d90b92c2866ca4776c473316
<pre>
Small cleanup on BMPImageReader.cpp

<a href="https://bugs.webkit.org/show_bug.cgi?id=253123">https://bugs.webkit.org/show_bug.cgi?id=253123</a>
rdar://problem/106387835

Reviewed by Fujii Hironori.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/a057769943417c61acd574458034ac6546ed6f6a">https://chromium.googlesource.com/chromium/blink/+/a057769943417c61acd574458034ac6546ed6f6a</a>

&apos;m_headerOffset + m_infoHeader.biSize&apos; is used often in BMPImageReader.cpp.
It is even recalulated several time in a same function. This patch cleans up
this kind of repeated code.

* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(BMPImageReader::BMPImageReader):
(BMPImageReader::decodeBMP):
(BMPImageReader::readInfoHeaderSize):
(BMPImageReader::processBitmasks):
(BMPImageReader::processColorTable):
* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.h: Remove &apos;m_tableSizeInBytes&apos;

Canonical link: <a href="https://commits.webkit.org/265704@main">https://commits.webkit.org/265704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58881a704a53c87d7bb9c87cfa74488cf429eec9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13707 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13903 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9171 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10296 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2802 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->