### PR TITLE
MessageEvent::m_data lock is not held when accessed

### DIFF
--- a/Source/WTF/wtf/Locker.h
+++ b/Source/WTF/wtf/Locker.h
@@ -59,7 +59,7 @@ using AdoptLockTag = std::adopt_lock_t;
 constexpr AdoptLockTag AdoptLock;
 
 template<typename T>
-class Locker : public AbstractLocker {
+class [[nodiscard]] Locker : public AbstractLocker { // NOLINT
 public:
     explicit Locker(T& lockable) : m_lockable(&lockable) { lock(); }
     explicit Locker(T* lockable) : m_lockable(lockable) { lock(); }

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -113,7 +113,7 @@ void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool
     initEvent(type, canBubble, cancelable);
 
     {
-        Locker { m_concurrentDataAccessLock };
+        Locker locker { m_concurrentDataAccessLock };
         m_data = JSValueTag { };
     }
     // FIXME: This code is wrong: we should emit a write-barrier. Otherwise, GC can collect it.
@@ -134,7 +134,7 @@ EventInterface MessageEvent::eventInterface() const
 
 size_t MessageEvent::memoryCost() const
 {
-    Locker { m_concurrentDataAccessLock };
+    Locker locker { m_concurrentDataAccessLock };
     return WTF::switchOn(m_data, [] (JSValueTag) -> size_t {
         return 0;
     }, [] (const Ref<SerializedScriptValue>& data) -> size_t {

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -94,7 +94,7 @@ private:
 
     EventInterface eventInterface() const final;
 
-    DataType m_data;
+    DataType m_data WTF_GUARDED_BY_LOCK(m_concurrentDataAccessLock);
     String m_origin;
     String m_lastEventId;
     std::optional<MessageEventSource> m_source;


### PR DESCRIPTION
#### 7b10b122b14d51717dd736bff4dcb6fa64545a2c
<pre>
MessageEvent::m_data lock is not held when accessed
<a href="https://bugs.webkit.org/show_bug.cgi?id=258806">https://bugs.webkit.org/show_bug.cgi?id=258806</a>
rdar://111681401

Reviewed by Yusuke Suzuki.

The unnamed Locker instance is discarded, releasing the lock.
Fix by naming the instance.
Add declarations to prevent similar bugs.

* Source/WTF/wtf/Locker.h:
(WTF::Locker::Locker): Deleted.
(WTF::Locker::~Locker): Deleted.
(WTF::Locker::tryLock): Deleted.
(WTF::Locker::lockable): Deleted.
(WTF::Locker::operator bool const): Deleted.
(WTF::Locker::unlockEarly): Deleted.
(WTF::Locker::operator=): Deleted.
(WTF::Locker::unlock): Deleted.
(WTF::Locker::lock): Deleted.
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::initMessageEvent):
(WebCore::MessageEvent::memoryCost const):
* Source/WebCore/dom/MessageEvent.h:

Canonical link: <a href="https://commits.webkit.org/265732@main">https://commits.webkit.org/265732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02bba32548a9f008a68e663eb5b25a4d10350b45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11153 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14021 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12714 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13774 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17769 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/9962 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11083 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13964 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9234 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11794 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10363 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2824 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14643 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12127 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11043 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2948 "Passed tests") | 
<!--EWS-Status-Bubble-End-->