### PR TITLE
REGRESSION (258177@main): Radio buttons are shifted up on facebook.com account sign up/creation page

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -140,6 +140,10 @@ fast/forms/search/search-padding-cancel-results-buttons.html [ Skip ]
 fast/forms/search/search-results-hidden-crash.html [ Skip ]
 fast/forms/search/search-recent-searches.html [ Skip ]
 
+# Only macOS has fixed size controls.
+fast/forms/fixed-size-checkbox-vertically-centered.html [ Skip ]
+fast/forms/fixed-size-radio-vertically-centered.html [ Skip ]
+
 # Only applicable on platforms with dark mode support
 css-dark-mode [ Skip ]
 fast/css/apple-system-control-colors.html [ Skip ]

--- a/LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered-expected.html
+++ b/LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input[type="checkbox"] {
+    margin-top: 44px;
+    width: 16px;
+    height: 16px;
+}
+
+</style>
+</head>
+<body>
+<input type="checkbox">
+</body>
+</html>

--- a/LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered.html
+++ b/LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input[type="checkbox"] {
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+<input type="checkbox">
+</body>
+</html>

--- a/LayoutTests/fast/forms/fixed-size-radio-vertically-centered-expected.html
+++ b/LayoutTests/fast/forms/fixed-size-radio-vertically-centered-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input[type="radio"] {
+    margin-top: 44px;
+    width: 18px;
+    height: 18px;
+}
+
+</style>
+</head>
+<body>
+<input type="radio">
+</body>
+</html>

--- a/LayoutTests/fast/forms/fixed-size-radio-vertically-centered.html
+++ b/LayoutTests/fast/forms/fixed-size-radio-vertically-centered.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+input[type="radio"] {
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+<input type="radio">
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -38,6 +38,9 @@ fast/events/autoscroll-main-document.html [ Pass ]
 
 fast/forms/enterkeyhint-attribute-values.html [ Pass ]
 
+fast/forms/fixed-size-checkbox-vertically-centered.html [ Pass ]
+fast/forms/fixed-size-radio-vertically-centered.html [ Pass ]
+
 accessibility/smart-invert.html [ Pass ]
 webkit.org/b/189818 accessibility/smart-invert-reference.html [ Pass ImageOnlyFailure ]
 fast/media/mq-inverted-colors-live-update.html [ Pass ]

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h
@@ -41,6 +41,8 @@ private:
     IntSize cellSize(NSControlSize, const ControlStyle&) const override;
     IntOutsets cellOutsets(NSControlSize, const ControlStyle&) const override;
 
+    FloatRect rectForBounds(const FloatRect& bounds, const ControlStyle&) const override;
+
     void draw(GraphicsContext&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) override;
 };
 

--- a/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm
@@ -95,28 +95,25 @@ IntOutsets ToggleButtonMac::cellOutsets(NSControlSize controlSize, const Control
     return (m_owningPart.type() == StyleAppearance::Checkbox ? checkboxOutsets : radioOutsets)[controlSize];
 }
 
+FloatRect ToggleButtonMac::rectForBounds(const FloatRect& bounds, const ControlStyle& style) const
+{
+    auto controlSize = [m_buttonCell controlSize];
+
+    FloatSize size = cellSize(controlSize, style);
+    size.scale(style.zoomFactor);
+
+    auto outsets = cellOutsets(controlSize, style);
+
+    return inflatedRect(bounds, size, outsets, style);
+}
+
 void ToggleButtonMac::draw(GraphicsContext& context, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle& style)
 {
     LocalDefaultSystemAppearance localAppearance(style.states.contains(ControlStyle::State::DarkAppearance), style.accentColor);
 
     GraphicsContextStateSaver stateSaver(context);
 
-    auto controlSize = [m_buttonCell controlSize];
-
-    auto zoomedSize = cellSize(controlSize, style);
-    zoomedSize.scale(style.zoomFactor);
-
-    auto outsets = cellOutsets(controlSize, style);
-    auto zoomedOutsets = FloatBoxExtent {
-        outsets.top() * style.zoomFactor,
-        outsets.right() * style.zoomFactor,
-        outsets.bottom() * style.zoomFactor,
-        outsets.left() * style.zoomFactor
-    };
-
-    auto logicalRect = borderRect.rect();
-    logicalRect.setSize(zoomedSize);
-    logicalRect.expand(zoomedOutsets);
+    auto logicalRect = rectForBounds(borderRect.rect(), style);
 
     if (style.zoomFactor != 1) {
         logicalRect.scale(1 / style.zoomFactor);


### PR DESCRIPTION
#### 462aff8197a6a242af245a355cdd5a4fcb2245bf
<pre>
REGRESSION (258177@main): Radio buttons are shifted up on facebook.com account sign up/creation page
<a href="https://bugs.webkit.org/show_bug.cgi?id=258754">https://bugs.webkit.org/show_bug.cgi?id=258754</a>
rdar://111343119

Reviewed by Wenson Hsieh.

On macOS, &quot;toggle buttons&quot;, which include radio button and checkboxes, are only
drawn at fixed sizes. When painted into a rect larger than their natural size,
the control is automatically vertically centered.

258177@main incorrectly adjusted the rect used to paint these controls to equal
the natural size, rather the size of the element itself. Radio buttons on
facebook.com have a tall size. Consequently, the control is painted at the top
of the box, rather than in the center.

Fix by ensuring the rect used for painting uses the full size of the element.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered-expected.html: Added.
* LayoutTests/fast/forms/fixed-size-checkbox-vertically-centered.html: Added.
* LayoutTests/fast/forms/fixed-size-radio-vertically-centered-expected.html: Added.
* LayoutTests/fast/forms/fixed-size-radio-vertically-centered.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.h:
* Source/WebCore/platform/graphics/mac/controls/ToggleButtonMac.mm:
(WebCore::ToggleButtonMac::rectForBounds const):

Implement `rectForBounds` so that the rect used for painting is accurately reported.

(WebCore::ToggleButtonMac::draw):

Do not constain the paint rect to the natural size of the control.

Canonical link: <a href="https://commits.webkit.org/265694@main">https://commits.webkit.org/265694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97bf45ce2088b95234bd69ae8ce53ac11836da76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13975 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17718 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13915 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9186 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2800 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->