### PR TITLE
Fix for an issue while breaking out of an empty list item in case of nested lists

### DIFF
--- a/LayoutTests/editing/inserting/break-out-of-nested-lists-expected.txt
+++ b/LayoutTests/editing/inserting/break-out-of-nested-lists-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Split the inner list into two
+PASS Break out of the first inner list
+PASS Break out of the outer list
+PASS insert XYZ
+

--- a/LayoutTests/editing/inserting/break-out-of-nested-lists.html
+++ b/LayoutTests/editing/inserting/break-out-of-nested-lists.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/assert-selection.js"></script>
+<script>
+// Tests breaking out of empty list item in case of nested lists.
+function insertNewline(selection) {
+  selection.document.execCommand('insertText', false, '\n')
+}
+
+selection_test(
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1|</li><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    insertNewline,
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li><li>|<br></li><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    'Split the inner list into two');
+selection_test(
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li><li>|<br></li><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    insertNewline,
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li></ul>',
+            '<li>|<br></li>',
+            '<ul><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    'Break out of the first inner list');
+selection_test(
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li></ul>',
+            '<li>|<br></li>',
+            '<ul><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    insertNewline,
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li></ul>',
+        '</ol>',
+        '<div>|<br></div>',
+        '<ol>',
+            '<ul><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    'Break out of the outer list');
+
+selection_test(
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li></ul>',
+            '<li>|<br></li>',
+            '<ul><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    'insertText XYZ',
+    [
+        '<div contenteditable><ol>',
+            '<li>one</li>',
+            '<ul><li>1</li></ul>',
+            '<li>XYZ|</li>',
+            '<ul><li>2</li></ul>',
+            '<li>two</li>',
+        '</ol></div>'
+    ],
+    'insert XYZ');
+</script>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -619,29 +619,6 @@ Node* enclosingListChild(Node *node)
     return nullptr;
 }
 
-static HTMLElement* embeddedSublist(Node* listItem)
-{
-    // Check the DOM so that we'll find collapsed sublists without renderers.
-    for (Node* n = listItem->firstChild(); n; n = n->nextSibling()) {
-        if (isListHTMLElement(n))
-            return downcast<HTMLElement>(n);
-    }
-    return nullptr;
-}
-
-static Node* appendedSublist(Node* listItem)
-{
-    // Check the DOM so that we'll find collapsed sublists without renderers.
-    for (Node* n = listItem->nextSibling(); n; n = n->nextSibling()) {
-        if (isListHTMLElement(n))
-            return downcast<HTMLElement>(n);
-        if (isListItem(listItem))
-            return nullptr;
-    }
-    
-    return nullptr;
-}
-
 // FIXME: This function should not need to call isStartOfParagraph/isEndOfParagraph.
 Node* enclosingEmptyListItem(const VisiblePosition& position)
 {
@@ -654,9 +631,6 @@ Node* enclosingEmptyListItem(const VisiblePosition& position)
     VisiblePosition lastInListChild(lastPositionInOrAfterNode(listChildNode));
 
     if (firstInListChild != position || lastInListChild != position)
-        return nullptr;
-
-    if (embeddedSublist(listChildNode) || appendedSublist(listChildNode))
         return nullptr;
 
     return listChildNode;


### PR DESCRIPTION
#### 484172ca1e49d8951d83cc876d92b171f0a0e1dd
<pre>
Fix for an issue while breaking out of an empty list item in case of nested lists

<a href="https://bugs.webkit.org/show_bug.cgi?id=258784">https://bugs.webkit.org/show_bug.cgi?id=258784</a>

Reviewed by Wenson Hsieh.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=164049

In case of nested lists, if we break out of the inner list in such a way that
it is split into two inner lists, then break out of the first inner list
(which lands us in outer list) and then try to break out of the outer list,
it fails. Currently, in such scenario we cannot break out of the outer list.

This is caused by appendedSublist() called from enclosingEmptyListItem().
In appendedSublist() we check if the next sibling of the list item(of outer list)
from which we are trying to break out is a list(second inner list), in this case
we will not consider this list item as an empty one. Thus, we cannot break out.

Extending the check in appendedSublist() so as to additionally check if the
list which is the next sibling of list item from which we are trying to break out
is not a descendant of the outer list(to which list item belongs), fixes the issue.

i.e. Change the following check in appendedSubList()
if (isListElement(n))
    return downcast&lt;HTMLElement&gt;(n);

to

if (isListElement(n) &amp;&amp; !n-&gt;isDescendantOf(enclosingList(listItem)))
    return downcast&lt;HTMLElement&gt;(n);

But further analysis seemed to show that the check
if (embeddedSublist(listChildNode) || appendedSublist(listChildNode))
    return nullptr;

which we do in enclosingEmptyListItem() is not needed. Because in the cases
where the list item from which we are trying to break out has an embeddedSublist
or appendedSublist we would still want to break out of the list. Getting rid of
this check and hence these functions(which are not used anywhere else),
fixes the issue.

* Source/WebCore/editing/Editing.cpp:
(embeddedSublist): Deleted static function
(appendedSublist): Ditto
 (enclosingEmptyListItem): Remove check about above functions
* LayoutTests/editing/inserting/break-out-of-nested-lists.html: Add Test Case
* LayoutTests/editing/inserting/break-out-of-nested-lists-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/265747@main">https://commits.webkit.org/265747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f14568441f50b358817df2d14f853cae72e8703

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11123 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13991 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11842 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13743 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17736 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13930 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10332 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10481 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->