### PR TITLE
[webkitbugspy] Surpress login errors in unit tests

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -31,15 +31,17 @@ RELATED_BLANK = {'related-to': [], 'blocked-by': [], 'blocking': [], 'parent-of'
 
 class TestRadar(unittest.TestCase):
     def test_encoding(self):
-        self.assertEqual(
-            radar.Tracker.Encoder().default(radar.Tracker(project='WebKit')),
-            dict(hide_title=True, type='radar', projects=['WebKit']),
-        )
+        with OutputCapture():
+            self.assertEqual(
+                radar.Tracker.Encoder().default(radar.Tracker(project='WebKit')),
+                dict(hide_title=True, type='radar', projects=['WebKit']),
+            )
 
     def test_decoding(self):
-        decoded = Tracker.from_json(json.dumps(radar.Tracker(), cls=Tracker.Encoder))
-        self.assertIsInstance(decoded, radar.Tracker)
-        self.assertEqual(decoded.from_string('rdar://1234').id, 1234)
+        with OutputCapture():
+            decoded = Tracker.from_json(json.dumps(radar.Tracker(), cls=Tracker.Encoder))
+            self.assertIsInstance(decoded, radar.Tracker)
+            self.assertEqual(decoded.from_string('rdar://1234').id, 1234)
 
     def test_no_radar(self):
         with mocks.NoRadar():


### PR DESCRIPTION
#### 664d22e6961c07819ad37ce118af58da64e07416
<pre>
[webkitbugspy] Surpress login errors in unit tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=258817">https://bugs.webkit.org/show_bug.cgi?id=258817</a>
<a href="https://rdar.apple.com/111696020">rdar://111696020</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadar.test_encoding): Surpress loging errors.
(TestRadar.test_decoding): Ditto.

Canonical link: <a href="https://commits.webkit.org/276780@main">https://commits.webkit.org/276780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83908a61280ae31e9001dabd890a4c0951284986

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41730 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/48001 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22217 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46273 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21897 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39417 "Build is in progress. Recent messages:") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/18568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45563 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19295 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40509 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3739 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41999 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40841 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20684 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39571 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6356 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/21678 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->