### PR TITLE
Use object lifetimes to manage message receiver registrations

### DIFF
--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -402,6 +402,7 @@ UIProcess/ProcessAssertion.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/ProvisionalPageProxy.cpp
+UIProcess/RemotePageDrawingAreaProxy.cpp
 UIProcess/RemotePageProxy.cpp
 UIProcess/ResponsivenessTimer.cpp
 UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -445,6 +446,7 @@ UIProcess/WebPageDiagnosticLoggingClient.cpp
 UIProcess/WebPageGroup.cpp
 UIProcess/WebPageInjectedBundleClient.cpp
 UIProcess/WebPageProxy.cpp
+UIProcess/WebPageProxyMessageReceiverRegistration.cpp
 UIProcess/WebPasteboardProxy.cpp
 UIProcess/WebPermissionControllerProxy.cpp
 UIProcess/WebPreferences.cpp

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -54,12 +54,20 @@ DrawingAreaProxy::~DrawingAreaProxy() = default;
 
 void DrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
 {
-    process.addMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier, *this);
+    for (auto& name : messageReceiverNames())
+        process.addMessageReceiver(name, m_identifier, *this);
 }
 
 void DrawingAreaProxy::stopReceivingMessages(WebProcessProxy& process)
 {
-    process.removeMessageReceiver(Messages::DrawingAreaProxy::messageReceiverName(), m_identifier);
+    for (auto& name : messageReceiverNames())
+        process.removeMessageReceiver(name, m_identifier);
+}
+
+std::span<IPC::ReceiverName> DrawingAreaProxy::messageReceiverNames() const
+{
+    static std::array<IPC::ReceiverName, 1> name { Messages::DrawingAreaProxy::messageReceiverName() };
+    return { name };
 }
 
 DelegatedScrollingMode DrawingAreaProxy::delegatedScrollingMode() const

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -69,8 +69,9 @@ public:
     DrawingAreaType type() const { return m_type; }
     DrawingAreaIdentifier identifier() const { return m_identifier; }
 
-    virtual void startReceivingMessages(WebProcessProxy&);
-    virtual void stopReceivingMessages(WebProcessProxy&);
+    void startReceivingMessages(WebProcessProxy&);
+    void stopReceivingMessages(WebProcessProxy&);
+    virtual std::span<IPC::ReceiverName> messageReceiverNames() const;
 
     virtual WebCore::DelegatedScrollingMode delegatedScrollingMode() const;
 
@@ -130,6 +131,9 @@ public:
     virtual void viewWillStartLiveResize() { };
     virtual void viewWillEndLiveResize() { };
 
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
 protected:
     DrawingAreaProxy(DrawingAreaType, WebPageProxy&);
 
@@ -139,9 +143,6 @@ protected:
 
     WebCore::IntSize m_size;
     WebCore::IntSize m_scrollOffset;
-
-    // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
 private:
     virtual void sizeDidChange() = 0;

