### PR TITLE
Undefined behavior in HashSet<CSSSelector::PseudoClassType>

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -145,18 +145,18 @@ SelectorSpecificity simpleSelectorSpecificity(const CSSSelector& simpleSelector)
         break;
     case CSSSelector::Match::PseudoClass:
         switch (simpleSelector.pseudoClassType()) {
-        case CSSSelector::PseudoClassIs:
-        case CSSSelector::PseudoClassMatches:
-        case CSSSelector::PseudoClassNot:
-        case CSSSelector::PseudoClassHas:
+        case CSSSelector::PseudoClassType::Is:
+        case CSSSelector::PseudoClassType::Matches:
+        case CSSSelector::PseudoClassType::Not:
+        case CSSSelector::PseudoClassType::Has:
             return maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClassWhere:
+        case CSSSelector::PseudoClassType::Where:
             return 0;
-        case CSSSelector::PseudoClassNthChild:
-        case CSSSelector::PseudoClassNthLastChild:
-        case CSSSelector::PseudoClassHost:
+        case CSSSelector::PseudoClassType::NthChild:
+        case CSSSelector::PseudoClassType::NthLastChild:
+        case CSSSelector::PseudoClassType::Host:
             return SelectorSpecificityIncrement::ClassB + maxSpecificity(simpleSelector.selectorList());
-        case CSSSelector::PseudoClassRelativeScope:
+        case CSSSelector::PseudoClassType::RelativeScope:
             return 0;
         default:
             return SelectorSpecificityIncrement::ClassB;
@@ -311,12 +311,12 @@ const CSSSelector* CSSSelector::firstInCompound() const
 static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelector* selector)
 {
     switch (selector->pseudoClassType()) {
-    case CSSSelector::PseudoClassDir:
-    case CSSSelector::PseudoClassLang:
-    case CSSSelector::PseudoClassNthChild:
-    case CSSSelector::PseudoClassNthLastChild:
-    case CSSSelector::PseudoClassNthOfType:
-    case CSSSelector::PseudoClassNthLastOfType:
+    case CSSSelector::PseudoClassType::Dir:
+    case CSSSelector::PseudoClassType::Lang:
+    case CSSSelector::PseudoClassType::NthChild:
+    case CSSSelector::PseudoClassType::NthLastChild:
+    case CSSSelector::PseudoClassType::NthOfType:
+    case CSSSelector::PseudoClassType::NthLastOfType:
         builder.append(selector->argument(), ')');
         break;
     default:
@@ -405,195 +405,195 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
         } else if (cs->match() == Match::PseudoClass) {
             switch (cs->pseudoClassType()) {
 #if ENABLE(FULLSCREEN_API)
-            case CSSSelector::PseudoClassAnimatingFullScreenTransition:
+            case CSSSelector::PseudoClassType::AnimatingFullScreenTransition:
                 builder.append(":-webkit-animating-full-screen-transition");
                 break;
 #endif
-            case CSSSelector::PseudoClassAny: {
+            case CSSSelector::PseudoClassType::Any: {
                 builder.append(":-webkit-any(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassAnyLink:
+            case CSSSelector::PseudoClassType::AnyLink:
                 builder.append(":any-link");
                 break;
-            case CSSSelector::PseudoClassAnyLinkDeprecated:
+            case CSSSelector::PseudoClassType::AnyLinkDeprecated:
                 builder.append(":-webkit-any-link");
                 break;
-            case CSSSelector::PseudoClassAutofill:
+            case CSSSelector::PseudoClassType::Autofill:
                 builder.append(":autofill");
                 break;
-            case CSSSelector::PseudoClassAutofillAndObscured:
+            case CSSSelector::PseudoClassType::AutofillAndObscured:
                 builder.append(":-webkit-autofill-and-obscured");
                 break;
-            case CSSSelector::PseudoClassAutofillStrongPassword:
+            case CSSSelector::PseudoClassType::AutofillStrongPassword:
                 builder.append(":-webkit-autofill-strong-password");
                 break;
-            case CSSSelector::PseudoClassAutofillStrongPasswordViewable:
+            case CSSSelector::PseudoClassType::AutofillStrongPasswordViewable:
                 builder.append(":-webkit-autofill-strong-password-viewable");
                 break;
-            case CSSSelector::PseudoClassDrag:
+            case CSSSelector::PseudoClassType::Drag:
                 builder.append(":-webkit-drag");
                 break;
-            case CSSSelector::PseudoClassFullPageMedia:
+            case CSSSelector::PseudoClassType::FullPageMedia:
                 builder.append(":-webkit-full-page-media");
                 break;
 #if ENABLE(FULLSCREEN_API)
-            case CSSSelector::PseudoClassFullscreen:
+            case CSSSelector::PseudoClassType::Fullscreen:
                 builder.append(":fullscreen");
                 break;
-            case CSSSelector::PseudoClassWebkitFullScreen:
+            case CSSSelector::PseudoClassType::WebkitFullScreen:
                 builder.append(":-webkit-full-screen");
                 break;
-            case CSSSelector::PseudoClassFullScreenAncestor:
+            case CSSSelector::PseudoClassType::FullScreenAncestor:
                 builder.append(":-webkit-full-screen-ancestor");
                 break;
-            case CSSSelector::PseudoClassFullScreenDocument:
+            case CSSSelector::PseudoClassType::FullScreenDocument:
                 builder.append(":-webkit-full-screen-document");
                 break;
-            case CSSSelector::PseudoClassFullScreenControlsHidden:
+            case CSSSelector::PseudoClassType::FullScreenControlsHidden:
                 builder.append(":-webkit-full-screen-controls-hidden");
                 break;
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
-            case CSSSelector::PseudoClassPictureInPicture:
+            case CSSSelector::PseudoClassType::PictureInPicture:
                 builder.append(":picture-in-picture");
                 break;
 #endif
-            case CSSSelector::PseudoClassActive:
+            case CSSSelector::PseudoClassType::Active:
                 builder.append(":active");
                 break;
-            case CSSSelector::PseudoClassChecked:
+            case CSSSelector::PseudoClassType::Checked:
                 builder.append(":checked");
                 break;
-            case CSSSelector::PseudoClassCornerPresent:
+            case CSSSelector::PseudoClassType::CornerPresent:
                 builder.append(":corner-present");
                 break;
-            case CSSSelector::PseudoClassDecrement:
+            case CSSSelector::PseudoClassType::Decrement:
                 builder.append(":decrement");
                 break;
-            case CSSSelector::PseudoClassDefault:
+            case CSSSelector::PseudoClassType::Default:
                 builder.append(":default");
                 break;
-            case CSSSelector::PseudoClassDir:
+            case CSSSelector::PseudoClassType::Dir:
                 builder.append(":dir(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassDisabled:
+            case CSSSelector::PseudoClassType::Disabled:
                 builder.append(":disabled");
                 break;
-            case CSSSelector::PseudoClassDoubleButton:
+            case CSSSelector::PseudoClassType::DoubleButton:
                 builder.append(":double-button");
                 break;
-            case CSSSelector::PseudoClassEmpty:
+            case CSSSelector::PseudoClassType::Empty:
                 builder.append(":empty");
                 break;
-            case CSSSelector::PseudoClassEnabled:
+            case CSSSelector::PseudoClassType::Enabled:
                 builder.append(":enabled");
                 break;
-            case CSSSelector::PseudoClassEnd:
+            case CSSSelector::PseudoClassType::End:
                 builder.append(":end");
                 break;
-            case CSSSelector::PseudoClassFirstChild:
+            case CSSSelector::PseudoClassType::FirstChild:
                 builder.append(":first-child");
                 break;
-            case CSSSelector::PseudoClassFirstOfType:
+            case CSSSelector::PseudoClassType::FirstOfType:
                 builder.append(":first-of-type");
                 break;
-            case CSSSelector::PseudoClassFocus:
+            case CSSSelector::PseudoClassType::Focus:
                 builder.append(":focus");
                 break;
-            case CSSSelector::PseudoClassFocusVisible:
+            case CSSSelector::PseudoClassType::FocusVisible:
                 builder.append(":focus-visible");
                 break;
-            case CSSSelector::PseudoClassFocusWithin:
+            case CSSSelector::PseudoClassType::FocusWithin:
                 builder.append(":focus-within");
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoClassFuture:
+            case CSSSelector::PseudoClassType::Future:
                 builder.append(":future");
                 break;
-            case CSSSelector::PseudoClassPlaying:
+            case CSSSelector::PseudoClassType::Playing:
                 builder.append(":playing");
                 break;
-            case CSSSelector::PseudoClassPaused:
+            case CSSSelector::PseudoClassType::Paused:
                 builder.append(":paused");
                 break;
-            case CSSSelector::PseudoClassSeeking:
+            case CSSSelector::PseudoClassType::Seeking:
                 builder.append(":seeking");
                 break;
-            case CSSSelector::PseudoClassBuffering:
+            case CSSSelector::PseudoClassType::Buffering:
                 builder.append(":buffering");
                 break;
-            case CSSSelector::PseudoClassStalled:
+            case CSSSelector::PseudoClassType::Stalled:
                 builder.append(":stalled");
                 break;
-            case CSSSelector::PseudoClassMuted:
+            case CSSSelector::PseudoClassType::Muted:
                 builder.append(":muted");
                 break;
-            case CSSSelector::PseudoClassVolumeLocked:
+            case CSSSelector::PseudoClassType::VolumeLocked:
                 builder.append(":volume-locked");
                 break;
 #endif
-            case CSSSelector::PseudoClassHas:
+            case CSSSelector::PseudoClassType::Has:
                 builder.append(":has(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
 #if ENABLE(ATTACHMENT_ELEMENT)
-            case CSSSelector::PseudoClassHasAttachment:
+            case CSSSelector::PseudoClassType::HasAttachment:
                 builder.append(":has-attachment");
                 break;
 #endif
-            case CSSSelector::PseudoClassHorizontal:
+            case CSSSelector::PseudoClassType::Horizontal:
                 builder.append(":horizontal");
                 break;
-            case CSSSelector::PseudoClassHover:
+            case CSSSelector::PseudoClassType::Hover:
                 builder.append(":hover");
                 break;
-            case CSSSelector::PseudoClassInRange:
+            case CSSSelector::PseudoClassType::InRange:
                 builder.append(":in-range");
                 break;
-            case CSSSelector::PseudoClassIncrement:
+            case CSSSelector::PseudoClassType::Increment:
                 builder.append(":increment");
                 break;
-            case CSSSelector::PseudoClassIndeterminate:
+            case CSSSelector::PseudoClassType::Indeterminate:
                 builder.append(":indeterminate");
                 break;
-            case CSSSelector::PseudoClassInvalid:
+            case CSSSelector::PseudoClassType::Invalid:
                 builder.append(":invalid");
                 break;
-            case CSSSelector::PseudoClassHtmlDocument:
+            case CSSSelector::PseudoClassType::HtmlDocument:
                 builder.append(":-internal-html-document");
                 break;
-            case CSSSelector::PseudoClassLang:
+            case CSSSelector::PseudoClassType::Lang:
                 builder.append(":lang(");
                 ASSERT_WITH_MESSAGE(cs->argumentList() && !cs->argumentList()->isEmpty(), "An empty :lang() is invalid and should never be generated by the parser.");
                 appendLangArgumentList(builder, *cs->argumentList());
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassLastChild:
+            case CSSSelector::PseudoClassType::LastChild:
                 builder.append(":last-child");
                 break;
-            case CSSSelector::PseudoClassLastOfType:
+            case CSSSelector::PseudoClassType::LastOfType:
                 builder.append(":last-of-type");
                 break;
-            case CSSSelector::PseudoClassLink:
+            case CSSSelector::PseudoClassType::Link:
                 builder.append(":link");
                 break;
-            case CSSSelector::PseudoClassModal:
+            case CSSSelector::PseudoClassType::Modal:
                 builder.append(":modal");
                 break;
-            case CSSSelector::PseudoClassNoButton:
+            case CSSSelector::PseudoClassType::NoButton:
                 builder.append(":no-button");
                 break;
-            case CSSSelector::PseudoClassNot:
+            case CSSSelector::PseudoClassType::Not:
                 builder.append(":not(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassNthChild:
+            case CSSSelector::PseudoClassType::NthChild:
                 builder.append(":nth-child(");
                 outputNthChildAnPlusB(*cs, builder);
                 if (const CSSSelectorList* selectorList = cs->selectorList()) {
@@ -602,7 +602,7 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 }
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassNthLastChild:
+            case CSSSelector::PseudoClassType::NthLastChild:
                 builder.append(":nth-last-child(");
                 outputNthChildAnPlusB(*cs, builder);
                 if (const CSSSelectorList* selectorList = cs->selectorList()) {
@@ -611,101 +611,101 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                 }
                 builder.append(')');
                 break;
-            case CSSSelector::PseudoClassNthLastOfType:
+            case CSSSelector::PseudoClassType::NthLastOfType:
                 builder.append(":nth-last-of-type(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassNthOfType:
+            case CSSSelector::PseudoClassType::NthOfType:
                 builder.append(":nth-of-type(");
                 appendPseudoClassFunctionTail(builder, cs);
                 break;
-            case CSSSelector::PseudoClassOnlyChild:
+            case CSSSelector::PseudoClassType::OnlyChild:
                 builder.append(":only-child");
                 break;
-            case CSSSelector::PseudoClassOnlyOfType:
+            case CSSSelector::PseudoClassType::OnlyOfType:
                 builder.append(":only-of-type");
                 break;
-            case CSSSelector::PseudoClassPopoverOpen:
+            case CSSSelector::PseudoClassType::PopoverOpen:
                 builder.append(":popover-open");
                 break;
-            case CSSSelector::PseudoClassOptional:
+            case CSSSelector::PseudoClassType::Optional:
                 builder.append(":optional");
                 break;
-            case CSSSelector::PseudoClassIs: {
+            case CSSSelector::PseudoClassType::Is: {
                 builder.append(":is(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassMatches: {
+            case CSSSelector::PseudoClassType::Matches: {
                 builder.append(":matches(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassWhere: {
+            case CSSSelector::PseudoClassType::Where: {
                 builder.append(":where(");
                 cs->selectorList()->buildSelectorsText(builder);
                 builder.append(')');
                 break;
             }
-            case CSSSelector::PseudoClassPlaceholderShown:
+            case CSSSelector::PseudoClassType::PlaceholderShown:
                 builder.append(":placeholder-shown");
                 break;
-            case CSSSelector::PseudoClassOutOfRange:
+            case CSSSelector::PseudoClassType::OutOfRange:
                 builder.append(":out-of-range");
                 break;
 #if ENABLE(VIDEO)
-            case CSSSelector::PseudoClassPast:
+            case CSSSelector::PseudoClassType::Past:
                 builder.append(":past");
                 break;
 #endif
-            case CSSSelector::PseudoClassReadOnly:
+            case CSSSelector::PseudoClassType::ReadOnly:
                 builder.append(":read-only");
                 break;
-            case CSSSelector::PseudoClassReadWrite:
+            case CSSSelector::PseudoClassType::ReadWrite:
                 builder.append(":read-write");
                 break;
-            case CSSSelector::PseudoClassRequired:
+            case CSSSelector::PseudoClassType::Required:
                 builder.append(":required");
                 break;
-            case CSSSelector::PseudoClassRoot:
+            case CSSSelector::PseudoClassType::Root:
                 builder.append(":root");
                 break;
-            case CSSSelector::PseudoClassScope:
+            case CSSSelector::PseudoClassType::Scope:
                 builder.append(":scope");
                 break;
-            case CSSSelector::PseudoClassRelativeScope:
+            case CSSSelector::PseudoClassType::RelativeScope:
                 // Remove the space from the start to generate a relative selector string like in ":has(> foo)".
                 return makeString(separator.substring(1), rightSide);
-            case CSSSelector::PseudoClassSingleButton:
+            case CSSSelector::PseudoClassType::SingleButton:
                 builder.append(":single-button");
                 break;
-            case CSSSelector::PseudoClassStart:
+            case CSSSelector::PseudoClassType::Start:
                 builder.append(":start");
                 break;
-            case CSSSelector::PseudoClassTarget:
+            case CSSSelector::PseudoClassType::Target:
                 builder.append(":target");
                 break;
-            case CSSSelector::PseudoClassUserInvalid:
+            case CSSSelector::PseudoClassType::UserInvalid:
                 builder.append(":user-invalid");
                 break;
-            case CSSSelector::PseudoClassUserValid:
+            case CSSSelector::PseudoClassType::UserValid:
                 builder.append(":user-valid");
                 break;
-            case CSSSelector::PseudoClassValid:
+            case CSSSelector::PseudoClassType::Valid:
                 builder.append(":valid");
                 break;
-            case CSSSelector::PseudoClassVertical:
+            case CSSSelector::PseudoClassType::Vertical:
                 builder.append(":vertical");
                 break;
-            case CSSSelector::PseudoClassVisited:
+            case CSSSelector::PseudoClassType::Visited:
                 builder.append(":visited");
                 break;
-            case CSSSelector::PseudoClassWindowInactive:
+            case CSSSelector::PseudoClassType::WindowInactive:
                 builder.append(":window-inactive");
                 break;
-            case CSSSelector::PseudoClassHost:
+            case CSSSelector::PseudoClassType::Host:
                 builder.append(":host");
                 if (auto* selectorList = cs->selectorList()) {
                     builder.append('(');
@@ -713,10 +713,10 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
                     builder.append(')');
                 }
                 break;
-            case CSSSelector::PseudoClassDefined:
+            case CSSSelector::PseudoClassType::Defined:
                 builder.append(":defined");
                 break;
-            case CSSSelector::PseudoClassUnknown:
+            case CSSSelector::PseudoClassType::Unknown:
                 ASSERT_NOT_REACHED();
             }
         } else if (cs->match() == Match::PseudoElement) {
@@ -1004,7 +1004,7 @@ void CSSSelector::resolveNestingParentSelectors(const CSSSelectorList& parent)
         if (selector.match() == CSSSelector::Match::NestingParent) {
             // FIXME: Optimize cases where we can include the parent selector directly instead of wrapping it in a ":is" pseudo class.
             selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClassType(PseudoClassType::PseudoClassIs);
+            selector.setPseudoClassType(PseudoClassType::Is);
             selector.setSelectorList(makeUnique<CSSSelectorList>(parent));
         }
     };
@@ -1018,7 +1018,7 @@ void CSSSelector::replaceNestingParentByPseudoClassScope()
         if (selector.match() == CSSSelector::Match::NestingParent) {
             // Replace by :scope
             selector.setMatch(Match::PseudoClass);
-            selector.setPseudoClassType(PseudoClassType::PseudoClassScope);
+            selector.setPseudoClassType(PseudoClassType::Scope);
         }
     };
 

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -23,6 +23,7 @@
 
 #include "QualifiedName.h"
 #include "RenderStyleConstants.h"
+#include <wtf/EnumTraits.h>
 #include <wtf/FixedVector.h>
 
 namespace WebCore {
@@ -96,103 +97,103 @@ struct PossiblyQuotedIdentifier {
             ShadowSlotted
         };
 
-        enum PseudoClassType {
-            PseudoClassUnknown = 0,
-            PseudoClassEmpty,
-            PseudoClassFirstChild,
-            PseudoClassFirstOfType,
-            PseudoClassLastChild,
-            PseudoClassLastOfType,
-            PseudoClassOnlyChild,
-            PseudoClassOnlyOfType,
-            PseudoClassNthChild,
-            PseudoClassNthOfType,
-            PseudoClassNthLastChild,
-            PseudoClassNthLastOfType,
-            PseudoClassLink,
-            PseudoClassVisited,
-            PseudoClassAny,
-            PseudoClassAnyLink,
-            PseudoClassAnyLinkDeprecated,
-            PseudoClassAutofill,
-            PseudoClassAutofillAndObscured,
-            PseudoClassAutofillStrongPassword,
-            PseudoClassAutofillStrongPasswordViewable,
-            PseudoClassHover,
-            PseudoClassDrag,
-            PseudoClassFocus,
-            PseudoClassFocusVisible,
-            PseudoClassFocusWithin,
-            PseudoClassActive,
-            PseudoClassChecked,
-            PseudoClassEnabled,
-            PseudoClassFullPageMedia,
-            PseudoClassDefault,
-            PseudoClassDisabled,
-            PseudoClassHtmlDocument, // for internal use only with forms in table case in UA stylesheet
-            PseudoClassIs,
-            PseudoClassMatches, // obsolete synonym for PseudoClassIs
-            PseudoClassWhere,
-            PseudoClassOptional,
-            PseudoClassPlaceholderShown,
-            PseudoClassRequired,
-            PseudoClassReadOnly,
-            PseudoClassReadWrite,
-            PseudoClassValid,
-            PseudoClassInvalid,
-            PseudoClassIndeterminate,
-            PseudoClassTarget,
-            PseudoClassLang,
-            PseudoClassNot,
-            PseudoClassRoot,
-            PseudoClassScope,
-            PseudoClassRelativeScope, // Like :scope but for internal use with relative selectors like :has(> foo).
-            PseudoClassWindowInactive,
-            PseudoClassCornerPresent,
-            PseudoClassDecrement,
-            PseudoClassIncrement,
-            PseudoClassHas,
-            PseudoClassHorizontal,
-            PseudoClassVertical,
-            PseudoClassStart,
-            PseudoClassEnd,
-            PseudoClassDoubleButton,
-            PseudoClassSingleButton,
-            PseudoClassNoButton,
+        enum class PseudoClassType : uint8_t {
+            Unknown = 0,
+            Empty,
+            FirstChild,
+            FirstOfType,
+            LastChild,
+            LastOfType,
+            OnlyChild,
+            OnlyOfType,
+            NthChild,
+            NthOfType,
+            NthLastChild,
+            NthLastOfType,
+            Link,
+            Visited,
+            Any,
+            AnyLink,
+            AnyLinkDeprecated,
+            Autofill,
+            AutofillAndObscured,
+            AutofillStrongPassword,
+            AutofillStrongPasswordViewable,
+            Hover,
+            Drag,
+            Focus,
+            FocusVisible,
+            FocusWithin,
+            Active,
+            Checked,
+            Enabled,
+            FullPageMedia,
+            Default,
+            Disabled,
+            HtmlDocument, // for internal use only with forms in table case in UA stylesheet
+            Is,
+            Matches, // obsolete synonym for PseudoClassIs
+            Where,
+            Optional,
+            PlaceholderShown,
+            Required,
+            ReadOnly,
+            ReadWrite,
+            Valid,
+            Invalid,
+            Indeterminate,
+            Target,
+            Lang,
+            Not,
+            Root,
+            Scope,
+            RelativeScope, // Like :scope but for internal use with relative selectors like :has(> foo).
+            WindowInactive,
+            CornerPresent,
+            Decrement,
+            Increment,
+            Has,
+            Horizontal,
+            Vertical,
+            Start,
+            End,
+            DoubleButton,
+            SingleButton,
+            NoButton,
 #if ENABLE(FULLSCREEN_API)
-            PseudoClassFullscreen,
-            PseudoClassWebkitFullScreen,
-            PseudoClassFullScreenDocument,
-            PseudoClassFullScreenAncestor,
-            PseudoClassAnimatingFullScreenTransition,
-            PseudoClassFullScreenControlsHidden,
+            Fullscreen,
+            WebkitFullScreen,
+            FullScreenDocument,
+            FullScreenAncestor,
+            AnimatingFullScreenTransition,
+            FullScreenControlsHidden,
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
-            PseudoClassPictureInPicture,
+            PictureInPicture,
 #endif
-            PseudoClassInRange,
-            PseudoClassOutOfRange,
+            InRange,
+            OutOfRange,
 #if ENABLE(VIDEO)
-            PseudoClassFuture,
-            PseudoClassPast,
-            PseudoClassPlaying,
-            PseudoClassPaused,
-            PseudoClassSeeking,
-            PseudoClassBuffering,
-            PseudoClassStalled,
-            PseudoClassMuted,
-            PseudoClassVolumeLocked,
+            Future,
+            Past,
+            Playing,
+            Paused,
+            Seeking,
+            Buffering,
+            Stalled,
+            Muted,
+            VolumeLocked,
 #endif
-            PseudoClassDir,
-            PseudoClassHost,
-            PseudoClassDefined,
+            Dir,
+            Host,
+            Defined,
 #if ENABLE(ATTACHMENT_ELEMENT)
-            PseudoClassHasAttachment,
+            HasAttachment,
 #endif
-            PseudoClassModal,
-            PseudoClassPopoverOpen,
-            PseudoClassUserInvalid,
-            PseudoClassUserValid
+            Modal,
+            PopoverOpen,
+            UserInvalid,
+            UserValid
         };
 
         enum PseudoElementType {
@@ -412,33 +413,33 @@ inline bool CSSSelector::isWebKitCustomPseudoElement() const
 
 static inline bool pseudoClassIsRelativeToSiblings(CSSSelector::PseudoClassType type)
 {
-    return type == CSSSelector::PseudoClassEmpty
-        || type == CSSSelector::PseudoClassFirstChild
-        || type == CSSSelector::PseudoClassFirstOfType
-        || type == CSSSelector::PseudoClassLastChild
-        || type == CSSSelector::PseudoClassLastOfType
-        || type == CSSSelector::PseudoClassOnlyChild
-        || type == CSSSelector::PseudoClassOnlyOfType
-        || type == CSSSelector::PseudoClassNthChild
-        || type == CSSSelector::PseudoClassNthOfType
-        || type == CSSSelector::PseudoClassNthLastChild
-        || type == CSSSelector::PseudoClassNthLastOfType;
+    return type == CSSSelector::PseudoClassType::Empty
+        || type == CSSSelector::PseudoClassType::FirstChild
+        || type == CSSSelector::PseudoClassType::FirstOfType
+        || type == CSSSelector::PseudoClassType::LastChild
+        || type == CSSSelector::PseudoClassType::LastOfType
+        || type == CSSSelector::PseudoClassType::OnlyChild
+        || type == CSSSelector::PseudoClassType::OnlyOfType
+        || type == CSSSelector::PseudoClassType::NthChild
+        || type == CSSSelector::PseudoClassType::NthOfType
+        || type == CSSSelector::PseudoClassType::NthLastChild
+        || type == CSSSelector::PseudoClassType::NthLastOfType;
 }
 
 static inline bool isTreeStructuralPseudoClass(CSSSelector::PseudoClassType type)
 {
-    return pseudoClassIsRelativeToSiblings(type) || type == CSSSelector::PseudoClassRoot;
+    return pseudoClassIsRelativeToSiblings(type) || type == CSSSelector::PseudoClassType::Root;
 }
 
 inline bool isLogicalCombinationPseudoClass(CSSSelector::PseudoClassType pseudoClassType)
 {
     switch (pseudoClassType) {
-    case CSSSelector::PseudoClassIs:
-    case CSSSelector::PseudoClassWhere:
-    case CSSSelector::PseudoClassNot:
-    case CSSSelector::PseudoClassAny:
-    case CSSSelector::PseudoClassMatches:
-    case CSSSelector::PseudoClassHas:
+    case CSSSelector::PseudoClassType::Is:
+    case CSSSelector::PseudoClassType::Where:
+    case CSSSelector::PseudoClassType::Not:
+    case CSSSelector::PseudoClassType::Any:
+    case CSSSelector::PseudoClassType::Matches:
+    case CSSSelector::PseudoClassType::Has:
         return true;
     default:
         return false;
@@ -546,8 +547,8 @@ inline auto CSSSelector::pseudoClassType() const -> PseudoClassType
 
 inline void CSSSelector::setPseudoClassType(PseudoClassType pseudoType)
 {
-    m_pseudoType = pseudoType;
-    ASSERT(m_pseudoType == pseudoType);
+    m_pseudoType = enumToUnderlyingType(pseudoType);
+    ASSERT(static_cast<PseudoClassType>(m_pseudoType) == pseudoType);
 }
 
 inline auto CSSSelector::pseudoElementType() const -> PseudoElementType

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -134,11 +134,11 @@ inline bool SelectorChecker::isCommonPseudoClassSelector(const CSSSelector* sele
     if (selector->match() != CSSSelector::Match::PseudoClass)
         return false;
     CSSSelector::PseudoClassType pseudoType = selector->pseudoClassType();
-    return pseudoType == CSSSelector::PseudoClassLink
-        || pseudoType == CSSSelector::PseudoClassAnyLink
-        || pseudoType == CSSSelector::PseudoClassAnyLinkDeprecated
-        || pseudoType == CSSSelector::PseudoClassVisited
-        || pseudoType == CSSSelector::PseudoClassFocus;
+    return pseudoType == CSSSelector::PseudoClassType::Link
+        || pseudoType == CSSSelector::PseudoClassType::AnyLink
+        || pseudoType == CSSSelector::PseudoClassType::AnyLinkDeprecated
+        || pseudoType == CSSSelector::PseudoClassType::Visited
+        || pseudoType == CSSSelector::PseudoClassType::Focus;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -523,7 +523,7 @@ ALWAYS_INLINE bool isFrameFocused(const Element& element)
 
 ALWAYS_INLINE bool matchesLegacyDirectFocusPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassFocus))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Focus))
         return true;
 
     return element.focused() && isFrameFocused(element);
@@ -537,7 +537,7 @@ ALWAYS_INLINE bool doesShadowTreeContainFocusedElement(const Element& element)
 
 ALWAYS_INLINE bool matchesFocusPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassFocus))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Focus))
         return true;
 
     return (element.focused() || doesShadowTreeContainFocusedElement(element)) && isFrameFocused(element);
@@ -548,7 +548,7 @@ ALWAYS_INLINE bool matchesFocusVisiblePseudoClass(const Element& element)
     if (!element.document().settings().focusVisibleEnabled())
         return matchesLegacyDirectFocusPseudoClass(element);
 
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassFocusVisible))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::FocusVisible))
         return true;
 
     return element.hasFocusVisible() && isFrameFocused(element);
@@ -556,7 +556,7 @@ ALWAYS_INLINE bool matchesFocusVisiblePseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesFocusWithinPseudoClass(const Element& element)
 {
-    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassFocusWithin))
+    if (InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::FocusWithin))
         return true;
 
     return element.hasFocusWithin() && isFrameFocused(element);

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -166,8 +166,8 @@ void SelectorFilter::collectSimpleSelectorHash(CollectedSelectorHashes& collecte
     }
     case CSSSelector::Match::PseudoClass:
         switch (selector.pseudoClassType()) {
-        case CSSSelector::PseudoClassIs:
-        case CSSSelector::PseudoClassWhere:
+        case CSSSelector::PseudoClassType::Is:
+        case CSSSelector::PseudoClassType::Where:
             // We can use the filter in the trivial case of single argument :is()/:where().
             // Supporting the multiargument case would require more than one hash.
             if (selector.selectorList()->listSize() == 1)

--- a/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
+++ b/Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in
@@ -1,7 +1,7 @@
 -khtml-drag
 -internal-html-document
 -webkit-any
--webkit-any-link, PseudoClassAnyLinkDeprecated, PseudoElementUnknown
+-webkit-any-link, PseudoClassType::AnyLinkDeprecated, PseudoElementUnknown
 -webkit-autofill
 -webkit-autofill-and-obscured
 -webkit-autofill-strong-password
@@ -9,10 +9,10 @@
 -webkit-drag
 -webkit-full-page-media
 active
-after, PseudoClassUnknown, PseudoElementAfter
+after, PseudoClassType::Unknown, PseudoElementAfter
 any-link
 autofill
-before, PseudoClassUnknown, PseudoElementBefore
+before, PseudoClassType::Unknown, PseudoElementBefore
 checked
 corner-present
 decrement
@@ -25,8 +25,8 @@ empty
 enabled
 end
 first-child
-first-letter, PseudoClassUnknown, PseudoElementFirstLetter
-first-line, PseudoClassUnknown, PseudoElementFirstLine
+first-letter, PseudoClassType::Unknown, PseudoElementFirstLetter
+first-line, PseudoClassType::Unknown, PseudoElementFirstLine
 first-of-type
 focus
 focus-visible
@@ -36,7 +36,7 @@ has
 has-attachment
 #endif
 horizontal
-host, PseudoClassHost, PseudoElementUnknown
+host, PseudoClassType::Host, PseudoElementUnknown
 hover
 in-range
 increment
@@ -80,7 +80,7 @@ window-inactive
 #if ENABLE(FULLSCREEN_API)
 fullscreen
 -webkit-animating-full-screen-transition
--webkit-full-screen, PseudoClassWebkitFullScreen, PseudoElementUnknown
+-webkit-full-screen, PseudoClassType::WebkitFullScreen, PseudoElementUnknown
 -webkit-full-screen-ancestor
 -webkit-full-screen-document
 -webkit-full-screen-controls-hidden

--- a/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
+++ b/Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py
@@ -29,7 +29,7 @@ import subprocess
 
 
 def enumerablePseudoType(stringPseudoType):
-    output = ['CSSSelector::PseudoClass']
+    output = ['CSSSelector::PseudoClassType::']
 
     if stringPseudoType.endswith('('):
         stringPseudoType = stringPseudoType[:-1]
@@ -112,7 +112,7 @@ struct SelectorPseudoClassOrCompatibilityPseudoElementEntry {
 
 %}
 %struct-type
-%define initializer-suffix ,{CSSSelector::PseudoClassUnknown,CSSSelector::PseudoElementUnknown}
+%define initializer-suffix ,{CSSSelector::PseudoClassType::Unknown,CSSSelector::PseudoElementUnknown}
 %define class-name SelectorPseudoClassAndCompatibilityElementMapHash
 %omit-struct-type
 %language=C++
@@ -198,7 +198,7 @@ PseudoClassOrCompatibilityPseudoElement parsePseudoClassAndCompatibilityElementS
 
     if (entry)
         return entry->pseudoTypes;
-    return { CSSSelector::PseudoClassUnknown, CSSSelector::PseudoElementUnknown };
+    return { CSSSelector::PseudoClassType::Unknown, CSSSelector::PseudoElementUnknown };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserSelector.cpp
+++ b/Source/WebCore/css/parser/CSSParserSelector.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoElementSelector
 std::unique_ptr<CSSParserSelector> CSSParserSelector::parsePseudoClassSelector(StringView pseudoTypeString)
 {
     auto pseudoType = parsePseudoClassAndCompatibilityElementString(pseudoTypeString);
-    if (pseudoType.pseudoClass != CSSSelector::PseudoClassUnknown) {
+    if (pseudoType.pseudoClass != CSSSelector::PseudoClassType::Unknown) {
         auto selector = makeUnique<CSSParserSelector>();
         selector->m_selector->setMatch(CSSSelector::Match::PseudoClass);
         selector->m_selector->setPseudoClassType(pseudoType.pseudoClass);
@@ -239,7 +239,7 @@ std::unique_ptr<CSSParserSelector> CSSParserSelector::releaseTagHistory()
 // FIXME-NEWPARSER: Add support for :host-context
 bool CSSParserSelector::isHostPseudoSelector() const
 {
-    return match() == CSSSelector::Match::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassHost;
+    return match() == CSSSelector::Match::PseudoClass && pseudoClassType() == CSSSelector::PseudoClassType::Host;
 }
 
 }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -350,7 +350,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
         return nullptr;
 
     auto hasScopePseudoClass = [](auto& selector) {
-        return selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClassType() == CSSSelector::PseudoClassScope;
+        return selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClassType() == CSSSelector::PseudoClassType::Scope;
     };
 
     bool hasExplicitScope = hasScopePseudoClass(*selector);
@@ -366,7 +366,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeScopeSelect
     if (!hasExplicitScope || scopeCombinator != CSSSelector::RelationType::DescendantSpace) {
         auto scopeSelector = makeUnique<CSSParserSelector>();
         scopeSelector->setMatch(CSSSelector::Match::PseudoClass);
-        scopeSelector->setPseudoClassType(CSSSelector::PseudoClassRelativeScope);
+        scopeSelector->setPseudoClassType(CSSSelector::PseudoClassType::RelativeScope);
 
         end->setRelation(scopeCombinator);
         end->setTagHistory(WTFMove(scopeSelector));
@@ -397,21 +397,21 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeRelativeNestedSelec
 static bool isScrollbarPseudoClass(CSSSelector::PseudoClassType pseudo)
 {
     switch (pseudo) {
-    case CSSSelector::PseudoClassEnabled:
-    case CSSSelector::PseudoClassDisabled:
-    case CSSSelector::PseudoClassHover:
-    case CSSSelector::PseudoClassActive:
-    case CSSSelector::PseudoClassHorizontal:
-    case CSSSelector::PseudoClassVertical:
-    case CSSSelector::PseudoClassDecrement:
-    case CSSSelector::PseudoClassIncrement:
-    case CSSSelector::PseudoClassStart:
-    case CSSSelector::PseudoClassEnd:
-    case CSSSelector::PseudoClassDoubleButton:
-    case CSSSelector::PseudoClassSingleButton:
-    case CSSSelector::PseudoClassNoButton:
-    case CSSSelector::PseudoClassCornerPresent:
-    case CSSSelector::PseudoClassWindowInactive:
+    case CSSSelector::PseudoClassType::Enabled:
+    case CSSSelector::PseudoClassType::Disabled:
+    case CSSSelector::PseudoClassType::Hover:
+    case CSSSelector::PseudoClassType::Active:
+    case CSSSelector::PseudoClassType::Horizontal:
+    case CSSSelector::PseudoClassType::Vertical:
+    case CSSSelector::PseudoClassType::Decrement:
+    case CSSSelector::PseudoClassType::Increment:
+    case CSSSelector::PseudoClassType::Start:
+    case CSSSelector::PseudoClassType::End:
+    case CSSSelector::PseudoClassType::DoubleButton:
+    case CSSSelector::PseudoClassType::SingleButton:
+    case CSSSelector::PseudoClassType::NoButton:
+    case CSSSelector::PseudoClassType::CornerPresent:
+    case CSSSelector::PseudoClassType::WindowInactive:
         return true;
     default:
         return false;
@@ -421,11 +421,11 @@ static bool isScrollbarPseudoClass(CSSSelector::PseudoClassType pseudo)
 static bool isUserActionPseudoClass(CSSSelector::PseudoClassType pseudo)
 {
     switch (pseudo) {
-    case CSSSelector::PseudoClassHover:
-    case CSSSelector::PseudoClassFocus:
-    case CSSSelector::PseudoClassActive:
-    case CSSSelector::PseudoClassFocusVisible:
-    case CSSSelector::PseudoClassFocusWithin:
+    case CSSSelector::PseudoClassType::Hover:
+    case CSSSelector::PseudoClassType::Focus:
+    case CSSSelector::PseudoClassType::Active:
+    case CSSSelector::PseudoClassType::FocusVisible:
+    case CSSSelector::PseudoClassType::FocusWithin:
         return true;
     default:
         return false;
@@ -452,7 +452,7 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClassType ps
     case CSSSelector::PseudoElementScrollbarTrackPiece:
         return isScrollbarPseudoClass(pseudoClass);
     case CSSSelector::PseudoElementSelection:
-        return pseudoClass == CSSSelector::PseudoClassWindowInactive;
+        return pseudoClass == CSSSelector::PseudoClassType::WindowInactive;
     case CSSSelector::PseudoElementWebKitCustom:
     case CSSSelector::PseudoElementWebKitCustomLegacyPrefixed:
         return isUserActionPseudoClass(pseudoClass);
@@ -713,18 +713,18 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumeAttribute(CSSParser
 static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassType)
 {
     switch (pseudoClassType) {
-    case CSSSelector::PseudoClassNot:
-    case CSSSelector::PseudoClassIs:
-    case CSSSelector::PseudoClassMatches:
-    case CSSSelector::PseudoClassWhere:
-    case CSSSelector::PseudoClassHas:
-    case CSSSelector::PseudoClassNthChild:
-    case CSSSelector::PseudoClassNthLastChild:
-    case CSSSelector::PseudoClassNthOfType:
-    case CSSSelector::PseudoClassNthLastOfType:
-    case CSSSelector::PseudoClassLang:
-    case CSSSelector::PseudoClassAny:
-    case CSSSelector::PseudoClassDir:
+    case CSSSelector::PseudoClassType::Not:
+    case CSSSelector::PseudoClassType::Is:
+    case CSSSelector::PseudoClassType::Matches:
+    case CSSSelector::PseudoClassType::Where:
+    case CSSSelector::PseudoClassType::Has:
+    case CSSSelector::PseudoClassType::NthChild:
+    case CSSSelector::PseudoClassType::NthLastChild:
+    case CSSSelector::PseudoClassType::NthOfType:
+    case CSSSelector::PseudoClassType::NthLastOfType:
+    case CSSSelector::PseudoClassType::Lang:
+    case CSSSelector::PseudoClassType::Any:
+    case CSSSelector::PseudoClassType::Dir:
         return true;
     default:
         break;
@@ -767,14 +767,14 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
         if (!selector)
             return nullptr;
         if (selector->match() == CSSSelector::Match::PseudoClass) {
-            if (!m_context.focusVisibleEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassFocusVisible)
+            if (!m_context.focusVisibleEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::FocusVisible)
                 return nullptr;
-            if (!m_context.hasPseudoClassEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassHas)
+            if (!m_context.hasPseudoClassEnabled && selector->pseudoClassType() == CSSSelector::PseudoClassType::Has)
                 return nullptr;
-            if (m_context.mode != UASheetMode && selector->pseudoClassType() == CSSSelector::PseudoClassHtmlDocument)
+            if (m_context.mode != UASheetMode && selector->pseudoClassType() == CSSSelector::PseudoClassType::HtmlDocument)
                 return nullptr;
 #if ENABLE(ATTACHMENT_ELEMENT)
-            if (!DeprecatedGlobalSettings::attachmentElementEnabled() && selector->pseudoClassType() == CSSSelector::PseudoClassHasAttachment)
+            if (!DeprecatedGlobalSettings::attachmentElementEnabled() && selector->pseudoClassType() == CSSSelector::PseudoClassType::HasAttachment)
                 return nullptr;
 #endif
         }
@@ -798,7 +798,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
     if (token.type() == IdentToken) {
         range.consume();
         if ((selector->match() == CSSSelector::Match::PseudoElement && (selector->pseudoElementType() == CSSSelector::PseudoElementUnknown || isOnlyPseudoElementFunction(selector->pseudoElementType())))
-            || (selector->match() == CSSSelector::Match::PseudoClass && (selector->pseudoClassType() == CSSSelector::PseudoClassUnknown || isOnlyPseudoClassFunction(selector->pseudoClassType()))))
+            || (selector->match() == CSSSelector::Match::PseudoClass && (selector->pseudoClassType() == CSSSelector::PseudoClassType::Unknown || isOnlyPseudoClassFunction(selector->pseudoClassType()))))
             return nullptr;
         return selector;
     }
@@ -810,7 +810,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
 
     if (selector->match() == CSSSelector::Match::PseudoClass) {
         switch (selector->pseudoClassType()) {
-        case CSSSelector::PseudoClassNot: {
+        case CSSSelector::PseudoClassType::Not: {
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
             auto selectorList = makeUnique<CSSSelectorList>();
             *selectorList = consumeComplexSelectorList(block);
@@ -819,10 +819,10 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(WTFMove(selectorList));
             return selector;
         }
-        case CSSSelector::PseudoClassNthChild:
-        case CSSSelector::PseudoClassNthLastChild:
-        case CSSSelector::PseudoClassNthOfType:
-        case CSSSelector::PseudoClassNthLastOfType: {
+        case CSSSelector::PseudoClassType::NthChild:
+        case CSSSelector::PseudoClassType::NthLastChild:
+        case CSSSelector::PseudoClassType::NthOfType:
+        case CSSSelector::PseudoClassType::NthLastOfType: {
             std::pair<int, int> ab;
             if (!consumeANPlusB(block, ab))
                 return nullptr;
@@ -831,7 +831,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setArgument(serializeANPlusB(ab));
             if (!block.atEnd()) {
                 auto type = selector->pseudoClassType();
-                if (type == CSSSelector::PseudoClassNthOfType || type == CSSSelector::PseudoClassNthLastOfType)
+                if (type == CSSSelector::PseudoClassType::NthOfType || type == CSSSelector::PseudoClassType::NthLastOfType)
                     return nullptr;
                 if (block.peek().type() != IdentToken)
                     return nullptr;
@@ -848,17 +848,17 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setNth(ab.first, ab.second);
             return selector;
         }
-        case CSSSelector::PseudoClassLang: {
+        case CSSSelector::PseudoClassType::Lang: {
             auto list = consumeLangArgumentList(block);
             if (list.isEmpty() || !block.atEnd())
                 return nullptr;
             selector->setArgumentList(WTFMove(list));
             return selector;
         }
-        case CSSSelector::PseudoClassIs:
-        case CSSSelector::PseudoClassWhere:
-        case CSSSelector::PseudoClassMatches:
-        case CSSSelector::PseudoClassAny: {
+        case CSSSelector::PseudoClassType::Is:
+        case CSSSelector::PseudoClassType::Where:
+        case CSSSelector::PseudoClassType::Matches:
+        case CSSSelector::PseudoClassType::Any: {
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
             auto selectorList = makeUnique<CSSSelectorList>();
             *selectorList = consumeForgivingComplexSelectorList(block);
@@ -867,7 +867,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(WTFMove(selectorList));
             return selector;
         }
-        case CSSSelector::PseudoClassHost: {
+        case CSSSelector::PseudoClassType::Host: {
             auto innerSelector = consumeCompoundSelector(block);
             block.consumeWhitespace();
             if (!innerSelector || !block.atEnd())
@@ -875,7 +875,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->adoptSelectorVector(Vector<std::unique_ptr<CSSParserSelector>>::from(WTFMove(innerSelector)));
             return selector;
         }
-        case CSSSelector::PseudoClassHas: {
+        case CSSSelector::PseudoClassType::Has: {
             if (m_disallowHasPseudoClass)
                 return nullptr;
             SetForScope resistDefaultNamespace(m_resistDefaultNamespace, true);
@@ -887,7 +887,7 @@ std::unique_ptr<CSSParserSelector> CSSSelectorParser::consumePseudo(CSSParserTok
             selector->setSelectorList(WTFMove(selectorList));
             return selector;
         }
-        case CSSSelector::PseudoClassDir: {
+        case CSSSelector::PseudoClassType::Dir: {
             const CSSParserToken& ident = block.consumeIncludingWhitespace();
             if (ident.type() != IdentToken || !block.atEnd())
                 return nullptr;
@@ -1253,7 +1253,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
                 lastSelector->setNotLastInSelectorList();
                 CSSSelector parentIsSelector;
                 parentIsSelector.setMatch(CSSSelector::Match::PseudoClass);
-                parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::PseudoClassIs);
+                parentIsSelector.setPseudoClassType(CSSSelector::PseudoClassType::Is);
                 parentIsSelector.setSelectorList(makeUnique<CSSSelectorList>(*parentResolvedSelectorList));
                 parentIsSelector.setLastInTagHistory();
                 if (isLastInSelectorList)

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -78,6 +78,8 @@
 namespace WebCore {
 namespace SelectorCompiler {
 
+using PseudoClassesSet = HashSet<CSSSelector::PseudoClassType, IntHash<CSSSelector::PseudoClassType>, WTF::StrongEnumHashTraits<CSSSelector::PseudoClassType>>;
+
 #if ENABLE(SELECTOR_OPERATION_STATS)
 
 #define FOR_EACH_SELECTOR_OPERATION(v) \
@@ -433,7 +435,7 @@ struct SelectorFragment {
     Vector<TextDirection> dirList;
     Vector<const FixedVector<PossiblyQuotedIdentifier>*> languageArgumentsList;
     Vector<const AtomStringImpl*, 8> classNames;
-    HashSet<unsigned> pseudoClasses;
+    PseudoClassesSet pseudoClasses;
     Vector<CodePtr<JSC::OperationPtrTag>, 4> unoptimizedPseudoClasses;
     Vector<AttributeMatchingInfo, 4> attributes;
     Vector<std::pair<int, int>, 2> nthChildFilters;
@@ -693,7 +695,7 @@ static inline FunctionType addPseudoElementPseudoClassType(const CSSSelector&, S
 }
 
 // Handle the forward :nth-child() and backward :nth-last-child().
-static FunctionType addNthChildType(const CSSSelector& selector, SelectorContext selectorContext, FragmentPositionInRootFragments positionInRootFragments, CSSSelector::PseudoClassType firstMatchAlternative, bool visitedMatchEnabled, Vector<std::pair<int, int>, 2>& simpleCases, Vector<NthChildOfSelectorInfo>& filteredCases, HashSet<unsigned>& pseudoClasses)
+static FunctionType addNthChildType(const CSSSelector& selector, SelectorContext selectorContext, FragmentPositionInRootFragments positionInRootFragments, CSSSelector::PseudoClassType firstMatchAlternative, bool visitedMatchEnabled, Vector<std::pair<int, int>, 2>& simpleCases, Vector<NthChildOfSelectorInfo>& filteredCases, PseudoClassesSet& pseudoClasses)
 {
     int a = selector.nthA();
     int b = selector.nthB();
@@ -1053,195 +1055,195 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     CSSSelector::PseudoClassType type = selector.pseudoClassType();
     switch (type) {
     // Unoptimized pseudo selector. They are just function call to a simple testing function.
-    case CSSSelector::PseudoClassAutofill:
+    case CSSSelector::PseudoClassType::Autofill:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilled));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassAutofillAndObscured:
+    case CSSSelector::PseudoClassType::AutofillAndObscured:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledAndObscured));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassAutofillStrongPassword:
+    case CSSSelector::PseudoClassType::AutofillStrongPassword:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledStrongPassword));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassAutofillStrongPasswordViewable:
+    case CSSSelector::PseudoClassType::AutofillStrongPasswordViewable:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsAutofilledStrongPasswordViewable));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassChecked:
+    case CSSSelector::PseudoClassType::Checked:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsChecked));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassDefault:
+    case CSSSelector::PseudoClassType::Default:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesDefaultPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassDisabled:
+    case CSSSelector::PseudoClassType::Disabled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesDisabledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassEnabled:
+    case CSSSelector::PseudoClassType::Enabled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesEnabledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassDefined:
+    case CSSSelector::PseudoClassType::Defined:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsDefinedElement));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFocus:
+    case CSSSelector::PseudoClassType::Focus:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFocusVisible:
+    case CSSSelector::PseudoClassType::FocusVisible:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusVisiblePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFocusWithin:
+    case CSSSelector::PseudoClassType::FocusWithin:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFocusWithinPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFullPageMedia:
+    case CSSSelector::PseudoClassType::FullPageMedia:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsMediaDocument));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassInRange:
+    case CSSSelector::PseudoClassType::InRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInRange));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassIndeterminate:
+    case CSSSelector::PseudoClassType::Indeterminate:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesIndeterminatePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassInvalid:
+    case CSSSelector::PseudoClassType::Invalid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsInvalid));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassOptional:
+    case CSSSelector::PseudoClassType::Optional:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsOptionalFormControl));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassOutOfRange:
+    case CSSSelector::PseudoClassType::OutOfRange:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsOutOfRange));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassReadOnly:
+    case CSSSelector::PseudoClassType::ReadOnly:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesReadOnlyPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassReadWrite:
+    case CSSSelector::PseudoClassType::ReadWrite:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesReadWritePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassRequired:
+    case CSSSelector::PseudoClassType::Required:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsRequiredFormControl));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassValid:
+    case CSSSelector::PseudoClassType::Valid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsValid));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassWindowInactive:
+    case CSSSelector::PseudoClassType::WindowInactive:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsWindowInactive));
         return FunctionType::SimpleSelectorChecker;
 
 #if ENABLE(FULLSCREEN_API)
-    case CSSSelector::PseudoClassFullscreen:
+    case CSSSelector::PseudoClassType::Fullscreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullscreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassWebkitFullScreen:
+    case CSSSelector::PseudoClassType::WebkitFullScreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesWebkitFullScreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFullScreenDocument:
+    case CSSSelector::PseudoClassType::FullScreenDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenDocumentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassFullScreenAncestor:
+    case CSSSelector::PseudoClassType::FullScreenAncestor:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAncestorPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassAnimatingFullScreenTransition:
+    case CSSSelector::PseudoClassType::AnimatingFullScreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenAnimatingFullScreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassFullScreenControlsHidden:
+    case CSSSelector::PseudoClassType::FullScreenControlsHidden:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFullScreenControlsHiddenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
-    case CSSSelector::PseudoClassPictureInPicture:
+    case CSSSelector::PseudoClassType::PictureInPicture:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPictureInPicturePseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(VIDEO)
-    case CSSSelector::PseudoClassFuture:
+    case CSSSelector::PseudoClassType::Future:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesFutureCuePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassPast:
+    case CSSSelector::PseudoClassType::Past:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPastCuePseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassPlaying:
+    case CSSSelector::PseudoClassType::Playing:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPlayingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassPaused:
+    case CSSSelector::PseudoClassType::Paused:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPausedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassSeeking:
+    case CSSSelector::PseudoClassType::Seeking:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesSeekingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassBuffering:
+    case CSSSelector::PseudoClassType::Buffering:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesBufferingPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassStalled:
+    case CSSSelector::PseudoClassType::Stalled:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesStalledPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassMuted:
+    case CSSSelector::PseudoClassType::Muted:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesMutedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassVolumeLocked:
+    case CSSSelector::PseudoClassType::VolumeLocked:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesVolumeLockedPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    case CSSSelector::PseudoClassHasAttachment:
+    case CSSSelector::PseudoClassType::HasAttachment:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationHasAttachment));
         return FunctionType::SimpleSelectorChecker;
 #endif
 
