### PR TITLE
Progressive JPEG in a composited layer should render while loading

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3185,9 +3185,11 @@ void RenderLayerBacking::updateImageContents(PaintedContentsInfo& contentsInfo)
     if (!image)
         return;
 
+#if (!PLATFORM(GTK) && !PLATFORM(WPE) && !PLATFORM(WIN) && !PLATFORM(PLAYSTATION))
     // We have to wait until the image is fully loaded before setting it on the layer.
     if (!cachedImage->isLoaded())
         return;
+#endif
 
     updateContentsRects();
     m_graphicsLayer->setContentsToImage(image);


### PR DESCRIPTION
<pre>
Progressive JPEG in a composited layer should render while loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=249113">https://bugs.webkit.org/show_bug.cgi?id=249113</a>
rdar://problem/103499397

Reviewed by NOBODY (OOPS!).

Inspired: <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=198593">https://src.chromium.org/viewvc/blink?view=revision&revision=198593</a>

A progressive JPEG image renders while it loads, but currently it does not
when the image is in a composited layer. It should render the same way, layered
or not, so do that.

Although this is required in case of Apple platforms leveraging Core Graphics.
Hence, I added platform flags to disable this behavior for other platforms.
It will lead to improved progressive JPEG loading from in specific scenarios
(i.e., transform: translateZ).

This patch is without test case since it would require serving JPEG
progressively and I am not sure, it would be possible within EWS.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(RenderLayerBacking::updateImageContents): Add platform flags around 'cachedImage' loading case
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b47cafd505a96dcb0614989074d16d7e2038ebf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14042 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13798 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17786 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->