--- a/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
+++ b/Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp
@@ -30,6 +30,7 @@
 #include "WebPageProxy.h"
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
+#include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/DiagnosticLoggingKeys.h>
 
 namespace WebKit {

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -34,6 +34,7 @@
 #include "SandboxExtension.h"
 #include "WebFramePolicyListenerProxy.h"
 #include "WebPageProxyIdentifier.h"
+#include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <WebCore/FrameIdentifier.h>
@@ -183,6 +184,7 @@ private:
     bool m_wasCommitted { false };
     bool m_isProcessSwappingOnNavigationResponse { false };
     URL m_provisionalLoadURL;
+    WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
 
 #if PLATFORM(COCOA)
     Vector<uint8_t> m_accessibilityToken;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -88,8 +88,7 @@ private:
     void minimumSizeForAutoLayoutDidChange() final;
     void sizeToContentAutoSizeMaximumSizeDidChange() final;
     void didUpdateGeometry();
-    void startReceivingMessages(WebProcessProxy&) final;
-    void stopReceivingMessages(WebProcessProxy&) final;
+    std::span<IPC::ReceiverName> messageReceiverNames() const final;
 
     virtual void scheduleDisplayRefreshCallbacks() { }
     virtual void pauseDisplayRefreshCallbacks() { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -27,6 +27,7 @@
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 
 #import "DrawingAreaMessages.h"
+#import "DrawingAreaProxyMessages.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"
@@ -66,16 +67,10 @@ RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& p
 
 RemoteLayerTreeDrawingAreaProxy::~RemoteLayerTreeDrawingAreaProxy() = default;
 
-void RemoteLayerTreeDrawingAreaProxy::startReceivingMessages(WebProcessProxy& process)
+std::span<IPC::ReceiverName> RemoteLayerTreeDrawingAreaProxy::messageReceiverNames() const
 {
-    DrawingAreaProxy::startReceivingMessages(process);
-    process.addMessageReceiver(Messages::RemoteLayerTreeDrawingAreaProxy::messageReceiverName(), m_identifier, *this);
-}
-
-void RemoteLayerTreeDrawingAreaProxy::stopReceivingMessages(WebProcessProxy& process)
-{
-    DrawingAreaProxy::stopReceivingMessages(process);
-    process.removeMessageReceiver(Messages::RemoteLayerTreeDrawingAreaProxy::messageReceiverName(), m_identifier);
+    static std::array<IPC::ReceiverName, 2> names { Messages::DrawingAreaProxy::messageReceiverName(), Messages::RemoteLayerTreeDrawingAreaProxy::messageReceiverName() };
+    return { names };
 }
 
 std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemoteLayerTreeHost()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingTreeIOS.cpp
@@ -28,8 +28,10 @@
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
 
+#include "RemoteScrollingCoordinatorProxy.h"
 #include "ScrollingTreeFrameScrollingNodeRemoteIOS.h"
 #include "ScrollingTreeOverflowScrollingNodeIOS.h"
+#include <WebCore/ScrollingTreeFixedNodeCocoa.h>
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -44,6 +44,9 @@ namespace WebCore {
 class PlatformWheelEvent;
 class WheelEventDeltaFilter;
 struct WheelEventHandlingResult;
+using ScrollingNodeID = uint64_t;
+enum class WheelScrollGestureState : uint8_t;
+enum class WheelEventProcessingSteps : uint8_t;
 };
 
 namespace WebKit {
@@ -86,10 +89,10 @@ public:
     void renderingUpdateComplete();
 
 private:
-    OptionSet<WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    OptionSet<WebCore::WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
 
-    void scrollingThreadHandleWheelEvent(const WebWheelEvent&, RectEdges<bool> rubberBandableEdges);
-    WebCore::WheelEventHandlingResult internalHandleWheelEvent(const WebCore::PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>);
+    void scrollingThreadHandleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    WebCore::WheelEventHandlingResult internalHandleWheelEvent(const WebCore::PlatformWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
 
     WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent&);
 
@@ -98,8 +101,8 @@ private:
     void wheelEventHysteresisUpdated(PAL::HysteresisState);
 
     void willHandleWheelEvent(const WebWheelEvent&);
-    void continueWheelEventHandling(WheelEventHandlingResult);
-    void wheelEventWasHandledByScrollingThread(WheelEventHandlingResult);
+    void continueWheelEventHandling(WebCore::WheelEventHandlingResult);
+    void wheelEventWasHandledByScrollingThread(WebCore::WheelEventHandlingResult);
 
     DisplayLink* displayLink() const;
     DisplayLink* existingDisplayLink() const;

--- a/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,28 @@
 
 #pragma once
 
-#if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
-
-#include "RemoteScrollingTree.h"
+#include "DrawingAreaInfo.h"
+#include "MessageReceiver.h"
 
 namespace WebKit {
 
-class RemoteScrollingCoordinatorProxy;
+class DrawingAreaProxy;
+class WebProcessProxy;
 
-class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+class RemotePageDrawingAreaProxy : public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
-    virtual ~RemoteScrollingTreeIOS();
+    RemotePageDrawingAreaProxy(DrawingAreaProxy&, WebProcessProxy&);
+    ~RemotePageDrawingAreaProxy();
 
 private:
-    Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
-    void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
+    WeakPtr<DrawingAreaProxy> m_drawingArea;
+    DrawingAreaIdentifier m_identifier;
+    std::span<IPC::ReceiverName> m_names;
+    Ref<WebProcessProxy> m_process;
 };
 
-} // namespace WebKit
-
-#endif // PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
+}

--- a/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
+++ b/Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,25 @@
 
 #pragma once
 
-#if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
-
-#include "RemoteScrollingTree.h"
-
 namespace WebKit {
 
-class RemoteScrollingCoordinatorProxy;
-
-class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+class RemotePageVisitedLinkStoreRegistration {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
-    virtual ~RemoteScrollingTreeIOS();
-
+    RemotePageVisitedLinkStoreRegistration(WebPageProxy& page, WebProcessProxy& process)
+        : m_page(page)
+        , m_process(process)
+    {
+        m_process->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
+    }
+    ~RemotePageVisitedLinkStoreRegistration()
+    {
+        if (m_page)
+            m_process->removeVisitedLinkStoreUser(m_page->visitedLinkStore(), m_page->identifier());
+    }
 private:
-    Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
-
-    void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
+    WeakPtr<WebPageProxy> m_page;
+    Ref<WebProcessProxy> m_process;
 };
 
-} // namespace WebKit
-
-#endif // PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
+}

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -29,6 +29,7 @@
 #include "MessageSender.h"
 #include "ProcessThrottler.h"
 #include "WebBackForwardListItem.h"
