### PR TITLE
Media Controls: Interaction region on visionOS <audio> volume button is too big

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -246,7 +246,7 @@
 
 .media-controls.vision.audio > .bottom.controls-bar,
 .media-controls.vision.audio > .bottom.controls-bar * {
-    --inline-controls-bar-height: 31px;
+    --inline-controls-bar-height: 32px;
 }
 
 .media-controls.vision > .bottom.controls-bar {
@@ -258,6 +258,28 @@
     padding: 10px;
     box-sizing: content-box;
     transform: translateX(-10px);
+}
+
+/* Adjust the padding and margins of the audio buttons to account for their smaller sizes */
+
+.media-controls.vision.audio > .bottom.controls-bar button {
+    border-radius: 50%;
+    padding: 6px;
+    box-sizing: content-box;
+    transform: translateX(-6px);
+}
+
+.media-controls.vision.audio > .bottom.controls-bar button.mute {
+    padding: 3px;
+    transform: translateX(-3px);
+}
+
+.media-controls.vision.audio > .bottom.controls-bar .buttons-container.left {
+    margin-left: -1px;
+}
+
+.media-controls.vision.audio > .bottom.controls-bar .buttons-container.right {
+    margin-left: 6px;
 }
 
 .media-controls.vision > .controls-bar > .background-tint,


### PR DESCRIPTION
#### aede64d8b36a0d1dd1b138674a497ee2f2ba378d
<pre>
Media Controls: Interaction region on visionOS &lt;audio&gt; volume button is too big
<a href="https://bugs.webkit.org/show_bug.cgi?id=258772">https://bugs.webkit.org/show_bug.cgi?id=258772</a>
rdar://110499146

Reviewed by Tim Horton.

The existing padding and margins of the media control bar buttons were designed for button and bar
sizes of the &lt;video&gt; element, which are larger than those of the &lt;audio&gt; element. This caused the
interaction regions of all the audio control bar buttons to be larger than they should.

Fix by reducing the padding to compensate and match the ratio of the &lt;video&gt; buttons&apos; padding, and
adjust the margins to maintain concentricity with the controls bar.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision.audio &gt; .bottom.controls-bar,):
(.media-controls.vision.audio &gt; .bottom.controls-bar button):
(.media-controls.vision.audio &gt; .bottom.controls-bar button.mute):
(.media-controls.vision.audio &gt; .bottom.controls-bar .buttons-container.left):
(.media-controls.vision.audio &gt; .bottom.controls-bar .buttons-container.right):

Canonical link: <a href="https://commits.webkit.org/265739@main">https://commits.webkit.org/265739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dab4497b7b16e6884c5609e48d41b4e8e6b0d295

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13728 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17725 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13921 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9189 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10317 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->