### PR TITLE
Scrollbar gutters don't update when scrollbar-width value does

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-expected.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  .line {
+    display: flex;
+  }
+
+  .container {
+    writing-mode: horizontal-tb;
+    direction: ltr;
+    block-size: 200px;
+    inline-size: 200px;
+    overflow-y: hidden;
+    margin: 10px;
+    background: deepskyblue;
+  }
+
+  .content {
+    inline-size: 100%;
+    block-size: 200%;
+    background: lightsalmon;
+  }
+
+  .width-auto {
+    scrollbar-width: auto;
+  }
+
+  .width-thin {
+    scrollbar-width: thin;
+  }
+
+  .width-none {
+    scrollbar-width: none;
+  }
+
+  .gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
+  .gutter-both {
+    scrollbar-gutter: stable both-edges;
+  }
+  </style>
+
+  <div class="line">
+    <div id="stable-auto" class="container gutter-stable width-none">
+      <div class="content"></div>
+    </div>
+    <div id="both-auto" class="container gutter-both width-none">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-thin" class="container gutter-stable width-auto">
+      <div class="content"></div>
+    </div>
+    <div id="both-thin" class="container gutter-both width-auto">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-none" class="container gutter-stable width-thin">
+      <div class="content"></div>
+    </div>
+    <div id="both-none" class="container gutter-both width-thin">
+      <div class="content"></div>
+    </div>
+  </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-ref.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<style>
+  .line {
+    display: flex;
+  }
+
+  .container {
+    writing-mode: horizontal-tb;
+    direction: ltr;
+    block-size: 200px;
+    inline-size: 200px;
+    overflow-y: hidden;
+    margin: 10px;
+    background: deepskyblue;
+  }
+
+  .content {
+    inline-size: 100%;
+    block-size: 200%;
+    background: lightsalmon;
+  }
+
+  .width-auto {
+    scrollbar-width: auto;
+  }
+
+  .width-thin {
+    scrollbar-width: thin;
+  }
+
+  .width-none {
+    scrollbar-width: none;
+  }
+
+  .gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
+  .gutter-both {
+    scrollbar-gutter: stable both-edges;
+  }
+  </style>
+
+  <div class="line">
+    <div id="stable-auto" class="container gutter-stable width-none">
+      <div class="content"></div>
+    </div>
+    <div id="both-auto" class="container gutter-both width-none">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-thin" class="container gutter-stable width-auto">
+      <div class="content"></div>
+    </div>
+    <div id="both-thin" class="container gutter-both width-auto">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-none" class="container gutter-stable width-thin">
+      <div class="content"></div>
+    </div>
+    <div id="both-none" class="container gutter-both width-thin">
+      <div class="content"></div>
+    </div>
+  </div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <meta charset="utf-8">
+  <title>CSS Overflow: test scrollbar-gutter when dynamically update scrollbar-width</title>
+  <link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev">
+  <link rel="help" href="https://drafts.csswg.org/css-overflow-4/#scrollbar-gutter-property">
+  <link rel="match" href="scrollbar-gutter-dynamic-003-ref.html">
+  <script src="/common/reftest-wait.js"></script>
+
+  <style>
+  .line {
+    display: flex;
+  }
+
+  .container {
+    writing-mode: horizontal-tb;
+    direction: ltr;
+    block-size: 200px;
+    inline-size: 200px;
+    overflow: hidden;
+    margin: 10px;
+    background: deepskyblue;
+  }
+
+  .content {
+    inline-size: 100%;
+    block-size: 200%;
+    background: lightsalmon;
+  }
+
+  .width-auto {
+    scrollbar-width: auto;
+  }
+
+  .width-thin {
+    scrollbar-width: thin;
+  }
+
+  .width-none {
+    scrollbar-width: none;
+  }
+
+  .gutter-stable {
+    scrollbar-gutter: stable;
+  }
+
+  .gutter-both {
+    scrollbar-gutter: stable both-edges;
+  }
+  </style>
+
+  <div class="line">
+    <div id="stable-auto" class="container gutter-stable width-auto">
+      <div class="content"></div>
+    </div>
+    <div id="both-auto" class="container gutter-both width-auto">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-thin" class="container gutter-stable width-thin">
+      <div class="content"></div>
+    </div>
+    <div id="both-thin" class="container gutter-both width-thin">
+      <div class="content"></div>
+    </div>
+  </div>
+
+  <div class="line">
+    <div id="stable-none" class="container gutter-stable width-none">
+      <div class="content"></div>
+    </div>
+    <div id="both-none" class="container gutter-both width-none">
+      <div class="content"></div>
+    </div>
+  </div>
+<script>
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    document.getElementById('stable-auto').style.scrollbarWidth = 'none';
+    document.getElementById('both-auto').style.scrollbarWidth = 'none';
+    document.getElementById('stable-thin').style.scrollbarWidth = 'auto';
+    document.getElementById('both-thin').style.scrollbarWidth = 'auto';
+    document.getElementById('stable-none').style.scrollbarWidth = 'thin';
+    document.getElementById('both-none').style.scrollbarWidth = 'thin';
+    takeScreenshot();
+  }));
+</script>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -866,6 +866,9 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.scrollbarGutter != second.scrollbarGutter)
         return true;
 
+    if (first.scrollbarWidth != second.scrollbarWidth)
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
#### 8d00d37d49601fbb0bd5320641f73a91d9bb01a2
<pre>
Scrollbar gutters don&apos;t update when scrollbar-width value does
<a href="https://bugs.webkit.org/show_bug.cgi?id=258770">https://bugs.webkit.org/show_bug.cgi?id=258770</a>

Reviewed by Tim Nguyen.

Correctly diff scrollbar-width inside of RenderStyle::rareDataChangeRequiresLayout.

Scrollbar gutters now correctly repaint.

Add a WPT test that tests this.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-dynamic-003.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):

Canonical link: <a href="https://commits.webkit.org/265726@main">https://commits.webkit.org/265726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ec1f05085230cee2cc77bb635ef0b6aa25b24e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13309 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11847 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13981 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13732 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10592 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13920 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10471 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2822 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->