### PR TITLE
[WPE][GTK] API test `TestWebProcessExtensions` `/webkit/WebKitWebProcessExtension/user-messages` is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp
@@ -707,7 +707,7 @@ static void testWebProcessExtensionUserMessages(UserMessageTest* test, gconstpoi
     g_assert_error(messageError, WEBKIT_USER_MESSAGE_ERROR, WEBKIT_USER_MESSAGE_UNHANDLED_MESSAGE);
 
     // Message that is never replied.
-    GRefPtr<WebKitWebView> webView = WEBKIT_WEB_VIEW(Test::createWebView(test->m_webContext.get()));
+    auto webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
     webkit_web_view_send_message_to_page(webView.get(), webkit_user_message_new("Test.Infinite", nullptr), nullptr,
         [](GObject* object, GAsyncResult* result, gpointer userData) {
             auto* test = static_cast<UserMessageTest*>(userData);
@@ -735,7 +735,7 @@ static void testWebProcessExtensionUserMessages(UserMessageTest* test, gconstpoi
     g_assert_cmpstr(webkit_user_message_get_name(message), ==, "Test.AsyncPong");
 
     // Create a new page and wait for page created message.
-    webView = WEBKIT_WEB_VIEW(Test::createWebView(test->m_webContext.get()));
+    webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
     webkit_web_view_load_html(webView.get(), "<html><body></body></html>", nullptr);
     message = test->waitUntilContextMessageReceived("PageCreated");
     g_assert_true(WEBKIT_IS_USER_MESSAGE(message));

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -111,10 +111,7 @@
                 "expected": {"all": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/205333"}}
             },
             "/webkit/WebKitWebProcessExtension/user-messages": {
-                "expected": {
-                    "gtk": {"status": ["FAIL", "TIMEOUT", "PASS"], "bug": "webkit.org/b/211336"},
-                    "wpe": {"status": ["FAIL", "TIMEOUT", "PASS", "CRASH"], "bug": ["webkit.org/b/211336", "webkit.org/b/219980"]}
-                }
+                "expected": {"all": {"slow": true}}
             },
             "/webkit/WebKitWebProcessExtension/dom-document-title": {
                 "expected": {"gtk": {"status": ["FAIL", "PASS"], "bug": "webkit.org/b/254002"}}


### PR DESCRIPTION
#### 7ca70abf650fc5c8a319d6a7cc2c982d90dcf0ba
<pre>
[WPE][GTK] API test `TestWebProcessExtensions` `/webkit/WebKitWebProcessExtension/user-messages` is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=258883">https://bugs.webkit.org/show_bug.cgi?id=258883</a>

Reviewed by Philippe Normand.

As explained in `190570@main`, on GTK `webkit_web_view_new` returns
a floating reference, where on WPE it returns an ordinary reference.
There is a special function - `Test::adoptView()` which allows us
not worry about this difference.

Also, this test does a lot of async stuff and can be slow,
so marking it as &quot;slow&quot;.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebProcessExtensions.cpp:
(testWebProcessExtensionUserMessages):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265772@main">https://commits.webkit.org/265772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2c02f89dfae331a6b9b8cb3dd0f7f3bcb3413b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11300 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11882 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14156 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12850 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13930 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17901 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14095 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9375 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10513 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2853 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->