### PR TITLE
[WPE] Implement click counting in mouse events

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1278,12 +1278,9 @@ Bug(WPE) fast/viewport/viewport-legacy-xhtmlmp.html [ Failure ]
 webkit.org/b/174673 fast/events/keyboardevent-code.html [ Failure ]
 
 # clickCount related failures
-webkit.org/b/174674 fast/events/click-count.html [ Failure ]
-webkit.org/b/174674 fast/events/dblclick-addEventListener.html [ Failure ]
 webkit.org/b/174674 fast/events/mouse-click-events.html [ Failure ]
 webkit.org/b/174674 fast/events/selectstart-by-double-triple-clicks.html [ Failure ]
 webkit.org/b/174674 fast/events/zoom-dblclick.html [ Failure ]
-webkit.org/b/174674 imported/w3c/web-platform-tests/uievents/click/dblclick_event_mouse.html [ Failure ]
 
 # The tests below need gardening after the EventSenderWPE has been added.
 # Most of them are probably failing because of missing support of event related


### PR DESCRIPTION
#### 0482f3984fab2efcfa7a4d32574c61ad144e27d0
<pre>
[WPE] Implement click counting in mouse events
<a href="https://bugs.webkit.org/show_bug.cgi?id=174674">https://bugs.webkit.org/show_bug.cgi?id=174674</a>

Reviewed by Carlos Garcia Campos.

Follow WinCairo logic to implement click counts for mouse events.

* LayoutTests/platform/wpe/TestExpectations:
* Source/WebKit/Shared/libwpe/WebEventFactory.cpp:
(WebKit::getDoubleClickTime):
(WebKit::clickCount):
(WebKit::WebEventFactory::createWebMouseEvent):

Canonical link: <a href="https://commits.webkit.org/265808@main">https://commits.webkit.org/265808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7062e8c46b7c6d177c1086f6696e56557cf4008b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14246 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12124 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14121 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10857 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14184 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10711 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2918 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->