-    case CSSSelector::PseudoClassHtmlDocument:
+    case CSSSelector::PseudoClassType::HtmlDocument:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesHtmlDocumentPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassPopoverOpen:
+    case CSSSelector::PseudoClassType::PopoverOpen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesPopoverOpenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassModal:
+    case CSSSelector::PseudoClassType::Modal:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesModalPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassUserInvalid:
+    case CSSSelector::PseudoClassType::UserInvalid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsUserInvalid));
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassUserValid:
+    case CSSSelector::PseudoClassType::UserValid:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationIsUserValid));
         return FunctionType::SimpleSelectorChecker;
 
     // These pseudo-classes only have meaning with scrollbars.
-    case CSSSelector::PseudoClassHorizontal:
-    case CSSSelector::PseudoClassVertical:
-    case CSSSelector::PseudoClassDecrement:
-    case CSSSelector::PseudoClassIncrement:
-    case CSSSelector::PseudoClassStart:
-    case CSSSelector::PseudoClassEnd:
-    case CSSSelector::PseudoClassDoubleButton:
-    case CSSSelector::PseudoClassSingleButton:
-    case CSSSelector::PseudoClassNoButton:
-    case CSSSelector::PseudoClassCornerPresent:
+    case CSSSelector::PseudoClassType::Horizontal:
+    case CSSSelector::PseudoClassType::Vertical:
+    case CSSSelector::PseudoClassType::Decrement:
+    case CSSSelector::PseudoClassType::Increment:
+    case CSSSelector::PseudoClassType::Start:
+    case CSSSelector::PseudoClassType::End:
+    case CSSSelector::PseudoClassType::DoubleButton:
+    case CSSSelector::PseudoClassType::SingleButton:
+    case CSSSelector::PseudoClassType::NoButton:
+    case CSSSelector::PseudoClassType::CornerPresent:
         return FunctionType::CannotMatchAnything;
 
     // FIXME: Compile these pseudoclasses, too!
