### PR TITLE
Add additional assertions to InlineCacheCompiler

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -226,6 +226,12 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCall(const RegisterSet&
 
     unsigned extraStackPadding = 0;
     unsigned numberOfStackBytesUsedForRegisterPreservation = ScratchRegisterAllocator::preserveRegistersToStackForCall(*m_jit, liveRegisters.buildAndValidate(), extraStackPadding);
+    RELEASE_ASSERT(liveRegisters.buildAndValidate().numberOfSetRegisters() == liveRegisters.buildScalarRegisterSet().numberOfSetRegisters(),
+        liveRegisters.buildAndValidate().numberOfSetRegisters(),
+        liveRegisters.buildScalarRegisterSet().numberOfSetRegisters());
+    RELEASE_ASSERT(liveRegisters.buildScalarRegisterSet().numberOfSetRegisters() || !numberOfStackBytesUsedForRegisterPreservation,
+        liveRegisters.buildScalarRegisterSet().numberOfSetRegisters(),
+        numberOfStackBytesUsedForRegisterPreservation);
     return SpillState {
         liveRegisters.buildScalarRegisterSet(),
         numberOfStackBytesUsedForRegisterPreservation
@@ -242,6 +248,12 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions()
 
     constexpr unsigned extraStackPadding = 0;
     unsigned numberOfStackBytesUsedForRegisterPreservation = ScratchRegisterAllocator::preserveRegistersToStackForCall(*m_jit, liveRegisters.buildAndValidate(), extraStackPadding);
+    RELEASE_ASSERT(liveRegisters.buildAndValidate().numberOfSetRegisters() == liveRegisters.buildScalarRegisterSet().numberOfSetRegisters(),
+        liveRegisters.buildAndValidate().numberOfSetRegisters(),
+        liveRegisters.buildScalarRegisterSet().numberOfSetRegisters());
+    RELEASE_ASSERT(liveRegisters.buildScalarRegisterSet().numberOfSetRegisters() || !numberOfStackBytesUsedForRegisterPreservation,
+        liveRegisters.buildScalarRegisterSet().numberOfSetRegisters(),
+        numberOfStackBytesUsedForRegisterPreservation);
     return SpillState {
         liveRegisters.buildScalarRegisterSet(),
         numberOfStackBytesUsedForRegisterPreservation

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -247,12 +247,25 @@ public:
     void setSpillStateForJSCall(SpillState& spillState)
     {
         if (!m_spillStateForJSCall.isEmpty()) {
-            ASSERT(m_spillStateForJSCall.numberOfStackBytesUsedForRegisterPreservation == spillState.numberOfStackBytesUsedForRegisterPreservation);
-            ASSERT(m_spillStateForJSCall.spilledRegisters == spillState.spilledRegisters);
+            RELEASE_ASSERT(m_spillStateForJSCall.numberOfStackBytesUsedForRegisterPreservation == spillState.numberOfStackBytesUsedForRegisterPreservation,
+                m_spillStateForJSCall.numberOfStackBytesUsedForRegisterPreservation,
+                spillState.numberOfStackBytesUsedForRegisterPreservation);
+            RELEASE_ASSERT(m_spillStateForJSCall.spilledRegisters == spillState.spilledRegisters,
+                m_spillStateForJSCall.spilledRegisters.bitsForDebugging(),
+                spillState.spilledRegisters.bitsForDebugging());
         }
+        RELEASE_ASSERT(spillState.spilledRegisters.numberOfSetRegisters() || !spillState.numberOfStackBytesUsedForRegisterPreservation,
+            spillState.spilledRegisters.numberOfSetRegisters(),
+            spillState.numberOfStackBytesUsedForRegisterPreservation);
         m_spillStateForJSCall = spillState;
     }
-    SpillState spillStateForJSCall() const { return m_spillStateForJSCall; }
+    SpillState spillStateForJSCall() const
+    {
+        RELEASE_ASSERT(m_spillStateForJSCall.spilledRegisters.numberOfSetRegisters() || !m_spillStateForJSCall.numberOfStackBytesUsedForRegisterPreservation,
+            m_spillStateForJSCall.spilledRegisters.numberOfSetRegisters(),
+            m_spillStateForJSCall.numberOfStackBytesUsedForRegisterPreservation);
+        return m_spillStateForJSCall;
+    }
 
     ScratchRegisterAllocator makeDefaultScratchAllocator(GPRReg extraToLock = InvalidGPRReg);
 

--- a/Source/JavaScriptCore/jit/RegisterSet.h
+++ b/Source/JavaScriptCore/jit/RegisterSet.h
@@ -462,6 +462,7 @@ public:
     constexpr ScalarRegisterSet() { }
 
     inline constexpr unsigned hash() const { return m_bits.hash(); }
+    inline uint64_t bitsForDebugging() const { return *m_bits.storage(); }
     inline constexpr bool operator==(const ScalarRegisterSet& other) const { return m_bits == other.m_bits; }
 
     inline constexpr RegisterSet toRegisterSet() const WARN_UNUSED_RETURN


### PR DESCRIPTION
#### 40df48799883c603be2823a3c86c2172ecb4ef8d
<pre>
Add additional assertions to InlineCacheCompiler
rdar://110382994

Reviewed by Mark Lam.

We are sometimes finding ourselves in an inconsistent state where
we have allocated stack space but have no live registers to preserve.
Let&apos;s add some additional assertions to make it easier to find the root cause.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCall):
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
(JSC::InlineCacheCompiler::setSpillStateForJSCall):
(JSC::InlineCacheCompiler::spillStateForJSCall const):

Canonical link: <a href="https://commits.webkit.org/265759@main">https://commits.webkit.org/265759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba9226ab90f2acf8cd6af88246b686456d5a59b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17793 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9992 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10814 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13987 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9260 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11825 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10394 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2843 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14675 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12159 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11075 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2950 "Passed tests") | 
<!--EWS-Status-Bubble-End-->