### PR TITLE
VideoEncoder does not call output callback on FullHD configuration

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace-expected.txt
@@ -2,4 +2,5 @@
 PASS VP8 decoded frame color space
 PASS VP9 decoded frame color space
 PASS H.264 decoded frame color space
+PASS H.264 high profile decoded frame color space
 

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace.html
@@ -62,11 +62,11 @@ async function doEncodeDecode(encoderConfig)
   return promise;
 }
 
-function doTest(codec, title)
+function doTest(codec, title, width = 320, height = 200)
 {
   const config = { codec };
-  config.width = 320;
-  config.height = 200;
+  config.width = width;
+  config.height = height;
   config.bitrate = 1000000;
   config.framerate = 30;
 
@@ -81,6 +81,7 @@ function doTest(codec, title)
 doTest('vp8', "VP8 decoded frame color space");
 doTest('vp09.00.10.08', "VP9 decoded frame color space");
 doTest('avc1.42001E', "H.264 decoded frame color space");
+doTest('avc1.64000b', "H.264 high profile decoded frame color space", 1000, 1000);
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1129,6 +1129,8 @@ imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?v
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
+http/wpt/webcodecs/videoFrame-colorSpace.html [ Skip ]
+
 # Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?av1 [ Failure ]


### PR DESCRIPTION
#### 9879838d03158883d5b1ff6d4df1bae65efe2342
<pre>
VideoEncoder does not call output callback on FullHD configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=258669">https://bugs.webkit.org/show_bug.cgi?id=258669</a>
rdar://111685821

Reviewed by Eric Carlson.

Extract the profile level id from the codec string for H.264 and send it to GPUProcess for proper initialization.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace-expected.txt:
* LayoutTests/http/wpt/webcodecs/videoFrame-colorSpace.html:
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createEncoder):

Canonical link: <a href="https://commits.webkit.org/265792@main">https://commits.webkit.org/265792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6053d8e9e663e8a1a1d8d6d1063a84ae7732661

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14006 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10833 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14161 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10711 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11264 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->