### PR TITLE
REGRESSION(265043@main): Twitter.com: Fullscreen mode only shows video in some part of the screen

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -23,11 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if PLATFORM(VISION)
 /* Enable container queries */
 
 .media-controls-container {
     container-type: size;
 }
+#endif
 
 /* Default values for some constants */
 


### PR DESCRIPTION
#### 682b4ab4dfed79325f7628b8d7e0bd55d9663d10
<pre>
REGRESSION(265043@main): Twitter.com: Fullscreen mode only shows video in some part of the screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=258907">https://bugs.webkit.org/show_bug.cgi?id=258907</a>
rdar://111095697

Reviewed by NOBODY (OOPS!).

265043@main caused size containment to be added on all platforms with a `container-type` declaration, causing weird interactions with fullscreen.
Gate `container-type` declaration to visionOS only (using `#if PLATFORM(VISION)`), since it is only needed for container queries.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(#if PLATFORM(VISION)):
(#endif):
(.media-controls-container): Deleted.
(.media-controls.vision,): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682b4ab4dfed79325f7628b8d7e0bd55d9663d10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11353 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14213 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12088 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12902 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13991 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10194 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10820 "1 flakes 6 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17950 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11272 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10979 "1 flakes 3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14149 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9424 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->