+#include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/RefCounted.h>
@@ -107,6 +108,7 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     Ref<WebFrameProxy> m_mainFrame;
+    WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
     bool m_isClosed { false };
     ShouldDelayClosingUntilFirstLayerFlush m_shouldDelayClosingUntilFirstLayerFlush { ShouldDelayClosingUntilFirstLayerFlush::No };
     bool m_shouldCloseWhenEnteringAcceleratedCompositingMode { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -746,18 +746,26 @@ WebPageProxy::~WebPageProxy()
     if (m_preferences->mediaSessionCoordinatorEnabled())
         GroupActivitiesSessionNotifier::sharedNotifier().removeWebPage(*this);
 #endif
+
+    internals().remotePageProxyInOpenerProcess = nullptr;
+    internals().openedRemotePageProxies.clear();
 }
 
 void WebPageProxy::addAllMessageReceivers()
 {
-    m_process->addMessageReceiver(Messages::WebPageProxy::messageReceiverName(), internals().webPageID, *this);
+    internals().messageReceiverRegistration.startReceivingMessages(m_process, internals().webPageID, *this);
     m_process->addMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), internals().webPageID, internals().notificationManagerMessageHandler);
 }
 
 void WebPageProxy::removeAllMessageReceivers()
 {
-    m_process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), internals().webPageID);
+    internals().messageReceiverRegistration.stopReceivingMessages();
     m_process->removeMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), internals().webPageID);
+}
+
+WebPageProxyMessageReceiverRegistration& WebPageProxy::messageReceiverRegistration()
+{
+    return internals().messageReceiverRegistration;
 }
 
 // FIXME: Should return a const PageClient& and add a separate non-const

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -387,6 +387,7 @@ class WebPageDebuggable;
 class WebPageGroup;
 class WebPageInjectedBundleClient;
 class WebPageInspectorController;
+class WebPageProxyMessageReceiverRegistration;
 class WebPopupMenuProxy;
 class WebPopupMenuProxyClient;
 class WebPreferences;
@@ -2259,6 +2260,8 @@ public:
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtectionsPolicies() const { return m_advancedPrivacyProtectionsPolicies; }
 #endif
+
+    WebPageProxyMessageReceiverRegistration& messageReceiverRegistration();
 
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -37,6 +37,7 @@
 #include "WebColorPicker.h"
 #include "WebNotificationManagerMessageHandler.h"
 #include "WebPageProxy.h"
