### PR TITLE
Setting outerHTML on child of DocumentFragment should not throw error

### DIFF
--- a/LayoutTests/fast/dom/set-outer-html-special-cases-expected.txt
+++ b/LayoutTests/fast/dom/set-outer-html-special-cases-expected.txt
@@ -6,7 +6,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS document.getElementById('svgElement').innerHTML is "<g></g>"
 PASS document.documentElement.outerHTML = '' threw exception NoModificationAllowedError: Cannot set outerHTML on element because its parent is not an Element.
 PASS a.parentNode is null
-PASS a.outerHTML = '' threw exception NoModificationAllowedError: Cannot set outerHTML on element because it doesn't have a parent.
+PASS a.outerHTML = '' did not throw exception.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/set-outer-html-special-cases.html
+++ b/LayoutTests/fast/dom/set-outer-html-special-cases.html
@@ -16,7 +16,7 @@
         // say this should be a no-op though.
         a = document.createElement("a");
         shouldBe("a.parentNode", "null");
-        shouldThrowErrorName("a.outerHTML = ''", "NoModificationAllowedError");
+        shouldNotThrow("a.outerHTML = ''");
     }
     </script>
 </head>

--- a/LayoutTests/fast/dynamic/outerHTML-no-element-expected.txt
+++ b/LayoutTests/fast/dynamic/outerHTML-no-element-expected.txt
@@ -1,5 +1,5 @@
 test for 4110775 Crash will occur when double-clicking outerHTML link on W3 DOM test
 
-If the test fails, Safari may crash, or you may see a failure message below. If the test passes, you should see a message with a description of the expected exception.
+If the test fails, Safari may crash, or you may see a failure message below. If the test passes, you should see "This test passed!".
 
-This test passed - expected error - NoModificationAllowedError: Cannot set outerHTML on element because it doesn't have a parent
+This test passed!

--- a/LayoutTests/fast/dynamic/outerHTML-no-element.html
+++ b/LayoutTests/fast/dynamic/outerHTML-no-element.html
@@ -1,19 +1,19 @@
 <html>
 <body>
 <p>test for <a href="rdar://problem/4110775">4110775</a> Crash will occur when double-clicking outerHTML link on W3 DOM test</p>
-<p>If the test fails, Safari may crash, or you may see a failure message below.  If the test passes, you should see a message with a description of the expected exception.</p>
+<p>If the test fails, Safari may crash, or you may see a failure message below. If the test passes, you should see "This test passed!".</p>
 <div id="test">This test failed.</div>
 
 <script type="text/javascript">
 if (window.testRunner)
     testRunner.dumpAsText();
 var t = document.getElementById("test");
-var outerStr = "<div id='test2'>This test failed!</div>";
+var outerStr = "<div id='test2'>This test passed!</div>";
 t.outerHTML = outerStr;
 try {
     t.outerHTML = "<div id='test2'>This test failed!!</div>"
 }catch(e) {
-    document.getElementById("test2").outerHTML = "<div id='test2'>This test passed - expected error - " + e + "</div>";
+    document.getElementById("test2").outerHTML = "<div id='test2'>This test failed since threw error - " + e + "</div>";
 }
 </script>
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3738,11 +3738,11 @@ String Element::outerHTML() const
 ExceptionOr<void> Element::setOuterHTML(const String& html)
 {
     // The specification allows setting outerHTML on an Element whose parent is a DocumentFragment and Gecko supports this.
-    // However, as of June 2021, Blink matches our behavior and throws a NoModificationAllowedError for non-Element parents.
+    // https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml
     RefPtr parent = parentElement();
     if (UNLIKELY(!parent)) {
         if (!parentNode())
-            return Exception { NoModificationAllowedError, "Cannot set outerHTML on element because it doesn't have a parent"_s };
+            return { };
         return Exception { NoModificationAllowedError, "Cannot set outerHTML on element because its parent is not an Element"_s };
     }
 


### PR DESCRIPTION
#### b41af45ee409c4445f2ffa18ee14959c044b083e
<pre>
Setting outerHTML on child of DocumentFragment should not throw error

<a href="https://bugs.webkit.org/show_bug.cgi?id=249737">https://bugs.webkit.org/show_bug.cgi?id=249737</a>
rdar://problem/103746193

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Web-Spec [1].

In 238774@main, WebKit aligned with behavior for better compatibility but
it was not correct and clarified later to not throw error [2]. This PR is
essentially revert part of 238774@main with update to align by not throwing error.

[1] <a href="https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml">https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml</a>
[2] <a href="https://github.com/whatwg/html/issues/8657">https://github.com/whatwg/html/issues/8657</a>

* Source/WebCore/dom/Element.cpp:
(Element::setOuterHTML): Update to not throw error
* LayoutTests/fast/dynamic/outerHTML-no-element.html: Rebaselined
* LayoutTests/fast/dynamic/outerHTML-no-element-expected.txt: Rebaselined
* LayoutTests/fast/dom/set-outer-html-special-cases.html: Rebaselined
* LayoutTests/fast/dom/set-outer-html-special-cases-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/266086@main">https://commits.webkit.org/266086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdf5c2e0521afcafda632858ec7323defc8e33a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13180 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15024 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18683 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12092 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10148 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11485 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15813 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12078 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->