### PR TITLE
The tracker lookup callback should match against the domain of the returned CNAME alias

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -460,7 +460,8 @@ void configureForAdvancedPrivacyProtections(NSURLSession *session)
         }
 
         if (auto host = hostname(endpoint)) {
-            if (auto info = TrackerDomainLookupInfo::find(String::fromLatin1(*host)); info.owner().length()) {
+            auto domain = WebCore::RegistrableDomain { URL { makeString("http://", String::fromLatin1(*host)) } };
+            if (auto info = TrackerDomainLookupInfo::find(domain.string()); info.owner().length()) {
                 *owner = info.owner().data();
                 *hostName = *host;
                 *canBlock = info.canBlock() == TrackerDomainLookupInfo::CanBlock::Yes;


### PR DESCRIPTION
#### a4a461f9b6bf487c60893dcbcd0451e581d2d78a
<pre>
The tracker lookup callback should match against the domain of the returned CNAME alias
<a href="https://bugs.webkit.org/show_bug.cgi?id=258822">https://bugs.webkit.org/show_bug.cgi?id=258822</a>
rdar://111701360

Reviewed by Wenson Hsieh.

Currently the tracker lookup is matching against the raw hostname, we should match against the domain instead.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::TrackerDomainLookupInfo::find):
(WebKit::configureForAdvancedPrivacyProtections):

Canonical link: <a href="https://commits.webkit.org/265740@main">https://commits.webkit.org/265740@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0d8270a5e9b13503b66b74fbfa3403f1a1b03bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14051 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13808 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10039 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17795 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13989 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9263 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10396 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->