### PR TITLE
Make <attachment> progress circle use a single element

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -68,7 +68,8 @@ layer at (0,0) size 800x888
             RenderGrid {DIV} at (0,0) size 76x92
               RenderImage {IMG} at (10,10) size 72x72
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
-                RenderBlock {DIV} at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+                RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+                  RenderText at (0,0) size 0x0
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
       RenderBlock {DIV} at (0,763) size 784x109
@@ -79,7 +80,8 @@ layer at (0,0) size 800x888
             RenderGrid {DIV} at (0,0) size 76x92
               RenderImage {IMG} at (10,10) size 72x72
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
-                RenderBlock {DIV} at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+                RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+                  RenderText at (0,0) size 0x0
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
 layer at (129,164) size 230x17

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -68,7 +68,8 @@ layer at (0,0) size 785x672
             RenderGrid {DIV} at (0,0) size 68x80
               RenderImage {IMG} at (14,14) size 52x52
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
-                RenderBlock {DIV} at (0,0) size 52x52 [border: (4px solid #0000007F)]
+                RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
+                  RenderText at (0,0) size 0x0
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,574) size 769x82
@@ -79,7 +80,8 @@ layer at (0,0) size 785x672
             RenderGrid {DIV} at (0,0) size 68x80
               RenderImage {IMG} at (14,14) size 52x52
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
-                RenderBlock {DIV} at (0,0) size 52x52 [border: (4px solid #0000007F)]
+                RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
+                  RenderText at (0,0) size 0x0
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
 layer at (119,117) size 170x16

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -135,12 +135,6 @@ static const AtomString& attachmentProgressCSSProperty()
     return property;
 }
 
-static const AtomString& attachmentProgressCircleIdentifier()
-{
-    static MainThreadNeverDestroyed<const AtomString> identifier("attachment-progress-circle"_s);
-    return identifier;
-}
-
 static const AtomString& attachmentInformationAreaIdentifier()
 {
     static MainThreadNeverDestroyed<const AtomString> identifier("attachment-information-area"_s);
@@ -231,8 +225,6 @@ void HTMLAttachmentElement::ensureWideLayoutShadowTree(ShadowRoot& root)
 
     m_progressElement = createContainedElement<HTMLDivElement>(previewArea, attachmentProgressIdentifier());
     updateProgress(attributeWithoutSynchronization(progressAttr));
-
-    createContainedElement<HTMLDivElement>(*m_progressElement, attachmentProgressCircleIdentifier());
 
     auto informationArea = createContainedElement<HTMLDivElement>(*m_containerElement, attachmentInformationAreaIdentifier());
 

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -101,7 +101,9 @@ div#attachment-progress {
 }
 
 /* FIXME: Move the border into attachment-progress above, and remove this div, when rdar://107621207 is fixed (currently it produces artifacts at the edges). */
-div#attachment-progress-circle {
+div#attachment-progress::before {
+    content: "";
+    display: block;
     width: 100%;
     aspect-ratio: 1;
     border-radius: 50%;


### PR DESCRIPTION
#### e8d22b587bfc47267c9c14a47c5a76f8d843c0e8
<pre>
Make &lt;attachment&gt; progress circle use a single element
<a href="https://bugs.webkit.org/show_bug.cgi?id=258840">https://bugs.webkit.org/show_bug.cgi?id=258840</a>
rdar://111719618

Reviewed by Antti Koivisto.

Use a pseudo-element (::before) to avoid needing to create a separate element in the DOM.

* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::attachmentProgressCircleIdentifier): Deleted.
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-progress::before):
(div#attachment-progress-circle): Deleted.

Canonical link: <a href="https://commits.webkit.org/265749@main">https://commits.webkit.org/265749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d5ed72f0e4229f224659a4086807feaf2a45eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11976 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/12793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13862 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/10866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14729 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1321 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->