### PR TITLE
pointerevent_movementxy.html?mouse WPT is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_movementxy_mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_movementxy_mouse-expected.txt
@@ -1,7 +1,5 @@
 Pointer Events movementX/Y attribute test
 
-Follow the test instructions with mouse. If you don't have the device skip it.
-
 Test Description: This test checks the movementX/Y properties of pointer events.
 Press down on the black square.
 Move your pointer slowly along a straight line to the red square.
@@ -10,5 +8,5 @@ Test passes if the proper behavior of the events is observed.
 
 
 
-FAIL mouse pointerevent attributes assert_equals: movementX should be 0 for event other than pointermove. expected 0 but got 20
+PASS mouse pointerevent attributes
 

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -84,6 +84,7 @@ Event::Event(const AtomString& eventType, const EventInit& initializer, IsTruste
         initializer.composed ? IsComposed::Yes : IsComposed::No }
 {
     ASSERT(!eventType.isNull());
+    m_isConstructedFromInitializer = true;
 }
 
 Event::~Event() = default;

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -160,6 +160,8 @@ protected:
 
     virtual void receivedTarget() { }
 
+    bool isConstructedFromInitializer() const { return m_isConstructedFromInitializer; }
+
 private:
     explicit Event(MonotonicTime createTime, const AtomString& type, IsTrusted, CanBubble, IsCancelable, IsComposed);
 
@@ -180,6 +182,10 @@ private:
     unsigned m_currentTargetIsInShadowTree : 1;
 
     unsigned m_eventPhase : 2;
+
+    // We consult this flag since the EventInit dictionary takes priority in initializing event attribute values.
+    // See step 4 of https://dom.spec.whatwg.org/#inner-event-creation-steps
+    unsigned m_isConstructedFromInitializer : 1 { false };
 
     AtomString m_type;
 

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -64,6 +64,14 @@ MouseRelatedEvent::MouseRelatedEvent(const AtomString& eventType, const MouseRel
     init(false, IntPoint(0, 0));
 }
 
+static inline bool isMoveEventType(const AtomString& eventType)
+{
+    auto& eventNames = WebCore::eventNames();
+    return eventType == eventNames.mousemoveEvent
+        || eventType == eventNames.pointermoveEvent
+        || eventType == eventNames.touchmoveEvent;
+}
+
 void MouseRelatedEvent::init(bool isSimulated, const IntPoint& windowLocation)
 {
     if (!isSimulated) {
@@ -76,6 +84,11 @@ void MouseRelatedEvent::init(bool isSimulated, const IntPoint& windowLocation)
     }
 
     initCoordinates();
+
+    if (!isConstructedFromInitializer() && !isMoveEventType(type())) {
+        m_movementX = 0;
+        m_movementY = 0;
+    }
 }
 
 void MouseRelatedEvent::initCoordinates()

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -96,12 +96,12 @@ protected:
     // Expose these so MouseEvent::initMouseEvent can set them.
     IntPoint m_screenLocation;
     LayoutPoint m_clientLocation;
-    double m_movementX { 0 };
-    double m_movementY { 0 };
 
 private:
     void init(bool isSimulated, const IntPoint&);
 
+    double m_movementX { 0 };
+    double m_movementY { 0 };
     LayoutPoint m_pageLocation;
     LayoutPoint m_layerLocation;
     LayoutPoint m_offsetLocation;


### PR DESCRIPTION
#### dd9d402d27a3e47ddc81f38df4e81617a6960d48
<pre>
pointerevent_movementxy.html?mouse WPT is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=258780">https://bugs.webkit.org/show_bug.cgi?id=258780</a>
rdar://111635046

Reviewed by Wenson Hsieh.

Currently, we are failing the pointerevent_movementxy.html?mouse WPT
variant with the error &quot;FAIL mouse pointerevent attributes
assert_equals: movementX should be 0 for event other than pointermove.
expected 0 but got 20&quot;. We fail this assertion because events that are
not of the pointermove type have non-zero movementX/Y values.

We address said issue in this commit by:

- Making sure that any event which isn&apos;t of type (mouse/pointer/touch)move
does not have non-zero movementX/movementY fields.
- Hardening against accidentally assigning movementX/movementY fields
outside of initialization, by making said fields private.
- Adjusting the expected result for the now passing WPT.

This commit also introduces some additional state into the
WebCore::Event class, through which we can consult if the Event was
constructed using an EventInit dictionary. We need this information
because the attribute values assigned from the EventInit dictionary
receive priority over other rules dictating the Event attribute.

* LayoutTests/imported/w3c/web-platform-tests/pointerevents/pointerevent_movementxy_mouse-expected.txt:
* Source/WebCore/dom/Event.cpp:
* Source/WebCore/dom/Event.h:
(WebCore::Event::isConstructedFromInitializer const):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::isMoveEventType):
(WebCore::MouseRelatedEvent::init):
* Source/WebCore/dom/MouseRelatedEvent.h:

Canonical link: <a href="https://commits.webkit.org/265730@main">https://commits.webkit.org/265730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53a5c8a4a7db918be9d0fe9f5f53c8131eae7ef2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10636 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17771 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11088 "2 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13966 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9238 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10368 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2823 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14648 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->