+#include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebPopupMenuProxy.h"
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WindowKind.h"
@@ -217,6 +218,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> domainToRemotePageProxyMap;
     RefPtr<RemotePageProxy> remotePageProxyInOpenerProcess;
     HashSet<Ref<RemotePageProxy>> openedRemotePageProxies;
+    WebPageProxyMessageReceiverRegistration messageReceiverRegistration;
 
 #if ENABLE(APPLE_PAY)
     std::unique_ptr<WebPaymentCoordinatorProxy> paymentCoordinator;

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebPageProxyMessageReceiverRegistration.h"
+
+#include "WebPageProxyMessages.h"
+#include "WebProcessProxy.h"
+
+namespace WebKit {
+
+WebPageProxyMessageReceiverRegistration::~WebPageProxyMessageReceiverRegistration()
+{
+    stopReceivingMessages();
+}
+
+void WebPageProxyMessageReceiverRegistration::startReceivingMessages(WebProcessProxy& process, WebCore::PageIdentifier webPageID, IPC::MessageReceiver& messageReceiver)
+{
+    stopReceivingMessages();
+    process.addMessageReceiver(Messages::WebPageProxy::messageReceiverName(), webPageID, messageReceiver);
+    m_data = { { webPageID, process } };
+}
+
+void WebPageProxyMessageReceiverRegistration::stopReceivingMessages()
+{
+    if (auto data = std::exchange(m_data, std::nullopt))
+        data->process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+}
+
+void WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom(WebPageProxyMessageReceiverRegistration& oldRegistration, IPC::MessageReceiver& newReceiver)
+{
+    if (auto data = std::exchange(oldRegistration.m_data, std::nullopt)) {
+        data->process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+        startReceivingMessages(data->process, data->webPageID, newReceiver);
+    } else {
+        stopReceivingMessages();
+        ASSERT_NOT_REACHED();
+    }
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,28 @@
 
 #pragma once
 
-#if PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)
+#include <WebCore/PageIdentifier.h>
 
-#include "RemoteScrollingTree.h"
+namespace IPC {
+class MessageReceiver;
+}
 
 namespace WebKit {
 
-class RemoteScrollingCoordinatorProxy;
+class WebProcessProxy;
 
-class RemoteScrollingTreeIOS final : public RemoteScrollingTree {
+class WebPageProxyMessageReceiverRegistration {
 public:
-    explicit RemoteScrollingTreeIOS(RemoteScrollingCoordinatorProxy&);
-    virtual ~RemoteScrollingTreeIOS();
-
+    ~WebPageProxyMessageReceiverRegistration();
+    void startReceivingMessages(WebProcessProxy&, WebCore::PageIdentifier, IPC::MessageReceiver&);
+    void stopReceivingMessages();
+    void transferMessageReceivingFrom(WebPageProxyMessageReceiverRegistration&, IPC::MessageReceiver& newReceiver);
 private:
-    Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) final;
-
-    void scrollingTreeNodeWillStartPanGesture(WebCore::ScrollingNodeID) final;
+    struct Data {
+        WebCore::PageIdentifier webPageID;
+        Ref<WebProcessProxy> process;
+    };
+    std::optional<Data> m_data;
 };
 
 } // namespace WebKit
-
-#endif // PLATFORM(IOS_FAMILY) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -30,6 +30,7 @@
 
 #include "WebPageProxy.h"
 #include <WebCore/DataListSuggestionInformation.h>
+#include <WebCore/GUniquePtrGtk.h>
 #include <WebCore/GtkUtilities.h>
 #include <WebCore/GtkVersioning.h>
 #include <WebCore/IntPoint.h>

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5505,6 +5505,8 @@
 		5CC333A3298487A200C7D77F /* PlatformCALayerRemoteHost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformCALayerRemoteHost.h; sourceTree = "<group>"; };
 		5CC5DB9121488E16006CB8A8 /* SharedBufferReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedBufferReference.h; sourceTree = "<group>"; };
 		5CC8612728CA81FD0076F563 /* WebsiteDataFetchOption.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebsiteDataFetchOption.serialization.in; sourceTree = "<group>"; };
+		5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageDrawingAreaProxy.h; sourceTree = "<group>"; };
+		5CCB54DC2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageDrawingAreaProxy.cpp; sourceTree = "<group>"; };
 		5CCE5B5E29F73CDE0086A188 /* APIData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APIData.serialization.in; sourceTree = "<group>"; };
 		5CD286491E722F440094FDC8 /* _WKUserContentFilterPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKUserContentFilterPrivate.h; sourceTree = "<group>"; };
 		5CD2864A1E722F440094FDC8 /* WKContentRuleList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentRuleList.h; sourceTree = "<group>"; };
@@ -5533,6 +5535,9 @@
 		5CE9120F2293C25F005BEC78 /* AuxiliaryProcessMain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AuxiliaryProcessMain.cpp; path = Cocoa/AuxiliaryProcessMain.cpp; sourceTree = "<group>"; };
 		5CEABA2A2333247700797797 /* LegacyGlobalSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LegacyGlobalSettings.h; sourceTree = "<group>"; };
 		5CEABA2B2333251400797797 /* LegacyGlobalSettings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyGlobalSettings.cpp; sourceTree = "<group>"; };
+		5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageVisitedLinkStoreRegistration.h; sourceTree = "<group>"; };
+		5CEB40A32A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageProxyMessageReceiverRegistration.cpp; sourceTree = "<group>"; };
+		5CEB40A42A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageProxyMessageReceiverRegistration.h; sourceTree = "<group>"; };
 		5CF62B9428D4436A00C0EAE0 /* DaemonCoders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DaemonCoders.h; sourceTree = "<group>"; };
 		5CF62B9528D4436A00C0EAE0 /* DaemonCoders.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DaemonCoders.cpp; sourceTree = "<group>"; };
 		5CFECB031E1ED1C800F88504 /* LegacyCustomProtocolManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LegacyCustomProtocolManager.cpp; sourceTree = "<group>"; };
@@ -12202,8 +12207,11 @@
 				1A0C227D2451130A00ED614D /* QuickLookThumbnailingSoftLink.mm */,
 				1AEE57232409F142002005D6 /* QuickLookThumbnailLoader.h */,
 				1AEE57242409F142002005D6 /* QuickLookThumbnailLoader.mm */,
+				5CCB54DC2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.cpp */,
+				5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */,
 				5C907E9A294D507100B3402D /* RemotePageProxy.cpp */,
 				5C907E99294D507100B3402D /* RemotePageProxy.h */,
+				5CEB40A22A534EE100563C91 /* RemotePageVisitedLinkStoreRegistration.h */,
 				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
 				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,
 				5CA98549210BEB5A0057EB6B /* SafeBrowsingWarning.h */,
@@ -12309,6 +12317,8 @@
 				BCBD38FA125BAB9A00D2C29F /* WebPageProxy.messages.in */,
 				46C392282316EC4D008EED9B /* WebPageProxyIdentifier.h */,
 				939EF86D29D0C16400F23AEE /* WebPageProxyInternals.h */,
+				5CEB40A32A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.cpp */,
+				5CEB40A42A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.h */,
 				7C4694CD1A51E36800AD5845 /* WebPasteboardProxy.cpp */,
 				7C4694CE1A51E36800AD5845 /* WebPasteboardProxy.h */,
 				7C4694CF1A51E36800AD5845 /* WebPasteboardProxy.messages.in */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1390,8 +1390,7 @@ static void enableWindowOpenPSON(WKWebViewConfiguration *configuration)
     }
 }
 
