### PR TITLE
Remote image buffer Context2D contexts are prepared needlessly

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -888,9 +888,6 @@ void HTMLCanvasElement::createImageBuffer() const
         const_cast<HTMLCanvasElement*>(this)->invalidateStyleAndLayerComposition();
     }
 #endif
-
-    if (m_context && buffer() && buffer()->prefersPreparationForDisplay())
-        const_cast<HTMLCanvasElement*>(this)->addObserver(document());
 }
 
 void HTMLCanvasElement::setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&& buffer)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2276,21 +2276,6 @@ GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
     return canvasBase().drawingContext();
 }
 
-void CanvasRenderingContext2DBase::prepareForDisplay()
-{
-    if (auto buffer = canvasBase().buffer())
-        buffer->flushDrawingContextAsync();
-}
-
-bool CanvasRenderingContext2DBase::needsPreparationForDisplay() const
-{
-    RefPtr buffer = canvasBase().buffer();
-    if (buffer && buffer->prefersPreparationForDisplay())
-        return true;
-
-    return false;
-}
-
 static void initializeEmptyImageData(const ImageData& imageData)
 {
     imageData.data().zeroFill();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -371,8 +371,6 @@ private:
     bool shouldDrawShadows() const;
 
     bool is2dBase() const final { return true; }
-    bool needsPreparationForDisplay() const final;
-    void prepareForDisplay() final;
 
     void clearAccumulatedDirtyRect() final;
     bool isEntireBackingStoreDirty() const;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -256,7 +256,7 @@ void ImageBuffer::flushDrawingContext()
 
 bool ImageBuffer::flushDrawingContextAsync()
 {
-    // This function is only really useful for the Remote subclass, where the prefersPreparationForDisplay() == true.
+    // This function is only really useful for the Remote subclass.
     flushDrawingContext();
     return true;
 }

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -128,7 +128,6 @@ public:
 
     WEBCORE_EXPORT virtual GraphicsContext& context() const;
 
-    virtual bool prefersPreparationForDisplay() { return false; }
     WEBCORE_EXPORT virtual void flushDrawingContext();
     WEBCORE_EXPORT virtual bool flushDrawingContextAsync();
 


### PR DESCRIPTION
#### 9993b211a8d617fc75b71606e82bc440675b209b
<pre>
Remote image buffer Context2D contexts are prepared needlessly
<a href="https://bugs.webkit.org/show_bug.cgi?id=258917">https://bugs.webkit.org/show_bug.cgi?id=258917</a>
<a href="https://rdar.apple.com/111838879">rdar://111838879</a>

Reviewed by NOBODY (OOPS!).

The preparation step prepares the canvas element context, webgl or
context2d, for compositing.

The Context2D does not use external access for compositing, rather the
image buffer is just drawn to another image buffer. There does not
need to be any preparation.
This avoids explicitly flushing the ImageBuffer context, which
in turn prevents RemoteImageBufferProxy creating IPC semaphores
for signaling flush completion.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createImageBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::prepareForDisplay): Deleted.
(WebCore::CanvasRenderingContext2DBase::needsPreparationForDisplay const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::flushDrawingContextAsync):
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::prefersPreparationForDisplay): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9993b211a8d617fc75b71606e82bc440675b209b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/29203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/7872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/30540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/31790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/26562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/29799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/10039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/5177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/26564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/29475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/6561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/25021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/5632 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/5799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/26057 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/33127 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/26696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/26491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/32000 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/5743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/3925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/29788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/7421 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/6255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/6265 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->