### PR TITLE
[UI-side compositing] Optimize setting NSScrollerImp members in ScrollerMac::updateValues

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -61,6 +61,21 @@ public:
     void updateScrollbarStyle();
     void updatePairScrollerImps();
 
+    struct Values {
+        bool enabled;
+        CGSize boundsSize;
+        float doubleValue;
+        float presentationValue;
+        float proportion;
+        bool propertyNeedsWrite[5];
+    };
+
+    void updateEnabledValue(bool);
+    void updateBoundsSizeValue(NSSize);
+    void updateDoubleValue(float);
+    void updatePresentationValue(float);
+    void updateProportionValue(float);
+
     void updateValues();
     
     String scrollbarState() const;
@@ -80,6 +95,7 @@ private:
     RetainPtr<CALayer> m_hostLayer;
     RetainPtr<NSScrollerImp> m_scrollerImp;
     RetainPtr<WebScrollerImpDelegateMac> m_scrollerImpDelegate;
+    Values m_lastSetValues;
 };
 
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -225,12 +225,12 @@ void ScrollerPairMac::setUsePresentationValues(bool inMomentumPhase)
 
 void ScrollerPairMac::setHorizontalScrollbarPresentationValue(float scrollbValue)
 {
-    [scrollerImpHorizontal() setPresentationValue:scrollbValue];
+    m_horizontalScroller.updatePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::setVerticalScrollbarPresentationValue(float scrollbValue)
 {
-    [scrollerImpVertical() setPresentationValue:scrollbValue];
+    m_verticalScroller.updatePresentationValue(scrollbValue);
 }
 
 void ScrollerPairMac::updateValues()


### PR DESCRIPTION
#### fc75c86972631acddf4bf3a70f8fdacae240a509
<pre>
[UI-side compositing] Optimize setting NSScrollerImp members in ScrollerMac::updateValues
<a href="https://bugs.webkit.org/show_bug.cgi?id=258904">https://bugs.webkit.org/show_bug.cgi?id=258904</a>
rdar://111816135

Reviewed by NOBODY (OOPS!).

Limit the amount of interaction we do with NSScrollerImp in ScrollerMac::updateValues by
keeping track of the last value we set on the NSScrollerImp and not setting the value
if it was the same as the previous value. Accomplish this by maintaining a struct that
holds the last values set on the NSScrollerImp.

* Source/WebCore/page/scrolling/mac/ScrollerMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::updateValues):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc75c86972631acddf4bf3a70f8fdacae240a509

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13736 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14270 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14148 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10878 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18007 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11037 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14209 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9497 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->