### PR TITLE
Focused text form controls should not get an Interaction Region

### DIFF
--- a/LayoutTests/interaction-region/text-controls-expected.txt
+++ b/LayoutTests/interaction-region/text-controls-expected.txt
@@ -1,0 +1,23 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (9,9) width=211 height=204)
+        (borderRadius 5.00),
+        (interaction (226,178) width=330 height=55)
+        (borderRadius 5.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/text-controls.html
+++ b/LayoutTests/interaction-region/text-controls.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<style>
+    textarea {
+        width: 200px;
+        height: 200px;
+        background: green;
+    }
+    input {
+        width: 300px;
+        font-size: 30px;
+        line-height: 40px;
+        background: blue;
+    }
+</style>
+<body>
+<textarea></textarea>
+<input type="text"></input>
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/text-input-focused-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-expected.txt
@@ -1,0 +1,17 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/text-input-focused.html
+++ b/LayoutTests/interaction-region/text-input-focused.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<style>
+    textarea {
+        width: 200px;
+        height: 200px;
+        background: green;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<textarea></textarea>
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    document.querySelector("textarea").focus();
+    await UIHelper.renderingUpdate();
+
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/textarea-focused-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-expected.txt
@@ -1,0 +1,17 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/textarea-focused.html
+++ b/LayoutTests/interaction-region/textarea-focused.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<style>
+    input {
+        width: 300px;
+        font-size: 30px;
+        line-height: 40px;
+        background: blue;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<input type="text"></input>
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    document.querySelector("input").focus();
+    await UIHelper.renderingUpdate();
+
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -148,6 +148,9 @@ static bool shouldAllowNonPointerCursorForElement(const Element& element)
         return true;
 #endif
 
+    if (is<HTMLTextFormControlElement>(element))
+        return !element.focused();
+
     if (is<HTMLFormControlElement>(element))
         return true;
 


### PR DESCRIPTION
#### a4a7ff9eae45b43802428aa8b520f7c884ad62da
<pre>
Focused text form controls should not get an Interaction Region
<a href="https://bugs.webkit.org/show_bug.cgi?id=258852">https://bugs.webkit.org/show_bug.cgi?id=258852</a>
&lt;rdar://111156944&gt;

Reviewed by Tim Nguyen.

All `HTMLFormControlElement` get an InteractionRegion. For
`HTMLTextFormControlElement`, add a check to make sure they&apos;re not
currently focused.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowNonPointerCursorForElement):
Add the check.

* LayoutTests/interaction-region/text-controls-expected.txt: Added.
* LayoutTests/interaction-region/text-controls.html: Added.
* LayoutTests/interaction-region/text-input-focused-expected.txt: Added.
* LayoutTests/interaction-region/text-input-focused.html: Added.
* LayoutTests/interaction-region/textarea-focused-expected.txt: Added.
* LayoutTests/interaction-region/textarea-focused.html: Added.
New tests covering the change.

Canonical link: <a href="https://commits.webkit.org/265764@main">https://commits.webkit.org/265764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/636e84ddab5ab6d27eee40ef9fc724011948a80c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14112 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12808 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17857 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14052 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11291 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9331 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2848 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->