### PR TITLE
[WPE] `TestWebKitWebView` `/webkit/WebKitWebView/fullscreen` is a timeout

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -524,6 +524,18 @@ WebKitWebResourceLoadManager* WebKitWebViewClient::webResourceLoadManager()
 {
     return webkitWebViewGetWebResourceLoadManager(m_webView);
 }
+
+#if ENABLE(FULLSCREEN_API)
+void WebKitWebViewClient::enterFullScreen(WKWPE::View&)
+{
+    webkitWebViewEnterFullScreen(m_webView);
+}
+
+void WebKitWebViewClient::exitFullScreen(WKWPE::View&)
+{
+    webkitWebViewExitFullScreen(m_webView);
+}
+#endif
 #endif
 
 static gboolean webkitWebViewLoadFail(WebKitWebView* webView, WebKitLoadEvent, const char* failingURI, GError* error)

--- a/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/APIViewClient.h
@@ -53,6 +53,11 @@ public:
     virtual void didChangePageID(WKWPE::View&) { }
     virtual void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&& completionHandler) { completionHandler(WebKit::UserMessage()); }
     virtual WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() { return nullptr; }
+
+#if ENABLE(FULLSCREEN_API)
+    virtual void enterFullScreen(WKWPE::View&) { };
+    virtual void exitFullScreen(WKWPE::View&) { };
+#endif
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -380,7 +380,6 @@ void PageClientImpl::exitFullScreen()
         fullScreenManagerProxy->willExitFullScreen();
         if (!m_view.setFullScreen(false))
             fullScreenManagerProxy->didEnterFullScreen();
-
     }
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEView.cpp
@@ -456,6 +456,10 @@ bool View::setFullScreen(bool fullScreenState)
         return false;
 #endif
     m_fullScreenModeActive = fullScreenState;
+    if (m_fullScreenModeActive)
+        m_client->enterFullScreen(*this);
+    else
+        m_client->exitFullScreen(*this);
     return true;
 };
 #endif

--- a/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h
@@ -55,5 +55,10 @@ private:
     void didReceiveUserMessage(WKWPE::View&, WebKit::UserMessage&&, CompletionHandler<void(WebKit::UserMessage&&)>&&) override;
     WebKit::WebKitWebResourceLoadManager* webResourceLoadManager() override;
 
+#if ENABLE(FULLSCREEN_API)
+    void enterFullScreen(WKWPE::View&) override;
+    void exitFullScreen(WKWPE::View&) override;
+#endif
+
     WebKitWebView* m_webView;
 };

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -177,10 +177,7 @@
                 "expected": {"all": {"slow": true }}
             },
             "/webkit/WebKitWebView/fullscreen": {
-                "expected": {
-                        "gtk": {"status": ["SKIP"], "bug": "webkit.org/b/248203"},
-                        "wpe": {"status": ["TIMEOUT", "PASS"]}
-                }
+                "expected": {"gtk": {"status": ["SKIP"], "bug": "webkit.org/b/248203"}}
             }
         }
     },


### PR DESCRIPTION
#### 59f29abe483ee8b33b50f5f476f88f67ef5836d8
<pre>
[WPE] `TestWebKitWebView` `/webkit/WebKitWebView/fullscreen` is a timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=258850">https://bugs.webkit.org/show_bug.cgi?id=258850</a>

Reviewed by Michael Catanzaro.

On WPE `WKWPE::View` creates a web page with its own page client.

But when using GLib API we must somehow notify the wrapper `WebKitWebView`
about entering and exiting fullscreen mode.

The solution is to extend `WKWPE::API::Client` with two new methods:
- `enterFullScreen()`
- `exitFullScreen()`

`WebKitWebViewClient`, which implements `WKWPE::API::Client` and has
a reference to `WebKitWebView` wrapper, can react on these events and
call appropriate handlers.

* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(WebKitWebViewClient::enterFullScreen):
(WebKitWebViewClient::exitFullScreen):
* Source/WebKit/UIProcess/API/wpe/APIViewClient.h:
(API::ViewClient::enterFullScreen):
(API::ViewClient::exitFullScreen):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::enterFullScreen):
(WebKit::PageClientImpl::exitFullScreen):
* Source/WebKit/UIProcess/API/wpe/WPEView.cpp:
(WKWPE::View::enterFullScreen):
(WKWPE::View::exitFullScreen):
* Source/WebKit/UIProcess/API/wpe/WPEView.h:
* Source/WebKit/UIProcess/API/wpe/WebKitWebViewClient.h:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265799@main">https://commits.webkit.org/265799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d2a60c44b889b06b1cd23a86ae26b46e8d7b104

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11369 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14229 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14011 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17967 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11290 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10590 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2879 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->