### PR TITLE
fast/mediastream/video-srcObject-set-twice.html is flaky

### DIFF
--- a/LayoutTests/fast/mediastream/video-srcObject-set-twice.html
+++ b/LayoutTests/fast/mediastream/video-srcObject-set-twice.html
@@ -1,11 +1,87 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <div>
 <canvas id="canvas1" width=100 height=100></canvas>
 <canvas id="canvas2" width=100 height=100></canvas>
 <br>
 <video id="video" width=100 height=100 autoplay playsinline></video>
+<br>
+<image id='image'></image>
 <script>
 if (window.testRunner)
     testRunner.waitUntilDone();
+
+function getPixel(x, y, canvas, data)
+{
+    const position = 4 * (x * canvas.width + y);
+    return {r: data[position], g: data[position+1], b: data[position+2]};
+}
+
+function isPixelGreen(x, y, canvas, data)
+{
+   const pixel = getPixel(x, y, canvas, data);
+   return pixel.r === 0 && pixel.g === 128 && pixel.b === 0;
+}
+
+function isPixelWhite(x, y, canvas, data)
+{
+   const pixel = getPixel(x, y, canvas, data);
+   return pixel.r === 255 && pixel.g === 255 && pixel.b === 255;
+}
+
+async function validateSnapshot()
+{
+console.log("validateSnapshot-1 ");
+    if (!window.testRunner)
+        return true;
+    const dataURL = await new Promise(resolve => testRunner.takeViewPortSnapshot(resolve));
+
+    const loadPromise = new Promise((resolve, reject) => {
+        image.onload = resolve;
+        image.onerror = reject;
+        setTimeout(() => reject("image load timed out"), 2000);
+    });
+    image.src = dataURL;
+    await loadPromise;
+console.log("validateSnapshot0 ");
+
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    const data = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height).data;
+
+console.log("validateSnapshot1 ");
+
+    // We inspect the vertial line at pixel 50. We should get white, then green, then white, then green, then white.
+    let i = 0;
+
+console.log("validateSnapshot2 " + i);
+    if (!isPixelWhite(i, 50, canvas, data))
+        return false;
+    while (isPixelWhite(++i, 50, canvas, data)) { };
+
+console.log("validateSnapshot3 " + i);
+    if (!isPixelGreen(i, 50, canvas, data))
+        return false;
+    while (isPixelGreen(++i, 50, canvas, data)) { };
+
+console.log("validateSnapshot4 " + i);
+    if (!isPixelWhite(i, 50, canvas, data))
+        return false;
+    while (isPixelWhite(++i, 50, canvas, data)) { };
+
+console.log("validateSnapshot5 " + i);
+    if (!isPixelGreen(i, 50, canvas, data))
+        return false;
+    while (isPixelGreen(++i, 50, canvas, data)) { };
+
+console.log("validateSnapshot6 " + i);
+    if (!isPixelWhite(i, 50, canvas, data))
+        return false;
+
+console.log("validateSnapshot7 " + i);
+    return true;
+}
 
 async function test()
 {
@@ -28,8 +104,17 @@ async function test()
     }, 100);
     video.srcObject = canvas2.captureStream();
     await video.play();
-    await new Promise(resolve => setTimeout(resolve, 500));
 
+    let counter = 0;
+    let result =  false;
+    while (counter++ < 150 && !result) {
+        await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+        try {
+            result = await validateSnapshot();
+        } catch (e) {
+        }
+    }
+    image.parentNode.removeChild(image);
     if (window.testRunner)
         testRunner.notifyDone();
 }


### PR DESCRIPTION
#### 13fa2acdd4842002cebe0ba83ca272cb4213f391
<pre>
fast/mediastream/video-srcObject-set-twice.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=258851">https://bugs.webkit.org/show_bug.cgi?id=258851</a>
rdar://111738593

Reviewed by Philippe Normand.

When taking a snapshot, we sometimes do not see the video element.
This might be related to rendering taking some time.
We replace the 500 ms timer by calling testRunner.takeViewPortSnapshot and checking the result before calling notifyDone.
If the result is not as expected, we wait for the next frame to retry.
We add console logs in case we need to do some additional debugging from bot results.

* LayoutTests/fast/mediastream/video-srcObject-set-twice.html:

Canonical link: <a href="https://commits.webkit.org/265767@main">https://commits.webkit.org/265767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/830a80c6cc661a3c74688b2f6731d2c1218b3a2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14103 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13871 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17848 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14043 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9320 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10597 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2850 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->