### PR TITLE
[WinCairo] Unreviewed test gardening

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -1912,6 +1912,7 @@ imported/w3c/web-platform-tests/paint-timing [ Skip ]
 imported/w3c/web-platform-tests/payment-request [ Skip ]
 imported/w3c/web-platform-tests/performance-timeline [ Skip ]
 imported/w3c/web-platform-tests/permissions [ Skip ]
+imported/w3c/web-platform-tests/permissions-policy [ Skip ]
 imported/w3c/web-platform-tests/picture-in-picture [ Skip ]
 imported/w3c/web-platform-tests/pointerevents [ Skip ]
 imported/w3c/web-platform-tests/pointerlock [ Skip ]
@@ -2309,8 +2310,6 @@ fast/css3-text/font-synthesis.html [ ImageOnlyFailure ]
 fast/css3-text/css3-text-decoration/text-underline-position/underline-visual-overflow-with-subpixel-position.html [ Failure ]
 
 fast/canvas/toDataURL-alpha-permutation.html [ ImageOnlyFailure ]
-
-webgl/2.0.y/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html [ Failure ]
 
 webkit.org/b/243992 fast/text/punctuation-break-all.html [ ImageOnlyFailure ]
 
@@ -2836,3 +2835,5 @@ http/tests/inspector/network/xhr-request-type.html [ Failure ]
 compositing/overlap-blending/reflection-opacity-huge.html [ ImageOnlyFailure Pass ]
 
 fast/css-grid-layout/grid-item-display.html [ Failure Pass ]