-    case CSSSelector::PseudoClassFirstOfType:
-    case CSSSelector::PseudoClassLastOfType:
-    case CSSSelector::PseudoClassOnlyOfType:
-    case CSSSelector::PseudoClassNthOfType:
-    case CSSSelector::PseudoClassNthLastOfType:
-    case CSSSelector::PseudoClassDrag:
-    case CSSSelector::PseudoClassHas:
-    case CSSSelector::PseudoClassRelativeScope:
+    case CSSSelector::PseudoClassType::FirstOfType:
+    case CSSSelector::PseudoClassType::LastOfType:
+    case CSSSelector::PseudoClassType::OnlyOfType:
+    case CSSSelector::PseudoClassType::NthOfType:
+    case CSSSelector::PseudoClassType::NthLastOfType:
+    case CSSSelector::PseudoClassType::Drag:
+    case CSSSelector::PseudoClassType::Has:
+    case CSSSelector::PseudoClassType::RelativeScope:
         return FunctionType::CannotCompile;
 
     // Optimized pseudo selectors.
-    case CSSSelector::PseudoClassAnyLink:
-    case CSSSelector::PseudoClassLink:
-    case CSSSelector::PseudoClassRoot:
+    case CSSSelector::PseudoClassType::AnyLink:
+    case CSSSelector::PseudoClassType::Link:
+    case CSSSelector::PseudoClassType::Root:
         fragment.pseudoClasses.add(type);
         return FunctionType::SimpleSelectorChecker;
