### PR TITLE
Avoid unnecessary tree traversal in customElements.define

### DIFF
--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -75,6 +75,8 @@ public:
 
     static void enqueueElementUpgrade(Element&, bool alreadyScheduledToUpgrade);
     static void tryToUpgradeElement(Element&);
+    static void didInsertUpgradeCandidate(Element&);
+    static void didRemoveUpgradeCandidate(Element&);
     static void enqueueConnectedCallbackIfNeeded(Element&);
     static void enqueueDisconnectedCallbackIfNeeded(Element&);
     static void enqueueAdoptedCallbackIfNeeded(Element&, Document& oldDocument, Document& newDocument);

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -62,7 +62,14 @@ public:
     RefPtr<DeferredPromise> addElementDefinition(Ref<JSCustomElementInterface>&&);
 
     bool& elementDefinitionIsRunning() { return m_elementDefinitionIsRunning; }
+    bool elementCountsAreSet() const { return m_elementCountsAreSet; }
 
+    struct Entry {
+        RefPtr<JSCustomElementInterface> elementInterface;
+        unsigned elementCount { 0 };
+    };
+
+    Entry* entryForElement(const Element&);
     JSCustomElementInterface* findInterface(const Element&) const;
     JSCustomElementInterface* findInterface(const QualifiedName&) const;
     JSCustomElementInterface* findInterface(const AtomString&) const;
@@ -80,13 +87,17 @@ public:
 private:
     CustomElementRegistry(LocalDOMWindow&, ScriptExecutionContext*);
 
+    bool enqueueKnownNumberOfUpgradesInShadowIncludingTreeOrder(ContainerNode&, JSCustomElementInterface&, unsigned&);
+    void enqueueUpgradesInShadowIncludingTreeOrderAndUpdateElementCounts(ContainerNode&, JSCustomElementInterface&);
+
     LocalDOMWindow& m_window;
-    HashMap<AtomString, Ref<JSCustomElementInterface>> m_nameMap;
+    HashMap<AtomString, Entry> m_nameMap;
     HashMap<const JSC::JSObject*, JSCustomElementInterface*> m_constructorMap WTF_GUARDED_BY_LOCK(m_constructorMapLock);
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>> m_promiseMap;
     MemoryCompactRobinHoodHashSet<AtomString> m_disabledShadowSet;
 
     bool m_elementDefinitionIsRunning { false };
+    bool m_elementCountsAreSet { false };
     mutable Lock m_constructorMapLock;
 
     friend class ElementDefinitionIsRunningSetForScope;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2662,7 +2662,7 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
         if (becomeConnected) {
             if (UNLIKELY(isCustomElementUpgradeCandidate())) {
                 ASSERT(isConnected());
-                CustomElementReactionQueue::tryToUpgradeElement(*this);
+                CustomElementReactionQueue::didInsertUpgradeCandidate(*this);
             }
             if (UNLIKELY(isDefinedCustomElement()))
                 CustomElementReactionQueue::enqueueConnectedCallbackIfNeeded(*this);
@@ -2749,8 +2749,12 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
         if (oldDocument && oldDocument->cssTarget() == this)
             oldDocument->setCSSTarget(nullptr);
 
-        if (removalType.disconnectedFromDocument && UNLIKELY(isDefinedCustomElement()))
-            CustomElementReactionQueue::enqueueDisconnectedCallbackIfNeeded(*this);
+        if (removalType.disconnectedFromDocument) {
+            if (UNLIKELY(isDefinedCustomElement()))
+                CustomElementReactionQueue::enqueueDisconnectedCallbackIfNeeded(*this);
+            else if (UNLIKELY(isCustomElementUpgradeCandidate()))
+                CustomElementReactionQueue::didRemoveUpgradeCandidate(*this);
+        }
     }
 
     if (!parentNode()) {


### PR DESCRIPTION
#### b1ff0819c890024434f29190d57ce4217d9a1c1d
<pre>
Avoid unnecessary tree traversal in customElements.define
<a href="https://bugs.webkit.org/show_bug.cgi?id=258916">https://bugs.webkit.org/show_bug.cgi?id=258916</a>

Reviewed by NOBODY (OOPS!).

This change introduces the notion of &quot;element count&quot; for each custom element name. It is the total number
of connected upgrade candidates in the document. The element counts are computed when customElements.define
is called for the very first time. Whether element counts had been computed or not is kept track by
CustomElementRegistry in newly introduced m_elementCountsAreSet.

When the element count is set for a custom element, subsequent calls to customElements.define can end
the tree traversal as soon as it has upgraded the said number of elements.

* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::didInsertUpgradeCandidate): Added. Updates the element count
when an element is connected to a document.
(WebCore::CustomElementReactionQueue::didRemoveUpgradeCandidate): Added. Ditto for removal.

* Source/WebCore/dom/CustomElementReactionQueue.h:

* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::enqueueUpgradeInShadowIncludingTreeOrder): Deleted.
(WebCore::CustomElementRegistry::enqueueKnownNumberOfUpgradesInShadowIncludingTreeOrder): Added.
(WebCore::CustomElementRegistry::enqueueUpgradesInShadowIncludingTreeOrderAndUpdateElementCounts): Added.
(WebCore::CustomElementRegistry::addElementDefinition):
(WebCore::CustomElementRegistry::entryForElement): Added.
(WebCore::CustomElementRegistry::findInterface const):
(WebCore::CustomElementRegistry::get):

* Source/WebCore/dom/CustomElementRegistry.h:
(WebCore::CustomElementRegistry::elementCountsAreSet const): Added.
(WebCore::CustomElementRegistry::Entry): Added.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::insertedIntoAncestor): Now calls CustomElementReactionQueue::didInsertUpgradeCandidate
instead of CustomElementReactionQueue::tryToUpgradeElement on upgrade candidates.
(WebCore::Element::removedFromAncestor): Ditto for didRemoveUpgradeCandidate.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ff0819c890024434f29190d57ce4217d9a1c1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11948 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12147 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12524 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13593 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11374 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12128 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/13593 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10107 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14016 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10843 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/14016 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11295 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11002 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/14016 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9444 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10595 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->