### PR TITLE
Make Attr.nodeValue/textContent not nullable

### DIFF
--- a/LayoutTests/fast/dom/coreDOM-element-attribute-js-null-expected.txt
+++ b/LayoutTests/fast/dom/coreDOM-element-attribute-js-null-expected.txt
@@ -1,6 +1,8 @@
 This test setting various attributes of a elements to JavaScript null.
 
 TEST SUCCEEDED: The value was the string 'null'. [tested Attr.value]
+TEST SUCCEEDED: The value was the empty string. [tested Attr.nodeValue]
+TEST SUCCEEDED: The value was the empty string. [tested Attr.textContent]
 
 TEST SUCCEEDED: The value was the empty string. [tested ProcessingInstruction.data]
 

--- a/LayoutTests/fast/dom/coreDOM-element-attribute-js-null.xhtml
+++ b/LayoutTests/fast/dom/coreDOM-element-attribute-js-null.xhtml
@@ -50,7 +50,9 @@
                     type: 'Attr',
                     elementToUse: document.createAttributeNS('http://www.w3.org/1999/xhtml','anAttribute'),
                     attributes: [
-                        {name: 'value', expectedNull: 'null'}
+                        {name: 'value', expectedNull: 'null'},
+                        {name: 'nodeValue', expectedNull: ''},
+                        {name: 'textContent', expectedNull: ''}
                     ]
                 },
                 {

--- a/Source/WebCore/dom/Attr.cpp
+++ b/Source/WebCore/dom/Attr.cpp
@@ -103,7 +103,7 @@ void Attr::setValue(const AtomString& value)
 
 void Attr::setNodeValue(const String& value)
 {
-    setValue(AtomString { value });
+    setValue(value.isNull() ? emptyAtom() : AtomString(value));
 }
 
 Ref<Node> Attr::cloneNodeInternal(Document& targetDocument, CloningOperation)


### PR DESCRIPTION
#### 2da4c96001cfb666ae7f6483b464ed5f9b07734b
<pre>
Make Attr.nodeValue/textContent not nullable

<a href="https://bugs.webkit.org/show_bug.cgi?id=249323">https://bugs.webkit.org/show_bug.cgi?id=249323</a>
rdar://problem/103602803

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired: <a href="https://chromium.googlesource.com/chromium/blink/+/a7c3bb9f22401c30e906a3ec53595247e707de83">https://chromium.googlesource.com/chromium/blink/+/a7c3bb9f22401c30e906a3ec53595247e707de83</a>

This patch updates Attr value for &apos;nodeVAlue&apos; and &apos;textContent&apos; to
return empty string if null.

Web-Spec: <a href="https://dom.spec.whatwg.org/#interface-attr">https://dom.spec.whatwg.org/#interface-attr</a>

* Source/WebCore/dom/Attr.cpp:
(Attr::setNodeValue): As per commit message
* LayoutTests/fast/dom/coreDOM-element-attribute-js-null.xhtml: Rebaselined
* LayoutTests/fast/dom/coreDOM-element-attribute-js-null-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/265769@main">https://commits.webkit.org/265769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e135721b3dfbd7a399177fafa26f0ec6966c154

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14160 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12854 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13932 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10776 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11340 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10515 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2851 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->