### PR TITLE
[WPE][GTK] API test `TestWebKitUserContentManager` `/webkit/WebKitUserContentManager/script-message-received` is a timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp
@@ -308,6 +308,8 @@ public:
 
     JSCValue* waitUntilMessageReceived(const char* handlerName)
     {
+        m_scriptMessage = nullptr;
+
         GUniquePtr<char> signalName(g_strdup_printf("script-message-received::%s", handlerName));
         g_signal_connect(m_userContentManager.get(), signalName.get(), G_CALLBACK(scriptMessageReceived), this);
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -257,11 +257,6 @@
                 "expected": {
                     "gtk": {"status": ["FAIL"], "bug": "webkit.org/b/254002"}
                 }
-            },
-            "/webkit/WebKitUserContentManager/script-message-received": {
-                "expected": {
-                    "all": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}
-                }
             }
         }
     },


### PR DESCRIPTION
#### 44564f381a286bca91da3fea7f3de0ddcaae8517
<pre>
[WPE][GTK] API test `TestWebKitUserContentManager` `/webkit/WebKitUserContentManager/script-message-received` is a timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=258797">https://bugs.webkit.org/show_bug.cgi?id=258797</a>

Reviewed by Carlos Garcia Campos.

Since we use one instance of `UserScriptMessageTest` for all tests in
`TestWebKitUserContentManager.cpp`, we must clear the previously
received `m_scriptMessage` every time we `postMessageAndWaitUntilReceived()`.

We&apos;ll get a failed assertion in `scriptMessageReceived()` if we don&apos;t:

```
g_assert_null(test-&gt;m_script Message.get());
```

This regression was introduced in 261320@main.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitUserContentManager.cpp:
(UserScriptMessageTest::waitUntilMessageReceived):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265716@main">https://commits.webkit.org/265716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/645fde0a471872773ed7b2bf496664701fbb5f7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14011 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13766 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17755 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13949 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11178 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10355 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->