### PR TITLE
Clean-up ArrayProfile usage in call opcodes

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -97,7 +97,6 @@ op :tail_call_varargs,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     },
     tmps: {
@@ -119,7 +118,6 @@ op :call_varargs,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     },
     tmps: {
@@ -147,7 +145,6 @@ op :iterator_next,
         doneProfile: ValueProfile,
         valueModeMetadata: GetByIdModeMetadata,
         valueProfile: ValueProfile,
-        arrayProfile: ArrayProfile,
         iterableProfile: ArrayProfile,
         iterationMetadata: IterationModeMetadata,
     },
@@ -171,7 +168,6 @@ op :construct_varargs,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     },
     tmps: {
@@ -253,7 +249,6 @@ op :construct,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     }
 
@@ -322,7 +317,6 @@ op :call_direct_eval,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     }
 
@@ -337,7 +331,6 @@ op :tail_call_forward_arguments,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        arrayProfile: ArrayProfile,
         profile: ValueProfile,
     }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h
@@ -32,26 +32,6 @@
 namespace JSC {
 
 template<typename BytecodeMetadata>
-ArrayProfile* arrayProfileForImpl(BytecodeMetadata& metadata, unsigned checkpointIndex)
-{
-    UNUSED_PARAM(checkpointIndex);
-    return &metadata.m_callLinkInfo.m_arrayProfile;
-}
-
-template<typename BytecodeMetadata>
-bool hasArrayProfileFor(BytecodeMetadata& metadata, unsigned checkpointIndex)
-{
-    return arrayProfileForImpl(metadata, checkpointIndex);
-}
-
-template<typename BytecodeMetadata>
-ArrayProfile& arrayProfileFor(BytecodeMetadata& metadata, unsigned checkpointIndex)
-{
-    ASSERT(hasArrayProfileFor(metadata, checkpointIndex));
-    return *arrayProfileForImpl(metadata, checkpointIndex);
-}
-
-template<typename BytecodeMetadata>
 ValueProfile* valueProfileForImpl(BytecodeMetadata& metadata, unsigned checkpointIndex)
 {
     UNUSED_PARAM(checkpointIndex);

--- a/Source/JavaScriptCore/bytecode/Opcode.h
+++ b/Source/JavaScriptCore/bytecode/Opcode.h
@@ -144,7 +144,7 @@ static constexpr unsigned bitWidthForMaxBytecodeStructLength = WTF::getMSBSetCon
     macro(OpTailCallForwardArguments) \
     macro(OpConstructVarargs) \
 
-#define FOR_EACH_OPCODE_WITH_ARRAY_PROFILE(macro) \
+#define FOR_EACH_OPCODE_WITH_SIMPLE_ARRAY_PROFILE(macro) \
     macro(OpGetByVal) \
     macro(OpInByVal) \
     macro(OpPutByVal) \
@@ -155,7 +155,9 @@ static constexpr unsigned bitWidthForMaxBytecodeStructLength = WTF::getMSBSetCon
     macro(OpEnumeratorPutByVal) \
     macro(OpEnumeratorHasOwnProperty) \
     macro(OpNewArrayWithSpecies) \
-    FOR_EACH_OPCODE_WITH_CALL_LINK_INFO(macro) \
+    macro(OpCall) \
+    macro(OpTailCall) \
+    macro(OpIteratorOpen) \
 
 #define FOR_EACH_OPCODE_WITH_ARRAY_ALLOCATION_PROFILE(macro) \
     macro(OpNewArray) \

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -403,7 +403,7 @@ void UnlinkedCodeBlock::allocateSharedProfiles(unsigned numBinaryArithProfiles, 
         unsigned numberOfArrayProfiles = 0;
 
 #define COUNT(__op) numberOfArrayProfiles += m_metadata->numEntries<__op>();
-        FOR_EACH_OPCODE_WITH_ARRAY_PROFILE(COUNT)
+        FOR_EACH_OPCODE_WITH_SIMPLE_ARRAY_PROFILE(COUNT)
 #undef COUNT
         numberOfArrayProfiles += m_metadata->numEntries<OpIteratorNext>();
         numberOfArrayProfiles += m_metadata->numEntries<OpGetById>();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1029,6 +1029,8 @@ private:
         CodeBlock* codeBlock = m_inlineStackTop->m_profiledBlock;
         ConcurrentJSLocker locker(codeBlock->m_lock);
         ArrayProfile* profile = codeBlock->getArrayProfile(locker, codeBlock->bytecodeIndex(m_currentInstruction));
+        if (!profile)
+            return { };
         return getArrayMode(locker, *profile, action);
     }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3266,6 +3266,11 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
     end
 
     metadata(t5, t0)
+    get(m_iterable, t0)
+    btqnz t0, notCellMask, .done
+    loadi JSCell::m_structureID[t0], t3
+    storei t3, OpIteratorOpen::Metadata::m_arrayProfile.m_lastSeenStructureID[t5]
+    .done:
     callHelper(op_iterator_open, _llint_slow_path_iterator_open_call, OpIteratorOpen, m_iteratorProfile, m_iterator, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetByIdCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
 
 .getByIdStart:


### PR DESCRIPTION
#### 8dcb7191395e7e21c6512a42a9fb0f40a92199a7
<pre>
Clean-up ArrayProfile usage in call opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=258894">https://bugs.webkit.org/show_bug.cgi?id=258894</a>

Reviewed by Justin Michaud.

Right now we have an ArrayProfile for every call opcode. This, I assume, was because the
templated code in the Baseline JIT expected a member in the metadata with the name
m_arrayProfile. However we would only ever write to this profile for op_call in the
Baseline. In the interpreter, however, we would write to the profile for op_call and
op_tail_call. This patch consolidates the behavior of the different tiers. Additionally,
I noticed that op_iterator_open does not use it&apos;s ArrayProfile but should because the
iterable could be a TypedArray, which requires ArrayProfile information use the intrinsic.

For all other call opcodes this patch removes the ArrayProfile as they would be effectively unused.

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/BytecodeOperandsForCheckpoint.h:
(JSC::arrayProfileForImpl): Deleted.
(JSC::hasArrayProfileFor): Deleted.
(JSC::arrayProfileFor): Deleted.
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::getArrayProfile):
(JSC::CodeBlock::updateAllArrayProfilePredictions):
* Source/JavaScriptCore/bytecode/Opcode.h:
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp:
(JSC::UnlinkedCodeBlock::allocateSharedProfiles):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::getArrayMode):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileSetupFrame):
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/265784@main">https://commits.webkit.org/265784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e12bb25ca000d7584de05692abf31992cb8327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11888 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11325 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14185 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13955 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17926 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14120 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11247 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9396 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/11970 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10537 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3210 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2864 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14821 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12306 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11218 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2976 "Passed tests") | 
<!--EWS-Status-Bubble-End-->