-// FIXME: Get this working.
-TEST(ProcessSwap, DISABLED_CrossSiteWindowOpenWithOpener)
+TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);


### PR DESCRIPTION
#### a2878138acd817eaa41c98ea75b1bc8e2e830729
<pre>
Use object lifetimes to manage message receiver registrations
<a href="https://bugs.webkit.org/show_bug.cgi?id=258829">https://bugs.webkit.org/show_bug.cgi?id=258829</a>
rdar://111064194

Reviewed by J Pascoe.

The receiving of messages to Messages::WebPageProxy::messageReceiverName
is a tricky thing.  When a RemotePageProxy is created during
ProvisionalPageProxy::didCommitLoadForFrame when the frame is the result of
a cross-site window.open in another process (enabled by an off-by-default
feature flag) then we need to transfer the receiving of the messages from
the WebPageProxy to the RemotePageProxy.  We then don&apos;t want the WebPageProxy
to start and stop messages from being received for that name any more.
To do this in the most straightforward way I could think of, I tied the
registrations to the lifetime of a new object WebPageProxyMessageReceiverRegistration
which also has the ability to start/stop/transfer its message receiving.
It&apos;s a little like a smart pointer, but with lots of metadata for each operation.
It removes the need for explicit calls to remoteMessageReceiver with
Messages::WebPageProxy::messageReceiverName.

