### PR TITLE
Do not convert testharness paths in import-w3c-tests

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
@@ -108,7 +108,7 @@ CONTENT OF TEST
         converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converter, converted[2], fake_dir_path, 1, 1)
+        self.verify_test_harness_paths(converted[2], 1, 1)
         self.verify_prefixed_properties(converted, [])
         self.verify_prefixed_property_values(converted, [])
 
@@ -140,7 +140,7 @@ CONTENT OF TEST
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converter, converted[2], fake_dir_path, 1, 1)
+        self.verify_test_harness_paths(converted[2], 1, 1)
         self.verify_prefixed_properties(converted, test_content[0])
         self.verify_prefixed_property_values(converted, test_content[1])
 
@@ -174,7 +174,7 @@ CONTENT OF TEST
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converter, converted[2], fake_dir_path, 1, 1)
+        self.verify_test_harness_paths(converted[2], 1, 1)
         self.verify_prefixed_properties(converted, test_content[0])
         self.verify_prefixed_property_values(converted, test_content[1])
 
@@ -196,7 +196,7 @@ CONTENT OF TEST
             converted = converter.output()
 
         self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converter, converted[2], fake_dir_path, 2, 1)
+        self.verify_test_harness_paths(converted[2], 2, 1)
 
     def test_convert_prefixed_properties(self):
         """ Tests convert_prefixed_properties() file that has 20 properties requiring the -webkit- prefix:
@@ -360,21 +360,13 @@ CONTENT OF TEST
     def verify_no_conversion_happened(self, converted, original):
         self.assertEqual(converted[2], original, 'test should not have been converted')
 
-    def verify_test_harness_paths(self, converter, converted, test_path, num_src_paths, num_href_paths):
+    def verify_test_harness_paths(self, converted, num_src_paths, num_href_paths):
         if isinstance(converted, str) or isinstance(converted, unicode):
             converted = BeautifulSoup(converted)
 
-        resources_dir = converter.path_from_webkit_root("LayoutTests", "resources")
-
-        # Verify the original paths are gone, and the new paths are present.
-        orig_path_pattern = re.compile('\"/resources/testharness')
-        self.assertEqual(len(converted.findAll(src=orig_path_pattern)), 0, 'testharness src path was not converted')
-        self.assertEqual(len(converted.findAll(href=orig_path_pattern)), 0, 'testharness href path was not converted')
-
-        new_relpath = os.path.relpath(resources_dir, test_path).replace(os.sep, '/')
-        relpath_pattern = re.compile(new_relpath)
-        self.assertEqual(len(converted.findAll(src=relpath_pattern)), num_src_paths, 'testharness src relative path not correct')
-        self.assertEqual(len(converted.findAll(href=relpath_pattern)), num_href_paths, 'testharness href relative path not correct')
+        orig_path_pattern = re.compile('^/resources/testharness')
+        self.assertEquals(len(converted.findAll(src=orig_path_pattern)), num_src_paths, 'testharness src path should not have been converted')
+        self.assertEquals(len(converted.findAll(href=orig_path_pattern)), num_href_paths, 'testharness href path should not have been converted')
 
     def verify_prefixed_properties(self, converted, test_properties):
         self.assertEqual(len(set(converted[0])), len(set(test_properties)), 'Incorrect number of properties converted')

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -48,14 +48,11 @@
          2. LayoutTests/imported/w3c/resources/ImportExpectations list the test suites or tests to NOT import.
 
     - All files are converted to work in WebKit:
-         1. Paths to testharness.js files are modified to point to Webkit's copy of them in
-            LayoutTests/resources, using the correct relative path from the new location.
-            This is applied to CSS tests but not to WPT tests.
-         2. All CSS properties requiring the -webkit-vendor prefix are prefixed - this current
+         1. All CSS properties requiring the -webkit-vendor prefix are prefixed - this current
             list of what needs prefixes is read from Source/WebCore/CSS/CSSProperties.in
-         3. Each reftest has its own copy of its reference file following the naming conventions
+         2. Each reftest has its own copy of its reference file following the naming conventions
             new-run-webkit-tests expects
-         4. If a reference files lives outside the directory of the test that uses it, it is checked
+         3. If a reference files lives outside the directory of the test that uses it, it is checked
             for paths to support files as it will be imported into a different relative position to the
             test file (in the same directory)
 
@@ -121,8 +118,6 @@ To import a web-platform-tests suite from a specific folder, use 'import-w3c-tes
 
     parser.add_argument('-n', '--no-overwrite', dest='overwrite', action='store_false', default=True,
         help='Flag to prevent duplicate test files from overwriting existing tests. By default, they will be overwritten')
-    parser.add_argument('-l', '--no-links-conversion', dest='convert_test_harness_links', action='store_false', default=True,
-       help='Do not change links (testharness js or css e.g.). This option only applies when providing a source directory, in which case by default, links are converted to point to WebKit testharness files. When tests are downloaded from W3C repository, links are converted for CSS tests and remain unchanged for WPT tests')
 
     parser.add_argument('-t', '--tip-of-tree', dest='use_tip_of_tree', action='store_true', default=False,
         help='Import all tests using the latest repository revision')
@@ -380,14 +375,6 @@ class TestImporter(object):
                 self.import_list.append({'dirname': root, 'copy_list': copy_list,
                     'reftests': reftests, 'jstests': jstests, 'crashtests': crashtests, 'total_tests': total_tests})
 
-    def should_convert_test_harness_links(self, test):
-        if self._importing_downloaded_tests:
-            for test_repository in self.test_downloader().test_repositories:
-                if test.startswith(test_repository['name']):
-                    return 'convert_test_harness_links' in test_repository['import_options']
-            return True
-        return self.options.convert_test_harness_links
-
     def _webkit_test_runner_options(self, path):
         if not(self.filesystem.isfile(path)):
             return ''
@@ -546,7 +533,7 @@ class TestImporter(object):
                                         and ('html' in str(mimetype[0]) or 'xml' in str(mimetype[0])  or 'css' in str(mimetype[0]) or 'javascript' in str(mimetype[0])):
                     _log.info("Rewriting: %s" % new_filepath)
                     try:
-                        converted_file = convert_for_webkit(new_path, filename=orig_filepath, reference_support_info=reference_support_info, host=self.host, convert_test_harness_links=self.should_convert_test_harness_links(subpath), webkit_test_runner_options=self._webkit_test_runner_options(new_filepath))
+                        converted_file = convert_for_webkit(new_path, filename=orig_filepath, reference_support_info=reference_support_info, host=self.host, webkit_test_runner_options=self._webkit_test_runner_options(new_filepath))
                     except:
                         _log.warn('Failed converting %s', orig_filepath)
                         failed_conversion_files.append(orig_filepath)


### PR DESCRIPTION
#### 1866a4e1cf4833ce8cfa2b7bc36e14d5c7dc0273
<pre>
Do not convert testharness paths in import-w3c-tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=185876">https://bugs.webkit.org/show_bug.cgi?id=185876</a>

Reviewed by Jonathan Bedard.

Since the csswg-tests repo was merged into WPT, there is only one test repository now in
imported/w3c/resources/TestRepositories, which does not specify the option to convert
testharness paths from relative paths to explicit paths. Additionally, wptserve has been
used for some time, so run-webkit-tests should have no problem with relative paths to
the testharness paths. Thus, there is no reason to continue converting testharness paths,
so this patch removes all code related to that conversion.

* Scripts/webkitpy/w3c/test_converter.py:
(convert_for_webkit):
(_W3CTestConverter.__init__):
(_W3CTestConverter.convert_attributes_if_needed):
* Scripts/webkitpy/w3c/test_converter_unittest.py:
(verify_test_harness_paths):
* Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.find_importable_tests):
(TestImporter.import_tests):

Canonical link: <a href="https://commits.webkit.org/265842@main">https://commits.webkit.org/265842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc990ee4d00e71041a3999b2902033b50e693f7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13885 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/11914 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17861 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14056 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14751 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->