### PR TITLE
Remove rendererWillBeDestroyed() from HTMLTextAreaElement.h and RenderTextControlMultiLine.cpp

### DIFF
--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -49,8 +49,6 @@ public:
     unsigned textLength() const { return value().length(); }
     String validationMessage() const final;
 
-    void rendererWillBeDestroyed() { updateValue(); }
-
     WEBCORE_EXPORT RefPtr<TextControlInnerTextElement> innerTextElement() const final;
 
     bool shouldSaveAndRestoreFormControlState() const final { return true; }

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.cpp
@@ -47,14 +47,6 @@ RenderTextControlMultiLine::~RenderTextControlMultiLine()
     // Do not add any code here. Add it to willBeDestroyed() instead.
 }
 
-void RenderTextControlMultiLine::willBeDestroyed()
-{
-    if (textAreaElement().isConnected())
-        textAreaElement().rendererWillBeDestroyed();
-
-    RenderTextControl::willBeDestroyed();
-}
-
 HTMLTextAreaElement& RenderTextControlMultiLine::textAreaElement() const
 {
     return downcast<HTMLTextAreaElement>(RenderTextControl::textFormControlElement());

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.h
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.h
@@ -35,7 +35,6 @@ public:
     HTMLTextAreaElement& textAreaElement() const;
 
 private:
-    void willBeDestroyed() override;
     void element() const = delete;
 
     bool isTextArea() const override { return true; }


### PR DESCRIPTION
#### c412d338b0081d855291ea6a50724861f97daa1e
<pre>
Remove rendererWillBeDestroyed() from HTMLTextAreaElement.h and RenderTextControlMultiLine.cpp

<a href="https://bugs.webkit.org/show_bug.cgi?id=258785">https://bugs.webkit.org/show_bug.cgi?id=258785</a>

Reviewed by Tim Nguyen.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/10c9bbc0ea2c10efe497897cbd12bb842f7b0ee2">https://chromium.googlesource.com/chromium/blink/+/10c9bbc0ea2c10efe497897cbd12bb842f7b0ee2</a>

This code was added in 2006 in <a href="https://trac.webkit.org/changeset/13051">https://trac.webkit.org/changeset/13051</a>
and the test that was added with it fast/forms/textarea-setvalue-submit.html
still passes without the code now. It doesn&apos;t make any sense that form
controls would need to do this update in the destructor of the renderer,
especially not only `textarea` since none of the other controls do this.

* Source/WebCore/html/HTMLTextAreaElement.h: Remove &apos;rendererWillBeDestroyed&apos;
* Source/WebCore/rendering/RenderTextControlMultiLine.cpp:
(RenderTextControlMultiLine::willBeDestroyed): Deleted
* Source/WebCore/rendering/RenderTextControlMultiLine.h: Delete &apos;willBeDestroyed&apos; definition

Canonical link: <a href="https://commits.webkit.org/265755@main">https://commits.webkit.org/265755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2084d4dcc2f6ea61857f6dd6ac1b6e8f6a03b1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12792 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13863 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17842 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9314 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10447 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2841 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->