-    case CSSSelector::PseudoClassAnyLinkDeprecated:
-        fragment.pseudoClasses.add(CSSSelector::PseudoClassAnyLink);
+    case CSSSelector::PseudoClassType::AnyLinkDeprecated:
+        fragment.pseudoClasses.add(CSSSelector::PseudoClassType::AnyLink);
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassVisited:
+    case CSSSelector::PseudoClassType::Visited:
         // Determine this :visited cannot match anything statically.
         if (!visitedMatchEnabled)
             return FunctionType::CannotMatchAnything;
@@ -1255,34 +1257,34 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         visitedMode = VisitedMode::Visited;
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassScope:
+    case CSSSelector::PseudoClassType::Scope:
         if (selectorContext != SelectorContext::QuerySelector) {
-            fragment.pseudoClasses.add(CSSSelector::PseudoClassRoot);
+            fragment.pseudoClasses.add(CSSSelector::PseudoClassType::Root);
             return FunctionType::SimpleSelectorChecker;
         }
-        fragment.pseudoClasses.add(CSSSelector::PseudoClassScope);
+        fragment.pseudoClasses.add(CSSSelector::PseudoClassType::Scope);
         return FunctionType::SelectorCheckerWithCheckingContext;
 
-    case CSSSelector::PseudoClassActive:
-    case CSSSelector::PseudoClassEmpty:
-    case CSSSelector::PseudoClassFirstChild:
-    case CSSSelector::PseudoClassHover:
-    case CSSSelector::PseudoClassLastChild:
-    case CSSSelector::PseudoClassOnlyChild:
-    case CSSSelector::PseudoClassPlaceholderShown:
-    case CSSSelector::PseudoClassTarget:
+    case CSSSelector::PseudoClassType::Active:
+    case CSSSelector::PseudoClassType::Empty:
+    case CSSSelector::PseudoClassType::FirstChild:
+    case CSSSelector::PseudoClassType::Hover:
+    case CSSSelector::PseudoClassType::LastChild:
+    case CSSSelector::PseudoClassType::OnlyChild:
+    case CSSSelector::PseudoClassType::PlaceholderShown:
+    case CSSSelector::PseudoClassType::Target:
         fragment.pseudoClasses.add(type);
         if (selectorContext == SelectorContext::QuerySelector)
             return FunctionType::SimpleSelectorChecker;
         return FunctionType::SelectorCheckerWithCheckingContext;
 
