### PR TITLE
Update LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js to work around Safari SVG specificites

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6245,7 +6245,6 @@ imported/w3c/web-platform-tests/wasm/serialization/module/cross-origin-module-sh
 imported/w3c/web-platform-tests/wasm/serialization/module/share-module-cross-origin-fails.sub.html [ Skip ]
 imported/w3c/web-platform-tests/wasm/serialization/module/window-domain-success.sub.html [ Skip ]
 imported/w3c/web-platform-tests/wasm/serialization/module/window-similar-but-cross-origin-success.sub.html [ Skip ]
-imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.html [ Skip ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceTransportPolicy.html [ Skip ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-onicecandidateerror.https.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test that timestamp is required when constructing VideoFrame from HTMLImageElement
-TIMEOUT Test that timestamp is required when constructing VideoFrame from SVGImageElement Test timed out
-NOTRUN Test that timeamp is required when constructing VideoFrame from HTMLCanvasElement
+PASS Test that timestamp is required when constructing VideoFrame from SVGImageElement
+PASS Test that timeamp is required when constructing VideoFrame from HTMLCanvasElement
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js
@@ -9,11 +9,15 @@ promise_test(async t => {
 }, 'Test that timestamp is required when constructing VideoFrame from HTMLImageElement');
 
 promise_test(async t => {
-    let svgImageElement = document.createElementNS('http://www.w3.org/2000/svg','image');
-    let loadPromise = new Promise(r => svgImageElement.onload = r);
+    const svgDocument = document.createElementNS('http://www.w3.org/2000/svg','svg');
+    document.body.appendChild(svgDocument);
+    const svgImageElement = document.createElementNS('http://www.w3.org/2000/svg','image');
+    svgDocument.appendChild(svgImageElement);
+    const loadPromise = new Promise(r => svgImageElement.onload = r);
     svgImageElement.setAttributeNS('http://www.w3.org/1999/xlink','href','data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==');
     await loadPromise;
     verifyTimestampRequiredToConstructFrame(svgImageElement);
+    document.body.removeChild(svgDocument);
 }, 'Test that timestamp is required when constructing VideoFrame from SVGImageElement');
 
 promise_test(async t => {


### PR DESCRIPTION
#### 17c12a1a2b68cbb55b97c3c201a2dd80ff982ef9
<pre>
Update LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js to work around Safari SVG specificites
<a href="https://bugs.webkit.org/show_bug.cgi?id=258803">https://bugs.webkit.org/show_bug.cgi?id=258803</a>
rdar://111679627

Reviewed by Eric Carlson.

Without a renderer and being in the DOM, SVG image element is not firing the load event, and does not have a cached image.
We update the test accoridngly, since the goal is to validate timestamps.
Bugs have been filed to track Safari SVG specifities.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-construction.window.js:
(promise_test.async t):

Canonical link: <a href="https://commits.webkit.org/265724@main">https://commits.webkit.org/265724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb2aef07daebd96c88f21619412e0ec5e576c4d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11151 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14017 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13771 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17759 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13953 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9230 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10360 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->