### PR TITLE
CustomElementQueue and CustomElementReactionQueue should have an inline capacity

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -27,9 +27,11 @@
 
 #include "CustomElementFormValue.h"
 #include "GCReachableRef.h"
+#include "QualifiedName.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Vector.h>
+#include <wtf/text/AtomString.h>
 
 namespace JSC {
 
@@ -40,29 +42,74 @@ class CallFrame;
 
 namespace WebCore {
 
-class CustomElementReactionQueueItem;
+class CustomElementQueue;
 class Document;
 class Element;
 class HTMLFormElement;
 class JSCustomElementInterface;
-class QualifiedName;
+
+class CustomElementReactionQueueItem {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(CustomElementReactionQueueItem);
+public:
+    enum class Type : uint8_t {
+        Invalid,
+        ElementUpgrade,
+        Connected,
+        Disconnected,
+        Adopted,
+        AttributeChanged,
+        FormAssociated,
+        FormReset,
+        FormDisabled,
+        FormStateRestore,
+    };
+
+    struct AdoptedPayload {
+        Ref<Document> oldDocument;
+        Ref<Document> newDocument;
+        ~AdoptedPayload();
+    };
+
+    struct FormAssociatedPayload {
+        RefPtr<HTMLFormElement> form;
+        ~FormAssociatedPayload();
+    };
+
+    using AttributeChangedPayload = std::tuple<QualifiedName, AtomString, AtomString>;
+    using FormDisabledPayload = bool;
+    using FormStateRestorePayload = CustomElementFormValue;
+    using Payload = std::optional<std::variant<AdoptedPayload, AttributeChangedPayload, FormAssociatedPayload, FormDisabledPayload, FormStateRestorePayload>>;
+
+    CustomElementReactionQueueItem();
+    CustomElementReactionQueueItem(CustomElementReactionQueueItem&&);
+    CustomElementReactionQueueItem(Type, Payload = std::nullopt);
+    ~CustomElementReactionQueueItem();
+    Type type() const { return m_type; }
+    void invoke(Element&, JSCustomElementInterface&);
+
+private:
+    Type m_type { Type::Invalid };
+    Payload m_payload;
+};
 
 // https://html.spec.whatwg.org/multipage/custom-elements.html#element-queue
 class CustomElementQueue {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CustomElementQueue);
 public:
-    CustomElementQueue() = default;
+    CustomElementQueue();
+    ~CustomElementQueue();
 
     void add(Element&);
     void processQueue(JSC::JSGlobalObject*);
 
-    Vector<GCReachableRef<Element>> takeElements();
+    Vector<GCReachableRef<Element>, 4> takeElements();
 
 private:
     void invokeAll();
 
-    Vector<GCReachableRef<Element>> m_elements;
+    Vector<GCReachableRef<Element>, 4> m_elements;
     bool m_invoking { false };
 };
 
@@ -109,7 +156,7 @@ private:
     using Item = CustomElementReactionQueueItem;
 
     Ref<JSCustomElementInterface> m_interface;
-    Vector<Item> m_items;
+    Vector<Item, 1> m_items;
     bool m_elementInternalsAttached { false };
 };
 
@@ -181,7 +228,7 @@ public:
         s_currentProcessingStack = m_previousProcessingStack;
     }
 
-    Vector<GCReachableRef<Element>> takeElements();
+    Vector<GCReachableRef<Element>, 4> takeElements();
 
 private:
     WEBCORE_EXPORT void processQueue(JSC::JSGlobalObject*);

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -57,7 +57,6 @@ class GCReachableRef {
     WTF_MAKE_NONCOPYABLE(GCReachableRef);
 public:
 
-    template<typename = std::enable_if_t<std::is_base_of<Node, T>::value>>
     GCReachableRef(T& object)
         : m_ptr(&object)
     {


### PR DESCRIPTION
#### 9b42484b8e812b6f398f55877d98a5a5845c7270
<pre>
CustomElementQueue and CustomElementReactionQueue should have an inline capacity
<a href="https://bugs.webkit.org/show_bug.cgi?id=258912">https://bugs.webkit.org/show_bug.cgi?id=258912</a>

Reviewed by Chris Dumez.

Both CustomElementQueue and CustomElementReactionQueue inline capacities of 4 and 1 respectively.

Also moved CustomElementReactionQueueItem from .cpp file to .h file and replaced some payload tuples
with structs to allow forward declarations of Document and HTMLFormElement.

* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueueItem::CustomElementReactionQueueItem):
(WebCore::CustomElementReactionQueueItem::invoke):
(WebCore::CustomElementReactionQueue::enqueueAdoptedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded):
(WebCore::CustomElementReactionQueue::invokeAll):
(WebCore::CustomElementQueue::takeElements):
(WebCore::CustomElementReactionStack::takeElements):

* Source/WebCore/dom/CustomElementReactionQueue.h:
(WebCore::CustomElementReactionQueueItem): Moved from .cpp file.
(WebCore::CustomElementReactionQueueItem::type const):

* Source/WebCore/dom/GCReachableRef.h:
(WebCore::GCReachableRef::GCReachableRef): Removed the explicit requirement that T must be a subclass
of Node as this would require including Element.h in CustomElementReactionQueue.h. GCReachableRefMap
only supports Node anyway so this check isn&apos;t needed.

Canonical link: <a href="https://commits.webkit.org/265829@main">https://commits.webkit.org/265829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/313e99dd3c58b80ffe37cf6fa09798d2f030e467

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11583 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14279 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14158 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18014 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11351 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15073 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1338 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->