### PR TITLE
Connection::sendSyncMessage changes NoError to Unspecified if there is no decoder

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -779,8 +779,11 @@ auto Connection::sendSyncMessage(SyncRequestID syncRequestID, UniqueRef<Encoder>
 
     popPendingSyncRequestID(syncRequestID);
 
-    if (!replyOrError.decoder)
-        didFailToSendSyncMessage(replyOrError.error != Error::NoError ? replyOrError.error : Error::Unspecified);
+    if (!replyOrError.decoder) {
+        if (replyOrError.error == Error::NoError)
+            replyOrError.error = Error::Unspecified;
+        didFailToSendSyncMessage(replyOrError.error);
+    }
 
     return replyOrError;
 }


### PR DESCRIPTION
#### 660682ad1542a3213cf4bdfb75c433a52faa0630
<pre>
Connection::sendSyncMessage changes NoError to Unspecified if there is no decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=258793">https://bugs.webkit.org/show_bug.cgi?id=258793</a>
rdar://111444264

Reviewed by Kimmo Kinnunen.

If sendSyncMessage return a null decoder along with NoError, callers may think the call succeeded and try to access the return value, which is actually an empty optional.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendSyncMessage):

Canonical link: <a href="https://commits.webkit.org/265736@main">https://commits.webkit.org/265736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00c3a82332440ae93fc529ee5d56045b56ffbe33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11139 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14005 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13759 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9990 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17750 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13944 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9218 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10348 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2828 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->