### PR TITLE
Crash in RemoteLayerTreeDrawingAreaProxyMac::displayLink()

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -118,7 +118,8 @@ DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink()
 
 DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::displayLink()
 {
-    ASSERT(m_displayID);
+    if (!m_displayID)
+        return;
 
     auto& displayLinks = m_webPageProxy.process().processPool().displayLinks();
     return displayLinks.displayLinkForDisplay(*m_displayID);


### PR DESCRIPTION
#### ffec206030cd12f9a8dda9f673f87e3dbfd91348
<pre>
Crash in RemoteLayerTreeDrawingAreaProxyMac::displayLink()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258892">https://bugs.webkit.org/show_bug.cgi?id=258892</a>
rdar://111348720

Reviewed by NOBODY (OOPS!).

Crash data suggest that m_displayID can be unset in RemoteLayerTreeDrawingAreaProxyMac::displayLink(), so
when it is unset, just early return.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffec206030cd12f9a8dda9f673f87e3dbfd91348

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12077 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12451 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11315 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14466 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12058 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12865 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/12451 "Failed to compile WebKit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13945 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10157 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/12451 "Failed to compile WebKit") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17914 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11235 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/12451 "Failed to compile WebKit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11353 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/12058 "Failed to compile WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10528 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/12451 "Failed to compile WebKit") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->