-    case CSSSelector::PseudoClassNthChild:
-        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassFirstChild, visitedMatchEnabled, fragment.nthChildFilters, fragment.nthChildOfFilters, fragment.pseudoClasses);
+    case CSSSelector::PseudoClassType::NthChild:
+        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassType::FirstChild, visitedMatchEnabled, fragment.nthChildFilters, fragment.nthChildOfFilters, fragment.pseudoClasses);
 
-    case CSSSelector::PseudoClassNthLastChild:
-        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassLastChild, visitedMatchEnabled, fragment.nthLastChildFilters, fragment.nthLastChildOfFilters, fragment.pseudoClasses);
+    case CSSSelector::PseudoClassType::NthLastChild:
+        return addNthChildType(selector, selectorContext, positionInRootFragments, CSSSelector::PseudoClassType::LastChild, visitedMatchEnabled, fragment.nthLastChildFilters, fragment.nthLastChildOfFilters, fragment.pseudoClasses);
 
-    case CSSSelector::PseudoClassNot:
+    case CSSSelector::PseudoClassType::Not:
         {
             const CSSSelectorList* selectorList = selector.selectorList();
 
@@ -1320,7 +1322,7 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
             return functionType;
         }
-    case CSSSelector::PseudoClassDir:
+    case CSSSelector::PseudoClassType::Dir:
         {
             auto& dirArgument = selector.argument();
             if (equalIgnoringASCIICase(dirArgument, "ltr"_s))
@@ -1332,15 +1334,15 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
             return FunctionType::SimpleSelectorChecker;
         }
 
-    case CSSSelector::PseudoClassLang:
+    case CSSSelector::PseudoClassType::Lang:
         ASSERT(selector.argumentList() && !selector.argumentList()->isEmpty());
         fragment.languageArgumentsList.append(selector.argumentList());
         return FunctionType::SimpleSelectorChecker;
 
-    case CSSSelector::PseudoClassIs:
-    case CSSSelector::PseudoClassWhere:
-    case CSSSelector::PseudoClassMatches:
-    case CSSSelector::PseudoClassAny:
+    case CSSSelector::PseudoClassType::Is:
+    case CSSSelector::PseudoClassType::Where:
+    case CSSSelector::PseudoClassType::Matches:
+    case CSSSelector::PseudoClassType::Any:
         {
             SelectorList matchesList;
             const CSSSelectorList* selectorList = selector.selectorList();
@@ -1384,9 +1386,9 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
             return functionType;
         }
-    case CSSSelector::PseudoClassHost:
+    case CSSSelector::PseudoClassType::Host:
         return FunctionType::CannotCompile;
-    case CSSSelector::PseudoClassUnknown:
+    case CSSSelector::PseudoClassType::Unknown:
         ASSERT_NOT_REACHED();
         return FunctionType::CannotMatchAnything;
     }
@@ -1420,7 +1422,7 @@ inline SelectorCodeGenerator::SelectorCodeGenerator(const CSSSelector* rootSelec
 static bool pseudoClassOnlyMatchesLinksInQuirksMode(const CSSSelector& selector)
 {
     CSSSelector::PseudoClassType pseudoClassType = selector.pseudoClassType();
-    return pseudoClassType == CSSSelector::PseudoClassHover || pseudoClassType == CSSSelector::PseudoClassActive;
+    return pseudoClassType == CSSSelector::PseudoClassType::Hover || pseudoClassType == CSSSelector::PseudoClassType::Active;
 }
 
 static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, SelectorContext selectorContext, SelectorFragmentList& selectorFragments, FragmentsLevel fragmentLevel, FragmentPositionInRootFragments positionInRootFragments, bool visitedMatchEnabled, VisitedMode& visitedMode, PseudoElementMatchingBehavior pseudoElementMatchingBehavior)
