### PR TITLE
WPT webcodecs videoDecoder-codec-specific.https.any.html test is failing due to resolve promises out of an event queue task

### DIFF
--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -119,23 +119,17 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
 
     queueControlMessageAndProcess([this, config = WTFMove(config), identifier = scriptExecutionContext()->identifier()]() mutable {
         m_isMessageQueueBlocked = true;
-        VideoDecoder::PostTaskCallback postTaskCallback;
-        if (isMainThread()) {
-            postTaskCallback = [](auto&& task) {
-                ensureOnMainThread(WTFMove(task));
-            };
-        } else {
-            postTaskCallback = [identifier](auto&& task) {
-                ScriptExecutionContext::postTaskTo(identifier, [task = WTFMove(task)](auto&) mutable {
+        VideoDecoder::PostTaskCallback postTaskCallback = [identifier, weakThis = WeakPtr { *this }](auto&& task) {
+            ScriptExecutionContext::postTaskTo(identifier, [weakThis, task = WTFMove(task)](auto&) mutable {
+                if (!weakThis)
+                    return;
+                weakThis->queueTaskKeepingObjectAlive(*weakThis, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
                     task();
                 });
-            };
-        }
+            });
+        };
 
-        VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [this, weakedThis = WeakPtr { *this }](auto&& result) {
-            if (!weakedThis)
-                return;
-
+        VideoDecoder::create(config.codec, createVideoDecoderConfig(config), [this](auto&& result) {
             if (!result.has_value()) {
                 closeDecoder(Exception { NotSupportedError, WTFMove(result.error()) });
                 return;
@@ -143,8 +137,8 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
             setInternalDecoder(WTFMove(result.value()));
             m_isMessageQueueBlocked = false;
             processControlMessageQueue();
-        }, [this, weakedThis = WeakPtr { *this }](auto&& result) {
-            if (!weakedThis || m_state != WebCodecsCodecState::Configured)
+        }, [this](auto&& result) {
+            if (m_state != WebCodecsCodecState::Configured)
                 return;
 
             if (!result.has_value()) {
@@ -184,15 +178,10 @@ ExceptionOr<void> WebCodecsVideoDecoder::decode(Ref<WebCodecsEncodedVideoChunk>&
         --m_decodeQueueSize;
         scheduleDequeueEvent();
 
-        m_internalDecoder->decode({ { chunk->data(), chunk->byteLength() }, chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }, [this, weakedThis = WeakPtr { *this }](auto&& result) {
-            if (!weakedThis)
-                return;
-
+        m_internalDecoder->decode({ { chunk->data(), chunk->byteLength() }, chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](auto&& result) {
             --m_beingDecodedQueueSize;
-            if (!result.isNull()) {
+            if (!result.isNull())
                 closeDecoder(Exception { EncodingError, WTFMove(result) });
-                return;
-            }
         });
     });
     return { };
@@ -206,9 +195,9 @@ ExceptionOr<void> WebCodecsVideoDecoder::flush(Ref<DeferredPromise>&& promise)
     m_isKeyChunkRequired = true;
     m_pendingFlushPromises.append(promise.copyRef());
     m_isFlushing = true;
-    queueControlMessageAndProcess([this, clearFlushPromiseCount = m_clearFlushPromiseCount]() mutable {
-        m_internalDecoder->flush([this, weakThis = WeakPtr { *this }, clearFlushPromiseCount] {
-            if (!weakThis || clearFlushPromiseCount != m_clearFlushPromiseCount)
+    queueControlMessageAndProcess([this, clearFlushPromiseCount = m_clearFlushPromiseCount] {
+        m_internalDecoder->flush([this, clearFlushPromiseCount] {
+            if (clearFlushPromiseCount != m_clearFlushPromiseCount)
                 return;
 
             m_pendingFlushPromises.takeFirst()->resolve();
@@ -269,7 +258,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::closeDecoder(Exception&& exception)
     return { };
 }
 
-ExceptionOr<void> WebCodecsVideoDecoder::resetDecoder(const Exception&)
+ExceptionOr<void> WebCodecsVideoDecoder::resetDecoder(const Exception& exception)
 {
     if (m_state == WebCodecsCodecState::Closed)
         return Exception { InvalidStateError, "VideoDecoder is closed"_s };
@@ -283,9 +272,9 @@ ExceptionOr<void> WebCodecsVideoDecoder::resetDecoder(const Exception&)
         scheduleDequeueEvent();
     }
     ++m_clearFlushPromiseCount;
-    // FIXME: Check whether aligning with the spec or with WPT tests.
+
     while (!m_pendingFlushPromises.isEmpty())
-        m_pendingFlushPromises.takeFirst()->reject(Exception { AbortError, "aborting flush as decoder is reset"_s });
+        m_pendingFlushPromises.takeFirst()->reject(exception);
 
     return { };
 }


### PR DESCRIPTION
#### 42d2cdbeda91de8b704599ae8305529869c5f99c
<pre>
WPT webcodecs videoDecoder-codec-specific.https.any.html test is failing due to resolve promises out of an event queue task
<a href="https://bugs.webkit.org/show_bug.cgi?id=258814">https://bugs.webkit.org/show_bug.cgi?id=258814</a>
rdar://111692360

Reviewed by Eric Carlson.

The WPT test change is coming from upstream and checks that the flush promise callbacks are executed before the error event handlers.
The implementation is correctly resolving the promises before scheduling a task to fire the error event.
But the promises are resolved outside of the event loop and are thus delayed to a loater task, and the error event fires before.
To prevent this, we are changing the way the internal decoder is calling back into WebCodecsVideoDecoder code.

Instead of just hoping to the right thread, we are now hoping to the right thread and then enqueueing a task.
We add a weakThis check there so that it is no longer necessary on each callback.

Covered by updated tests.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.js:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
(WebCore::WebCodecsVideoDecoder::resetDecoder):

Canonical link: <a href="https://commits.webkit.org/265843@main">https://commits.webkit.org/265843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29e5a366d520ea9e53a29b185f8a6048be8874a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13796 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10650 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17784 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10385 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->