### PR TITLE
[visionOS] Hide ornaments when entering fullscreen

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
@@ -86,4 +86,19 @@ typedef void (^MRUIWindowSceneResizeRequestCompletion)(CGSize grantedSize, NSErr
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
+// FIXME: <rdar://111655142> Import ornaments SPI using framework headers.
+
+@interface MRUIPlatterOrnament : NSObject
+@property (nonatomic, assign, getter=_depthDisplacement, setter=_setDepthDisplacement:) CGFloat depthDisplacement;
+@end
+
+@interface MRUIPlatterOrnamentManager : NSObject
+@property (nonatomic, readonly) NSArray<MRUIPlatterOrnament *> *ornaments;
+@end
+
+@interface UIWindowScene (MRUIPlatterOrnaments)
+@property (nonatomic, readonly) MRUIPlatterOrnamentManager *_mrui_platterOrnamentManager;
+@property (nonatomic, readwrite) BOOL prefersOrnamentsHidden_forLMKOnly;
+@end
+
 #endif // PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -193,12 +193,11 @@ static constexpr NSTimeInterval kAnimationDuration = 0.2;
 static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
 static constexpr CGFloat kDarknessAnimationDuration = 0.6;
 static constexpr CGFloat kOutgoingWindowFadeDuration = 0.4;
-static constexpr CGFloat kOutgoingWindowTranslationDuration = 0.6;
 static constexpr CGFloat kOutgoingWindowZOffset = -150;
 static constexpr CGFloat kIncomingWindowFadeDuration = 0.6;
 static constexpr CGFloat kIncomingWindowFadeDelay = 0.2;
-static constexpr CGFloat kIncomingWindowTranslationDuration = 0.6;
 static constexpr CGFloat kIncomingWindowZOffset = -170;
+static constexpr CGFloat kWindowTranslationDuration = 0.6;
 static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScreenDimming";
 #endif
 
@@ -476,12 +475,17 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 @property (nonatomic, readonly) RSSSceneChromeOptions sceneChromeOptions;
 @property (nonatomic, readonly) MRUISceneResizingBehavior sceneResizingBehavior;
 @property (nonatomic, readonly) MRUIDarknessPreference preferredDarkness;
+@property (nonatomic, readonly) BOOL prefersOrnamentsHidden;
+
+@property (nonatomic, readonly) NSMapTable<MRUIPlatterOrnament *, NSNumber *> *ornamentDepths;
 
 - (id)initWithWindow:(UIWindow *)window;
 
 @end
 
-@implementation WKFullScreenParentWindowState
+@implementation WKFullScreenParentWindowState {
+    RetainPtr<NSMapTable<MRUIPlatterOrnament *, NSNumber *>> _ornamentDepths;
+}
 
 - (id)initWithWindow:(UIWindow *)window
 {
@@ -490,12 +494,26 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
     _transform3D = window.transform3D;
     _windowClass = object_getClass(window);
-    _sceneMinimumSize = window.windowScene.sizeRestrictions.minimumSize;
-    _sceneChromeOptions = window.windowScene.mrui_placement.preferredChromeOptions;
-    _sceneResizingBehavior = window.windowScene.mrui_placement.preferredResizingBehavior;
     _preferredDarkness = UIApplication.sharedApplication.mrui_activeStage.preferredDarkness;
 
+    UIWindowScene *windowScene = window.windowScene;
+    _sceneMinimumSize = windowScene.sizeRestrictions.minimumSize;
+    _sceneChromeOptions = windowScene.mrui_placement.preferredChromeOptions;
+    _sceneResizingBehavior = windowScene.mrui_placement.preferredResizingBehavior;
+    _prefersOrnamentsHidden = windowScene.prefersOrnamentsHidden_forLMKOnly;
+
+    _ornamentDepths = [NSMapTable weakToStrongObjectsMapTable];
+
+    MRUIPlatterOrnamentManager *ornamentManager = windowScene._mrui_platterOrnamentManager;
+    for (MRUIPlatterOrnament *ornament in ornamentManager.ornaments)
+        [_ornamentDepths setObject:@(ornament._depthDisplacement) forKey:ornament];
+
     return self;
+}
+
+- (NSMapTable<MRUIPlatterOrnament *, NSNumber *> *)ornamentDepths
+{
+    return _ornamentDepths.get();
 }
 
 @end
@@ -1557,15 +1575,30 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
     [UIView animateWithDuration:kOutgoingWindowFadeDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
         outWindow.alpha = 0;
+        if (enter)
+            outWindow.windowScene.prefersOrnamentsHidden_forLMKOnly = YES;
     } completion:nil];
 
-    [UIView animateWithDuration:kOutgoingWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+    [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
         outWindow.transform3D = CATransform3DTranslate(outWindow.transform3D, 0, 0, kOutgoingWindowZOffset);
     } completion:nil];
 
-    [UIView animateWithDuration:kIncomingWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+    [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
         inWindow.transform3D = originalState.transform3D;
     } completion:nil];
+
+    for (MRUIPlatterOrnament *ornament in originalState.ornamentDepths) {
+        CGFloat originalDepth = [[originalState.ornamentDepths objectForKey:ornament] floatValue];
+        CGFloat finalDepth = originalDepth;
+        if (enter)
+            finalDepth += kOutgoingWindowZOffset;
+        else
+            [ornament _setDepthDisplacement:originalDepth + kIncomingWindowZOffset];
+
+        [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
+            [ornament _setDepthDisplacement:finalDepth];
+        } completion:nil];
+    }
 
     auto completion = makeBlockPtr([controller = retainPtr(controller), inWindow = retainPtr(inWindow), originalState = retainPtr(originalState), enter, completionHandler = WTFMove(completionHandler)] (BOOL finished) mutable {
         WebKit::resizeScene([inWindow windowScene], [inWindow bounds].size, [controller, inWindow, originalState, enter, completionHandler = WTFMove(completionHandler)]() mutable {
@@ -1594,6 +1627,8 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
     [UIView animateWithDuration:kIncomingWindowFadeDuration delay:kIncomingWindowFadeDelay options:UIViewAnimationOptionCurveEaseInOut animations:^{
         inWindow.alpha = 1;
+        if (!enter)
+            inWindow.windowScene.prefersOrnamentsHidden_forLMKOnly = originalState.prefersOrnamentsHidden;
     } completion:completion.get()];
 }
 


### PR DESCRIPTION
#### d131b55339dfc87378ccda0140cee339e31b242b
<pre>
[visionOS] Hide ornaments when entering fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=258786">https://bugs.webkit.org/show_bug.cgi?id=258786</a>
rdar://111453364

Reviewed by Tim Horton.

Ornaments are smaller pieces of UI associated with a particular window scene.
When performing the fullscreen transition, these pieces of UI should be hidden
alongside the presenting window.

* Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenParentWindowState initWithWindow:]):

Store the original depth of ornaments to restore their depth after exiting fullscreen.

(-[WKFullScreenParentWindowState ornamentDepths]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):

Animate the ornaments as if they were a part of the presenting window, matching
the fade and depth animations.

Canonical link: <a href="https://commits.webkit.org/265733@main">https://commits.webkit.org/265733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/451dbd9f8c0d5969e910aed647c0592fa07f475c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13747 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9980 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17740 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13934 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9208 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10336 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2825 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->