@@ -3142,13 +3144,13 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     generateElementLinkMatching(matchingPostTagNameFailureCases, fragment);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassRoot))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Root))
         generateElementIsRoot(matchingPostTagNameFailureCases);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassScope))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Scope))
         generateElementIsScopeRoot(matchingPostTagNameFailureCases);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassTarget))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Target))
         generateElementIsTarget(matchingPostTagNameFailureCases);
 
     for (unsigned i = 0; i < fragment.unoptimizedPseudoClasses.size(); ++i)
@@ -3156,19 +3158,19 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     generateElementDataMatching(matchingPostTagNameFailureCases, fragment);
 
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassActive))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Active))
         generateElementIsActive(matchingPostTagNameFailureCases, fragment);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassEmpty))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Empty))
         generateElementIsEmpty(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassHover))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Hover))
         generateElementIsHovered(matchingPostTagNameFailureCases, fragment);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassOnlyChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::OnlyChild))
         generateElementIsOnlyChild(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassPlaceholderShown))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::PlaceholderShown))
         generateElementHasPlaceholderShown(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassFirstChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::FirstChild))
         generateElementIsFirstChild(matchingPostTagNameFailureCases);
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassLastChild))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::LastChild))
         generateElementIsLastChild(matchingPostTagNameFailureCases);
     if (!fragment.nthChildFilters.isEmpty())
         generateElementIsNthChild(matchingPostTagNameFailureCases, fragment);
@@ -3193,7 +3195,7 @@ void SelectorCodeGenerator::generateElementMatching(Assembler::JumpList& matchin
 
     // Reach here when the generateElementMatching matching succeeded.
     // Only when the matching succeeeded, the last visited element should be stored and checked at the end of the whole matching.
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassVisited))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Visited))
         generateStoreLastVisitedElement(elementAddressRegister);
 }
 
@@ -3220,9 +3222,9 @@ void SelectorCodeGenerator::generateElementDataMatching(Assembler::JumpList& fai
 
 void SelectorCodeGenerator::generateElementLinkMatching(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
 {
-    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassLink)
-        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassAnyLink)
-        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassVisited))
+    if (fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Link)
+        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::AnyLink)
+        || fragment.pseudoClasses.contains(CSSSelector::PseudoClassType::Visited))
         generateElementIsLink(failureCases);
 }
 
@@ -3716,7 +3718,7 @@ void SelectorCodeGenerator::generateElementFunctionCallTest(Assembler::JumpList&
 JSC_DEFINE_JIT_OPERATION(operationElementIsActive, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsActive);
-    return element->active() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassActive);
+    return element->active() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Active);
 }
 
 void SelectorCodeGenerator::generateElementIsActive(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
@@ -3823,7 +3825,7 @@ void SelectorCodeGenerator::generateElementIsFirstChild(Assembler::JumpList& fai
 JSC_DEFINE_JIT_OPERATION(operationElementIsHovered, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsHovered);
-    return element->hovered() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassHover);
+    return element->hovered() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Hover);
 }
 
 void SelectorCodeGenerator::generateElementIsHovered(Assembler::JumpList& failureCases, const SelectorFragment& fragment)
@@ -4458,7 +4460,7 @@ void SelectorCodeGenerator::generateElementIsScopeRoot(Assembler::JumpList& fail
 JSC_DEFINE_JIT_OPERATION(operationElementIsTarget, bool, (const Element* element))
 {
     COUNT_SELECTOR_OPERATION(operationElementIsTarget);
-    return element == element->document().cssTarget() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassTarget);
+    return element == element->document().cssTarget() || InspectorInstrumentation::forcePseudoState(*element, CSSSelector::PseudoClassType::Target);
 }
 
 void SelectorCodeGenerator::generateElementIsTarget(Assembler::JumpList& failureCases)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5112,11 +5112,11 @@ void Document::setCSSTarget(Element* newTarget)
 
     std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
     if (m_cssTarget)
-        emplace(oldInvalidation, *m_cssTarget, { { CSSSelector::PseudoClassTarget, false } });
+        emplace(oldInvalidation, *m_cssTarget, { { CSSSelector::PseudoClassType::Target, false } });
 
     std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
     if (newTarget)
-        emplace(newInvalidation, *newTarget, { { CSSSelector::PseudoClassTarget, true } });
+        emplace(newInvalidation, *newTarget, { { CSSSelector::PseudoClassType::Target, true } });
     m_cssTarget = newTarget;
 }
 
@@ -7834,16 +7834,16 @@ void Document::updateHoverActiveState(const HitTestRequest& request, Element* in
             setter(*element);
     };
 
-    changeState(elementsToClearActive, CSSSelector::PseudoClassActive, false, [](auto& element) {
+    changeState(elementsToClearActive, CSSSelector::PseudoClassType::Active, false, [](auto& element) {
         element.setActive(false, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
-    changeState(elementsToSetActive, CSSSelector::PseudoClassActive, true, [](auto& element) {
+    changeState(elementsToSetActive, CSSSelector::PseudoClassType::Active, true, [](auto& element) {
         element.setActive(true, Style::InvalidationScope::SelfChildrenAndSiblings);
     });
-    changeState(elementsToClearHover, CSSSelector::PseudoClassHover, false, [request](auto& element) {
+    changeState(elementsToClearHover, CSSSelector::PseudoClassType::Hover, false, [request](auto& element) {
         element.setHovered(false, Style::InvalidationScope::SelfChildrenAndSiblings, request);
     });
-    changeState(elementsToSetHover, CSSSelector::PseudoClassHover, true, [request](auto& element) {
+    changeState(elementsToSetHover, CSSSelector::PseudoClassType::Hover, true, [request](auto& element) {
         element.setHovered(true, Style::InvalidationScope::SelfChildrenAndSiblings, request);
     });
 }
@@ -9495,11 +9495,11 @@ void Document::setPictureInPictureElement(HTMLVideoElement* element)
 
     std::optional<Style::PseudoClassChangeInvalidation> oldInvalidation;
     if (oldElement)
-        emplace(oldInvalidation, *oldElement, { { CSSSelector::PseudoClassPictureInPicture, false } });
+        emplace(oldInvalidation, *oldElement, { { CSSSelector::PseudoClassType::PictureInPicture, false } });
 
     std::optional<Style::PseudoClassChangeInvalidation> newInvalidation;
     if (element)
-        emplace(newInvalidation, *element, { { CSSSelector::PseudoClassPictureInPicture, true } });
+        emplace(newInvalidation, *element, { { CSSSelector::PseudoClassType::PictureInPicture, true } });
 
     m_pictureInPictureElement = element;
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -857,7 +857,7 @@ void Element::setActive(bool value, Style::InvalidationScope invalidationScope)
     if (value == active())
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassActive, value, invalidationScope);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Active, value, invalidationScope);
         document().userActionElements().setActive(*this, value);
     }
 
@@ -878,7 +878,7 @@ void Element::setFocus(bool value, FocusVisibility visibility)
     if (value == focused())
         return;
     
-    Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClassFocus, value }, { CSSSelector::PseudoClassFocusVisible, value } });
+    Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClassType::Focus, value }, { CSSSelector::PseudoClassType::FocusVisible, value } });
     document().userActionElements().setFocused(*this, value);
 
     // Shadow host with a slot that contain focused element is not considered focused.
@@ -914,7 +914,7 @@ void Element::setHasFocusWithin(bool value)
     if (hasFocusWithin() == value)
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassFocusWithin, value);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::FocusWithin, value);
         document().userActionElements().setHasFocusWithin(*this, value);
     }
 }
@@ -933,7 +933,7 @@ void Element::setHovered(bool value, Style::InvalidationScope invalidationScope,
     if (value == hovered())
         return;
     {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassHover, value, invalidationScope);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Hover, value, invalidationScope);
         document().userActionElements().setHovered(*this, value);
     }
 
@@ -946,7 +946,7 @@ void Element::setBeingDragged(bool value)
     if (value == isBeingDragged())
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassDrag, value);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Drag, value);
     document().userActionElements().setBeingDragged(*this, value);
 }
 
@@ -2140,7 +2140,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
 
 void Element::updateEffectiveLangStateAndPropagateToDescendants()
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
     updateEffectiveLangState();
 
     for (auto it = descendantsOfType<Element>(*this).begin(); it;) {
@@ -2149,7 +2149,7 @@ void Element::updateEffectiveLangStateAndPropagateToDescendants()
             it.traverseNextSkippingChildren();
             continue;
         }
-        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassLang, Style::PseudoClassChangeInvalidation::AnyValue);
+        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassType::Lang, Style::PseudoClassChangeInvalidation::AnyValue);
         element.updateEffectiveLangStateFromParent();
         it.traverseNext();
     }
@@ -2963,7 +2963,7 @@ inline void Node::setCustomElementState(CustomElementState state)
 {
     RELEASE_ASSERT(is<Element>(this));
     Style::PseudoClassChangeInvalidation styleInvalidation(downcast<Element>(*this),
-        CSSSelector::PseudoClassDefined,
+        CSSSelector::PseudoClassType::Defined,
         state == CustomElementState::Custom || state == CustomElementState::Uncustomized
     );
     auto bitfields = rareDataBitfields();
@@ -4374,7 +4374,7 @@ void Element::requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&& p
 
 void Element::setFullscreenFlag(bool flag)
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClassFullscreen, flag }, { CSSSelector::PseudoClassModal, flag } });
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, { { CSSSelector::PseudoClassType::Fullscreen, flag }, { CSSSelector::PseudoClassType::Modal, flag } });
     if (flag)
         setNodeFlag(NodeFlag::IsFullscreen);
     else

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -691,7 +691,7 @@ void FullscreenManager::setAnimatingFullscreen(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassAnimatingFullScreenTransition, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassType::AnimatingFullScreenTransition, flag } });
     m_isAnimatingFullscreen = flag;
 }
 
@@ -709,7 +709,7 @@ void FullscreenManager::setFullscreenControlsHidden(bool flag)
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_fullscreenElement)
-        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassFullScreenControlsHidden, flag } });
+        emplace(styleInvalidation, *m_fullscreenElement, { { CSSSelector::PseudoClassType::FullScreenControlsHidden, flag } });
     m_areFullscreenControlsHidden = flag;
 }
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2219,9 +2219,9 @@ static Vector<Style::PseudoClassChangeInvalidation> invalidateFocusedElementAndS
 {
     Vector<Style::PseudoClassChangeInvalidation> invalidations;
     for (RefPtr element = focusedElement; element; element = element->shadowHost()) {
-        invalidations.append({ *element, { { CSSSelector::PseudoClassFocus, activeAndFocused }, { CSSSelector::PseudoClassFocusVisible, activeAndFocused } } });
+        invalidations.append({ *element, { { CSSSelector::PseudoClassType::Focus, activeAndFocused }, { CSSSelector::PseudoClassType::FocusVisible, activeAndFocused } } });
         for (auto& lineage : lineageOfType<Element>(*element))
-            invalidations.append({ lineage, CSSSelector::PseudoClassFocusWithin, activeAndFocused });
+            invalidations.append({ lineage, CSSSelector::PseudoClassType::FocusWithin, activeAndFocused });
     }
     return invalidations;
 }

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -173,7 +173,7 @@ void HTMLDialogElement::setIsModal(bool newValue)
 {
     if (m_isModal == newValue)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassModal, newValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Modal, newValue);
     m_isModal = newValue;
 }
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -912,7 +912,7 @@ void HTMLElement::dirAttributeChanged(const AtomString& value)
 
 void HTMLElement::updateEffectiveDirectionality(std::optional<TextDirection> direction)
 {
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassDir, Style::PseudoClassChangeInvalidation::AnyValue);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
     auto effectiveDirection = direction.value_or(TextDirection::LTR);
     setUsesEffectiveTextDirection(!!direction);
     if (direction)
@@ -931,7 +931,7 @@ void HTMLElement::updateEffectiveDirectionality(std::optional<TextDirection> dir
             continue;
         }
         updateEffectiveTextDirectionOfShadowRoot(element);
-        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassDir, Style::PseudoClassChangeInvalidation::AnyValue);
+        Style::PseudoClassChangeInvalidation styleInvalidation(element, CSSSelector::PseudoClassType::Dir, Style::PseudoClassChangeInvalidation::AnyValue);
         element.setUsesEffectiveTextDirection(!!direction);
         if (direction)
             element.setEffectiveTextDirection(effectiveDirection);
@@ -1402,7 +1402,7 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
 
     popoverData()->setPreviouslyFocusedElement(nullptr);
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassPopoverOpen, true);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, true);
     popoverData()->setVisibilityState(PopoverVisibilityState::Showing);
 
     runPopoverFocusingSteps(*this);
@@ -1456,7 +1456,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
 
     removeFromTopLayer();
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassPopoverOpen, false);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, false);
     popoverData()->setVisibilityState(PopoverVisibilityState::Hidden);
 
     if (fireEvents == FireEvents::Yes)
