### PR TITLE
Service Worker: Redirect loses hash fragment

### DIFF
--- a/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash-worker.js
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash-worker.js
@@ -1,0 +1,3 @@
+addEventListener("fetch", (e) => {
+    e.respondWith(fetch(e.request));
+});

--- a/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS setup
+PASS load iframe with hash
+

--- a/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Navigation redirect with hash</title>
+<meta name=timeout content=long>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<body>
+<script>
+promise_test(async () => {
+    const registration = await navigator.serviceWorker.register("navigation-redirect-with-hash-worker.js", { scope : "resources" });
+    var activeWorker = registration.active;
+    if (!activeWorker) {
+        activeWorker = registration.installing;
+        await new Promise(resolve => {
+            activeWorker.addEventListener('statechange', () => {
+                if (activeWorker.state === "activated")
+                    resolve(registration);
+            });
+        });
+    }
+}, "setup");
+
+promise_test(async () => {
+   const frame = await with_iframe("/WebKit/service-workers/resources/redirect-with-hash.py#test");
+   assert_equals(frame.contentWindow.location.hash, "#test");
+   frame.remove(); 
+}, "load iframe with hash");
+</script>
+</body>

--- a/LayoutTests/http/wpt/service-workers/resources/redirect-with-hash.py
+++ b/LayoutTests/http/wpt/service-workers/resources/redirect-with-hash.py
@@ -1,0 +1,8 @@
+from wptserve.utils import isomorphic_decode
+
+
+def main(request, response):
+    headers = []
+    headers.append((b"Location", b"/redirected"))
+
+    return 302, headers, b""

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -128,7 +128,9 @@ public:
     WEBCORE_EXPORT void setURL(const URL& url);
 
     void redirectAsGETIfNeeded(const ResourceRequestBase &, const ResourceResponse&);
-    WEBCORE_EXPORT ResourceRequest redirectedRequest(const ResourceResponse&, bool shouldClearReferrerOnHTTPSToHTTPRedirect) const;
+
+    enum class ShouldSetHash : bool { No, Yes };
+    WEBCORE_EXPORT ResourceRequest redirectedRequest(const ResourceResponse&, bool shouldClearReferrerOnHTTPSToHTTPRedirect, ShouldSetHash = ShouldSetHash::No) const;
 
     WEBCORE_EXPORT void removeCredentials();
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -205,7 +205,7 @@ void ServiceWorkerFetchTask::processRedirectResponse(ResourceResponse&& response
 
     if (shouldSetSource == ShouldSetSource::Yes)
         response.setSource(ResourceResponse::Source::ServiceWorker);
-    auto newRequest = m_currentRequest.redirectedRequest(response, m_loader.parameters().shouldClearReferrerOnHTTPSToHTTPRedirect);
+    auto newRequest = m_currentRequest.redirectedRequest(response, m_loader.parameters().shouldClearReferrerOnHTTPSToHTTPRedirect, ResourceRequest::ShouldSetHash::Yes);
 
     m_loader.willSendServiceWorkerRedirectedRequest(ResourceRequest(m_currentRequest), WTFMove(newRequest), WTFMove(response));
 }


### PR DESCRIPTION
#### e4b3080bb04a0f54d1c3d9cd707d92d37d5feb54
<pre>
Service Worker: Redirect loses hash fragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=258195">https://bugs.webkit.org/show_bug.cgi?id=258195</a>
rdar://111208014

Reviewed by Chris Dumez.

Make sure to implement the fragment identifier handling defined in <a href="https://fetch.spec.whatwg.org/#concept-response-location-url">https://fetch.spec.whatwg.org/#concept-response-location-url</a>:
- If the response has a fragment identifier and the URL computed from the location header does not, add the fragment identifier back.

* LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash-worker.js: Added.
* LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https.html: Added.
* LayoutTests/http/wpt/service-workers/resources/redirect-with-hash.py: Added.
(main):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::redirectedRequest const):
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::processRedirectResponse):

Canonical link: <a href="https://commits.webkit.org/265845@main">https://commits.webkit.org/265845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d6a0f76ef3ff87b5aee1713ba22abdc68374535

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13780 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14311 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14194 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18046 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14251 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9523 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10796 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2947 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->