+
+fast/canvas/canvas-ellipse-connecting-line.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wincairo/compositing/geometry/clipping-foreground-expected.txt
+++ b/LayoutTests/platform/wincairo/compositing/geometry/clipping-foreground-expected.txt
@@ -13,8 +13,8 @@ layer at (0,0) size 800x600
 layer at (68,259) size 200x200 layerType: background only
 layer at (28,219) size 150x150
   RenderBlock (positioned) zI: -1 {DIV} at (-40,-40) size 150x150 [color=#808080] [bgcolor=#C86464] [border: (2px solid #000000)]
-    RenderText zI: -1 {#text} at (22,23) size 106x40
-      text run at (22,23) width 106: "Behind"
+    RenderText zI: -1 {#text} at (22,23) size 109x40
+      text run at (22,23) width 109: "Behind"
     RenderText zI: -1 {#text} at (0,0) size 0x0
 layer at (50,301) size 100x100
   RenderBlock (positioned) {DIV} at (22,82) size 100x100 [bgcolor=#008000] [border: (2px solid #000000)]
@@ -23,21 +23,21 @@ layer at (50,301) size 100x100
       text run at (22,43) width 53: "behind"
 layer at (68,259) size 200x200 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (60,215) size 200x200 [color=#0000FF] [bgcolor=#FFFFFFCC] [border: (10px solid #000000)]
-    RenderText {#text} at (30,31) size 126x82
+    RenderText {#text} at (30,31) size 128x82
       text run at (30,31) width 59: "Box"
-      text run at (30,73) width 126: "contents"
+      text run at (30,73) width 128: "contents"
     RenderText {#text} at (0,0) size 0x0
     RenderText {#text} at (0,0) size 0x0
 layer at (158,349) size 150x150
   RenderBlock (positioned) zI: 1 {DIV} at (90,90) size 150x150 [color=#808080] [bgcolor=#C8C880] [border: (2px solid #000000)]
-    RenderText zI: 1 {#text} at (22,23) size 85x82
-      text run at (22,23) width 33: "In"
-      text run at (22,65) width 85: "Front"
+    RenderText zI: 1 {#text} at (22,23) size 87x82
+      text run at (22,23) width 34: "In"
+      text run at (22,65) width 87: "Front"
 layer at (392,104) size 200x200 clip at (402,114) size 180x180 scrollWidth 230 scrollHeight 230 layerType: background only
 layer at (352,64) size 150x150 backgroundClip at (402,114) size 180x180 clip at (402,114) size 180x180
   RenderBlock (positioned) zI: -1 {DIV} at (-40,-40) size 150x150 [color=#808080] [bgcolor=#C86464] [border: (2px solid #000000)]
-    RenderText zI: -1 {#text} at (22,23) size 106x40
-      text run at (22,23) width 106: "Behind"
+    RenderText zI: -1 {#text} at (22,23) size 109x40
+      text run at (22,23) width 109: "Behind"
     RenderText zI: -1 {#text} at (0,0) size 0x0
 layer at (374,146) size 100x100 backgroundClip at (402,114) size 180x180 clip at (402,114) size 180x180
   RenderBlock (positioned) {DIV} at (22,82) size 100x100 [bgcolor=#008000] [border: (2px solid #000000)]
@@ -46,13 +46,13 @@ layer at (374,146) size 100x100 backgroundClip at (402,114) size 180x180 clip at
       text run at (22,43) width 53: "behind"
 layer at (392,104) size 200x200 clip at (402,114) size 180x180 scrollWidth 230 scrollHeight 230 layerType: foreground only
   RenderBlock (relative positioned) {DIV} at (384,60) size 200x200 [color=#0000FF] [bgcolor=#FFFFFFCC] [border: (10px solid #000000)]
-    RenderText {#text} at (30,31) size 126x82
+    RenderText {#text} at (30,31) size 128x82
       text run at (30,31) width 59: "Box"
-      text run at (30,73) width 126: "contents"
+      text run at (30,73) width 128: "contents"
     RenderText {#text} at (0,0) size 0x0
     RenderText {#text} at (0,0) size 0x0
 layer at (482,194) size 150x150 backgroundClip at (402,114) size 180x180 clip at (402,114) size 180x180
   RenderBlock (positioned) zI: 1 {DIV} at (90,90) size 150x150 [color=#808080] [bgcolor=#C8C880] [border: (2px solid #000000)]
-    RenderText zI: 1 {#text} at (22,23) size 85x82
-      text run at (22,23) width 33: "In"
-      text run at (22,65) width 85: "Front"
+    RenderText zI: 1 {#text} at (22,23) size 87x82
+      text run at (22,23) width 34: "In"
+      text run at (22,65) width 87: "Front"

--- a/LayoutTests/platform/wincairo/compositing/shadows/shadow-drawing-expected.txt
+++ b/LayoutTests/platform/wincairo/compositing/shadows/shadow-drawing-expected.txt
@@ -13,13 +13,13 @@ layer at (0,0) size 800x312
         RenderText {#text} at (0,0) size 0x0
 layer at (59,140) size 200x88
   RenderBlock {P} at (1,38) size 200x89 [color=#0000FF]
-    RenderText {#text} at (22,1) size 156x86
-      text run at (22,1) width 156: "Shadowed"
+    RenderText {#text} at (21,1) size 158x86
+      text run at (21,1) width 158: "Shadowed"
       text run at (72,45) width 56: "text"
 layer at (364,102) size 202x152
   RenderBlock {DIV} at (356,50) size 202x152 [border: (1px solid #000000)]
 layer at (365,140) size 200x88
   RenderBlock {P} at (1,38) size 200x89 [color=#0000FF]
-    RenderText {#text} at (22,1) size 156x86
-      text run at (22,1) width 156: "Shadowed"
+    RenderText {#text} at (21,1) size 158x86
+      text run at (21,1) width 158: "Shadowed"
       text run at (72,45) width 56: "text"

--- a/LayoutTests/platform/wincairo/css1/basic/inheritance-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/basic/inheritance-expected.txt
@@ -23,26 +23,26 @@ layer at (0,0) size 785x767
           text run at (0,96) width 184: ".three {color: purple;}"
           text run at (184,96) width 0: " "
       RenderBlock {H3} at (0,181) size 769x25 [color=#0000FF]
-        RenderText {#text} at (0,0) size 220x22
-          text run at (0,0) width 220: "This sentence should show "
-        RenderInline {STRONG} at (0,0) size 35x22
-          RenderText {#text} at (220,0) size 35x22
-            text run at (220,0) width 35: "blue"
-        RenderText {#text} at (255,0) size 42x22
-          text run at (255,0) width 42: " and "
-        RenderInline {EM} at (0,0) size 51x22 [color=#800080]
-          RenderText {#text} at (297,1) size 51x22
-            text run at (297,1) width 51: "purple"
-        RenderText {#text} at (348,0) size 5x22
-          text run at (348,0) width 5: "."
+        RenderText {#text} at (0,0) size 211x22
+          text run at (0,0) width 211: "This sentence should show "
+        RenderInline {STRONG} at (0,0) size 33x22
+          RenderText {#text} at (211,0) size 33x22
+            text run at (211,0) width 33: "blue"
+        RenderText {#text} at (244,0) size 39x22
+          text run at (244,0) width 39: " and "
+        RenderInline {EM} at (0,0) size 48x22 [color=#800080]
+          RenderText {#text} at (283,1) size 48x22
+            text run at (283,1) width 48: "purple"
+        RenderText {#text} at (331,0) size 5x22
+          text run at (331,0) width 5: "."
       RenderBlock {H3} at (0,224) size 769x25 [color=#0000FF]
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "This sentence should be "
-        RenderInline {SPAN} at (0,0) size 34x22
-          RenderText {#text} at (197,1) size 34x22
-            text run at (197,1) width 34: "blue"
-        RenderText {#text} at (231,0) size 104x22
-          text run at (231,0) width 104: " throughout."
+        RenderText {#text} at (0,0) size 189x22
+          text run at (0,0) width 189: "This sentence should be "
+        RenderInline {SPAN} at (0,0) size 32x22
+          RenderText {#text} at (189,1) size 32x22
+            text run at (189,1) width 32: "blue"
+        RenderText {#text} at (221,0) size 97x22
+          text run at (221,0) width 97: " throughout."
       RenderBlock {P} at (0,267) size 769x21
         RenderText {#text} at (0,0) size 226x19
           text run at (0,0) width 226: "This should be green except for the "
@@ -52,8 +52,8 @@ layer at (0,0) size 785x767
         RenderText {#text} at (343,0) size 160x19
           text run at (343,0) width 160: ", which should be purple."
       RenderBlock {H3} at (0,305) size 769x24 [color=#0000FF]
-        RenderText {#text} at (0,0) size 296x22
-          text run at (0,0) width 296: "This should be blue and underlined."
+        RenderText {#text} at (0,0) size 280x22
+          text run at (0,0) width 280: "This should be blue and underlined."
       RenderBlock {P} at (0,347) size 769x21
         RenderText {#text} at (0,0) size 293x19
           text run at (0,0) width 293: "This sentence should be underlined, including "
@@ -111,26 +111,26 @@ layer at (0,0) size 785x767
                 text run at (4,4) width 4: " "
             RenderTableCell {TD} at (12,28) size 600x266 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {H3} at (4,4) size 592x24 [color=#0000FF]
-                RenderText {#text} at (0,0) size 220x22
-                  text run at (0,0) width 220: "This sentence should show "
-                RenderInline {STRONG} at (0,0) size 35x22
-                  RenderText {#text} at (220,0) size 35x22
-                    text run at (220,0) width 35: "blue"
-                RenderText {#text} at (255,0) size 42x22
-                  text run at (255,0) width 42: " and "
-                RenderInline {EM} at (0,0) size 51x22 [color=#800080]
-                  RenderText {#text} at (297,1) size 51x22
-                    text run at (297,1) width 51: "purple"
-                RenderText {#text} at (348,0) size 5x22
-                  text run at (348,0) width 5: "."
+                RenderText {#text} at (0,0) size 211x22
+                  text run at (0,0) width 211: "This sentence should show "
+                RenderInline {STRONG} at (0,0) size 33x22
+                  RenderText {#text} at (211,0) size 33x22
+                    text run at (211,0) width 33: "blue"
+                RenderText {#text} at (244,0) size 39x22
+                  text run at (244,0) width 39: " and "
+                RenderInline {EM} at (0,0) size 48x22 [color=#800080]
+                  RenderText {#text} at (283,1) size 48x22
+                    text run at (283,1) width 48: "purple"
+                RenderText {#text} at (331,0) size 5x22
+                  text run at (331,0) width 5: "."
               RenderBlock {H3} at (4,46) size 592x25 [color=#0000FF]
-                RenderText {#text} at (0,0) size 197x22
-                  text run at (0,0) width 197: "This sentence should be "
-                RenderInline {SPAN} at (0,0) size 34x22
-                  RenderText {#text} at (197,1) size 34x22
-                    text run at (197,1) width 34: "blue"
-                RenderText {#text} at (231,0) size 104x22
-                  text run at (231,0) width 104: " throughout."
+                RenderText {#text} at (0,0) size 189x22
+                  text run at (0,0) width 189: "This sentence should be "
+                RenderInline {SPAN} at (0,0) size 32x22
+                  RenderText {#text} at (189,1) size 32x22
+                    text run at (189,1) width 32: "blue"
+                RenderText {#text} at (221,0) size 97x22
+                  text run at (221,0) width 97: " throughout."
               RenderBlock {P} at (4,89) size 592x21
                 RenderText {#text} at (0,0) size 226x19
                   text run at (0,0) width 226: "This should be green except for the "
@@ -140,8 +140,8 @@ layer at (0,0) size 785x767
                 RenderText {#text} at (343,0) size 160x19
                   text run at (343,0) width 160: ", which should be purple."
               RenderBlock {H3} at (4,128) size 592x24 [color=#0000FF]
-                RenderText {#text} at (0,0) size 296x22
-                  text run at (0,0) width 296: "This should be blue and underlined."
+                RenderText {#text} at (0,0) size 280x22
+                  text run at (0,0) width 280: "This should be blue and underlined."
               RenderBlock {P} at (4,169) size 592x21
                 RenderText {#text} at (0,0) size 293x19
                   text run at (0,0) width 293: "This sentence should be underlined, including "

--- a/LayoutTests/platform/wincairo/css1/box_properties/clear_float-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/box_properties/clear_float-expected.txt
@@ -26,8 +26,8 @@ layer at (0,0) size 785x846
           text run at (0,128) width 0: " "
       RenderBlock (floating) {DIV} at (0,200) size 192x126 [color=#FFFFFF] [bgcolor=#008000]
         RenderBlock {H1} at (8,8) size 176x23
-          RenderText {#text} at (0,0) size 83x22
-            text run at (0,0) width 83: "Top menu"
+          RenderText {#text} at (0,0) size 84x22
+            text run at (0,0) width 84: "Top menu"
         RenderBlock {UL} at (24,34) size 156x81
           RenderListItem {LI} at (0,0) size 156x20
             RenderListMarker at (-18,0) size 7x19: bullet
@@ -47,8 +47,8 @@ layer at (0,0) size 785x846
               text run at (0,0) width 87: "0.5em margin"
       RenderBlock (floating) {DIV} at (0,335) size 192x126 [color=#FFFFFF] [bgcolor=#0000FF]
         RenderBlock {H1} at (8,8) size 176x23
-          RenderText {#text} at (0,0) size 112x22
-            text run at (0,0) width 112: "Bottom menu"
+          RenderText {#text} at (0,0) size 113x22
+            text run at (0,0) width 113: "Bottom menu"
         RenderBlock {UL} at (24,34) size 156x81
           RenderListItem {LI} at (0,0) size 156x20
             RenderListMarker at (-18,0) size 7x19: bullet
@@ -96,8 +96,8 @@ layer at (0,0) size 785x846
             RenderTableCell {TD} at (12,28) size 563x364 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
               RenderBlock (floating) {DIV} at (4,4) size 192x126 [color=#FFFFFF] [bgcolor=#008000]
                 RenderBlock {H1} at (8,8) size 176x23
-                  RenderText {#text} at (0,0) size 83x22
-                    text run at (0,0) width 83: "Top menu"
+                  RenderText {#text} at (0,0) size 84x22
+                    text run at (0,0) width 84: "Top menu"
                 RenderBlock {UL} at (24,34) size 156x81
                   RenderListItem {LI} at (0,0) size 156x20
                     RenderListMarker at (-18,0) size 7x19: bullet
@@ -117,8 +117,8 @@ layer at (0,0) size 785x846
                       text run at (0,0) width 87: "0.5em margin"
               RenderBlock (floating) {DIV} at (4,139) size 192x126 [color=#FFFFFF] [bgcolor=#0000FF]
                 RenderBlock {H1} at (8,8) size 176x23
-                  RenderText {#text} at (0,0) size 112x22
-                    text run at (0,0) width 112: "Bottom menu"
+                  RenderText {#text} at (0,0) size 113x22
+                    text run at (0,0) width 113: "Bottom menu"
                 RenderBlock {UL} at (24,34) size 156x81
                   RenderListItem {LI} at (0,0) size 156x20
                     RenderListMarker at (-18,0) size 7x19: bullet

--- a/LayoutTests/platform/wincairo/css1/font_properties/font-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/font_properties/font-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x4293
+layer at (0,0) size 785x4287
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x4293
-  RenderBlock {HTML} at (0,0) size 785x4293
-    RenderBody {BODY} at (8,8) size 769x4277 [bgcolor=#CCCCCC]
+layer at (0,0) size 785x4287
+  RenderBlock {HTML} at (0,0) size 785x4287
+    RenderBody {BODY} at (8,8) size 769x4271 [bgcolor=#CCCCCC]
       RenderBlock {P} at (0,0) size 769x16
         RenderText {#text} at (0,0) size 264x15
           text run at (0,0) width 264: "The style declarations which apply to the text below are:"
@@ -37,8 +37,8 @@ layer at (0,0) size 785x4293
           text run at (0,0) width 422: "This element is unstyled, and should inherit a font-size of 12px from the BODY element. "
           text run at (422,0) width 283: "This is the \"base font size\" referred to in the following tests."
       RenderBlock {P} at (0,267) size 769x22
-        RenderText {#text} at (0,0) size 495x20
-          text run at (0,0) width 495: "This element should be 13pt. Helvetica which is in small-cap italics."
+        RenderText {#text} at (0,0) size 500x20
+          text run at (0,0) width 500: "This element should be 13pt. Helvetica which is in small-cap italics."
       RenderBlock {P} at (0,306) size 769x82
         RenderText {#text} at (0,3) size 762x74
           text run at (0,3) width 282: "This element should be in a serif font. "
@@ -104,12 +104,13 @@ layer at (0,0) size 785x4293
           text run at (0,79) width 176: "element's font size). "
           text run at (176,79) width 500: "Extra text is included for the purposes of testing this more"
           text run at (0,115) width 92: "effectively."
-      RenderBlock {P} at (0,1537) size 769x51
-        RenderText {#text} at (0,6) size 754x38
-          text run at (0,6) width 301: "This element should be in a sans-serif font, with a weight of 400. "
-          text run at (301,6) width 453: "Its font-size should be 80% of 12px, or 9.6px, and its line-height shoud be 2.5 times that, or 24px."
-          text run at (0,31) width 317: "Extra text is included for the purposes of testing this more effectively."
-      RenderBlock {P} at (0,1605) size 769x217
+      RenderBlock {P} at (0,1537) size 769x47
+        RenderText {#text} at (0,5) size 738x36
+          text run at (0,5) width 274: "This element should be in a sans-serif font, with a weight of 400. "
+          text run at (274,5) width 413: "Its font-size should be 80% of 12px, or 9.6px, and its line-height shoud be 2.5 times that, or 24px. "
+          text run at (687,5) width 51: "Extra text is"
+          text run at (0,28) width 236: "included for the purposes of testing this more effectively."
+      RenderBlock {P} at (0,1601) size 769x217
         RenderInline {SPAN} at (0,0) size 766x184 [bgcolor=#C0C0C0]
           RenderText {#text} at (0,16) size 766x184
             text run at (0,16) width 699: "This element should be in a sans-serif font, italicized and small caps, with a weight of 100. "
@@ -118,26 +119,26 @@ layer at (0,0) size 785x4293
             text run at (0,124) width 748: "54px, respectively). The text should have a silver background. The background color has been set"
             text run at (0,178) width 678: "on an inline element and should therefore only cover the text, not the interline spacing."
         RenderText {#text} at (0,0) size 0x0
-      RenderTable {TABLE} at (0,1839) size 769x2438 [border: (1px outset #808080)]
-        RenderTableSection {TBODY} at (1,1) size 767x2436
+      RenderTable {TABLE} at (0,1835) size 769x2436 [border: (1px outset #808080)]
+        RenderTableSection {TBODY} at (1,1) size 767x2434
           RenderTableRow {TR} at (0,0) size 767x28
             RenderTableCell {TD} at (0,0) size 767x28 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=0 c=0 rs=1 cs=2]
               RenderInline {STRONG} at (0,0) size 160x19
                 RenderText {#text} at (4,4) size 160x19
                   text run at (4,4) width 160: "TABLE Testing Section"
-          RenderTableRow {TR} at (0,28) size 767x2408
-            RenderTableCell {TD} at (0,1217) size 12x29 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
+          RenderTableRow {TR} at (0,28) size 767x2406
+            RenderTableCell {TD} at (0,1216) size 12x29 [bgcolor=#C0C0C0] [border: (1px inset #808080)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (4,3) size 4x21
                 text run at (4,4) width 4: " "
-            RenderTableCell {TD} at (12,28) size 755x2408 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (12,28) size 755x2406 [border: (1px inset #808080)] [r=1 c=1 rs=1 cs=1]
               RenderBlock {P} at (4,4) size 747x40
                 RenderText {#text} at (0,0) size 731x39
                   text run at (0,0) width 563: "This element is unstyled, and should inherit a font-size of 12px from the BODY element. "
                   text run at (563,0) width 168: "This is the \"base font size\""
                   text run at (0,20) width 204: "referred to in the following tests."
               RenderBlock {P} at (4,61) size 747x22
-                RenderText {#text} at (0,0) size 495x20
-                  text run at (0,0) width 495: "This element should be 13pt. Helvetica which is in small-cap italics."
+                RenderText {#text} at (0,0) size 500x20
+                  text run at (0,0) width 500: "This element should be 13pt. Helvetica which is in small-cap italics."
               RenderBlock {P} at (4,106) size 747x145
                 RenderText {#text} at (0,4) size 735x135
                   text run at (0,4) width 374: "This element should be in a serif font. "
@@ -208,13 +209,13 @@ layer at (0,0) size 785x4293
                   text run at (0,79) width 176: "element's font size). "
                   text run at (176,79) width 500: "Extra text is included for the purposes of testing this more"
                   text run at (0,115) width 92: "effectively."
-              RenderBlock {P} at (4,1883) size 747x65
-                RenderText {#text} at (0,8) size 714x48
-                  text run at (0,8) width 378: "This element should be in a sans-serif font, with a weight of 400. "
-                  text run at (378,8) width 336: "Its font-size should be 80% of 12px, or 9.6px, and its line-"
-                  text run at (0,40) width 235: "height shoud be 2.5 times that, or 24px. "
-                  text run at (235,40) width 403: "Extra text is included for the purposes of testing this more effectively."
-              RenderBlock {P} at (4,1971) size 747x433
+              RenderBlock {P} at (4,1883) size 747x63
+                RenderText {#text} at (0,7) size 736x47
+                  text run at (0,7) width 373: "This element should be in a sans-serif font, with a weight of 400. "
+                  text run at (373,7) width 363: "Its font-size should be 80% of 12px, or 9.6px, and its line-height"
+                  text run at (0,38) width 193: "shoud be 2.5 times that, or 24px. "
+                  text run at (193,38) width 392: "Extra text is included for the purposes of testing this more effectively."
+              RenderBlock {P} at (4,1969) size 747x433
                 RenderInline {SPAN} at (0,0) size 747x388 [bgcolor=#C0C0C0]
                   RenderText {#text} at (0,22) size 747x388
                     text run at (0,22) width 701: "This element should be in a sans-serif font, italicized and small caps,"

--- a/LayoutTests/platform/wincairo/css1/font_properties/font_size-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/font_properties/font_size-expected.txt
@@ -59,8 +59,8 @@ layer at (0,0) size 785x2878
         RenderText {#text} at (234,0) size 361x19
           text run at (234,0) width 361: ", which may or may not be the same size as unstyled text."
       RenderBlock {P} at (0,462) size 769x23
-        RenderText {#text} at (0,0) size 377x21
-          text run at (0,0) width 377: "This sentence should be larger than unstyled text."
+        RenderText {#text} at (0,0) size 387x21
+          text run at (0,0) width 387: "This sentence should be larger than unstyled text."
       RenderBlock {P} at (0,503) size 769x17
         RenderText {#text} at (0,0) size 276x15
           text run at (0,0) width 276: "This sentence should be smaller than unstyled text."
@@ -119,11 +119,11 @@ layer at (0,0) size 785x2878
           text run at (0,1) width 695: "This sentence should be half an inch"
           text run at (0,58) width 72: "tall."
       RenderBlock {P} at (0,1050) size 769x46
-        RenderText {#text} at (0,1) size 676x43
-          text run at (0,1) width 676: "This sentence should be one centimeter tall."
+        RenderText {#text} at (0,1) size 674x43
+          text run at (0,1) width 674: "This sentence should be one centimeter tall."
       RenderBlock {P} at (0,1133) size 769x46
-        RenderText {#text} at (0,1) size 682x43
-          text run at (0,1) width 682: "This sentence should be ten millimeters tall."
+        RenderText {#text} at (0,1) size 679x43
+          text run at (0,1) width 679: "This sentence should be ten millimeters tall."
       RenderBlock {P} at (0,1216) size 769x29
         RenderText {#text} at (0,0) size 430x27
           text run at (0,0) width 430: "This sentence should be eighteen points tall."
@@ -169,8 +169,8 @@ layer at (0,0) size 785x2878
                 RenderText {#text} at (234,0) size 361x19
                   text run at (234,0) width 361: ", which may or may not be the same size as unstyled text."
               RenderBlock {P} at (4,79) size 747x23
-                RenderText {#text} at (0,0) size 377x21
-                  text run at (0,0) width 377: "This sentence should be larger than unstyled text."
+                RenderText {#text} at (0,0) size 387x21
+                  text run at (0,0) width 387: "This sentence should be larger than unstyled text."
               RenderBlock {P} at (4,120) size 747x17
                 RenderText {#text} at (0,0) size 276x15
                   text run at (0,0) width 276: "This sentence should be smaller than unstyled text."
@@ -229,11 +229,11 @@ layer at (0,0) size 785x2878
                   text run at (0,1) width 695: "This sentence should be half an inch"
                   text run at (0,58) width 72: "tall."
               RenderBlock {P} at (4,667) size 747x46
-                RenderText {#text} at (0,1) size 676x43
-                  text run at (0,1) width 676: "This sentence should be one centimeter tall."
+                RenderText {#text} at (0,1) size 674x43
+                  text run at (0,1) width 674: "This sentence should be one centimeter tall."
               RenderBlock {P} at (4,750) size 747x46
-                RenderText {#text} at (0,1) size 682x43
-                  text run at (0,1) width 682: "This sentence should be ten millimeters tall."
+                RenderText {#text} at (0,1) size 679x43
+                  text run at (0,1) width 679: "This sentence should be ten millimeters tall."
               RenderBlock {P} at (4,833) size 747x29
                 RenderText {#text} at (0,0) size 430x27
                   text run at (0,0) width 430: "This sentence should be eighteen points tall."

--- a/LayoutTests/platform/wincairo/css1/formatting_model/inline_elements-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/formatting_model/inline_elements-expected.txt
@@ -41,16 +41,16 @@ layer at (0,0) size 785x790
       RenderBlock {P} at (0,387) size 769x64
         RenderText {#text} at (0,0) size 159x15
           text run at (0,0) width 159: "This is a paragraph that has a "
-        RenderInline {SPAN} at (0,0) size 764x93 [border: (12px solid #FF0000)]
-          RenderText {#text} at (173,0) size 764x63
+        RenderInline {SPAN} at (0,0) size 768x93 [border: (12px solid #FF0000)]
+          RenderText {#text} at (173,0) size 768x63
             text run at (173,0) width 553: "very long span in it, and the span has a 12px red border separated from the span by 2pt of padding (the"
-            text run at (0,16) width 764: "difference between the line-height and the font-size), which should overlap with the lines of text above and below the span, since the padding"
+            text run at (0,16) width 768: "difference between the line-height and the font-size), which should overlap with the lines of text above and below the span, since the padding"
             text run at (0,32) width 240: "and border should not effect the line height. "
-            text run at (240,32) width 524: "The span's border should have vertical lines only at the beginning and end of the whole span, not"
+            text run at (240,32) width 525: "The span's border should have vertical lines only at the beginning and end of the whole span, not"
             text run at (0,48) width 69: "on each line."
-        RenderText {#text} at (83,48) size 416x15
+        RenderText {#text} at (83,48) size 418x15
           text run at (83,48) width 4: " "
-          text run at (86,48) width 413: "The line spacing in the whole paragraph should be 12pt, with font-size 10pt."
+          text run at (86,48) width 415: "The line spacing in the whole paragraph should be 12pt, with font-size 10pt."
       RenderTable {TABLE} at (0,464) size 769x311 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 767x308
           RenderTableRow {TR} at (0,0) size 767x28
@@ -86,12 +86,12 @@ layer at (0,0) size 785x790
                 RenderInline {SPAN} at (0,0) size 726x93 [border: (12px solid #FF0000)]
                   RenderText {#text} at (173,0) size 726x63
                     text run at (173,0) width 553: "very long span in it, and the span has a 12px red border separated from the span by 2pt of padding (the"
-                    text run at (0,16) width 716: "difference between the line-height and the font-size), which should overlap with the lines of text above and below the span, since the"
+                    text run at (0,16) width 720: "difference between the line-height and the font-size), which should overlap with the lines of text above and below the span, since the"
                     text run at (0,32) width 288: "padding and border should not effect the line height. "
                     text run at (288,32) width 436: "The span's border should have vertical lines only at the beginning and end of the"
-                    text run at (0,48) width 157: "whole span, not on each line."
-                RenderText {#text} at (171,48) size 416x15
-                  text run at (171,48) width 4: " "
-                  text run at (174,48) width 413: "The line spacing in the whole paragraph should be 12pt, with font-size 10pt."
+                    text run at (0,48) width 158: "whole span, not on each line."
+                RenderText {#text} at (172,48) size 418x15
+                  text run at (172,48) width 4: " "
+                  text run at (175,48) width 415: "The line spacing in the whole paragraph should be 12pt, with font-size 10pt."
 layer at (8,169) size 769x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,161) size 769x2 [border: (1px inset #000000)]

--- a/LayoutTests/platform/wincairo/css1/text_properties/vertical_align-expected.txt
+++ b/LayoutTests/platform/wincairo/css1/text_properties/vertical_align-expected.txt
@@ -143,54 +143,56 @@ layer at (0,0) size 785x4501
           text run at (0,0) width 742: "In the following paragraph, all images should be aligned with the top of the 14-point text, which is identical to the first"
           text run at (0,20) width 661: "section of text, whereas any size text should be aligned with the text baseline (which is the default value)."
       RenderBlock {P} at (0,1482) size 769x329
-        RenderText {#text} at (0,27) size 120x21
-          text run at (0,27) width 120: "This paragraph "
-        RenderImage {IMG} at (120,27) size 9x30
-        RenderText {#text} at (129,27) size 5x21
-          text run at (129,27) width 5: " "
-        RenderInline {SPAN} at (0,0) size 422x53
-          RenderText {#text} at (134,1) size 422x53
-            text run at (134,1) width 422: "contains many images"
-        RenderText {#text} at (556,27) size 5x21
-          text run at (556,27) width 5: " "
-        RenderImage {IMG} at (561,27) size 15x50
-        RenderText {#text} at (576,27) size 5x21
-          text run at (576,27) width 5: " "
+        RenderText {#text} at (0,27) size 114x21
+          text run at (0,27) width 114: "This paragraph "
+        RenderImage {IMG} at (114,27) size 9x30
+        RenderText {#text} at (123,27) size 5x21
+          text run at (123,27) width 5: " "
+        RenderInline {SPAN} at (0,0) size 414x53
+          RenderText {#text} at (128,1) size 414x53
+            text run at (128,1) width 414: "contains many images"
+        RenderText {#text} at (542,27) size 5x21
+          text run at (542,27) width 5: " "
+        RenderImage {IMG} at (547,27) size 15x50
+        RenderText {#text} at (562,27) size 5x21
+          text run at (562,27) width 5: " "
         RenderInline {BIG} at (0,0) size 156x23
-          RenderText {#text} at (581,25) size 156x23
-            text run at (581,25) width 156: "of varying heights"
-        RenderText {#text} at (737,27) size 5x21
-          text run at (737,27) width 5: " "
-        RenderImage {IMG} at (742,27) size 3x10
-        RenderText {#text} at (0,0) size 0x0
-        RenderInline {SMALL} at (0,0) size 69x19
-          RenderText {#text} at (0,126) size 69x19
-            text run at (0,126) width 69: "and widths"
-        RenderText {#text} at (69,125) size 5x21
-          text run at (69,125) width 5: " "
-        RenderImage {IMG} at (74,125) size 6x20
-        RenderText {#text} at (80,125) size 101x21
-          text run at (80,125) width 101: " all of which "
-        RenderImage {IMG} at (181,125) size 20x65
-        RenderText {#text} at (200,125) size 6x21
-          text run at (200,125) width 6: " "
-        RenderInline {SPAN} at (0,0) size 263x42
-          RenderText {#text} at (205,108) size 263x42
-            text run at (205,108) width 263: "should be aligned"
-        RenderText {#text} at (467,125) size 6x21
-          text run at (467,125) width 6: " "
-        RenderImage {IMG} at (472,125) size 11x35
-        RenderText {#text} at (483,125) size 123x21
-          text run at (483,125) width 123: " with the top of "
-        RenderImage {IMG} at (606,125) size 9x30
-        RenderText {#text} at (615,125) size 5x21
-          text run at (615,125) width 5: " "
-        RenderInline {SPAN} at (0,0) size 732x146
-          RenderText {#text} at (620,115) size 19x33
-            text run at (620,115) width 19: "a "
-          RenderInline {SPAN} at (0,0) size 732x193
-            RenderText {#text} at (639,78) size 732x193
-              text run at (639,78) width 93: "14-"
+          RenderText {#text} at (567,25) size 156x23
+            text run at (567,25) width 156: "of varying heights"
+        RenderText {#text} at (723,27) size 5x21
+          text run at (723,27) width 5: " "
+        RenderImage {IMG} at (728,27) size 3x10
+        RenderText {#text} at (731,27) size 5x21
+          text run at (731,27) width 5: " "
+        RenderInline {SMALL} at (0,0) size 759x117
+          RenderText {#text} at (736,28) size 759x117
+            text run at (736,28) width 23: "and"
+            text run at (0,126) width 42: "widths"
+        RenderText {#text} at (42,125) size 5x21
+          text run at (42,125) width 5: " "
+        RenderImage {IMG} at (47,125) size 6x20
+        RenderText {#text} at (53,125) size 97x21
+          text run at (53,125) width 97: " all of which "
+        RenderImage {IMG} at (150,125) size 20x65
+        RenderText {#text} at (169,125) size 6x21
+          text run at (169,125) width 6: " "
+        RenderInline {SPAN} at (0,0) size 267x42
+          RenderText {#text} at (174,108) size 267x42
+            text run at (174,108) width 267: "should be aligned"
+        RenderText {#text} at (440,125) size 6x21
+          text run at (440,125) width 6: " "
+        RenderImage {IMG} at (445,125) size 11x35
+        RenderText {#text} at (456,125) size 117x21
+          text run at (456,125) width 117: " with the top of "
+        RenderImage {IMG} at (573,125) size 9x30
+        RenderText {#text} at (582,125) size 5x21
+          text run at (582,125) width 5: " "
+        RenderInline {SPAN} at (0,0) size 699x146
+          RenderText {#text} at (587,115) size 19x33
+            text run at (587,115) width 19: "a "
+          RenderInline {SPAN} at (0,0) size 699x193
+            RenderText {#text} at (606,78) size 699x193
+              text run at (606,78) width 93: "14-"
               text run at (0,191) width 143: "point"
           RenderText {#text} at (143,228) size 144x33
             text run at (143,228) width 144: " text element"
@@ -207,12 +209,12 @@ layer at (0,0) size 785x4501
         RenderImage {IMG} at (506,238) size 5x15
         RenderText {#text} at (510,238) size 6x21
           text run at (510,238) width 6: " "
-        RenderInline {BIG} at (0,0) size 156x23
-          RenderText {#text} at (515,236) size 156x23
-            text run at (515,236) width 156: "the images appear."
-        RenderText {#text} at (670,238) size 6x21
-          text run at (670,238) width 6: " "
-        RenderImage {IMG} at (675,238) size 28x90
+        RenderInline {BIG} at (0,0) size 157x23
+          RenderText {#text} at (515,236) size 157x23
+            text run at (515,236) width 157: "the images appear."
+        RenderText {#text} at (671,238) size 6x21
+          text run at (671,238) width 6: " "
+        RenderImage {IMG} at (676,238) size 28x90
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,1829) size 769x41
         RenderText {#text} at (0,0) size 749x39
@@ -280,12 +282,12 @@ layer at (0,0) size 785x4501
         RenderImage {IMG} at (294,180) size 5x16
         RenderText {#text} at (298,176) size 5x20
           text run at (298,176) width 5: " "
-        RenderInline {BIG} at (0,0) size 156x24
-          RenderText {#text} at (302,173) size 156x24
-            text run at (302,173) width 156: "the images appear."
-        RenderText {#text} at (457,176) size 5x20
-          text run at (457,176) width 5: " "
-        RenderImage {IMG} at (461,142) size 28x91
+        RenderInline {BIG} at (0,0) size 157x24
+          RenderText {#text} at (302,173) size 157x24
+            text run at (302,173) width 157: "the images appear."
+        RenderText {#text} at (458,176) size 5x20
+          text run at (458,176) width 5: " "
+        RenderImage {IMG} at (462,142) size 28x91
         RenderText {#text} at (0,0) size 0x0
       RenderBlock {P} at (0,2134) size 769x40
         RenderText {#text} at (0,0) size 733x39
@@ -369,10 +371,10 @@ layer at (0,0) size 785x4501
         RenderInline {BIG} at (0,0) size 743x88
           RenderText {#text} at (654,48) size 743x88
             text run at (654,48) width 89: "whichever"
-            text run at (0,113) width 207: "line the elements appear."
-        RenderText {#text} at (207,113) size 4x19
-          text run at (207,113) width 4: " "
-        RenderImage {IMG} at (211,113) size 27x90
+            text run at (0,113) width 208: "line the elements appear."
+        RenderText {#text} at (208,113) size 4x19
+          text run at (208,113) width 4: " "
+        RenderImage {IMG} at (212,113) size 27x90
         RenderText {#text} at (0,0) size 0x0
       RenderTable {TABLE} at (0,2409) size 769x2076 [border: (1px outset #808080)]
         RenderTableSection {TBODY} at (1,1) size 767x2074
@@ -487,25 +489,25 @@ layer at (0,0) size 785x4501
                   text run at (0,0) width 742: "In the following paragraph, all images should be aligned with the top of the 14-point text, which is identical to the first"
                   text run at (0,20) width 661: "section of text, whereas any size text should be aligned with the text baseline (which is the default value)."
               RenderBlock {P} at (4,1131) size 747x329
-                RenderText {#text} at (0,27) size 120x21
-                  text run at (0,27) width 120: "This paragraph "
-                RenderImage {IMG} at (120,27) size 9x30
-                RenderText {#text} at (129,27) size 5x21
-                  text run at (129,27) width 5: " "
-                RenderInline {SPAN} at (0,0) size 422x53
-                  RenderText {#text} at (134,1) size 422x53
-                    text run at (134,1) width 422: "contains many images"
-                RenderText {#text} at (556,27) size 5x21
-                  text run at (556,27) width 5: " "
-                RenderImage {IMG} at (561,27) size 15x50
-                RenderText {#text} at (576,27) size 5x21
-                  text run at (576,27) width 5: " "
+                RenderText {#text} at (0,27) size 114x21
+                  text run at (0,27) width 114: "This paragraph "
+                RenderImage {IMG} at (114,27) size 9x30
+                RenderText {#text} at (123,27) size 5x21
+                  text run at (123,27) width 5: " "
+                RenderInline {SPAN} at (0,0) size 414x53
+                  RenderText {#text} at (128,1) size 414x53
+                    text run at (128,1) width 414: "contains many images"
+                RenderText {#text} at (542,27) size 5x21
+                  text run at (542,27) width 5: " "
+                RenderImage {IMG} at (547,27) size 15x50
+                RenderText {#text} at (562,27) size 5x21
+                  text run at (562,27) width 5: " "
                 RenderInline {BIG} at (0,0) size 156x23
-                  RenderText {#text} at (581,25) size 156x23
-                    text run at (581,25) width 156: "of varying heights"
-                RenderText {#text} at (737,27) size 5x21
-                  text run at (737,27) width 5: " "
-                RenderImage {IMG} at (742,27) size 3x10
+                  RenderText {#text} at (567,25) size 156x23
+                    text run at (567,25) width 156: "of varying heights"
+                RenderText {#text} at (723,27) size 5x21
+                  text run at (723,27) width 5: " "
+                RenderImage {IMG} at (728,27) size 3x10
                 RenderText {#text} at (0,0) size 0x0
                 RenderInline {SMALL} at (0,0) size 69x19
                   RenderText {#text} at (0,126) size 69x19
@@ -513,28 +515,28 @@ layer at (0,0) size 785x4501
                 RenderText {#text} at (69,125) size 5x21
                   text run at (69,125) width 5: " "
                 RenderImage {IMG} at (74,125) size 6x20
-                RenderText {#text} at (80,125) size 101x21
-                  text run at (80,125) width 101: " all of which "
-                RenderImage {IMG} at (181,125) size 20x65
-                RenderText {#text} at (200,125) size 6x21
-                  text run at (200,125) width 6: " "
-                RenderInline {SPAN} at (0,0) size 263x42
-                  RenderText {#text} at (205,108) size 263x42
-                    text run at (205,108) width 263: "should be aligned"
+                RenderText {#text} at (80,125) size 97x21
+                  text run at (80,125) width 97: " all of which "
+                RenderImage {IMG} at (177,125) size 20x65
+                RenderText {#text} at (196,125) size 6x21
+                  text run at (196,125) width 6: " "
+                RenderInline {SPAN} at (0,0) size 267x42
+                  RenderText {#text} at (201,108) size 267x42
+                    text run at (201,108) width 267: "should be aligned"
                 RenderText {#text} at (467,125) size 6x21
                   text run at (467,125) width 6: " "
                 RenderImage {IMG} at (472,125) size 11x35
-                RenderText {#text} at (483,125) size 123x21
-                  text run at (483,125) width 123: " with the top of "
-                RenderImage {IMG} at (606,125) size 9x30
-                RenderText {#text} at (615,125) size 5x21
-                  text run at (615,125) width 5: " "
-                RenderInline {SPAN} at (0,0) size 732x146
-                  RenderText {#text} at (620,115) size 19x33
-                    text run at (620,115) width 19: "a "
-                  RenderInline {SPAN} at (0,0) size 732x193
-                    RenderText {#text} at (639,78) size 732x193
-                      text run at (639,78) width 93: "14-"
+                RenderText {#text} at (483,125) size 117x21
+                  text run at (483,125) width 117: " with the top of "
+                RenderImage {IMG} at (600,125) size 9x30
+                RenderText {#text} at (609,125) size 5x21
+                  text run at (609,125) width 5: " "
+                RenderInline {SPAN} at (0,0) size 726x146
+                  RenderText {#text} at (614,115) size 19x33
+                    text run at (614,115) width 19: "a "
+                  RenderInline {SPAN} at (0,0) size 726x193
+                    RenderText {#text} at (633,78) size 726x193
+                      text run at (633,78) width 93: "14-"
                       text run at (0,191) width 143: "point"
                   RenderText {#text} at (143,228) size 144x33
                     text run at (143,228) width 144: " text element"
@@ -551,12 +553,12 @@ layer at (0,0) size 785x4501
                 RenderImage {IMG} at (506,238) size 5x15
                 RenderText {#text} at (510,238) size 6x21
                   text run at (510,238) width 6: " "
-                RenderInline {BIG} at (0,0) size 156x23
-                  RenderText {#text} at (515,236) size 156x23
-                    text run at (515,236) width 156: "the images appear."
-                RenderText {#text} at (670,238) size 6x21
-                  text run at (670,238) width 6: " "
-                RenderImage {IMG} at (675,238) size 28x90
+                RenderInline {BIG} at (0,0) size 157x23
+                  RenderText {#text} at (515,236) size 157x23
+                    text run at (515,236) width 157: "the images appear."
+                RenderText {#text} at (671,238) size 6x21
+                  text run at (671,238) width 6: " "
+                RenderImage {IMG} at (676,238) size 28x90
                 RenderText {#text} at (0,0) size 0x0
               RenderBlock {P} at (4,1478) size 747x41
                 RenderText {#text} at (0,0) size 730x39
@@ -624,12 +626,12 @@ layer at (0,0) size 785x4501
                 RenderImage {IMG} at (294,180) size 5x16
                 RenderText {#text} at (298,176) size 5x20
                   text run at (298,176) width 5: " "
-                RenderInline {BIG} at (0,0) size 156x24
-                  RenderText {#text} at (302,173) size 156x24
-                    text run at (302,173) width 156: "the images appear."
-                RenderText {#text} at (457,176) size 5x20
-                  text run at (457,176) width 5: " "
-                RenderImage {IMG} at (461,142) size 28x91
+                RenderInline {BIG} at (0,0) size 157x24
+                  RenderText {#text} at (302,173) size 157x24
+                    text run at (302,173) width 157: "the images appear."
+                RenderText {#text} at (458,176) size 5x20
+                  text run at (458,176) width 5: " "
+                RenderImage {IMG} at (462,142) size 28x91
                 RenderText {#text} at (0,0) size 0x0
               RenderBlock {P} at (4,1783) size 747x40
                 RenderText {#text} at (0,0) size 733x39
@@ -713,10 +715,10 @@ layer at (0,0) size 785x4501
                 RenderInline {BIG} at (0,0) size 743x88
                   RenderText {#text} at (654,48) size 743x88
                     text run at (654,48) width 89: "whichever"
-                    text run at (0,113) width 207: "line the elements appear."
-                RenderText {#text} at (207,113) size 4x19
-                  text run at (207,113) width 4: " "
-                RenderImage {IMG} at (211,113) size 27x90
+                    text run at (0,113) width 208: "line the elements appear."
+                RenderText {#text} at (208,113) size 4x19
+                  text run at (208,113) width 4: " "
+                RenderImage {IMG} at (212,113) size 27x90
                 RenderText {#text} at (0,0) size 0x0
 layer at (8,345) size 769x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,337) size 769x2 [border: (1px inset #000000)]

--- a/LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-023-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-023-expected.txt
@@ -6,18 +6,18 @@ layer at (0,0) size 800x160
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Test passes if the bottom of the \"Filler Text\" below is aligned."
-      RenderTable {TABLE} at (0,36) size 353x100
-        RenderTableSection {TBODY} at (0,0) size 353x100
-          RenderTableRow {TR} at (0,2) size 353x96
+      RenderTable {TABLE} at (0,36) size 347x100
+        RenderTableSection {TBODY} at (0,0) size 347x100
+          RenderTableRow {TR} at (0,2) size 347x96
             RenderTableCell {TD} at (2,27) size 58x18 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 56x16
                 RenderText {#text} at (0,0) size 56x15
                   text run at (0,0) width 56: "Filler Text"
-            RenderTableCell {TD} at (62,15) size 118x34 [r=0 c=1 rs=1 cs=1]
-              RenderBlock {DIV} at (1,1) size 116x32
-                RenderText {#text} at (0,0) size 116x31
-                  text run at (0,0) width 116: "Filler Text"
-            RenderTableCell {TD} at (182,2) size 169x50 [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (62,15) size 112x34 [r=0 c=1 rs=1 cs=1]
+              RenderBlock {DIV} at (1,1) size 110x32
+                RenderText {#text} at (0,0) size 110x31
+                  text run at (0,0) width 110: "Filler Text"
+            RenderTableCell {TD} at (176,2) size 169x50 [r=0 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 167x48
                 RenderText {#text} at (0,1) size 167x46
                   text run at (0,1) width 167: "Filler Text"

--- a/LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-024-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-024-expected.txt
@@ -6,18 +6,18 @@ layer at (0,0) size 800x160
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 388x19
           text run at (0,0) width 388: "Test passes if the bottom of the \"Filler Text\" below is aligned."
-      RenderTable {TABLE} at (0,36) size 353x100
-        RenderTableSection {TBODY} at (0,0) size 353x100
-          RenderTableRow {TR} at (0,2) size 353x96
+      RenderTable {TABLE} at (0,36) size 347x100
+        RenderTableSection {TBODY} at (0,0) size 347x100
+          RenderTableRow {TR} at (0,2) size 347x96
             RenderTableCell {TD} at (2,27) size 58x18 [r=0 c=0 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 56x16
                 RenderText {#text} at (0,0) size 56x15
                   text run at (0,0) width 56: "Filler Text"
-            RenderTableCell {TD} at (62,15) size 118x34 [r=0 c=1 rs=1 cs=1]
-              RenderBlock {DIV} at (1,1) size 116x32
-                RenderText {#text} at (0,0) size 116x31
-                  text run at (0,0) width 116: "Filler Text"
-            RenderTableCell {TD} at (182,2) size 169x50 [r=0 c=2 rs=1 cs=1]
+            RenderTableCell {TD} at (62,15) size 112x34 [r=0 c=1 rs=1 cs=1]
+              RenderBlock {DIV} at (1,1) size 110x32
+                RenderText {#text} at (0,0) size 110x31
+                  text run at (0,0) width 110: "Filler Text"
+            RenderTableCell {TD} at (176,2) size 169x50 [r=0 c=2 rs=1 cs=1]
               RenderBlock {DIV} at (1,1) size 167x48
                 RenderText {#text} at (0,1) size 167x46
                   text run at (0,1) width 167: "Filler Text"

--- a/LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-02-d-agi-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-02-d-agi-expected.txt
@@ -1,85 +1,85 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x360
-  RenderBlock {HTML} at (0,0) size 800x360
-    RenderBody {BODY} at (8,16) size 784x329
+layer at (0,0) size 800x359
+  RenderBlock {HTML} at (0,0) size 800x359
+    RenderBody {BODY} at (8,16) size 784x328
       RenderBlock {P} at (0,0) size 784x40
         RenderText {#text} at (0,0) size 727x39
           text run at (0,0) width 387: "Change your window size. However the lines wrap, the blue "
           text run at (387,0) width 340: "rectanglues should always have their tops on the same"
           text run at (0,20) width 83: "alignment as "
           text run at (83,20) width 204: "other blue rectangles on the line."
-      RenderBlock {P} at (15,56) size 754x273 [color=#0000FF] [bgcolor=#FFFFFF] [border: (1px solid #C0C0C0)]
-        RenderText {#text} at (8,26) size 61x16
-          text run at (8,26) width 61: "xxx "
-        RenderImage {IMG} at (68,26) size 31x31
-        RenderText {#text} at (98,26) size 16x16
-          text run at (98,26) width 16: " "
+      RenderBlock {P} at (15,56) size 754x272 [color=#0000FF] [bgcolor=#FFFFFF] [border: (1px solid #C0C0C0)]
+        RenderText {#text} at (8,25) size 61x16
+          text run at (8,25) width 61: "xxx "
+        RenderImage {IMG} at (68,25) size 31x31
+        RenderText {#text} at (98,25) size 16x16
+          text run at (98,25) width 16: " "
         RenderInline {SPAN} at (0,0) size 115x39 [color=#C0C0C0]
-          RenderText {#text} at (113,8) size 115x39
-            text run at (113,8) width 115: "xxx"
-        RenderText {#text} at (227,26) size 16x16
-          text run at (227,26) width 16: " "
-        RenderImage {IMG} at (242,26) size 51x51
-        RenderText {#text} at (292,26) size 16x16
-          text run at (292,26) width 16: " "
+          RenderText {#text} at (113,7) size 115x39
+            text run at (113,7) width 115: "xxx"
+        RenderText {#text} at (227,25) size 16x16
+          text run at (227,25) width 16: " "
+        RenderImage {IMG} at (242,25) size 51x51
+        RenderText {#text} at (292,25) size 16x16
+          text run at (292,25) width 16: " "
         RenderInline {BIG} at (0,0) size 61x21 [color=#C0C0C0]
-          RenderText {#text} at (307,22) size 61x21
-            text run at (307,22) width 61: "xxx"
-        RenderText {#text} at (367,26) size 16x16
-          text run at (367,26) width 16: " "
-        RenderImage {IMG} at (382,26) size 11x11
-        RenderText {#text} at (392,26) size 16x16
-          text run at (392,26) width 16: " "
+          RenderText {#text} at (307,21) size 61x21
+            text run at (307,21) width 61: "xxx"
+        RenderText {#text} at (367,25) size 16x16
+          text run at (367,25) width 16: " "
+        RenderImage {IMG} at (382,25) size 11x11
+        RenderText {#text} at (392,25) size 16x16
+          text run at (392,25) width 16: " "
         RenderInline {SMALL} at (0,0) size 31x11 [color=#C0C0C0]
-          RenderText {#text} at (407,30) size 31x11
-            text run at (407,30) width 31: "xxx"
-        RenderText {#text} at (437,26) size 16x16
-          text run at (437,26) width 16: " "
-        RenderImage {IMG} at (452,26) size 21x21
-        RenderText {#text} at (472,26) size 76x16
-          text run at (472,26) width 16: " "
-          text run at (487,26) width 61: "xxx "
-        RenderImage {IMG} at (547,26) size 66x66
-        RenderText {#text} at (612,26) size 16x16
-          text run at (612,26) width 16: " "
+          RenderText {#text} at (407,29) size 31x11
+            text run at (407,29) width 31: "xxx"
+        RenderText {#text} at (437,25) size 16x16
+          text run at (437,25) width 16: " "
+        RenderImage {IMG} at (452,25) size 21x21
+        RenderText {#text} at (472,25) size 76x16
+          text run at (472,25) width 16: " "
+          text run at (487,25) width 61: "xxx "
+        RenderImage {IMG} at (547,25) size 66x66
+        RenderText {#text} at (612,25) size 16x16
+          text run at (612,25) width 16: " "
         RenderInline {SPAN} at (0,0) size 91x31 [color=#C0C0C0]
-          RenderText {#text} at (627,14) size 91x31
-            text run at (627,14) width 91: "xxx"
+          RenderText {#text} at (627,13) size 91x31
+            text run at (627,13) width 91: "xxx"
         RenderText {#text} at (0,0) size 0x0
-        RenderImage {IMG} at (8,124) size 36x36
-        RenderText {#text} at (43,124) size 76x16
-          text run at (43,124) width 16: " "
-          text run at (58,124) width 61: "xxx "
-        RenderImage {IMG} at (118,124) size 31x31
-        RenderText {#text} at (148,124) size 16x16
-          text run at (148,124) width 16: " "
+        RenderImage {IMG} at (8,123) size 36x36
+        RenderText {#text} at (43,123) size 76x16
+          text run at (43,123) width 16: " "
+          text run at (58,123) width 61: "xxx "
+        RenderImage {IMG} at (118,123) size 31x31
+        RenderText {#text} at (148,123) size 16x16
+          text run at (148,123) width 16: " "
         RenderInline {SPAN} at (0,0) size 353x24 [color=#C0C0C0]
-          RenderText {#text} at (163,118) size 93x24
-            text run at (163,118) width 93: "xxx "
+          RenderText {#text} at (163,117) size 93x24
+            text run at (163,117) width 93: "xxx "
           RenderInline {SPAN} at (0,0) size 169x57
-            RenderText {#text} at (255,91) size 169x57
-              text run at (255,91) width 169: "xxx"
-          RenderText {#text} at (423,118) size 93x24
-            text run at (423,118) width 93: " xxx"
-        RenderText {#text} at (515,124) size 16x16
-          text run at (515,124) width 16: " "
-        RenderImage {IMG} at (530,124) size 51x51
-        RenderText {#text} at (580,124) size 16x16
-          text run at (580,124) width 16: " "
+            RenderText {#text} at (255,90) size 169x57
+              text run at (255,90) width 169: "xxx"
+          RenderText {#text} at (423,117) size 93x24
+            text run at (423,117) width 93: " xxx"
+        RenderText {#text} at (515,123) size 16x16
+          text run at (515,123) width 16: " "
+        RenderImage {IMG} at (530,123) size 51x51
+        RenderText {#text} at (580,123) size 16x16
+          text run at (580,123) width 16: " "
         RenderInline {SMALL} at (0,0) size 31x11 [color=#C0C0C0]
-          RenderText {#text} at (595,128) size 31x11
-            text run at (595,128) width 31: "xxx"
-        RenderText {#text} at (625,124) size 16x16
-          text run at (625,124) width 16: " "
-        RenderImage {IMG} at (640,124) size 16x16
-        RenderText {#text} at (655,124) size 16x16
-          text run at (655,124) width 16: " "
+          RenderText {#text} at (595,127) size 31x11
+            text run at (595,127) width 31: "xxx"
+        RenderText {#text} at (625,123) size 16x16
+          text run at (625,123) width 16: " "
+        RenderImage {IMG} at (640,123) size 16x16
+        RenderText {#text} at (655,123) size 16x16
+          text run at (655,123) width 16: " "
         RenderInline {BIG} at (0,0) size 61x21 [color=#C0C0C0]
-          RenderText {#text} at (670,120) size 61x21
-            text run at (670,120) width 61: "xxx"
+          RenderText {#text} at (670,119) size 61x21
+            text run at (670,119) width 61: "xxx"
         RenderText {#text} at (0,0) size 0x0
-        RenderImage {IMG} at (8,174) size 91x91
-        RenderText {#text} at (98,174) size 61x16
-          text run at (98,174) width 16: " "
-          text run at (113,174) width 46: "xxx"
+        RenderImage {IMG} at (8,173) size 91x91
+        RenderText {#text} at (98,173) size 61x16
+          text run at (98,173) width 16: " "
+          text run at (113,173) width 46: "xxx"

--- a/LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-04-d-agi-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-04-d-agi-expected.txt
@@ -19,8 +19,8 @@ layer at (0,0) size 800x259
         RenderText {#text} at (78,8) size 16x16
           text run at (78,8) width 16: " "
         RenderInline {SPAN} at (0,0) size 115x39
-          RenderText {#text} at (93,8) size 115x39
-            text run at (93,8) width 115: "xxx"
+          RenderText {#text} at (93,7) size 115x39
+            text run at (93,7) width 115: "xxx"
         RenderText {#text} at (207,8) size 16x16
           text run at (207,8) width 16: " "
         RenderImage {IMG} at (222,8) size 11x11

--- a/LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-00-b-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-00-b-expected.txt
@@ -10,8 +10,8 @@ layer at (0,0) size 800x334
         RenderText {#text} at (0,0) size 214x19
           text run at (0,0) width 214: "This sentence should be the same."
       RenderBlock {P} at (10,60) size 764x22 [color=#000080]
-        RenderText {#text} at (0,0) size 333x21
-          text run at (0,0) width 333: "This sentence should be larger than normal."
+        RenderText {#text} at (0,0) size 342x21
+          text run at (0,0) width 342: "This sentence should be larger than normal."
       RenderBlock {P} at (10,92) size 764x16 [color=#000080]
         RenderText {#text} at (0,0) size 243x15
           text run at (0,0) width 243: "This sentence should be smaller than normal."

--- a/LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-02-b-a-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-02-b-a-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x157
-  RenderBlock {HTML} at (0,0) size 800x157
-    RenderBody {BODY} at (8,16) size 784x133
+layer at (0,0) size 800x156
+  RenderBlock {HTML} at (0,0) size 800x156
+    RenderBody {BODY} at (8,16) size 784x132
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 471x19
           text run at (0,0) width 471: "There should be a solid single uninterrupted smooth column of blue below."
-      RenderBlock {DIV} at (0,36) size 784x97 [color=#000080]
+      RenderBlock {DIV} at (0,36) size 784x96 [color=#000080]
         RenderBlock {DIV} at (0,0) size 784x32
           RenderText {#text} at (0,0) size 32x32
             text run at (0,0) width 32: "x"
-        RenderBlock {DIV} at (0,32) size 784x33
-          RenderText {#text} at (0,0) size 33x33
-            text run at (0,0) width 33: "x"
-        RenderBlock {DIV} at (0,65) size 784x32
+        RenderBlock {DIV} at (0,32) size 784x32
+          RenderText {#text} at (0,-1) size 33x33
+            text run at (0,-1) width 33: "x"
+        RenderBlock {DIV} at (0,64) size 784x32
           RenderText {#text} at (0,0) size 32x32
             text run at (0,0) width 32: "x"

--- a/LayoutTests/platform/wincairo/css2.1/t1508-c527-font-09-b-expected.txt
+++ b/LayoutTests/platform/wincairo/css2.1/t1508-c527-font-09-b-expected.txt
@@ -1,22 +1,21 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x119
-  RenderBlock {HTML} at (0,0) size 800x120
-    RenderBody {BODY} at (8,9) size 784x101 [color=#000080]
-      RenderBlock {P} at (0,0) size 784x100
-        RenderText {#text} at (0,6) size 472x13
-          text run at (0,6) width 472: "This test should be about 10px, sans-serif, and light. There should be about 15px between each line. "
-        RenderInline {SPAN} at (0,0) size 781x88 [color=#C0C0C0]
-          RenderText {#text} at (472,6) size 781x88
-            text run at (472,6) width 277: "dummy text dummy text dummy text dummy text dummy text"
-            text run at (0,31) width 36: "dummy "
-            text run at (36,31) width 336: "text dummy text dummy text dummy text dummy text dummy text dummy "
-            text run at (372,31) width 336: "text dummy text dummy text dummy text dummy text dummy text dummy "
-            text run at (708,31) width 73: "text dummy text"
-            text run at (0,56) width 260: "dummy text dummy text dummy text dummy text dummy "
-            text run at (260,56) width 336: "text dummy text dummy text dummy text dummy text dummy text dummy "
-            text run at (596,56) width 185: "text dummy text dummy text dummy text"
-            text run at (0,81) width 148: "dummy text dummy text dummy "
-            text run at (148,81) width 336: "text dummy text dummy text dummy text dummy text dummy text dummy "
-            text run at (484,81) width 297: "text dummy text dummy text dummy text dummy text dummy text"
+layer at (0,0) size 800x111
+  RenderBlock {HTML} at (0,0) size 800x112
+    RenderBody {BODY} at (8,9) size 784x93 [color=#000080]
+      RenderBlock {P} at (0,0) size 784x92
+        RenderText {#text} at (0,5) size 423x13
+          text run at (0,5) width 423: "This test should be about 10px, sans-serif, and light. There should be about 15px between each line. "
+        RenderInline {SPAN} at (0,0) size 773x82 [color=#C0C0C0]
+          RenderText {#text} at (423,5) size 773x82
+            text run at (423,5) width 299: "dummy text dummy text dummy text dummy text dummy text dummy "
+            text run at (722,5) width 50: "text dummy"
+            text run at (0,28) width 265: "text dummy text dummy text dummy text dummy text dummy "
+            text run at (265,28) width 318: "text dummy text dummy text dummy text dummy text dummy text dummy "
+            text run at (583,28) width 175: "text dummy text dummy text dummy text"
+            text run at (0,51) width 140: "dummy text dummy text dummy "
+            text run at (140,51) width 318: "text dummy text dummy text dummy text dummy text dummy text dummy "
+            text run at (458,51) width 315: "text dummy text dummy text dummy text dummy text dummy text dummy"
+            text run at (0,74) width 318: "text dummy text dummy text dummy text dummy text dummy text dummy "
+            text run at (318,74) width 281: "text dummy text dummy text dummy text dummy text dummy text"
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wincairo/editing/selection/select-text-overflow-ellipsis-expected.txt
+++ b/LayoutTests/platform/wincairo/editing/selection/select-text-overflow-ellipsis-expected.txt
@@ -4,13 +4,13 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {H3} at (0,0) size 784x23
-        RenderText {#text} at (0,0) size 66x22
-          text run at (0,0) width 66: "Test for "
-        RenderInline {A} at (0,0) size 155x22 [color=#0000EE]
-          RenderText {#text} at (66,0) size 155x22
-            text run at (66,0) width 155: "WebKit bug 29968"
-        RenderText {#text} at (221,0) size 560x22
-          text run at (221,0) width 560: ": Selecting text with text-overflow ellipsis should not show cut off text"
+        RenderText {#text} at (0,0) size 65x22
+          text run at (0,0) width 65: "Test for "
+        RenderInline {A} at (0,0) size 146x22 [color=#0000EE]
+          RenderText {#text} at (65,0) size 146x22
+            text run at (65,0) width 146: "WebKit bug 29968"
+        RenderText {#text} at (211,0) size 539x22
+          text run at (211,0) width 539: ": Selecting text with text-overflow ellipsis should not show cut off text"
 layer at (8,50) size 95x20 scrollWidth 121
   RenderBlock {DIV} at (0,41) size 95x21
     RenderText {#text} at (0,0) size 121x19

--- a/LayoutTests/platform/wincairo/fast/css-generated-content/013-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css-generated-content/013-expected.txt
@@ -22,11 +22,11 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,0) size 207x19
           text run at (0,0) width 207: "Should read: \"Chapter: TEST 2\""
       RenderBlock {H3} at (0,183) size 784x24
-        RenderInline (generated) at (0,0) size 118x22
-          RenderText at (0,0) size 118x22
-            text run at (0,0) width 118: "Chapter One: "
-        RenderText {#text} at (118,0) size 64x22
-          text run at (118,0) width 64: "TEST 3"
+        RenderInline (generated) at (0,0) size 114x22
+          RenderText at (0,0) size 114x22
+            text run at (0,0) width 114: "Chapter One: "
+        RenderText {#text} at (114,0) size 63x22
+          text run at (114,0) width 63: "TEST 3"
       RenderBlock (anonymous) at (0,225) size 784x21
         RenderText {#text} at (0,0) size 238x19
           text run at (0,0) width 238: "Should read: \"Chapter One: TEST 3\""

--- a/LayoutTests/platform/wincairo/fast/css-generated-content/014-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css-generated-content/014-expected.txt
@@ -83,8 +83,8 @@ layer at (0,0) size 785x915
           text run at (386,0) width 9: "):"
       RenderBlock {DIV} at (0,506) size 769x169 [border: (1px solid #000000)]
         RenderBlock {H3} at (26,44) size 717x24
-          RenderText {#text} at (0,0) size 48x22
-            text run at (0,0) width 48: "Box 1"
+          RenderText {#text} at (0,0) size 46x22
+            text run at (0,0) width 46: "Box 1"
         RenderBlock {P} at (26,86) size 717x41
           RenderBlock (anonymous) at (0,0) size 717x20
             RenderText {#text} at (0,0) size 650x19
@@ -94,8 +94,8 @@ layer at (0,0) size 785x915
               text run at (0,0) width 111: "generated content"
       RenderBlock {DIV} at (0,699) size 769x170 [border: (1px solid #000000)]
         RenderBlock {H3} at (26,44) size 717x24
-          RenderText {#text} at (0,0) size 48x22
-            text run at (0,0) width 48: "Box 2"
+          RenderText {#text} at (0,0) size 46x22
+            text run at (0,0) width 46: "Box 2"
         RenderBlock {P} at (26,86) size 717x41
           RenderBlock (anonymous) at (0,0) size 717x20
             RenderText {#text} at (0,0) size 628x19

--- a/LayoutTests/platform/wincairo/fast/css-generated-content/015-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css-generated-content/015-expected.txt
@@ -3,18 +3,18 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
-      RenderTable {DIV} at (0,0) size 308x62
-        RenderTableSection (anonymous) at (0,0) size 308x62
-          RenderTableRow (anonymous) at (0,0) size 308x62
-            RenderTableCell (anonymous) at (0,0) size 308x62 [r=0 c=0 rs=1 cs=1]
-              RenderBlock (anonymous) at (0,0) size 308x0
+      RenderTable {DIV} at (0,0) size 294x62
+        RenderTableSection (anonymous) at (0,0) size 294x62
+          RenderTableRow (anonymous) at (0,0) size 294x62
+            RenderTableCell (anonymous) at (0,0) size 294x62 [r=0 c=0 rs=1 cs=1]
+              RenderBlock (anonymous) at (0,0) size 294x0
                 RenderInline {FORM} at (0,0) size 0x0
                   RenderText {#text} at (0,0) size 0x0
-              RenderBlock (anonymous) at (0,0) size 308x23
-                RenderBlock {H3} at (0,0) size 308x23
-                  RenderText {#text} at (0,0) size 308x22
-                    text run at (0,0) width 308: "There should be a fourth dot bellow..."
-              RenderBlock (anonymous) at (0,41) size 308x21
+              RenderBlock (anonymous) at (0,0) size 294x23
+                RenderBlock {H3} at (0,0) size 294x23
+                  RenderText {#text} at (0,0) size 294x22
+                    text run at (0,0) width 294: "There should be a fourth dot bellow..."
+              RenderBlock (anonymous) at (0,41) size 294x21
                 RenderInline {FORM} at (0,0) size 0x19
                 RenderInline (generated) at (0,0) size 4x19
                   RenderText at (0,0) size 4x19

--- a/LayoutTests/platform/wincairo/fast/css/css1_forward_compatible_parsing-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/css1_forward_compatible_parsing-expected.txt
@@ -14,9 +14,9 @@ layer at (0,0) size 800x427
             text run at (0,0) width 776: "Second sentence: this text should be green according to CSS 1 but it should be red according to CSS 2.1. The markup code"
             text run at (0,20) width 751: "is also invalid according to W3C HTML validator but the CSS code is perfectly valid according to W3C CSS validator."
       RenderBlock {H3} at (0,114) size 784x47 [color=#008000] [bgcolor=#FFFFFF]
-        RenderText {#text} at (0,0) size 766x45
-          text run at (0,0) width 766: "Third sentence: this text should be green. The markup code is valid according to W3C HTML"
-          text run at (0,23) width 580: "validator but the CSS code is invalid according to W3C CSS validator."
+        RenderText {#text} at (0,0) size 735x45
+          text run at (0,0) width 735: "Third sentence: this text should be green. The markup code is valid according to W3C HTML"
+          text run at (0,23) width 550: "validator but the CSS code is invalid according to W3C CSS validator."
       RenderBlock {H4} at (0,181) size 784x61 [color=#FF0000] [bgcolor=#FFFFFF]
         RenderText {#text} at (0,0) size 776x59
           text run at (0,0) width 776: "Fourth sentence: this text should be green according to CSS 1 (class name can not start with a dash in CSS 1) but it"

--- a/LayoutTests/platform/wincairo/fast/css/first-line-text-decoration-inherited-from-parent-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/first-line-text-decoration-inherited-from-parent-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {H3} at (0,0) size 784x23
-        RenderText {#text} at (0,0) size 581x22
-          text run at (0,0) width 581: "Test case for First-line text-decoration style inherited from Parent Block"
+        RenderText {#text} at (0,0) size 561x22
+          text run at (0,0) width 561: "Test case for First-line text-decoration style inherited from Parent Block"
       RenderBlock {P} at (0,41) size 784x21
         RenderText {#text} at (0,0) size 453x19
           text run at (0,0) width 453: "The First line text and its text-decoration must be of the same color."

--- a/LayoutTests/platform/wincairo/fast/css/h1-in-section-elements-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/h1-in-section-elements-expected.txt
@@ -49,12 +49,12 @@ layer at (0,0) size 800x417
                   RenderBlock {ARTICLE} at (0,0) size 71x67
                     RenderBlock {SECTION} at (0,0) size 71x67
                       RenderBlock {H1} at (0,24) size 71x19 [border: (1px solid #00FF00)]
-                        RenderText {#text} at (1,1) size 36x15
-                          text run at (1,1) width 36: "MMM"
+                        RenderText {#text} at (1,1) size 39x15
+                          text run at (1,1) width 39: "MMM"
             RenderTableCell {TD} at (77,221) size 73x70 [r=3 c=1 rs=1 cs=1]
               RenderBlock {H5} at (1,25) size 71x19 [border: (1px solid #00FF00)]
-                RenderText {#text} at (1,1) size 36x15
-                  text run at (1,1) width 36: "MMM"
+                RenderText {#text} at (1,1) size 39x15
+                  text run at (1,1) width 39: "MMM"
           RenderTableRow {TR} at (0,292) size 152x72
             RenderTableCell {TD} at (2,292) size 73x72 [r=4 c=0 rs=1 cs=1]
               RenderBlock {SECTION} at (1,1) size 71x69
@@ -113,12 +113,12 @@ layer at (0,0) size 800x417
                   RenderBlock {ARTICLE} at (0,0) size 67x71
                     RenderBlock {SECTION} at (0,0) size 67x71
                       RenderBlock {H1} at (24,0) size 19x71 [border: (1px solid #00FF00)]
-                        RenderText {#text} at (1,1) size 15x36
-                          text run at (1,1) width 36: "MMM"
+                        RenderText {#text} at (1,1) size 15x39
+                          text run at (1,1) width 39: "MMM"
             RenderTableCell {TD} at (221,77) size 70x73 [r=3 c=1 rs=1 cs=1]
               RenderBlock {H5} at (25,1) size 19x71 [border: (1px solid #00FF00)]
-                RenderText {#text} at (1,1) size 15x36
-                  text run at (1,1) width 36: "MMM"
+                RenderText {#text} at (1,1) size 15x39
+                  text run at (1,1) width 39: "MMM"
           RenderTableRow {TR} at (292,0) size 72x152
             RenderTableCell {TD} at (292,2) size 72x73 [r=4 c=0 rs=1 cs=1]
               RenderBlock {SECTION} at (1,1) size 69x71

--- a/LayoutTests/platform/wincairo/fast/css/invalid-percentage-property-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/invalid-percentage-property-expected.txt
@@ -18,5 +18,5 @@ layer at (0,0) size 800x600
             RenderText {#text} at (512,0) size 194x19
               text run at (512,0) width 194: ":%} style are ignored by Safari"
       RenderBlock {H3} at (0,38) size 784x24 [color=#008000]
-        RenderText {#text} at (0,0) size 254x22
-          text run at (0,0) width 254: "This text should show in green."
+        RenderText {#text} at (0,0) size 243x22
+          text run at (0,0) width 243: "This text should show in green."

--- a/LayoutTests/platform/wincairo/fast/css/preserve-user-specified-zoom-level-on-reload-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/preserve-user-specified-zoom-level-on-reload-expected.txt
@@ -4,7 +4,7 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (23,23) size 754x530
       RenderBlock {P} at (0,0) size 753x171
-        RenderText {#text} at (0,1) size 714x169
-          text run at (0,1) width 714: "This test ensures that we preserve the"
+        RenderText {#text} at (0,1) size 713x169
+          text run at (0,1) width 713: "This test ensures that we preserve the"
           text run at (0,58) width 713: "user-specified zoom level of the page"
           text run at (0,115) width 191: "on reload."

--- a/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-center-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-center-expected.txt
@@ -10,29 +10,29 @@ layer at (0,0) size 785x912
         RenderText {#text} at (0,0) size 386x19
           text run at (0,0) width 386: "The text in all boxes should have the text centered in the box."
       RenderBlock {H3} at (0,74) size 769x24
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,158) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,302) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,395) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,489) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,573) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,717) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,810) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,124) size 310x22 clip at (9,125) size 308x20 scrollWidth 718
   RenderBlock {DIV} at (0,116) size 310x23 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 718x19

--- a/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-justify-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-justify-expected.txt
@@ -11,29 +11,29 @@ layer at (0,0) size 785x932
           text run at (0,0) width 739: "LTR text should be aligned with the left hand side of their box. RTL text should be aligned with the right hand side of"
           text run at (0,20) width 60: "their box."
       RenderBlock {H3} at (0,94) size 769x24
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,178) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,322) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,415) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,509) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,593) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,737) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,830) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,144) size 310x22 clip at (9,145) size 308x20 scrollWidth 718
   RenderBlock {DIV} at (0,136) size 310x23 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 718x19

--- a/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-left-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-left-expected.txt
@@ -10,29 +10,29 @@ layer at (0,0) size 785x912
         RenderText {#text} at (0,0) size 484x19
           text run at (0,0) width 484: "The text in all boxes should be left aligned, sticking to the left side of the box"
       RenderBlock {H3} at (0,74) size 769x24
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,158) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,302) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,395) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,489) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,573) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,717) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,810) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,124) size 310x22 clip at (9,125) size 308x20 scrollWidth 718
   RenderBlock {DIV} at (0,116) size 310x23 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 718x19

--- a/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-right-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-right-expected.txt
@@ -10,29 +10,29 @@ layer at (0,0) size 785x912
         RenderText {#text} at (0,0) size 502x19
           text run at (0,0) width 502: "The text in all boxes should be right aligned, sticking to the right side of the box"
       RenderBlock {H3} at (0,74) size 769x24
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,158) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,302) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,395) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,489) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,573) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,717) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,810) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,124) size 310x22 clip at (9,125) size 308x20 scrollWidth 718
   RenderBlock {DIV} at (0,116) size 310x23 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 718x19

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 785x2982
   RenderBlock {HTML} at (0,0) size 785x2982
     RenderBody {BODY} at (8,8) size 769x2954
       RenderBlock {H3} at (0,0) size 769x23
-        RenderText {#text} at (0,0) size 84x22
-          text run at (0,0) width 84: "Single line"
+        RenderText {#text} at (0,0) size 80x22
+          text run at (0,0) width 80: "Single line"
       RenderBlock {H3} at (0,371) size 769x24
-        RenderText {#text} at (0,0) size 79x22
-          text run at (0,0) width 79: "Multi line"
+        RenderText {#text} at (0,0) size 77x22
+          text run at (0,0) width 77: "Multi line"
       RenderBlock {H3} at (0,743) size 769x24
-        RenderText {#text} at (0,0) size 232x22
-          text run at (0,0) width 232: "Containing replaced content"
+        RenderText {#text} at (0,0) size 220x22
+          text run at (0,0) width 220: "Containing replaced content"
       RenderBlock {H3} at (0,1115) size 769x24
-        RenderText {#text} at (0,0) size 396x22
-          text run at (0,0) width 396: "Containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 377x22
+          text run at (0,0) width 377: "Containing replaced content blocking the ellipsis"
       RenderBlock {H3} at (0,1486) size 769x24
-        RenderText {#text} at (0,0) size 197x22
-          text run at (0,0) width 197: "Right-To-Left single line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left single line"
       RenderBlock {H3} at (0,1858) size 769x24
-        RenderText {#text} at (0,0) size 196x22
-          text run at (0,0) width 196: "Right-To-Left Multi line"
+        RenderText {#text} at (0,0) size 191x22
+          text run at (0,0) width 191: "Right-To-Left Multi line"
       RenderBlock {H3} at (0,2230) size 769x24
-        RenderText {#text} at (0,0) size 343x22
-          text run at (0,0) width 343: "Right-To-Left containing replaced content"
+        RenderText {#text} at (0,0) size 328x22
+          text run at (0,0) width 328: "Right-To-Left containing replaced content"
       RenderBlock {H3} at (0,2602) size 769x24
-        RenderText {#text} at (0,0) size 507x22
-          text run at (0,0) width 507: "Right-To-Left containing replaced content blocking the ellipsis"
+        RenderText {#text} at (0,0) size 485x22
+          text run at (0,0) width 485: "Right-To-Left containing replaced content blocking the ellipsis"
 layer at (8,50) size 22x310 clip at (9,51) size 20x308 scrollHeight 718
   RenderBlock {DIV} at (0,41) size 22x311 [border: (1px solid #000000)]
     RenderText {#text} at (1,1) size 19x718

--- a/LayoutTests/platform/wincairo/fast/css/word-space-extra-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/css/word-space-extra-expected.txt
@@ -439,10 +439,10 @@ layer at (0,0) size 785x2595
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,456) size 769x24
         RenderBlock {H3} at (0,0) size 769x23
-          RenderText {#text} at (0,0) size 117x22
-            text run at (0,0) width 18: "In"
-            text run at (38,0) width 15: " a"
-            text run at (73,0) width 44: " span"
+          RenderText {#text} at (0,0) size 112x22
+            text run at (0,0) width 17: "In"
+            text run at (37,0) width 14: " a"
+            text run at (71,0) width 41: " span"
       RenderBlock (anonymous) at (0,497) size 769x301
         RenderInline {SPAN} at (0,0) size 752x259
           RenderText {#text} at (0,0) size 176x19
@@ -951,8 +951,8 @@ layer at (0,0) size 785x2595
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,1306) size 769x24
         RenderBlock {H3} at (0,0) size 769x23
-          RenderText {#text} at (0,0) size 122x22
-            text run at (0,0) width 122: "In a span"
+          RenderText {#text} at (0,0) size 117x22
+            text run at (0,0) width 117: "In a span"
       RenderBlock (anonymous) at (0,1348) size 769x301
         RenderInline {SPAN} at (0,0) size 727x259
           RenderText {#text} at (0,0) size 218x19
@@ -1573,10 +1573,10 @@ layer at (0,0) size 785x2595
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,2157) size 769x24
         RenderBlock {H3} at (0,0) size 769x23
-          RenderText {#text} at (0,0) size 162x22
-            text run at (0,0) width 28: "In"
-            text run at (48,0) width 25: " a"
-            text run at (93,0) width 69: " span"
+          RenderText {#text} at (0,0) size 157x22
+            text run at (0,0) width 27: "In"
+            text run at (47,0) width 24: " a"
+            text run at (91,0) width 66: " span"
       RenderBlock (anonymous) at (0,2199) size 769x381
         RenderInline {SPAN} at (0,0) size 760x379
           RenderText {#text} at (0,0) size 423x19

--- a/LayoutTests/platform/wincairo/fast/text/basic/generic-family-changes-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/text/basic/generic-family-changes-expected.txt
@@ -37,7 +37,7 @@ layer at (0,0) size 800x317
             RenderText {#text} at (0,0) size 100x19
               text run at (0,0) width 100: "Should be 16px"
       RenderBlock {P} at (0,271) size 784x22
-        RenderInline {TT} at (0,0) size 124x16
-          RenderInline {SPAN} at (0,0) size 124x21
-            RenderText {#text} at (0,0) size 124x21
-              text run at (0,0) width 124: "Should be 19px"
+        RenderInline {TT} at (0,0) size 125x16
+          RenderInline {SPAN} at (0,0) size 125x21
+            RenderText {#text} at (0,0) size 125x21
+              text run at (0,0) width 125: "Should be 19px"

--- a/LayoutTests/platform/wincairo/fast/text/basic/generic-family-reset-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/text/basic/generic-family-reset-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x584
       RenderBlock {H3} at (0,0) size 784x23
-        RenderText {#text} at (0,0) size 507x23
-          text run at (0,0) width 507: "tt's, font-family inheriting and font-size: a bug"
+        RenderText {#text} at (0,0) size 492x23
+          text run at (0,0) width 492: "tt's, font-family inheriting and font-size: a bug"
       RenderTable {TABLE} at (0,41) size 784x365
         RenderTableSection {TBODY} at (0,0) size 784x364
           RenderTableRow {TR} at (0,10) size 784x200
@@ -38,52 +38,52 @@ layer at (0,0) size 800x600
                 text run at (1,181) width 136: "for a <tt> block."
               RenderBR {BR} at (137,181) size 0x18
           RenderTableRow {TR} at (0,220) size 784x20
-            RenderTableCell {TH} at (10,220) size 380x20 [r=1 c=0 rs=1 cs=1]
-              RenderText {#text} at (168,1) size 43x18
-                text run at (168,1) width 43: "<tt>"
-            RenderTableCell {TH} at (399,220) size 376x20 [r=1 c=1 rs=1 cs=1]
-              RenderText {#text} at (151,1) size 72x18
-                text run at (151,1) width 72: "<span>"
+            RenderTableCell {TH} at (10,220) size 378x20 [r=1 c=0 rs=1 cs=1]
+              RenderText {#text} at (167,1) size 43x18
+                text run at (167,1) width 43: "<tt>"
+            RenderTableCell {TH} at (397,220) size 378x20 [r=1 c=1 rs=1 cs=1]
+              RenderText {#text} at (152,1) size 72x18
+                text run at (152,1) width 72: "<span>"
           RenderTableRow {TR} at (0,250) size 784x18
-            RenderTableCell {TD} at (10,250) size 380x18 [r=2 c=0 rs=1 cs=1]
-              RenderInline {TT} at (0,0) size 267x16
-                RenderText {#text} at (1,1) size 267x16
-                  text run at (1,1) width 267: "font-family: Verdana; font-size: 0.8em;"
+            RenderTableCell {TD} at (10,250) size 378x18 [r=2 c=0 rs=1 cs=1]
+              RenderInline {TT} at (0,0) size 264x16
+                RenderText {#text} at (1,1) size 264x16
+                  text run at (1,1) width 264: "font-family: Verdana; font-size: 0.8em;"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (399,250) size 376x18 [r=2 c=1 rs=1 cs=1]
-              RenderInline {SPAN} at (0,0) size 267x16
-                RenderText {#text} at (1,1) size 267x16
-                  text run at (1,1) width 267: "font-family: Verdana; font-size: 0.8em;"
+            RenderTableCell {TD} at (397,250) size 378x18 [r=2 c=1 rs=1 cs=1]
+              RenderInline {SPAN} at (0,0) size 264x16
+                RenderText {#text} at (1,1) size 264x16
+                  text run at (1,1) width 264: "font-family: Verdana; font-size: 0.8em;"
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,278) size 784x18
-            RenderTableCell {TD} at (10,278) size 380x18 [r=3 c=0 rs=1 cs=1]
-              RenderInline {TT} at (0,0) size 327x16
-                RenderText {#text} at (1,1) size 327x16
-                  text run at (1,1) width 327: "font-family: inherit (Verdana); font-size: 0.8em;"
+            RenderTableCell {TD} at (10,278) size 378x18 [r=3 c=0 rs=1 cs=1]
+              RenderInline {TT} at (0,0) size 323x16
+                RenderText {#text} at (1,1) size 323x16
+                  text run at (1,1) width 323: "font-family: inherit (Verdana); font-size: 0.8em;"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (399,278) size 376x18 [r=3 c=1 rs=1 cs=1]
-              RenderInline {SPAN} at (0,0) size 256x16
-                RenderText {#text} at (1,1) size 256x16
-                  text run at (1,1) width 256: "font-family: inherit; font-size: 0.8em;"
+            RenderTableCell {TD} at (397,278) size 378x18 [r=3 c=1 rs=1 cs=1]
+              RenderInline {SPAN} at (0,0) size 253x16
+                RenderText {#text} at (1,1) size 253x16
+                  text run at (1,1) width 253: "font-family: inherit; font-size: 0.8em;"
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,306) size 784x20
-            RenderTableCell {TD} at (10,306) size 380x20 [r=4 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (10,306) size 378x20 [r=4 c=0 rs=1 cs=1]
               RenderInline {TT} at (0,0) size 322x18
                 RenderText {#text} at (1,1) size 322x18
                   text run at (1,1) width 322: "font-family: Verdana; font-size: 1.0em;"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (399,306) size 376x20 [r=4 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (397,306) size 378x20 [r=4 c=1 rs=1 cs=1]
               RenderInline {SPAN} at (0,0) size 322x18
                 RenderText {#text} at (1,1) size 322x18
                   text run at (1,1) width 322: "font-family: Verdana; font-size: 1.0em;"
               RenderText {#text} at (0,0) size 0x0
           RenderTableRow {TR} at (0,336) size 784x18
-            RenderTableCell {TD} at (10,338) size 380x14 [r=5 c=0 rs=1 cs=1]
+            RenderTableCell {TD} at (10,338) size 378x14 [r=5 c=0 rs=1 cs=1]
               RenderInline {TT} at (0,0) size 186x12
                 RenderText {#text} at (1,1) size 186x12
                   text run at (1,1) width 186: "default font; font-size: 0.8em;"
               RenderText {#text} at (0,0) size 0x0
-            RenderTableCell {TD} at (399,336) size 376x18 [r=5 c=1 rs=1 cs=1]
+            RenderTableCell {TD} at (397,336) size 378x18 [r=5 c=1 rs=1 cs=1]
               RenderInline {SPAN} at (0,0) size 312x16
                 RenderText {#text} at (1,1) size 312x16
                   text run at (1,1) width 312: "font-family: courier; font-size: 0.8em;"

--- a/LayoutTests/platform/wincairo/fast/text/line-breaks-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/text/line-breaks-expected.txt
@@ -8,30 +8,30 @@ layer at (0,0) size 800x489
           text run at (0,0) width 82: "This is good:"
       RenderBlock {DIV} at (0,41) size 100x51
         RenderBlock {P} at (0,0) size 100x50 [border: (1px solid #008000)]
-          RenderText {#text} at (43,1) size 56x47
-            text run at (43,1) width 56: "Lorem"
-            text run at (47,25) width 52: "ipsum"
+          RenderText {#text} at (42,1) size 57x47
+            text run at (42,1) width 57: "Lorem"
+            text run at (46,25) width 53: "ipsum"
       RenderBlock (anonymous) at (0,112) size 784x21
         RenderText {#text} at (0,0) size 284x19
           text run at (0,0) width 284: "The following three should look like \x{201C}good\x{201D}:"
       RenderBlock {DIV} at (0,153) size 100x194
         RenderBlock {P} at (0,0) size 100x50 [border: (1px solid #0000FF)]
-          RenderText {#text} at (43,1) size 56x47
-            text run at (43,1) width 56: "Lorem"
-            text run at (47,25) width 52: "\x{131}psum"
+          RenderText {#text} at (42,1) size 57x47
+            text run at (42,1) width 57: "Lorem"
+            text run at (46,25) width 53: "\x{131}psum"
         RenderBlock {P} at (0,71) size 100x51 [border: (1px solid #0000FF)]
-          RenderText {#text} at (43,1) size 56x47
-            text run at (43,1) width 56: "Lorem"
-            text run at (47,25) width 52: "\x{131}psum"
+          RenderText {#text} at (42,1) size 57x47
+            text run at (42,1) width 57: "Lorem"
+            text run at (46,25) width 53: "\x{131}psum"
         RenderBlock {P} at (0,142) size 100x51 [border: (1px solid #0000FF)]
-          RenderText {#text} at (43,1) size 56x47
-            text run at (43,1) width 56: "Lore\x{1E3F}"
-            text run at (47,25) width 52: "ipsum"
+          RenderText {#text} at (42,1) size 57x47
+            text run at (42,1) width 57: "Lore\x{1E3F}"
+            text run at (46,25) width 53: "ipsum"
       RenderBlock (anonymous) at (0,367) size 784x21
         RenderText {#text} at (0,0) size 73x19
           text run at (0,0) width 73: "This is bad:"
       RenderBlock {DIV} at (0,409) size 100x51
         RenderBlock {P} at (0,0) size 100x50 [border: (1px solid #FF0000)]
-          RenderText {#text} at (38,1) size 61x47
-            text run at (38,1) width 61: "Lorem "
-            text run at (47,25) width 52: "ipsum"
+          RenderText {#text} at (37,1) size 62x47
+            text run at (37,1) width 62: "Lorem "
+            text run at (46,25) width 53: "ipsum"

--- a/LayoutTests/platform/wincairo/fast/transforms/bounding-rect-zoom-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/transforms/bounding-rect-zoom-expected.txt
@@ -4,23 +4,23 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (7,7) size 786x586
       RenderBlock {P} at (0,0) size 786x34
-        RenderText {#text} at (0,0) size 302x16
-          text run at (0,0) width 302: "Tests that these functions account for full page zoom."
-        RenderBR {BR} at (302,0) size 0x16
-        RenderText {#text} at (0,17) size 176x16
-          text run at (0,17) width 176: "There should be no red visible."
+        RenderText {#text} at (0,0) size 306x16
+          text run at (0,0) width 306: "Tests that these functions account for full page zoom."
+        RenderBR {BR} at (306,0) size 0x16
+        RenderText {#text} at (0,17) size 178x16
+          text run at (0,17) width 178: "There should be no red visible."
       RenderTable {TABLE} at (0,48) size 786x23
         RenderTableSection {TBODY} at (0,0) size 786x23
           RenderTableRow {TR} at (0,1) size 786x20
             RenderTableCell {TD} at (1,1) size 183x20 [r=0 c=0 rs=1 cs=1]
-              RenderText {#text} at (0,0) size 146x17
-                text run at (0,0) width 146: "getClientBoundingRect():"
+              RenderText {#text} at (0,0) size 149x17
+                text run at (0,0) width 149: "getClientBoundingRect():"
               RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0
             RenderTableCell {TD} at (185,1) size 599x20 [r=0 c=1 rs=1 cs=1]
-              RenderText {#text} at (0,0) size 96x17
-                text run at (0,0) width 96: "getClientRects():"
+              RenderText {#text} at (0,0) size 99x17
+                text run at (0,0) width 99: "getClientRects():"
               RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0
               RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/wincairo/fast/transforms/transforms-with-zoom-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/transforms/transforms-with-zoom-expected.txt
@@ -4,12 +4,12 @@ layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (0,0) size 800x581
       RenderBlock {P} at (0,0) size 800x22
-        RenderInline {A} at (0,0) size 375x21 [color=#0000EE]
-          RenderText {#text} at (0,0) size 375x21
-            text run at (0,0) width 375: "https://bugs.webkit.org/show_bug.cgi?id=24784"
+        RenderInline {A} at (0,0) size 378x21 [color=#0000EE]
+          RenderText {#text} at (0,0) size 378x21
+            text run at (0,0) width 378: "https://bugs.webkit.org/show_bug.cgi?id=24784"
       RenderBlock {P} at (0,41) size 800x23
-        RenderText {#text} at (0,0) size 639x21
-          text run at (0,0) width 639: "Test transform lengths with zoom. You should see two green squares below, no red."
+        RenderText {#text} at (0,0) size 651x21
+          text run at (0,0) width 651: "Test transform lengths with zoom. You should see two green squares below, no red."
 layer at (120,84) size 120x120
   RenderBlock (positioned) {DIV} at (120,84) size 120x120 [bgcolor=#FF0000]
 layer at (300,84) size 120x120


### PR DESCRIPTION
#### 53c9beee074782ce0c200522de1e26fc232e88d1
<pre>
[WinCairo] Unreviewed test gardening

* LayoutTests/platform/wincairo/TestExpectations:
* LayoutTests/platform/wincairo/compositing/geometry/clipping-foreground-expected.txt:
* LayoutTests/platform/wincairo/compositing/shadows/shadow-drawing-expected.txt:
* LayoutTests/platform/wincairo/css1/basic/inheritance-expected.txt:
* LayoutTests/platform/wincairo/css1/box_properties/clear_float-expected.txt:
* LayoutTests/platform/wincairo/css1/font_properties/font-expected.txt:
* LayoutTests/platform/wincairo/css1/font_properties/font_size-expected.txt:
* LayoutTests/platform/wincairo/css1/formatting_model/inline_elements-expected.txt:
* LayoutTests/platform/wincairo/css1/text_properties/vertical_align-expected.txt:
* LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-023-expected.txt:
* LayoutTests/platform/wincairo/css2.1/20110323/table-height-algorithm-024-expected.txt:
* LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-02-d-agi-expected.txt:
* LayoutTests/platform/wincairo/css2.1/t100801-c544-valgn-04-d-agi-expected.txt:
* LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-00-b-expected.txt:
* LayoutTests/platform/wincairo/css2.1/t1507-c526-font-sz-02-b-a-expected.txt:
* LayoutTests/platform/wincairo/css2.1/t1508-c527-font-09-b-expected.txt:
* LayoutTests/platform/wincairo/editing/selection/select-text-overflow-ellipsis-expected.txt:
* LayoutTests/platform/wincairo/fast/css-generated-content/013-expected.txt:
* LayoutTests/platform/wincairo/fast/css-generated-content/014-expected.txt:
* LayoutTests/platform/wincairo/fast/css-generated-content/015-expected.txt:
* LayoutTests/platform/wincairo/fast/css/css1_forward_compatible_parsing-expected.txt:
* LayoutTests/platform/wincairo/fast/css/first-line-text-decoration-inherited-from-parent-expected.txt:
* LayoutTests/platform/wincairo/fast/css/h1-in-section-elements-expected.txt:
* LayoutTests/platform/wincairo/fast/css/invalid-percentage-property-expected.txt:
* LayoutTests/platform/wincairo/fast/css/preserve-user-specified-zoom-level-on-reload-expected.txt:
* LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-center-expected.txt:
* LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-justify-expected.txt:
* LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-left-expected.txt:
* LayoutTests/platform/wincairo/fast/css/text-overflow-ellipsis-text-align-right-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-expected.txt:
* LayoutTests/platform/wincairo/fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed-expected.txt:
* LayoutTests/platform/wincairo/fast/css/word-space-extra-expected.txt:
* LayoutTests/platform/wincairo/fast/text/basic/generic-family-changes-expected.txt:
* LayoutTests/platform/wincairo/fast/text/basic/generic-family-reset-expected.txt:
* LayoutTests/platform/wincairo/fast/text/line-breaks-expected.txt:
* LayoutTests/platform/wincairo/fast/transforms/bounding-rect-zoom-expected.txt:
* LayoutTests/platform/wincairo/fast/transforms/transforms-with-zoom-expected.txt:

Canonical link: <a href="https://commits.webkit.org/265682@main">https://commits.webkit.org/265682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31ab18b22f611a5e6b859ef38cbf179960b57176

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11814 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/13954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13699 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/9938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/13894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11112 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1300 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->