### PR TITLE
REGRESSION(264685@main): Introduced page load time regression

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -714,6 +714,47 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void deliberateCrashForTesting()
 #endif
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+static void prewarmLogs()
+{
+    static std::array<std::pair<const char*, const char*>, 29> logs { {
+        { "com.apple.CFBundle", "strings" },
+        { "com.apple.containermanager", "unspecified" },
+        { "com.apple.containermanager", "cache" },
+        { "com.apple.containermanager", "sandbox" },
+        { "com.apple.containermanager", "xpc" },
+        { "com.apple.containermanager", "query" },
+        { "com.apple.containermanager", "paths" },
+        { "com.apple.containermanager", "locking" },
+        { "com.apple.containermanager", "database" },
+        { "com.apple.containermanager", "upcall" },
+        { "com.apple.containermanager", "lifecycle" },
+        { "com.apple.containermanager", "fs" },
+        { "com.apple.containermanager", "startup" },
+        { "com.apple.containermanager", "test" },
+        { "com.apple.containermanager", "metadata" },
+        { "com.apple.containermanager", "codesignmapping" },
+        { "com.apple.containermanager", "longterm" },
+        { "com.apple.containermanager", "schema" },
+        { "com.apple.containermanager", "codesign" },
+        { "com.apple.containermanager", "repair" },
+        { "com.apple.containermanager", "disk" },
+        { "com.apple.containermanager", "persona" },
+        { "com.apple.containermanager", "command" },
+        { "com.apple.containermanager", "telemetry" },
+        { "com.apple.network", "" },
+        { "com.apple.CFNetwork", "ATS" },
+        { "com.apple.coremedia", "" },
+        { "com.apple.coremedia", "" },
+        { "com.apple.SafariShared", "Translation" },
+    } };
+
+    for (auto& log : logs) {
+        auto logHandle = os_log_create(log.first, log.second);
+        bool enabled = os_log_type_enabled(logHandle, OS_LOG_TYPE_ERROR);
+        UNUSED_PARAM(enabled);
+    }
+}
+
 static void registerLogHook()
 {
     if (os_trace_get_mode() != OS_TRACE_MODE_DISABLE && os_trace_get_mode() != OS_TRACE_MODE_OFF)
@@ -771,6 +812,7 @@ static void registerLogHook()
 void WebProcess::platformInitializeProcess(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
+    prewarmLogs();
     registerLogHook();
 #endif
 


### PR DESCRIPTION
#### 695ee5dcb9e5d659b4b7def7736630fdbf109276
<pre>
REGRESSION(264685@main): Introduced page load time regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=258887">https://bugs.webkit.org/show_bug.cgi?id=258887</a>
rdar://111788974

Reviewed by Brent Fulgham.

When the log daemon is blocked, the WebContent process will have to read log preferences directly
from plist files on disk, which can slow down page loading. Address this issue by prewarming some
log objects.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::prewarmLogs):
(WebKit::WebProcess::platformInitializeProcess):

Canonical link: <a href="https://commits.webkit.org/265807@main">https://commits.webkit.org/265807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cc8a056c219780ab93c33bcd2b346dbda172b7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11304 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12856 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13934 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10148 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17904 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14098 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9378 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10517 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2920 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->