### PR TITLE
Improve how to serialize fulfilled promise status

### DIFF
--- a/LayoutTests/inspector/model/remote-object/promise-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/promise-expected.txt
@@ -95,7 +95,7 @@ EXPRESSION: Promise.resolve()
       {
         "_name": "status",
         "_type": "string",
-        "_value": "resolved",
+        "_value": "fulfilled",
         "_internal": true
       },
       {
@@ -124,7 +124,7 @@ EXPRESSION: Promise.resolve({result:1})
       {
         "_name": "status",
         "_type": "string",
-        "_value": "resolved",
+        "_value": "fulfilled",
         "_internal": true
       },
       {

--- a/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
@@ -183,7 +183,7 @@ Getting displayable properties...
 Properties:
     "__proto__"  =>  "Promise" (object)  [writable | configurable | isOwn]
 Internal Properties:
-    "status"  =>  "resolved" (string)  []
+    "status"  =>  "fulfilled" (string)  []
     "result"  =>  123 (number)  []
 
 -- Running test case: Runtime.getDisplayableProperties.Promise.Rejected

--- a/LayoutTests/inspector/runtime/getProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getProperties-expected.txt
@@ -163,7 +163,7 @@ Getting own properties...
 Properties:
     "__proto__"  =>  "Promise" (object)  [writable | configurable | isOwn]
 Internal Properties:
-    "status"  =>  "resolved" (string)  []
+    "status"  =>  "fulfilled" (string)  []
     "result"  =>  123 (number)  []
 
 -- Running test case: Runtime.getProperties.Promise.Rejected

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -347,7 +347,7 @@ JSValue JSInjectedScriptHost::getInternalProperties(JSGlobalObject* globalObject
             array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "status"_s, jsNontrivialString(vm, "pending"_s)));
             return array;
         case JSPromise::Status::Fulfilled:
-            array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "status"_s, jsNontrivialString(vm, "resolved"_s)));
+            array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "status"_s, jsNontrivialString(vm, "fulfilled"_s)));
             RETURN_IF_EXCEPTION(scope, JSValue());
             scope.release();
             array->putDirectIndex(globalObject, index++, constructInternalProperty(globalObject, "result"_s, promise->result(vm)));


### PR DESCRIPTION
#### 359976cda05e9714df3462327e2b3d0fc8527649
<pre>
Improve how to serialize fulfilled promise status
<a href="https://bugs.webkit.org/show_bug.cgi?id=225328">https://bugs.webkit.org/show_bug.cgi?id=225328</a>

Reviewed by Patrick Angle.

While the `[[PromiseStatus]]` enum matches the spec to have `fulfilled`
status, WebKit is translating it to `resolved` which doesn&apos;t match the
spec[1]. Thus, this commit will make `fulfilled` status to be serialized
as `fulfilled` instead of `resolved`.

[1]: <a href="https://tc39.es/ecma262/#sec-properties-of-promise-instances">https://tc39.es/ecma262/#sec-properties-of-promise-instances</a>

* LayoutTests/inspector/model/remote-object/promise-expected.txt:
* LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt:
* LayoutTests/inspector/runtime/getProperties-expected.txt:
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getInternalProperties):

Canonical link: <a href="https://commits.webkit.org/266058@main">https://commits.webkit.org/266058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e3d3cf1cc46a825c12ce2aa39314fd8abd2f776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14138 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13910 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17882 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10051 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14077 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9355 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11925 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10493 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14776 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12261 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11174 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2973 "Passed tests") | 
<!--EWS-Status-Bubble-End-->