@@ -1515,7 +1515,7 @@ void HTMLElement::popoverAttributeChanged(const AtomString& value)
     if (newPopoverState == oldPopoverState)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassPopoverOpen, false);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PopoverOpen, false);
 
     if (isPopoverShowing()) {
         hidePopoverInternal(FocusPreviousElement::Yes, FireEvents::Yes);

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -206,7 +206,7 @@ void HTMLFieldSetElement::addInvalidDescendant(const HTMLElement& invalidFormCon
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidDescendants.isEmptyIgnoringNullReferences())
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, false }, { CSSSelector::PseudoClassInvalid, true } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, false }, { CSSSelector::PseudoClassType::Invalid, true } });
 
     m_invalidDescendants.add(invalidFormControlElement);
 }
@@ -218,7 +218,7 @@ void HTMLFieldSetElement::removeInvalidDescendant(const HTMLElement& formControl
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidDescendants.computeSize() == 1)
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, true }, { CSSSelector::PseudoClassInvalid, false } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, true }, { CSSSelector::PseudoClassType::Invalid, false } });
 
     m_invalidDescendants.remove(formControlElement);
 }

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -148,7 +148,7 @@ void HTMLFormControlElement::attributeChanged(const QualifiedName& name, const A
     if (name == requiredAttr) {
         bool newRequired = !newValue.isNull();
         if (m_isRequired != newRequired) {
-            Style::PseudoClassChangeInvalidation requiredInvalidation(*this, { { CSSSelector::PseudoClassRequired, newRequired }, { CSSSelector::PseudoClassOptional, !newRequired } });
+            Style::PseudoClassChangeInvalidation requiredInvalidation(*this, { { CSSSelector::PseudoClassType::Required, newRequired }, { CSSSelector::PseudoClassType::Optional, !newRequired } });
             m_isRequired = newRequired;
             requiredStateChanged();
         }

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -632,7 +632,7 @@ void HTMLFormElement::addInvalidFormControl(const HTMLElement& formControlElemen
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidFormControls.isEmptyIgnoringNullReferences())
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, false }, { CSSSelector::PseudoClassInvalid, true } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, false }, { CSSSelector::PseudoClassType::Invalid, true } });
 
     m_invalidFormControls.add(formControlElement);
 }
@@ -644,7 +644,7 @@ void HTMLFormElement::removeInvalidFormControlIfNeeded(const HTMLElement& formCo
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (m_invalidFormControls.computeSize() == 1)
-        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassValid, true }, { CSSSelector::PseudoClassInvalid, false } });
+        emplace(styleInvalidation, *this, { { CSSSelector::PseudoClassType::Valid, true }, { CSSSelector::PseudoClassType::Invalid, false } });
 
     m_invalidFormControls.remove(formControlElement);
 }

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -543,7 +543,7 @@ void HTMLInputElement::updateType(const AtomString& typeAttributeValue)
         updateTextDirectionalityAfterTelephoneInputTypeChange();
 
     if (UNLIKELY(didSupportReadOnly != willSupportReadOnly && hasAttributeWithoutSynchronization(readonlyAttr))) {
-        emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClassReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClassReadOnly, willSupportReadOnly } });
+        emplace(readWriteInvalidation, *this, { { CSSSelector::PseudoClassType::ReadWrite, !willSupportReadOnly }, { CSSSelector::PseudoClassType::ReadOnly, willSupportReadOnly } });
         readOnlyStateChanged();
     }
 
@@ -1007,7 +1007,7 @@ void HTMLInputElement::setChecked(bool isChecked)
 
     m_inputType->willUpdateCheckedness(isChecked);
 
-    Style::PseudoClassChangeInvalidation checkedInvalidation(*this, CSSSelector::PseudoClassChecked, isChecked);
+    Style::PseudoClassChangeInvalidation checkedInvalidation(*this, CSSSelector::PseudoClassType::Checked, isChecked);
 
     m_isChecked = isChecked;
 
@@ -1031,7 +1031,7 @@ void HTMLInputElement::setIndeterminate(bool newValue)
     if (indeterminate() == newValue)
         return;
 
-    Style::PseudoClassChangeInvalidation indeterminateInvalidation(*this, CSSSelector::PseudoClassIndeterminate, newValue);
+    Style::PseudoClassChangeInvalidation indeterminateInvalidation(*this, CSSSelector::PseudoClassType::Indeterminate, newValue);
     m_isIndeterminate = newValue;
 
     if (auto* renderer = this->renderer(); renderer && renderer->style().hasEffectiveAppearance())
@@ -1434,7 +1434,7 @@ void HTMLInputElement::setAutoFilled(bool autoFilled)
     if (autoFilled == m_isAutoFilled)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassAutofill, autoFilled);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Autofill, autoFilled);
     m_isAutoFilled = autoFilled;
 }
 
@@ -1443,7 +1443,7 @@ void HTMLInputElement::setAutoFilledAndViewable(bool autoFilledAndViewable)
     if (autoFilledAndViewable == m_isAutoFilledAndViewable)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassAutofillStrongPasswordViewable, autoFilledAndViewable);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::AutofillStrongPasswordViewable, autoFilledAndViewable);
     m_isAutoFilledAndViewable = autoFilledAndViewable;
 }
 
@@ -1452,7 +1452,7 @@ void HTMLInputElement::setAutoFilledAndObscured(bool autoFilledAndObscured)
     if (autoFilledAndObscured == m_isAutoFilledAndObscured)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassAutofillAndObscured, autoFilledAndObscured);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::AutofillAndObscured, autoFilledAndObscured);
     m_isAutoFilledAndObscured = autoFilledAndObscured;
 
     if (auto* cache = document().existingAXObjectCache())

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3646,7 +3646,7 @@ void HTMLMediaElement::setSeeking(bool seeking)
 {
     if (m_seeking == seeking)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassSeeking, seeking);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Seeking, seeking);
     m_seeking = seeking;
 }
 
@@ -3815,8 +3815,8 @@ void HTMLMediaElement::setPaused(bool paused)
     if (m_paused == paused)
         return;
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, {
-        { CSSSelector::PseudoClassPaused, paused },
-        { CSSSelector::PseudoClassPlaying, !paused },
+        { CSSSelector::PseudoClassType::Paused, paused },
+        { CSSSelector::PseudoClassType::Playing, !paused },
     });
     m_paused = paused;
     updateBufferingState();
@@ -4287,7 +4287,7 @@ void HTMLMediaElement::setMuted(bool muted)
             if (hasAudio() && muted)
                 userDidInterfereWithAutoplay();
         }
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassMuted, muted);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Muted, muted);
         m_muted = muted;
         m_explicitlyMuted = true;
 
@@ -4322,7 +4322,7 @@ void HTMLMediaElement::setVolumeLocked(bool locked)
     if (m_volumeLocked == locked)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassVolumeLocked, locked);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::VolumeLocked, locked);
     m_volumeLocked = locked;
 }
 
@@ -4339,7 +4339,7 @@ void HTMLMediaElement::updateBufferingState()
     // matches the element.)
     bool buffering = !paused() && m_networkState == NETWORK_LOADING && m_readyState <= HAVE_CURRENT_DATA;
     if (m_buffering != buffering) {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassBuffering, buffering);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Buffering, buffering);
         m_buffering = buffering;
     }
 }
@@ -4358,7 +4358,7 @@ void HTMLMediaElement::updateStalledState()
     // also matches the element.)
     bool stalled = !paused() && m_networkState == NETWORK_LOADING && m_readyState <= HAVE_CURRENT_DATA && m_sentStalledEvent;
     if (m_stalled != stalled) {
-        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassStalled, stalled);
+        Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Stalled, stalled);
         m_stalled = stalled;
     }
 }

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -98,11 +98,11 @@ void HTMLOptGroupElement::attributeChanged(const QualifiedName& name, const Atom
     if (name == disabledAttr) {
         bool newDisabled = !newValue.isNull();
         if (m_isDisabled != newDisabled) {
-            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassDisabled, newDisabled }, { CSSSelector::PseudoClassEnabled, !newDisabled } });
+            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassType::Disabled, newDisabled }, { CSSSelector::PseudoClassType::Enabled, !newDisabled } });
 
             Vector<Style::PseudoClassChangeInvalidation> optionInvalidation;
             for (auto& descendant : descendantsOfType<HTMLOptionElement>(*this))
-                optionInvalidation.append({ descendant, { { CSSSelector::PseudoClassDisabled, newDisabled }, { CSSSelector::PseudoClassEnabled, !newDisabled } } });
+                optionInvalidation.append({ descendant, { { CSSSelector::PseudoClassType::Disabled, newDisabled }, { CSSSelector::PseudoClassType::Enabled, !newDisabled } } });
 
             m_isDisabled = newDisabled;
         }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -171,7 +171,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::disabledAttr: {
         bool newDisabled = !newValue.isNull();
         if (m_disabled != newDisabled) {
-            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassDisabled, newDisabled },  { CSSSelector::PseudoClassEnabled, !newDisabled } });
+            Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassType::Disabled, newDisabled },  { CSSSelector::PseudoClassType::Enabled, !newDisabled } });
             m_disabled = newDisabled;
             if (renderer() && renderer()->style().hasEffectiveAppearance())
                 renderer()->theme().stateChanged(*renderer(), ControlStates::States::Enabled);
@@ -180,7 +180,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
     }
     case AttributeNames::selectedAttr: {
         // FIXME: Use PseudoClassChangeInvalidation in other elements that implement matchesDefaultPseudoClass().
-        Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassDefault, !newValue.isNull());
+        Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassType::Default, !newValue.isNull());
         m_isDefault = !newValue.isNull();
 
         // FIXME: WebKit still need to implement 'dirtiness'. See: https://bugs.webkit.org/show_bug.cgi?id=258073
@@ -239,7 +239,7 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
 
     std::optional<Style::PseudoClassChangeInvalidation> checkedInvalidation;
     if (allowStyleInvalidation == AllowStyleInvalidation::Yes)
-        emplace(checkedInvalidation, *this, { { CSSSelector::PseudoClassChecked, selected } });
+        emplace(checkedInvalidation, *this, { { CSSSelector::PseudoClassType::Checked, selected } });
 
     m_isSelected = selected;
 

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -129,7 +129,7 @@ void HTMLProgressElement::updateDeterminateState()
     bool newIsDeterminate = hasAttributeWithoutSynchronization(valueAttr);
     if (m_isDeterminate == newIsDeterminate)
         return;
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassIndeterminate, !newIsDeterminate);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::Indeterminate, !newIsDeterminate);
     m_isDeterminate = newIsDeterminate;
 }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -188,7 +188,7 @@ void HTMLTextFormControlElement::updatePlaceholderVisibility()
     if (m_isPlaceholderVisible == newIsPlaceholderVisible)
         return;
 
