### PR TITLE
REGRESSION(265657@main): svg/W3C-I18N/tspan-direction-rtl.svg is failing

### DIFF
--- a/LayoutTests/platform/mac/svg/W3C-I18N/tspan-direction-rtl-expected.txt
+++ b/LayoutTests/platform/mac/svg/W3C-I18N/tspan-direction-rtl-expected.txt
@@ -12,9 +12,9 @@ layer at (0,0) size 800x600
             chunk 1 (middle anchor) text run 1 at (148.58,150.00) startOffset 0 endOffset 14 width 135.07: "dirRTL ubEmbed"
         RenderSVGInlineText {#text} at (0,0) size 12x21
           chunk 1 (middle anchor) text run 1 at (92.21,150.00) startOffset 0 endOffset 2 width 11.39 RTL: "\"!"
-      RenderSVGText {text} at (20,170) size 87x13 contains 1 chunk(s)
-        RenderSVGInlineText {#text} at (0,0) size 87x12
-          chunk 1 text run 1 at (20.00,180.00) startOffset 0 endOffset 18 width 86.18: "Reference graphic:"
+      RenderSVGText {text} at (20,170) size 85x13 contains 1 chunk(s)
+        RenderSVGInlineText {#text} at (0,0) size 85x12
+          chunk 1 text run 1 at (20.00,180.00) startOffset 0 endOffset 18 width 84.49: "Reference graphic:"
       RenderSVGImage {image} at (100,300) size 584x65
     RenderSVGContainer {g} at (16,557) size 73x12
       RenderSVGText {text} at (10,334) size 44x8 contains 1 chunk(s)
@@ -23,6 +23,6 @@ layer at (0,0) size 800x600
     RenderSVGRect {rect} at (0,0) size 800x600 [stroke={[type=SOLID] [color=#000000]}] [x=1.00] [y=1.00] [width=478.00] [height=358.00]
     RenderSVGContainer {g} at (0,0) size 800x38
       RenderSVGRect {rect} at (0,0) size 800x36 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FF0000]}] [x=1.00] [y=1.00] [width=478.00] [height=20.00]
-      RenderSVGText {text} at (206,0) size 68x23 contains 1 chunk(s)
+      RenderSVGText {text} at (206,-1) size 68x24 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 68x23
-          chunk 1 (middle anchor) text run 1 at (206.46,18.00) startOffset 0 endOffset 5 width 67.09: "DRAFT"
+          chunk 1 (middle anchor) text run 1 at (206.12,18.00) startOffset 0 endOffset 5 width 67.76: "DRAFT"


### PR DESCRIPTION
#### 2ce829b573fa79059fedf82b13be8ea472cb6ab6
<pre>
REGRESSION(265657@main): svg/W3C-I18N/tspan-direction-rtl.svg is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=258751">https://bugs.webkit.org/show_bug.cgi?id=258751</a>
rdar://111591383

Unreviewed test gardening.

Simply needs a rebaseline.

* LayoutTests/platform/mac/svg/W3C-I18N/tspan-direction-rtl-expected.txt:

Canonical link: <a href="https://commits.webkit.org/265676@main">https://commits.webkit.org/265676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b96eda931ba683173fae509c6ba41a3d32743a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13258 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13680 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10545 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10699 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10271 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->