### PR TITLE
[Win] Skip TestWTF.WTF_DateMath.calculateLocalTimeOffset not in Pacific Time Zone

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp
@@ -133,8 +133,22 @@ TEST(WTF_DateMath, dayInMonthFromDayInYear)
     EXPECT_EQ(32, dayInMonthFromDayInYear(366, true));
 }
 
+static bool isPacificTimeZone()
+{
+#if PLATFORM(WIN)
+    TIME_ZONE_INFORMATION info;
+    GetTimeZoneInformation(&info);
+    return info.Bias == 8 * 60 && !info.StandardBias && info.DaylightBias == -60;
+#else
+    return true;
+#endif
+}
+
 TEST(WTF_DateMath, calculateLocalTimeOffset)
 {
+    if (!isPacificTimeZone())
+        GTEST_SKIP() << "Not in Pacific Time Zone";
+
     // DST Start: April 30, 1967 (02:00 am)
     LocalTimeOffset dstStart1967 = calculateLocalTimeOffset(-84301200000, WTF::LocalTime);
     EXPECT_TRUE(dstStart1967.isDST);


### PR DESCRIPTION
#### e3acb13330e48747c0995c82edf45b28bdf00709
<pre>
[Win] Skip TestWTF.WTF_DateMath.calculateLocalTimeOffset not in Pacific Time Zone
<a href="https://bugs.webkit.org/show_bug.cgi?id=258839">https://bugs.webkit.org/show_bug.cgi?id=258839</a>

Reviewed by Ross Kirsling.

The test can pass only in Pacific Time Zone. Skip the test in the
outside of the timezone by getting the current timezone with a Windows
API.

* Tools/TestWebKitAPI/Tests/WTF/DateMath.cpp:
(TestWebKitAPI::isPacificTimeZone):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265744@main">https://commits.webkit.org/265744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ee2fe19a49909a083e9a072053671c7f2ce9b01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14079 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12774 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/9993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13842 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17822 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10427 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14710 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1319 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->