### PR TITLE
WPT webcodecs/videoFrame-canvasImageSource.html is failing a test due to AV1 usage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL <video> and VideoFrame constructed VideoFrame assert_unreached: Reached unreachable code
+NOTRUN <video> and VideoFrame constructed VideoFrame AV.1 file streaming unsupported
 PASS CSSImageValue constructed VideoFrame
 PASS Image element constructed VideoFrame
 PASS SVGImageElement constructed VideoFrame

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html
@@ -61,7 +61,21 @@ async_test(t => {
     frame.close();
     t.done();
   }));
-  video.src = 'four-colors.mp4';
+
+  const mediaConfig = {
+    type: 'file',
+    video: {
+      contentType: 'video/mp4; codecs="av01.0.04M.08"',
+      width: 320,
+      height: 240,
+      bitrate: 1000000,
+      framerate: '30'
+    }
+  };
+  navigator.mediaCapabilities.decodingInfo(mediaConfig).then(t.step_func(result => {
+    assert_implements_optional(result.supported, "AV.1 file streaming unsupported");
+    video.src = 'four-colors.mp4';
+  }));
 }, '<video> and VideoFrame constructed VideoFrame');
 
 test(t => {


### PR DESCRIPTION
#### 339c8613fecfdd1d8b696085e5aa771a3a1892a5
<pre>
WPT webcodecs/videoFrame-canvasImageSource.html is failing a test due to AV1 usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=258809">https://bugs.webkit.org/show_bug.cgi?id=258809</a>
rdar://111685981

Reviewed by Eric Carlson.

The failing test is using AV.1 video streaming.
Marking it as optional based on whether media capabilities API tells us whether AV.1 video streaming is supported.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-canvasImageSource.html:

Canonical link: <a href="https://commits.webkit.org/267282@main">https://commits.webkit.org/267282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3b0d20668bb48cf83fd807a42a55d069fdb9726

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16183 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16611 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16377 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18713 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21487 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14811 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18046 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/14485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->