### PR TITLE
[WPE] The bots WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests are failing to autoinstall the python dependency bcrypt

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -88,7 +88,11 @@ AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
 AutoInstall.register(Package('cffi', Version(1, 15, 1)))
 
 if sys.version_info > (3, 0):
-    AutoInstall.register(Package('cryptography', Version(36, 0, 2), wheel=True, implicit_deps=['cffi']))
+    # There are no prebuilt binaries for arm-32 of 'cryptography' and building it requires cargo/rust
+    # Since this dep is not really needed for the current arm-32 bots we skip it instead of
+    # adding the overhead of a cargo/rust toolchain into the yocto-based image the bots run.
+    if not (platform.machine().startswith('arm') and platform.architecture()[0] == '32bit'):
+        AutoInstall.register(Package('cryptography', Version(36, 0, 2), wheel=True, implicit_deps=['cffi']))
 
 if sys.version_info >= (3, 6):
     if sys.platform == 'linux':

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -20,6 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import platform
 import sys
 
 from webkitscmpy import AutoInstall, Package, Version
@@ -32,7 +33,11 @@ if sys.version_info >= (3, 0):
     AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
 
     AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
-    AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
+    # There are no prebuilt binaries for arm-32 of 'bcrypt' and building it requires cargo/rust
+    # Since this dep is not really needed for the current arm-32 bots we skip it instead of
+    # adding the overhead of a cargo/rust toolchain into the yocto-based image the bots run.
+    if not (platform.machine().startswith('arm') and platform.architecture()[0] == '32bit'):
+        AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
     AutoInstall.install(Package('pycparser', Version(2, 21), wheel=True))
 
     from twisted.protocols.tls import TLSMemoryBIOFactory


### PR DESCRIPTION
#### 61e425731b476531dd5c009b3de0e6dd7daaca90
<pre>
[WPE] The bots WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests are failing to autoinstall the python dependency bcrypt
<a href="https://bugs.webkit.org/show_bug.cgi?id=258941">https://bugs.webkit.org/show_bug.cgi?id=258941</a>

Reviewed by Philippe Normand.

There are no pre-built packages on the python repository for ARM-32 arcitecture
for the depency bcrypt. And installing it from source is a major headache because
this dependency requires a cargo/rust toolchain that is complicated to add into
the yocto-based image that the bots execute.

The dependency itself (bcrypt) is not needed at all in the bots so if we avoid
trying to autoinstall it things work as expected.

But for that we have also to avoid autoinstalling as well the cryptography python
dependency, which also depends on a cargo/rust toolchain and has no prebuilt
version for ARM-32 bits.

I tested to run the usual python tools: run-webkit-tests, run-minibrowser, run-benchmark
and everything works as expected without installing this two dependencies.

The architecture name is not unique and can be at least any of this: &apos;armv7l&apos;, &apos;armv7&apos;, &apos;armv8l&apos;
so to match it we check if starts with &apos;arm&apos; and is &apos;32bit&apos;

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/265835@main">https://commits.webkit.org/265835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c18929bc3d2605afe38e921aa8f29709d05d65f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13781 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12199 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14195 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/12130 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11569 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/11926 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15108 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1341 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->