### PR TITLE
ScrollerMac shouldn't use hardcoded NSControlSize

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -330,7 +330,7 @@ ScrollerMac::~ScrollerMac()
 void ScrollerMac::attach()
 {
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 }
 
@@ -369,7 +369,7 @@ void ScrollerMac::updateValues()
 
 void ScrollerMac::updateScrollbarStyle()
 {
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
     updatePairScrollerImps();
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -72,6 +72,7 @@ public:
 
     FloatSize visibleSize() const;
     bool useDarkAppearance() const;
+    ScrollbarWidth scrollbarWidthStyle() const;
 
     struct Values {
         float value;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -260,6 +260,12 @@ bool ScrollerPairMac::useDarkAppearance() const
     return m_scrollingNode.useDarkAppearanceForScrollbars();
 }
 
+ScrollbarWidth ScrollerPairMac::scrollbarWidthStyle() const
+{
+    // FIXME: This should be based on the element style. See <https://webkit.org/b/257430>
+    return ScrollbarWidth::Auto;
+}
+
 ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientation orientation)
 {
     float position;

--- a/Source/WebCore/platform/mac/ScrollTypesMac.h
+++ b/Source/WebCore/platform/mac/ScrollTypesMac.h
@@ -56,6 +56,20 @@ inline ScrollbarStyle scrollbarStyle(NSScrollerStyle style)
     return ScrollbarStyle::AlwaysVisible;
 }
 
+inline NSControlSize nsControlSizeFromScrollbarWidth(ScrollbarWidth width)
+{
+    switch (width) {
+    case ScrollbarWidth::Auto:
+    case ScrollbarWidth::None:
+        return NSControlSizeRegular;
+    case ScrollbarWidth::Thin:
+        return NSControlSizeSmall;
+    }
+
+    ASSERT_NOT_REACHED();
+    return NSControlSizeRegular;
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -35,6 +35,7 @@
 #import "LocalDefaultSystemAppearance.h"
 #import "NSScrollerImpDetails.h"
 #import "PlatformMouseEvent.h"
+#import "ScrollTypesMac.h"
 #import "ScrollView.h"
 #import "ScrollbarTrackCornerSystemImageMac.h"
 #import <Carbon/Carbon.h>
@@ -142,20 +143,6 @@ static bool gUsesOverlayScrollbars = false;
 
 static ScrollbarButtonsPlacement gButtonPlacement = ScrollbarButtonsDoubleEnd;
 
-static NSControlSize scrollbarWidthToNSControlSize(ScrollbarWidth scrollbarWidth)
-{
-    switch (scrollbarWidth) {
-    case ScrollbarWidth::Auto:
-    case ScrollbarWidth::None:
-        return NSControlSizeRegular;
-    case ScrollbarWidth::Thin:
-        return NSControlSizeSmall;
-    }
-
-    ASSERT_NOT_REACHED();
-    return NSControlSizeRegular;
-}
-
 void ScrollbarThemeMac::didCreateScrollerImp(Scrollbar& scrollbar)
 {
 #if PLATFORM(MAC)
@@ -173,7 +160,7 @@ void ScrollbarThemeMac::registerScrollbar(Scrollbar& scrollbar)
         return;
 
     bool isHorizontal = scrollbar.orientation() == ScrollbarOrientation::Horizontal;
-    auto scrollerImp = retainPtr([NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:scrollbarWidthToNSControlSize(scrollbar.widthStyle()) horizontal:isHorizontal replacingScrollerImp:nil]);
+    auto scrollerImp = retainPtr([NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbar.widthStyle()) horizontal:isHorizontal replacingScrollerImp:nil]);
     scrollbarMap().add(&scrollbar, WTFMove(scrollerImp));
     didCreateScrollerImp(scrollbar);
     updateEnabledState(scrollbar);
@@ -250,7 +237,7 @@ int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, Scrollb
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;
-    NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:scrollbarWidthToNSControlSize(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
+    NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
     return [scrollerImp trackBoxWidth];
     END_BLOCK_OBJC_EXCEPTIONS


### PR DESCRIPTION
#### 78b4149d570a3d45b62b4d6312c7692d2f7f18e4
<pre>
ScrollerMac shouldn&apos;t use hardcoded NSControlSize
<a href="https://bugs.webkit.org/show_bug.cgi?id=258752">https://bugs.webkit.org/show_bug.cgi?id=258752</a>

Reviewed by Simon Fraser.

This patch moves the function to convert from ScrollbarWidth to NSControlSize into ScrollTypesMac.h.
This is then used inside of ScrollerMac instead of a hard coded NSControlSizeRegular.
ScrollerPairMac currently returns a hardcoded ScrollbarWidth::Auto, so this patch has no behaviour changes.

* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::updateScrollbarStyle):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::scrollbarWidthStyle const):
* Source/WebCore/platform/mac/ScrollTypesMac.h:
(WebCore::nsControlSizeFromScrollbarWidth):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::registerScrollbar):
(WebCore::ScrollbarThemeMac::scrollbarThickness):
(WebCore::scrollbarWidthToNSControlSize): Deleted.

Canonical link: <a href="https://commits.webkit.org/265691@main">https://commits.webkit.org/265691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f2d4a2d1267071fa9bd52521791552275247c85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11103 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13723 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17716 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11032 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13913 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10312 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14592 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10992 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->