### PR TITLE
Legacy scrollbar corner pseudo styles used despite standard scrollbar property usage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+    scrollbar-color: yellow blue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+    scrollbar-color: yellow blue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color on scrollable areas correctly interacts with ::-webkit-scrollbar-corner</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-006-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+    scrollbar-color: yellow blue;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: purple;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-expected.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color on scrollable areas correctly interacts with ::-webkit-scrollbar-corner on container</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-007-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+    scrollbar-color: yellow blue;
+  }
+
+  .container::-webkit-scrollbar-corner {
+    background-color: purple;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-expected.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<style>
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color on body correctly interacts with ::-webkit-scrollbar-corner on container</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-008-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  body {
+    scrollbar-color: yellow blue;
+  }
+
+  .container {
+    scrollbar-gutter: stable;
+    overflow: auto;
+    height: 200px;
+    min-width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .container::-webkit-scrollbar-corner {
+    background-color: purple;
+  }
+
+  .content {
+    height: 300px;
+    width: 300px;
+    background: red;
+  }
+</style>
+<div id="one" class="container">
+  <div class="content"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color on root correctly interacts with ::-webkit-scrollbar-corner</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-009-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: purple;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-expected.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+</style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<title>CSS Scrollbars: scrollbar-color on root correctly interacts with ::-webkit-scrollbar-corner on body</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="match" href="scrollbar-color-010-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  body {
+    overflow: scroll;
+  }
+
+  body::-webkit-scrollbar-corner {
+    background-color: purple;
+  }
+</style>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4513,10 +4513,19 @@ void LocalFrameView::updateScrollCorner()
     RenderElement* renderer = nullptr;
     std::unique_ptr<RenderStyle> cornerStyle;
     IntRect cornerRect = scrollCornerRect();
-    
-    if (!cornerRect.isEmpty()) {
+    Document* doc = m_frame->document();
+
+    auto usesStandardScrollbarStyle = [](auto& doc) {
+        if (!doc || !doc->documentElement())
+            return false;
+        if (!doc->documentElement()->renderer())
+            return false;
+
+        return doc->documentElement()->renderer()->style().usesStandardScrollbarStyle();
+    };
+
+    if (!(usesStandardScrollbarStyle(doc) || cornerRect.isEmpty())) {
         // Try the <body> element first as a scroll corner source.
-        Document* doc = m_frame->document();
         Element* body = doc ? doc->bodyOrFrameset() : nullptr;
         if (body && body->renderer()) {
             renderer = body->renderer();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1768,7 +1768,7 @@ void RenderLayerScrollableArea::updateScrollCornerStyle()
 {
     auto& renderer = m_layer.renderer();
     RenderElement* actualRenderer = rendererForScrollbar(renderer);
-    auto corner = renderer.hasNonVisibleOverflow() ? actualRenderer->getUncachedPseudoStyle({ PseudoId::ScrollbarCorner }, &actualRenderer->style()) : nullptr;
+    auto corner = (renderer.hasNonVisibleOverflow() && !renderer.style().usesStandardScrollbarStyle()) ? actualRenderer->getUncachedPseudoStyle({ PseudoId::ScrollbarCorner }, &actualRenderer->style()) : nullptr;
 
     if (!corner) {
         clearScrollCorner();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1041,6 +1041,7 @@ public:
 
     bool shouldPlaceVerticalScrollbarOnLeft() const;
 
+    inline bool usesStandardScrollbarStyle() const;
     inline bool usesLegacyScrollbarStyle() const;
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -722,7 +722,8 @@ constexpr LengthType RenderStyle::zeroLength() { return LengthType::Fixed; }
 inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 
 // ignore non-standard ::-webkit-scrollbar when standard properties are in use
-inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoId::Scrollbar) && scrollbarWidth() == ScrollbarWidth::Auto && !scrollbarColor().has_value(); }
+inline bool RenderStyle::usesStandardScrollbarStyle() const { return scrollbarWidth() != ScrollbarWidth::Auto || scrollbarColor().has_value(); }
+inline bool RenderStyle::usesLegacyScrollbarStyle() const { return hasPseudoStyle(PseudoId::Scrollbar) && !usesStandardScrollbarStyle(); }
 
 #if ENABLE(APPLE_PAY)
 inline ApplePayButtonStyle RenderStyle::applePayButtonStyle() const { return static_cast<ApplePayButtonStyle>(m_nonInheritedData->rareData->applePayButtonStyle); }


### PR DESCRIPTION
#### 3ac44ba11fa34b3d06f0baca832d453e14c7f185
<pre>
Legacy scrollbar corner pseudo styles used despite standard scrollbar property usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=258773">https://bugs.webkit.org/show_bug.cgi?id=258773</a>

Reviewed by Simon Fraser.

This patch changes the code that retrieves the ScrollbarCorner pseudo styles to check that there&apos;s no standard
property usage.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-006.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-007.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-008.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-009.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-010.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateScrollCorner):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollCornerStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::usesStandardScrollbarStyle const):
(WebCore::RenderStyle::usesLegacyScrollbarStyle const):

Canonical link: <a href="https://commits.webkit.org/265990@main">https://commits.webkit.org/265990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab8a56167e0a5a96396968ba5438e0c813f86c7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13733 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10594 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13923 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3071 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->