### PR TITLE
[GTK][WPE] UIScriptController::zoomToScale not implemented

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1352,7 +1352,7 @@ webkit.org/b/212202 css3/scroll-snap/scroll-snap-wheel-event.html [ Skip ]
 css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainframe.html [ Skip ]
 css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html [ Skip ]
 
-webkit.org/b/213921 fast/visual-viewport/scroll-event-fired-during-scroll-alone.html [ Crash ]
+fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Scrolling-related bugs
@@ -2662,22 +2662,6 @@ webkit.org/b/162815 fast/text/variations/font-selection-properties.html [ ImageO
 webkit.org/b/162815 fast/text/variations/skia-postscript-name.html [ ImageOnlyFailure ]
 webkit.org/b/163981 fast/css3-text/css3-text-decoration/text-underline-position/underline-visual-overflow-with-subpixel-position.html [ Failure ]
 
-# Skip tests requiring UIScriptController::zoomToScale.
-webkit.org/b/168050 fast/visual-viewport/resize-event-fired.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/rtl-zoomed-rects.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/scroll-event-fired.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/viewport-dimensions-exclude-custom-scrollbars.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/viewport-dimensions-exclude-scrollbars.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/viewport-dimensions.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/viewport-dimensions-iframe.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/viewport-dimensions-under-page-zoom.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/zoomed-fixed-header-and-footer.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/zoomed-fixed.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/zoomed-fixed-scroll-down-then-up.html [ Skip ]
-webkit.org/b/168050 fast/visual-viewport/zoomed-rects.html [ Skip ]
-webkit.org/b/168050 fast/zooming/client-rect-in-fixed-zoomed.html [ Skip ]
-webkit.org/b/168050 fast/zooming/uiscript-zooming.html [ Skip ]
-
 # Skip tests requiring UIScriptController::singleTapAtPoint.
 media/modern-media-controls/button/button-active-state.html [ Skip ]
 media/modern-media-controls/button/button.html [ Skip ]
@@ -2713,6 +2697,12 @@ media/modern-media-controls/volume-support/volume-support-drag-to-mute.html [ Sk
 
 webkit.org/b/168191 fast/text/system-font-weight.html [ Failure ]
 webkit.org/b/168370 accessibility/hidden-th-still-column-header.html [ Failure ]
+
+# Skip tests requiring unimplemented features in UIScriptController.
+fast/events/autoscroll-when-input-is-offscreen.html [ Skip ]
+fast/events/autoscroll-with-software-keyboard.html [ Skip ]
+fast/events/before-input-prevent-insert-replacement.html [ Skip ]
+fast/events/input-event-insert-replacement.html [ Skip ]
 
 # [GTK][WPE] Some reftest fail with only one or two pixel differences in diff image
 webkit.org/b/168426 fast/html/details-comment-crash.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -819,8 +819,6 @@ fast/text/hangul-generic-font-families.html [ WontFix ]
 # Skip tests requiring UIScriptController to generate events
 webkit.org/b/153833 css3/touch-action/touch-action-manipulation-fast-clicks.html [ Skip ]
 webkit.org/b/153833 fast/events/can-click-element-on-page-with-active-pseudo-class-and-search-field.html [ Skip ]
-webkit.org/b/153833 fast/events/before-input-prevent-insert-replacement.html [ Skip ]
-webkit.org/b/153833 fast/events/input-event-insert-replacement.html [ Skip ]
 
 # These tests test the Shadow DOM based HTML form validation UI but GTK WK2 is using native dialogs instead.
 fast/forms/validation-message-on-listbox.html [ Skip ]
@@ -2010,10 +2008,6 @@ webkit.org/b/172270 fast/text/font-interstitial-invisible-width-while-loading.ht
 webkit.org/b/172271 fast/text/softbank-emoji.html [ Failure ]
 webkit.org/b/172271 fast/text/tatechuyoko.html [ Failure ]
 
-webkit.org/b/172272 fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html [ Failure Crash ]
-
-webkit.org/b/172273 fast/visual-viewport/client-rects-relative-to-layout-viewport.html [ Failure Crash ]
-
 webkit.org/b/172811 fast/forms/input-text-word-wrap.html [ Failure ]
 webkit.org/b/172811 fast/forms/number/number-appearance-rtl.html [ Failure ]
 webkit.org/b/172811 fast/forms/number/number-appearance-spinbutton-disabled-readonly.html [ Failure ]
@@ -2146,9 +2140,6 @@ webkit.org/b/196061 editing/pasteboard/smart-paste-paragraph-002.html [ Failure 
 webkit.org/b/196061 editing/pasteboard/smart-paste-paragraph-004.html [ Failure ]
 
 webkit.org/b/196197 http/wpt/cache-storage/cache-quota-after-restart.any.html [ Failure ]
-
-webkit.org/b/197248 fast/events/autoscroll-when-input-is-offscreen.html [ Failure Crash ]
-webkit.org/b/197248 fast/events/autoscroll-with-software-keyboard.html [ Failure Crash ]
 
 webkit.org/b/197708 http/wpt/beacon/beacon-async-error-logging.html [ Failure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -646,14 +646,6 @@ webkit.org/b/89052 fast/css/image-orientation [ Skip ]
 # No support for resource load statistics yet
 webkit.org/b/177943 http/tests/resourceLoadStatistics/ [ Skip ]
 
-# Missing UIScriptController implementation, causing crashes
-webkit.org/b/200295 fast/events/autoscroll-when-input-is-offscreen.html [ Crash ]
-webkit.org/b/200295 fast/events/autoscroll-with-software-keyboard.html [ Crash ]
-webkit.org/b/200295 fast/events/before-input-prevent-insert-replacement.html [ Crash ]
-webkit.org/b/200295 fast/events/input-event-insert-replacement.html [ Crash ]
-webkit.org/b/200295 fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html [ Crash ]
-webkit.org/b/200295 fast/visual-viewport/client-rects-relative-to-layout-viewport.html [ Crash ]
-
 # Inspector tests don't work with platform WebSockets API
 webkit.org/b/200162 http/tests/websocket/tests/hybi/inspector/ [ Skip ]
 

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp
@@ -214,4 +214,17 @@ void UIScriptControllerGtk::setWebViewEditable(bool editable)
     WKViewSetEditable(webView, editable);
 }
 
+void UIScriptControllerGtk::zoomToScale(double scale, JSValueRef callback)
+{
+    auto page = TestController::singleton().mainWebView()->page();
+    WKPageSetScaleFactor(page, scale, WKPointMake(0, 0));
+    doAsyncTask(callback);
+}
+
+double UIScriptControllerGtk::zoomScale() const
+{
+    auto page = TestController::singleton().mainWebView()->page();
+    return WKPageGetScaleFactor(page);
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
+++ b/Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h
@@ -54,6 +54,8 @@ public:
     void removeViewFromWindow(JSValueRef) override;
     void addViewToWindow(JSValueRef) override;
     void setWebViewEditable(bool) override;
+    double zoomScale() const override;
+    void zoomToScale(double, JSValueRef) override;
 
 private:
     void overridePreference(JSStringRef, JSStringRef) override;

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp
@@ -125,4 +125,17 @@ void UIScriptControllerWPE::addViewToWindow(JSValueRef callback)
     });
 }
 
+void UIScriptControllerWPE::zoomToScale(double scale, JSValueRef callback)
+{
+    auto page = TestController::singleton().mainWebView()->page();
+    WKPageSetScaleFactor(page, scale, WKPointMake(0, 0));
+    doAsyncTask(callback);
+}
+
+double UIScriptControllerWPE::zoomScale() const
+{
+    auto page = TestController::singleton().mainWebView()->page();
+    return WKPageGetScaleFactor(page);
+}
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
+++ b/Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h
@@ -47,6 +47,8 @@ public:
     void simulateAccessibilitySettingsChangeNotification(JSValueRef) override;
     void removeViewFromWindow(JSValueRef) override;
     void addViewToWindow(JSValueRef) override;
+    double zoomScale() const override;
+    void zoomToScale(double, JSValueRef) override;
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 74c3186fd1d74e681bc3c3b0c8b36dac8cbee1ae
<pre>
[GTK][WPE] UIScriptController::zoomToScale not implemented
<a href="https://bugs.webkit.org/show_bug.cgi?id=168050">https://bugs.webkit.org/show_bug.cgi?id=168050</a>

Reviewed by Carlos Garcia Campos.

Same implementation as WinCairo port.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.cpp:
(WTR::UIScriptControllerWPE::zoomToScale):
(WTR::UIScriptControllerWPE::zoomScale const):
* Tools/WebKitTestRunner/gtk/UIScriptControllerGtk.h:
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.cpp:
(WTR::UIScriptControllerWPE::zoomToScale):
(WTR::UIScriptControllerWPE::zoomScale const):
* Tools/WebKitTestRunner/wpe/UIScriptControllerWPE.h:

Canonical link: <a href="https://commits.webkit.org/265793@main">https://commits.webkit.org/265793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd02076e21f536e3af441a425470582b0fa8d62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14217 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13994 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10826 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17953 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14152 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9427 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10575 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2874 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->