I did something quite similar for the VisitedLinkStore registration of a
RemotePageProxy, which only needs to register and unregister when
RemotePageProxy::injectPageIntoNewProcess is called, which happens if that
RemotePageProxy is used for a remote iframe but not for a cross-site window.open.

I also introduce RemotePageDrawingAreaProxy which is similar for the DrawingAreaProxy
messages.  Its existence makes it so that each DrawingArea has one unique proxy
object it communicates with, which will aid in future development of drawing
with site isolation.  Right now it just forwards all its messages to the DrawingAreaProxy
of the page, but in the future it can have the ability to intercept those messages.
In order to know what message receiver names to register for, I replaced the virtual calls
in RemoteLayerTreeDrawingAreaProxy::startReceivingMessages with a function that returns
a std::span of names.  This is safe because all implementations return pointers to
static std::array&apos;s, so their lifetimes are forever.  This saves unnecessary allocations.

A few other changes are needed to fix the build after adding new files.
Aren&apos;t unified builds fun?

* Source/WebKit/Sources.txt:
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::startReceivingMessages):
(WebKit::DrawingAreaProxy::stopReceivingMessages):
(WebKit::DrawingAreaProxy::messageReceiverNames const):
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/PerActivityStateCPUUsageSampler.cpp:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::messageReceiverNames const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::startReceivingMessages): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::stopReceivingMessages): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.cpp: Added.
(WebKit::RemotePageDrawingAreaProxy::RemotePageDrawingAreaProxy):
(WebKit::RemotePageDrawingAreaProxy::~RemotePageDrawingAreaProxy):
(WebKit::RemotePageDrawingAreaProxy::didReceiveMessage):
(WebKit::RemotePageDrawingAreaProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/RemotePageDrawingAreaProxy.h: Added.
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
(WebKit::RemotePageProxy::~RemotePageProxy):
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::create):
(WebKit::RemotePageProxy::messageReceiverRegistration):
* Source/WebKit/UIProcess/RemotePageVisitedLinkStoreRegistration.h: Added.
(WebKit::RemotePageVisitedLinkStoreRegistration::RemotePageVisitedLinkStoreRegistration):
(WebKit::RemotePageVisitedLinkStoreRegistration::~RemotePageVisitedLinkStoreRegistration):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::~SuspendedPageProxy):
(WebKit::SuspendedPageProxy::didProcessRequestToSuspend):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::removeAllMessageReceivers):
(WebKit::WebPageProxy::messageReceiverRegistration):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp: Added.
(WebKit::WebPageProxyMessageReceiverRegistration::~WebPageProxyMessageReceiverRegistration):
(WebKit::WebPageProxyMessageReceiverRegistration::startReceivingMessages):
(WebKit::WebPageProxyMessageReceiverRegistration::stopReceivingMessages):
(WebKit::WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom):
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/265771@main">https://commits.webkit.org/265771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb84c7a9e10e3bc0f2fad00363b6bafc13dd7fad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14074 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13838 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17818 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10423 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14706 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1327 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->