### PR TITLE
HTMLTableSectionElement.insertRow(0) / HTMLTableRowElement.insertCell(0) do not behave correctly

### DIFF
--- a/LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th-expected.txt
+++ b/LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th-expected.txt
@@ -1,0 +1,15 @@
+Tests that HTMLTableRowElement.insertCell() skips non <td> / <th> children.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS tr.__proto__ is HTMLTableRowElement.prototype
+PASS childNodes.length is 4
+PASS childNodes[0].nodeValue is "TEXT"
+PASS childNodes[1].tagName is "A"
+PASS childNodes[2].innerHTML is "0"
+PASS childNodes[3].innerHTML is "1"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th.html
+++ b/LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/tabular-data.html#dom-tr-insertcell">
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that HTMLTableRowElement.insertCell() skips non &lt;td&gt; / &lt;th&gt; children.");
+var tr = document.createElement("tr");
+shouldBe("tr.__proto__", "HTMLTableRowElement.prototype");
+tr.appendChild(new Text("TEXT"));
+tr.appendChild(document.createElement("a"));
+tr.insertCell(-1).innerHTML = "1";
+// The insertCell() method must create a td element, insert it as a child of the
+// tr element, immediately before the indexth td or th element in the cells
+// collection, and finally must return the newly created td element.
+tr.insertCell(0).innerHTML = "0";
+var childNodes = tr.childNodes;
+shouldBe("childNodes.length", "4");
+shouldBeEqualToString("childNodes[0].nodeValue", "TEXT");
+shouldBeEqualToString("childNodes[1].tagName", "A");
+shouldBeEqualToString("childNodes[2].innerHTML", "0");
+shouldBeEqualToString("childNodes[3].innerHTML", "1");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr-expected.txt
+++ b/LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr-expected.txt
@@ -1,0 +1,15 @@
+Tests that HTMLTableSectionElement.insertRow() skips non <tr> children.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS tb.__proto__ is HTMLTableSectionElement.prototype
+PASS childNodes.length is 4
+PASS childNodes[0].nodeValue is "TEXT"
+PASS childNodes[1].tagName is "A"
+PASS childNodes[2].innerHTML is "0"
+PASS childNodes[3].innerHTML is "1"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr.html
+++ b/LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="help" href="http://www.whatwg.org/specs/web-apps/current-work/multipage/tabular-data.html#dom-tbody-insertrow">
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that HTMLTableSectionElement.insertRow() skips non &lt;tr&gt; children.");
+var tb = document.createElement("tbody");
+shouldBe("tb.__proto__", "HTMLTableSectionElement.prototype");
+tb.appendChild(new Text("TEXT"));
+tb.appendChild(document.createElement("a"));
+tb.insertRow(-1).innerHTML = "1";
+// The insertRow() method must create a tr element, insert it as a child of the
+// table section element, immediately before the indexth tr element in the rows
+// collection, and finally must return the newly created tr element.
+tb.insertRow(0).innerHTML = "0";
+var childNodes = tb.childNodes;
+shouldBe("childNodes.length", "4");
+shouldBeEqualToString("childNodes[0].nodeValue", "TEXT");
+shouldBeEqualToString("childNodes[1].tagName", "A");
+shouldBeEqualToString("childNodes[2].innerHTML", "0");
+shouldBeEqualToString("childNodes[3].innerHTML", "1");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -4,7 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -121,10 +122,10 @@ ExceptionOr<Ref<HTMLTableCellElement>> HTMLTableRowElement::insertCell(int index
         return Exception { IndexSizeError };
     auto cell = HTMLTableCellElement::create(tdTag, document());
     ExceptionOr<void> result;
-    if (index < 0 || index >= numCells)
+    if (numCells == index || index == -1)
         result = appendChild(cell);
     else
-        result = insertBefore(cell, index < 1 ? firstChild() : children->item(index));
+        result = insertBefore(cell, children->item(index));
     if (result.hasException())
         return result.releaseException();
     return cell;

--- a/Source/WebCore/html/HTMLTableSectionElement.cpp
+++ b/Source/WebCore/html/HTMLTableSectionElement.cpp
@@ -4,7 +4,8 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -72,7 +73,7 @@ ExceptionOr<Ref<HTMLTableRowElement>> HTMLTableSectionElement::insertRow(int ind
     if (numRows == index || index == -1)
         result = appendChild(row);
     else
-        result = insertBefore(row, index < 1 ? firstChild() : children->item(index));
+        result = insertBefore(row, children->item(index));
     if (result.hasException())
         return result.releaseException();
     return row;


### PR DESCRIPTION
#### 8e5e36c1b25ec65f2e41dfab2b7ac7a7e9f11944
<pre>
HTMLTableSectionElement.insertRow(0) / HTMLTableRowElement.insertCell(0) do not behave correctly

<a href="https://bugs.webkit.org/show_bug.cgi?id=258768">https://bugs.webkit.org/show_bug.cgi?id=258768</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and Web-Spec [1] [2].

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/2f46be9abd9350909c03b95b2597ee164d1c38b8">https://chromium.googlesource.com/chromium/blink/+/2f46be9abd9350909c03b95b2597ee164d1c38b8</a>

Previously, WebKit was adding the new element before the first node, instead
of before the first `tr` (for insertRow) or `td` / `th` (for insertCell)
element.

[1] <a href="https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-insertrow">https://html.spec.whatwg.org/multipage/tables.html#dom-tbody-insertrow</a>
[2] <a href="https://html.spec.whatwg.org/multipage/tables.html#dom-tr-insertcell">https://html.spec.whatwg.org/multipage/tables.html#dom-tr-insertcell</a>

* Source/WebCore/html/HTMLTableRowElement.cpp:
(HTMLTableRowElement::insertCell): As commit log
* Source/WebCore/html/HTMLTableSectionElement.cpp:
(HTMLTableSectionElement::insertRow): As commit log
* LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr.html: Add Test Case
* LayoutTests/fast/dom/HTMLTableSectionElement/insertRow-skips-non-tr-expected.txt: Add Test Case Expectation
* LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th.html: Add Test Case
* LayoutTests/fast/dom/HTMLTableRowElement/insertCell-skips-non-td-th-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/265768@main">https://commits.webkit.org/265768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53adf01c36d118090a6f5e2c650054d3d9b25425

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13968 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13713 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17709 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11024 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9176 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10302 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10456 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->