### PR TITLE
Hide icon's <img> when showing progress or placeholder

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -57,7 +57,6 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (97,16) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
             RenderFlexibleBox {DIV} at (82,0) size 230x92
               RenderGrid {DIV} at (0,37) size 230x18
       RenderBlock {DIV} at (0,654) size 784x109
@@ -66,7 +65,6 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (96,16) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
                 RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
                   RenderText at (0,0) size 0x0
@@ -78,7 +76,6 @@ layer at (0,0) size 800x888
         RenderAttachment {ATTACHMENT} at (104,16) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
                 RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
                   RenderText at (0,0) size 0x0

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -57,7 +57,6 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (97,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
             RenderFlexibleBox {DIV} at (70,0) size 172x80
               RenderGrid {DIV} at (0,32) size 172x16
       RenderBlock {DIV} at (0,492) size 769x82
@@ -66,7 +65,6 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (96,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
                 RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
                   RenderText at (0,0) size 0x0
@@ -78,7 +76,6 @@ layer at (0,0) size 785x672
         RenderAttachment {ATTACHMENT} at (104,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
                 RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
                   RenderText at (0,0) size 0x0

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -278,6 +278,7 @@ void HTMLAttachmentElement::updateProgress(const AtomString& progress)
     bool validProgress = false;
     float value = progress.toFloat(&validProgress);
     if (validProgress && std::isfinite(value)) {
+        m_imageElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
         if (!value) {
             m_placeholderElement->removeInlineStyleProperty(CSSPropertyDisplay);
             m_progressElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
@@ -290,6 +291,7 @@ void HTMLAttachmentElement::updateProgress(const AtomString& progress)
         return;
     }
 
+    m_imageElement->removeInlineStyleProperty(CSSPropertyDisplay);
     m_placeholderElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
     m_progressElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
     m_progressElement->removeInlineStyleCustomProperty(attachmentProgressCSSProperty());


### PR DESCRIPTION
#### a9b327ab90e2343446671f7a7b00baadcc5e60cd
<pre>
Hide icon&apos;s &lt;img&gt; when showing progress or placeholder
<a href="https://bugs.webkit.org/show_bug.cgi?id=258844">https://bugs.webkit.org/show_bug.cgi?id=258844</a>
rdar://problem/111720923

Reviewed by Tim Nguyen.

This was an incorrect change in <a href="https://bugs.webkit.org/show_bug.cgi?id=258437">https://bugs.webkit.org/show_bug.cgi?id=258437</a> rdar://105252742,
`updateProgress` should just have replaced `m_innerLegacyAttachment` with `m_imageElement`.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::updateProgress):

Canonical link: <a href="https://commits.webkit.org/265785@main">https://commits.webkit.org/265785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7625bae63fe8b3ee59c698399a52c33499930a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13551 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14198 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13973 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17939 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10970 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9409 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10555 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->