-    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassPlaceholderShown, newIsPlaceholderVisible);
+    Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassType::PlaceholderShown, newIsPlaceholderVisible);
     m_isPlaceholderVisible = newIsPlaceholderVisible;
 
     if (RefPtr placeholder = placeholderElement())

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -822,7 +822,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
 
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (wasInRange != inRange)
-        emplace(styleInvalidation, *element(), { { CSSSelector::PseudoClassInRange, inRange }, { CSSSelector::PseudoClassOutOfRange, !inRange } });
+        emplace(styleInvalidation, *element(), { { CSSSelector::PseudoClassType::InRange, inRange }, { CSSSelector::PseudoClassType::OutOfRange, !inRange } });
 
     element()->setValueInternal(sanitizedValue, eventBehavior);
 

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -212,8 +212,8 @@ void ValidatedFormListedElement::setDisabledInternal(bool disabled, bool disable
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (changingDisabledState) {
         emplace(styleInvalidation, asHTMLElement(), {
-            { CSSSelector::PseudoClassDisabled, newDisabledState },
-            { CSSSelector::PseudoClassEnabled, !newDisabledState },
+            { CSSSelector::PseudoClassType::Disabled, newDisabledState },
+            { CSSSelector::PseudoClassType::Enabled, !newDisabledState },
         });
     }
 
@@ -253,10 +253,10 @@ void ValidatedFormListedElement::updateValidity()
     if (newIsValid != m_isValid) {
         HTMLElement& element = asHTMLElement();
         Style::PseudoClassChangeInvalidation styleInvalidation(element, {
-            { CSSSelector::PseudoClassValid, newIsValid },
-            { CSSSelector::PseudoClassInvalid, !newIsValid },
-            { CSSSelector::PseudoClassUserValid, m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
-            { CSSSelector::PseudoClassUserInvalid, m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
+            { CSSSelector::PseudoClassType::Valid, newIsValid },
+            { CSSSelector::PseudoClassType::Invalid, !newIsValid },
+            { CSSSelector::PseudoClassType::UserValid, m_wasInteractedWithSinceLastFormSubmitEvent && newIsValid },
+            { CSSSelector::PseudoClassType::UserInvalid, m_wasInteractedWithSinceLastFormSubmitEvent && !newIsValid },
         });
 
         m_isValid = newIsValid;
@@ -313,7 +313,7 @@ void ValidatedFormListedElement::parseReadOnlyAttribute(const AtomString& value)
     bool newHasReadOnlyAttribute = !value.isNull();
     if (m_hasReadOnlyAttribute != newHasReadOnlyAttribute) {
         bool newMatchesReadWrite = supportsReadOnly() && !newHasReadOnlyAttribute;
-        Style::PseudoClassChangeInvalidation readWriteInvalidation(asHTMLElement(), { { CSSSelector::PseudoClassReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClassReadOnly, !newMatchesReadWrite } });
+        Style::PseudoClassChangeInvalidation readWriteInvalidation(asHTMLElement(), { { CSSSelector::PseudoClassType::ReadWrite, newMatchesReadWrite }, { CSSSelector::PseudoClassType::ReadOnly, !newMatchesReadWrite } });
         m_hasReadOnlyAttribute = newHasReadOnlyAttribute;
         readOnlyStateChanged();
     }
@@ -504,8 +504,8 @@ void ValidatedFormListedElement::setInteractedWithSinceLastFormSubmitEvent(bool 
         return;
 
     Style::PseudoClassChangeInvalidation styleInvalidation(asHTMLElement(), {
-        { CSSSelector::PseudoClassUserValid, interactedWith && matchesValidPseudoClass() },
-        { CSSSelector::PseudoClassUserInvalid, interactedWith && matchesInvalidPseudoClass() },
+        { CSSSelector::PseudoClassType::UserValid, interactedWith && matchesValidPseudoClass() },
+        { CSSSelector::PseudoClassType::UserInvalid, interactedWith && matchesInvalidPseudoClass() },
     });
 
     m_wasInteractedWithSinceLastFormSubmitEvent = interactedWith;

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -924,31 +924,31 @@ Protocol::ErrorStringOr<void> InspectorCSSAgent::forcePseudoState(Protocol::DOM:
 
         switch (*pseudoClass) {
         case Protocol::CSS::ForceablePseudoClass::Active:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassActive);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Active);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Hover:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassHover);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Hover);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Focus:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassFocus);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Focus);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::FocusVisible:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassFocusVisible);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::FocusVisible);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::FocusWithin:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassFocusWithin);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::FocusWithin);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Target:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassTarget);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Target);
             break;
 
         case Protocol::CSS::ForceablePseudoClass::Visited:
-            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassVisited);
+            forcedPseudoClassesToSet.add(CSSSelector::PseudoClassType::Visited);
             break;
         }
     }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3723,7 +3723,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
         bool userHasInteractedViaKeyword = keydown->modifierKeys().isEmpty() || ((keydown->shiftKey() || keydown->capsLockKey()) && !initialKeyEvent.text().isEmpty());
 
         if (element.focused() && userHasInteractedViaKeyword) {
-            Style::PseudoClassChangeInvalidation focusVisibleStyleInvalidation(element, CSSSelector::PseudoClassFocusVisible, true);
+            Style::PseudoClassChangeInvalidation focusVisibleStyleInvalidation(element, CSSSelector::PseudoClassType::FocusVisible, true);
             element.setHasFocusVisible(true);
         }
     };

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -117,7 +117,7 @@ static bool elementMatchesHoverRules(Element& element)
     bool foundHoverRules = false;
     bool initialValue = element.isUserActionElement() && element.document().userActionElements().isHovered(element);
 
-    for (auto key : Style::makePseudoClassInvalidationKeys(CSSSelector::PseudoClassHover, element)) {
+    for (auto key : Style::makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType::Hover, element)) {
         auto& ruleSets = element.styleResolver().ruleSets();
         auto* invalidationRuleSets = ruleSets.pseudoClassInvalidationRuleSets(key);
         if (!invalidationRuleSets)

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -102,7 +102,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         }
     };
 
-    for (auto key : makePseudoClassInvalidationKeys(CSSSelector::PseudoClassHas, changedElement))
+    for (auto key : makePseudoClassInvalidationKeys(CSSSelector::PseudoClassType::Has, changedElement))
         addHasInvalidation(ruleSets.hasPseudoClassInvalidationRuleSets(key));
 
     Invalidator::invalidateWithMatchElementRuleSets(changedElement, matchElementRuleSets);

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -68,7 +68,7 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
     SelectorFilter::CollectedSelectorHashes hashes;
     bool hasHoverInCompound = false;
     for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->tagHistory()) {
-        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClassType() == CSSSelector::PseudoClassHover)
+        if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClassType() == CSSSelector::PseudoClassType::Hover)
             hasHoverInCompound = true;
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);
         if (!hashes.ids.isEmpty())

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -78,7 +78,7 @@ static bool isHostSelectorMatchingInShadowTree(const CSSSelector& startSelector)
     bool hasOnlyOneCompound = true;
     bool hasHostInLastCompound = false;
     for (auto* selector = &startSelector; selector; selector = selector->tagHistory()) {
-        if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassHost)
+        if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClassType() == CSSSelector::PseudoClassType::Host)
             hasHostInLastCompound = true;
         if (selector->tagHistory() && selector->relation() != CSSSelector::RelationType::Subselector) {
             hasOnlyOneCompound = false;
@@ -197,17 +197,17 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             break;
         case CSSSelector::Match::PseudoClass:
             switch (selector->pseudoClassType()) {
-            case CSSSelector::PseudoClassLink:
-            case CSSSelector::PseudoClassVisited:
-            case CSSSelector::PseudoClassAnyLink:
-            case CSSSelector::PseudoClassAnyLinkDeprecated:
+            case CSSSelector::PseudoClassType::Link:
+            case CSSSelector::PseudoClassType::Visited:
+            case CSSSelector::PseudoClassType::AnyLink:
+            case CSSSelector::PseudoClassType::AnyLinkDeprecated:
                 linkSelector = selector;
                 break;
-            case CSSSelector::PseudoClassFocus:
-            case CSSSelector::PseudoClassFocusVisible:
+            case CSSSelector::PseudoClassType::Focus:
+            case CSSSelector::PseudoClassType::FocusVisible:
                 focusSelector = selector;
                 break;
-            case CSSSelector::PseudoClassHost:
+            case CSSSelector::PseudoClassType::Host:
                 hostPseudoClassSelector = selector;
                 break;
             default:

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -263,7 +263,7 @@ ResolvedStyle Resolver::styleForElement(const Element& element, const Resolution
         style.setIsLink(true);
         InsideLink linkState = document().visitedLinkState().determineLinkState(element);
         if (linkState != InsideLink::NotInside) {
-            bool forceVisited = InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassVisited);
+            bool forceVisited = InspectorInstrumentation::forcePseudoState(element, CSSSelector::PseudoClassType::Visited);
             if (forceVisited)
                 linkState = InsideLink::InsideVisited;
         }


### PR DESCRIPTION
#### cacc9a183c3e854c7478221014706a45dfcdbfe3
<pre>
Undefined behavior in HashSet&lt;CSSSelector::PseudoClassType&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258755">https://bugs.webkit.org/show_bug.cgi?id=258755</a>

Reviewed by Ryosuke Niwa.

Undefined behavior in HashSet&lt;CSSSelector::PseudoClassType&gt;:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/local/include/wtf/RefPtr.h:75:82 in
/usr/local/include/wtf/HashTable.h:301:114: runtime error: load of value 4294967295, which is not a valid value for type &apos;const WebCore::CSSSelector::PseudoClassType&apos;
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/local/include/wtf/HashTable.h:301:114 in
/usr/local/include/wtf/HashFunctions.h:104:46: runtime error: load of value 4294967295, which is not a valid value for type &apos;WebCore::CSSSelector::PseudoClassType&apos;
```

The issue is that CSSSelector is not a scoped enumeration but we use
`StrongEnumHashTraits&lt;CSSSelector::PseudoClassType&gt;` for HashSets (in
RuleFeature.h for example). This means we end up using
`std::underlying_type&lt;CSSSelector::PseudoClassType&gt;::max()` and
`std::underlying_type&lt;CSSSelector::PseudoClassType&gt;::max() -1` as special
HashMap values. Casting values outside the enum value range to an enumeration
that is not scoped is undefined behavior.

To address the issue, I am converting CSSSelector::PseudoClassType to a scoped
enumeration.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::appendPseudoClassFunctionTail):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::resolveNestingParentSelectors):
(WebCore::CSSSelector::replaceNestingParentByPseudoClassScope):
* Source/WebCore/css/CSSSelector.h:
(WebCore::pseudoClassIsRelativeToSiblings):
(WebCore::isTreeStructuralPseudoClass):
(WebCore::isLogicalCombinationPseudoClass):
(WebCore::CSSSelector::setPseudoClassType):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::localContextForParent):
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
(WebCore::SelectorChecker::checkScrollbarPseudoClass const):
(WebCore::SelectorChecker::determineLinkMatchType):
* Source/WebCore/css/SelectorChecker.h:
(WebCore::SelectorChecker::isCommonPseudoClassSelector):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLegacyDirectFocusPseudoClass):
(WebCore::matchesFocusPseudoClass):
(WebCore::matchesFocusVisiblePseudoClass):
(WebCore::matchesFocusWithinPseudoClass):
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::SelectorFilter::collectSimpleSelectorHash):
* Source/WebCore/css/SelectorPseudoClassAndCompatibilityElementMap.in:
* Source/WebCore/css/makeSelectorPseudoClassAndCompatibilityElementMap.py:
(enumerablePseudoType):
* Source/WebCore/css/parser/CSSParserSelector.cpp:
(WebCore::CSSParserSelector::parsePseudoClassSelector):
(WebCore::CSSParserSelector::isHostPseudoSelector const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeRelativeScopeSelector):
(WebCore::isScrollbarPseudoClass):
(WebCore::isUserActionPseudoClass):
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::isOnlyPseudoClassFunction):
(WebCore::CSSSelectorParser::consumePseudo):
(WebCore::CSSSelectorParser::resolveNestingParent):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addNthChildType):
(WebCore::SelectorCompiler::addPseudoClassType):
(WebCore::SelectorCompiler::pseudoClassOnlyMatchesLinksInQuirksMode):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementMatching):
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateElementLinkMatching):
(WebCore::SelectorCompiler::JSC_DEFINE_JIT_OPERATION):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setCSSTarget):
(WebCore::Document::updateHoverActiveState):
(WebCore::Document::setPictureInPictureElement):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setActive):
(WebCore::Element::setFocus):
(WebCore::Element::setHasFocusWithin):
(WebCore::Element::setHovered):
(WebCore::Element::setBeingDragged):
(WebCore::Element::updateEffectiveLangStateAndPropagateToDescendants):
(WebCore::Node::setCustomElementState):
(WebCore::Element::setFullscreenFlag):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::setAnimatingFullscreen):
(WebCore::FullscreenManager::setFullscreenControlsHidden):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::invalidateFocusedElementAndShadowIncludingAncestors):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::setIsModal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::updateEffectiveDirectionality):
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):
(WebCore::HTMLElement::popoverAttributeChanged):
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::addInvalidDescendant):
(WebCore::HTMLFieldSetElement::removeInvalidDescendant):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::attributeChanged):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::addInvalidFormControl):
(WebCore::HTMLFormElement::removeInvalidFormControlIfNeeded):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::updateType):
(WebCore::HTMLInputElement::setChecked):
(WebCore::HTMLInputElement::setIndeterminate):
(WebCore::HTMLInputElement::setAutoFilled):
(WebCore::HTMLInputElement::setAutoFilledAndViewable):
(WebCore::HTMLInputElement::setAutoFilledAndObscured):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSeeking):
(WebCore::HTMLMediaElement::setPaused):
(WebCore::HTMLMediaElement::setMuted):
(WebCore::HTMLMediaElement::setVolumeLocked):
(WebCore::HTMLMediaElement::updateBufferingState):
(WebCore::HTMLMediaElement::updateStalledState):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::attributeChanged):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
(WebCore::HTMLOptionElement::setSelectedState):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::updateDeterminateState):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::updatePlaceholderVisibility):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::setValue):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::setDisabledInternal):
(WebCore::ValidatedFormListedElement::updateValidity):
(WebCore::ValidatedFormListedElement::parseReadOnlyAttribute):
(WebCore::ValidatedFormListedElement::setInteractedWithSinceLastFormSubmitEvent):
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::forcePseudoState):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::elementMatchesHoverRules):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::computeSubSelectorMatchElement):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::makePseudoClassInvalidationKey):
(WebCore::Style::RuleFeatureSet::collectFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::isHostSelectorMatchingInShadowTree):
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForElement):

Canonical link: <a href="https://commits.webkit.org/265679@main">https://commits.webkit.org/265679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e43ae8de218da6a99d316db4aef571be719349c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11069 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13945 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10554 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9152 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10277 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2793 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->