### PR TITLE
Prevent counter values from over/underflowing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#auto-numbering">
+<div>
+<h3>2050000000</h3>
+<h3>2100000000</h3>
+<h3>2100000000</h3>
+</div>
+<div>
+<h3>-2050000000</h3>
+<h3>-2100000000</h3>
+<h3>-2100000000</h3>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#auto-numbering">
+<div>
+<h3>2050000000</h3>
+<h3>2100000000</h3>
+<h3>2100000000</h3>
+</div>
+<div>
+<h3>-2050000000</h3>
+<h3>-2100000000</h3>
+<h3>-2100000000</h3>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<link rel="author" title="Vitor Roriz" href="https://github.com/vitorroriz">
+<link rel="help" href="https://drafts.csswg.org/css-lists-3/#auto-numbering">
+<link rel="match" href="counter-reset-increment-overflow-underflow-ref.html">
+<style>
+.overflow {
+  counter-reset: over-counter 2000000000;
+}
+.overflow h3:before {
+  counter-increment: over-counter 50000000;
+}
+.overflow h3::before {
+  content: counter(over-counter);
+}
+
+.underflow {
+  counter-reset: under-counter -2000000000
+}
+.underflow h3:before {
+  counter-increment: under-counter -50000000;
+}
+.underflow h3::before {
+  content: counter(under-counter);
+}
+</style>
+<div class="overflow">
+<h3></h3>
+<h3></h3>
+<h3></h3>
+</div>
+<div class="underflow">
+<h3></h3>
+<h3></h3>
+<h3></h3>
+</div>

--- a/Source/WTF/wtf/CheckedArithmetic.h
+++ b/Source/WTF/wtf/CheckedArithmetic.h
@@ -1013,6 +1013,12 @@ template<typename T, typename U> bool differenceOverflows(U left, U right)
     return checkedDifference<T>(left, right).hasOverflowed();
 }
 
+template<typename T> T sumIfNoOverflowOrFirstValue(T firstValue, T secondValue)
+{
+    auto result = Checked<T, RecordOverflow>(firstValue) + Checked<T, RecordOverflow>(secondValue);
+    return result.hasOverflowed() ? firstValue : result.value();
+}
+
 template<typename T, typename U>
 Checked<T, RecordOverflow> checkedProduct(U value)
 {


### PR DESCRIPTION
#### a3717f099f7779455b1f37625f208f6115dba449
<pre>
Prevent counter values from over/underflowing
<a href="https://bugs.webkit.org/show_bug.cgi?id=258730">https://bugs.webkit.org/show_bug.cgi?id=258730</a>
rdar://111743827

Reviewed by Chris Dumez.

We will ignore the counter-increment() operation if
this would result in overflow/underflow for compatibility
with other vendors (<a href="https://github.com/w3c/csswg-drafts/issues/9029).">https://github.com/w3c/csswg-drafts/issues/9029).</a>

 * LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-expected.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow-ref.html: Added.
 * LayoutTests/imported/w3c/web-platform-tests/css/css-lists/counter-reset-increment-overflow-underflow.html: Added.
 * Source/WTF/wtf/CheckedArithmetic.h:
 (WTF::sumIfNoOverflowOrFirstValue):
 * Source/WebCore/rendering/CounterNode.cpp:
 (WebCore::CounterNode::computeCountInParent const):

Canonical link: <a href="https://commits.webkit.org/266817@main">https://commits.webkit.org/266817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8064ffbdd11a9411f4a643c26587d5edd3186d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16613 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17329 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20371 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12706 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16801 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11926 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15047 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13251 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3581 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17735 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15277 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13955 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3650 "Passed tests") | 
<!--EWS-Status-Bubble-End-->