### PR TITLE
[browserperfdash-benchmark] Allow to send benchmark data with the timestamp of the git checkout and use it on the bots

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1237,7 +1237,8 @@ class RunBenchmarkTests(shell.Test):
     descriptionDone = ["benchmark tests"]
     command = ["python3", "Tools/Scripts/browserperfdash-benchmark", "--plans-from-config",
                "--config-file", "../../browserperfdash-benchmark-config.txt",
-               "--browser-version", WithProperties("%(archive_revision)s")]
+               "--browser-version", WithProperties("%(archive_revision)s"),
+               "--timestamp-from-repo", "."]
 
     def start(self):
         platform = self.getProperty("platform")


### PR DESCRIPTION
#### 9204150b17ce55af8037fac41b58fd0e0d458b26
<pre>
[browserperfdash-benchmark] Allow to send benchmark data with the timestamp of the git checkout and use it on the bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=258920">https://bugs.webkit.org/show_bug.cgi?id=258920</a>

Reviewed by Carlos Garcia Campos.

Now that we are running several bots in parallel for the same worker
there is no guarantee that the bots will finish in the same order
than they started. So it can happen that we send the benchmark data
in different ordering than the commits on the repository.

To avoid this (and also allow re-testing old checkouts) this implements
a way of sending to the server dashboard as timestamp of the benchmark
the same timestamp of the git commit that is checked out (HEAD).

And since the bots always check-out the same git commit than the build
they are testing, we can use this there and run everything in parallel
safely.

* Tools/CISupport/build-webkit-org/steps.py:
(RunBenchmarkTests):
* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(parse_args):
(BrowserPerfDashRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/265798@main">https://commits.webkit.org/265798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5bbd20d536e73e876e3ebb5dec27636e2389e87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11380 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12134 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14022 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/12049 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10849 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/17975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11301 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9450 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/11846 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->