### PR TITLE
Unreviewed build fix for MobileMiniBrowser

### DIFF
--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
@@ -27,6 +27,8 @@
 
 #import "WebViewController.h"
 
+#import <wtf/Compiler.h>
+
 @interface AppDelegate ()
 @end
 
@@ -34,6 +36,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     UIStoryboard *frameworkMainStoryboard = [UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle bundleForClass:[AppDelegate class]]];
     WebViewController *viewController = [frameworkMainStoryboard instantiateInitialViewController];
     if (!viewController)
@@ -45,6 +48,7 @@
     [self.window makeKeyAndVisible];
 
     return YES;
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -27,6 +27,7 @@
 
 #import "SettingsViewController.h"
 #import "TabViewController.h"
+#import <WTF/Compiler.h>
 #import <WebKit/WKNavigation.h>
 #import <WebKit/WKNavigationDelegate.h>
 #import <WebKit/WKPreferencesPrivate.h>
@@ -73,6 +74,7 @@ void* URLContext = &URLContext;
 
 - (void)viewDidLoad
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [super viewDidLoad];
     self.webViews = [[NSMutableArray alloc] initWithCapacity:1];
     self.tabViewController = [self.storyboard instantiateViewControllerWithIdentifier:@"idTabViewController"];
@@ -86,6 +88,7 @@ void* URLContext = &URLContext;
     WKWebView *webView = [self createWebView];
     [webView loadRequest:[NSURLRequest requestWithURL:[self targetURLorDefaultURL]]];
     [self setCurrentWebView:webView];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 


### PR DESCRIPTION
#### 9d3fb7df06cbe91637125849c201c3e700b5688b
<pre>
Unreviewed build fix for MobileMiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=258837">https://bugs.webkit.org/show_bug.cgi?id=258837</a>
rdar://111715742

Unreviewed build fix for MobileMiniBrowser.

* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m:
(-[AppDelegate application:didFinishLaunchingWithOptions:]):
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController viewDidLoad]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3fb7df06cbe91637125849c201c3e700b5688b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11776 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11975 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11795 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14364 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14078 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11940 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/14364 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9992 "53 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13841 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/14364 "Failed to compile WebKit") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17821 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/14364 "Failed to compile WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->