### PR TITLE
[iOS 17] Software keyboard overlaps position: fixed; text fields near the bottom of the viewport

### DIFF
--- a/LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input-expected.txt
+++ b/LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input-expected.txt
@@ -1,0 +1,10 @@
+
+This test verifies that we properly reveal focused elements in fixed position containers which would otherwise be obscured by the software keyboard. To reproduce, tap on the input field below. The software keyboard should not obscure the selection caret.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS inputViewBounds.top is >= caretRect.top + caretRect.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input.html
+++ b/LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+    html, body {
+        width: 100%;
+        height: 100%;
+        color: lightgray;
+        font-size: 20px;
+    }
+
+    body {
+        margin: 0;
+        text-align: center;
+        font-family: system-ui;
+        background-color: #222;
+        overflow: scroll;
+    }
+
+    .tall {
+        width: 100%;
+        height: 200vh;
+    }
+
+    .container {
+        position: fixed;
+        width: 100%;
+        height: 100%;
+    }
+
+    input {
+        border: none;
+        border-radius: 4px;
+        outline: none;
+        font-size: 20px;
+        background-color: lightgray;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        padding: 8px;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description(`This test verifies that we properly reveal focused elements in fixed position
+        containers which would otherwise be obscured by the software keyboard. To reproduce, tap on
+        the input field below. The software keyboard should not obscure the selection caret.`);
+
+    await UIHelper.setHardwareKeyboardAttached(false);
+
+    const textField = document.querySelector("input");
+    await UIHelper.activateElementAndWaitForInputSession(textField);
+
+    caretRect = await UIHelper.getUICaretViewRectInGlobalCoordinates();
+    inputViewBounds = await UIHelper.inputViewBounds();
+
+    shouldBeGreaterThanOrEqual("inputViewBounds.top", "caretRect.top + caretRect.height");
+
+    textField.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div class="container">
+    <input autofocus placeholder="Tap here"></input>
+</div>
+<div class="tall"></div>
+<div id="description"></div>
+<div id="console"></div>
+</body>
+
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -896,6 +896,22 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static getUICaretViewRectInGlobalCoordinates()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve();
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(`(function() {
+                uiController.doAfterNextStablePresentationUpdate(function() {
+                    uiController.uiScriptComplete(JSON.stringify(uiController.selectionCaretViewRectInGlobalCoordinates));
+                });
+            })()`, jsonString => {
+                resolve(JSON.parse(jsonString));
+            });
+        });
+    }
+
     static getUISelectionViewRects()
     {
         if (!this.isWebKit2() || !this.isIOSFamily())

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -320,12 +320,14 @@ interface UIScriptController {
     // When false, content rect updates to the web process have inStableState=false, as if a scroll or zoom were in progress.
     attribute boolean? stableStateOverride;
 
-    readonly attribute object contentVisibleRect; // Returned object has 'left', 'top', 'width', 'height' properties.
-
+    // The attributes below return an array of objects with 'left', 'top', 'width', and 'height' properties.
+    readonly attribute object contentVisibleRect;
     readonly attribute object selectionStartGrabberViewRect;
     readonly attribute object selectionEndGrabberViewRect;
-    readonly attribute object selectionCaretViewRect; // An array of objects with 'left', 'top', 'width', and 'height' properties.
-    readonly attribute object selectionRangeViewRects; // An object with 'left', 'top', 'width', 'height' properties.
+    readonly attribute object selectionCaretViewRect;
+    readonly attribute object selectionCaretViewRectInGlobalCoordinates;
+    readonly attribute object selectionRangeViewRects;
+
     readonly attribute object calendarType;
     undefined setDefaultCalendarType(DOMString calendarIdentifier, DOMString localeIdentifier);
     readonly attribute object inputViewBounds;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -309,6 +309,7 @@ public:
     virtual JSObjectRef selectionStartGrabberViewRect() const { notImplemented(); return nullptr; }
     virtual JSObjectRef selectionEndGrabberViewRect() const { notImplemented(); return nullptr; }
     virtual JSObjectRef selectionCaretViewRect() const { notImplemented(); return nullptr; }
+    virtual JSObjectRef selectionCaretViewRectInGlobalCoordinates() const { notImplemented(); return nullptr; }
     virtual JSObjectRef selectionRangeViewRects() const { notImplemented(); return nullptr; }
 
     // Rotation

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -33,6 +33,8 @@
 typedef struct CGRect CGRect;
 OBJC_CLASS UITextSelectionDisplayInteraction;
 
+@protocol UICoordinateSpace;
+
 namespace WebCore {
 class FloatPoint;
 class FloatRect;
@@ -115,6 +117,8 @@ private:
     JSObjectRef selectionStartGrabberViewRect() const override;
     JSObjectRef selectionEndGrabberViewRect() const override;
     JSObjectRef selectionCaretViewRect() const override;
+    JSObjectRef selectionCaretViewRectInGlobalCoordinates() const override;
+    JSObjectRef selectionCaretViewRect(id<UICoordinateSpace>) const;
     JSObjectRef selectionRangeViewRects() const override;
     JSObjectRef inputViewBounds() const override;
     JSRetainPtr<JSStringRef> scrollingTreeAsText() const override;


### PR DESCRIPTION
#### 6669d12b7b43d2d36a549d9fcad0a1577b66a1f4
<pre>
[iOS 17] Software keyboard overlaps position: fixed; text fields near the bottom of the viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=258828">https://bugs.webkit.org/show_bug.cgi?id=258828</a>
rdar://109127515

Reviewed by Aditya Keerthi.

On iOS 17, in the case where out-of-process keyboard is enabled and the software keyboard is shown,
we end up getting two sets of `&quot;KeyboardWillShow&quot;` -&gt; `&quot;KeyboardDidShow&quot;` notifications when the
keyboard animates up, after reloading input views. When the first set of notifications is dispatched
underneath the  call to `-reloadInputViews`, the keyboard hasn&apos;t yet become full height, and so our
attempts to zoom to reveal the focused element using the current input view bounds will fail.

I filed &lt;rdar://111704216&gt; for UIKit to investigate restoring pre-iOS-17 behavior, with respect to
dispatching these intermediate keyboard notifications; in the meantime, this patch works around this
behavior change by deferring the call to `-_zoomToRevealFocusedElement` until the first
`&quot;KeyboardWillShow&quot;` notification arrives *after* `-reloadInputViews` has already been invoked, in
the case where OOP keyboard is enabled and the keyboard is full height.

We limit this to the case of OOP keyboard because when that feature is disabled, we receive a
&quot;KeyboardWillShow&quot; notification underneath the call to `-reloadInputViews` that already contains the
final keyboard height; furthermore, we limit this to the case where the keyboard is full height,
because when OOP keyboard is enabled and the keyboard is minimized (e.g. the hardware keyboard is
attached), we only get a single set of keyboard appearance notifications.

* LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input-expected.txt: Added.
* LayoutTests/fast/forms/ios/scroll-to-reveal-fixed-input.html: Added.

Add a new layout test to exercise keyboard scrolling, in the case where:

1. We&apos;re showing the software keyboard.
2. The focused element that would be overlapped by the keyboard is in a fixed position container.
3. The page itself is scrollable.

...and verify that we successfully scroll such that the bottom of the caret rect is above the top of
the keyboard (input view bounds).

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.getUICaretViewRectInGlobalCoordinates.return.new.Promise.):
(window.UIHelper.getUICaretViewRectInGlobalCoordinates.return.new.Promise):
(window.UIHelper.getUICaretViewRectInGlobalCoordinates):

Add support for a new `UIHelper` method to grab the selection caret rect in web view coordinates.
The &quot;global&quot; here is consistent terminology used elsewhere in `UIScriptController`.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):

See comments above for more details.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::selectionCaretViewRectInGlobalCoordinates const):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionCaretViewRectInGlobalCoordinates const):

Canonical link: <a href="https://commits.webkit.org/265741@main">https://commits.webkit.org/265741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d371d12874313f39a67484af6192604e172f2b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14068 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12761 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13829 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17809 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11130 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14004 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10558 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2832 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11097 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->