### PR TITLE
WTF_Ref.StaticReferenceCastFromRValueReference and WTF_RefPtr.Basic fail due to buffered logs of preceding tests

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Ref.cpp
@@ -274,18 +274,22 @@ TEST(WTF_Ref, AssignBeforeDeref)
 
 TEST(WTF_Ref, StaticReferenceCastFromConstReference)
 {
-    DerivedRefCheckingRefLogger a("a");
-    const Ref<DerivedRefCheckingRefLogger> ref(a);
-    auto ref2 = static_reference_cast<RefCheckingRefLogger>(ref);
-    EXPECT_STREQ("ref(a) ref(a) ", takeLogStr().c_str());
+    {
+        DerivedRefCheckingRefLogger a("a");
+        const Ref<DerivedRefCheckingRefLogger> ref(a);
+        auto ref2 = static_reference_cast<RefCheckingRefLogger>(ref);
+    }
+    EXPECT_STREQ("ref(a) ref(a) deref(a) deref(a) ", takeLogStr().c_str());
 }
 
 TEST(WTF_Ref, StaticReferenceCastFromRValueReference)
 {
-    DerivedRefCheckingRefLogger a("a");
-    Ref<DerivedRefCheckingRefLogger> ref(a);
-    auto ref2 = static_reference_cast<RefCheckingRefLogger>(WTFMove(ref));
-    EXPECT_STREQ("ref(a) ", takeLogStr().c_str());
+    {
+        DerivedRefCheckingRefLogger a("a");
+        Ref<DerivedRefCheckingRefLogger> ref(a);
+        auto ref2 = static_reference_cast<RefCheckingRefLogger>(WTFMove(ref));
+    }
+    EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 4660c0d124bb5361653b48162b8209786917c1d2
<pre>
WTF_Ref.StaticReferenceCastFromRValueReference and WTF_RefPtr.Basic fail due to buffered logs of preceding tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=258843">https://bugs.webkit.org/show_bug.cgi?id=258843</a>

Reviewed by Chris Dumez.

run-api-tests script runs each test separately by spawning processes.
But, if I manually run TestWTF.exe, some ref counter tests fail due to
logs of previous tests.

We should call takeLogStr() after all RefLogger objects are
destructed.

* Tools/TestWebKitAPI/Tests/WTF/Ref.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265820@main">https://commits.webkit.org/265820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14decffa03a081701b5529cf780bce82d19760ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14083 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13847 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10431 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2932 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->