### PR TITLE
Add invalid checks for static ranges

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4900,7 +4900,6 @@ webkit.org/b/220325 http/wpt/css/css-highlight-api/highlight-text-cascade.html [
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-008.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-target-text-decoration-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-014.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-below-target-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-iframe-006.html [ ImageOnlyFailure ]
@@ -4908,8 +4907,7 @@ imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-invalidation-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-invalidation-006.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-staticrange-001.html [ ImageOnlyFailure ]
- imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-017.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-017.html [ ImageOnlyFailure ]
 
 http/tests/webgl/1.0.x/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]
 http/tests/webgl/2.0.y/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html [ Skip ]

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -83,4 +83,19 @@ void StaticRange::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) cons
     addWebCoreOpaqueRoot(visitor, end.container.get());
 }
 
+bool StaticRange::computeValidity() const
+{
+    Node& startContainer = this->startContainer();
+    Node& endContainer = this->endContainer();
+
+    if (!connectedInSameTreeScope(&startContainer.rootNode(), &endContainer.rootNode()))
+        return false;
+    if (startOffset() > startContainer.length())
+        return false;
+    if (endOffset() > endContainer.length())
+        return false;
+    if (&startContainer == &endContainer)
+        return endOffset() > startOffset();
+    return !is_gt(treeOrder<ComposedTree>(startContainer, endContainer));
+}
 } // namespace WebCore

--- a/Source/WebCore/dom/StaticRange.h
+++ b/Source/WebCore/dom/StaticRange.h
@@ -58,6 +58,9 @@ public:
     unsigned endOffset() const final { return SimpleRange::endOffset(); }
     bool collapsed() const final { return SimpleRange::collapsed(); }
 
+    // https://dom.spec.whatwg.org/#staticrange-valid
+    bool computeValidity() const;
+
     void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const;
 
 private:

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -122,6 +122,20 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
                 for (auto& rangeData : highlightRegister->map().get(highlightName)->rangesData()) {
                     if (!highlightData.setRenderRange(rangeData))
                         continue;
+                    if (auto* staticRange = dynamicDowncast<StaticRange>(rangeData->range()); staticRange
+                        && (!staticRange->computeValidity() || staticRange->collapsed()))
+                        continue;
+                    // FIXME: Potentially move this check elsewhere, to where we collect this range information.
+                    auto hasRenderer = [&] {
+                        IntersectingNodeRange nodes(makeSimpleRange(rangeData->range()));
+                        for (auto& iterator : nodes) {
+                            if (iterator.renderer())
+                                return true;
+                        }
+                        return false;
+                    }();
+                    if (!hasRenderer)
+                        continue;
 
                     auto [highlightStart, highlightEnd] = highlightData.rangeForTextBox(renderer, selectableRange);
 

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -147,10 +147,10 @@ static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMark
             if (previousStyledMarkedText.priority <= it->priority) {
                 previousStyledMarkedText.priority = it->priority;
                 // If highlight, take textDecorationStyles of latest StyledMarkedText.
-                // FIXME: Check for taking textDecorationStyles needs to be changed to accommodate other MarkedText type
+                // FIXME: Check for taking textDecorationStyles needs to be changed to accommodate other MarkedText type.
                 if (!it->highlightName.isNull())
                     previousStyledMarkedText.style.textDecorationStyles = it->style.textDecorationStyles;
-                // If higher or same priority and opaque, just override background color.
+                // If higher or same priority and opaque, override background color.
                 if (it->style.backgroundColor.isOpaque())
                     previousStyledMarkedText.style.backgroundColor = it->style.backgroundColor;
             }


### PR DESCRIPTION
#### 8afe94ae85ece85e0453b8cdf574b3c23b01c800
<pre>
Add invalid checks for static ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=258826">https://bugs.webkit.org/show_bug.cgi?id=258826</a>
rdar://111706100

Reviewed by Ryosuke Niwa.

Added invalid checks for static range.
Thus, ignoring the invalid range when painting highlights.
Changed TestExpectations due to more tests passing.

* LayoutTests/TestExpectations:
* Source/WebCore/dom/StaticRange.cpp:
(WebCore::StaticRange::computeRangeValidity const):
(WebCore::StaticRange::isValidForPaintingHighlights const):
* Source/WebCore/dom/StaticRange.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::coalesceAdjacentWithSameRanges):

Canonical link: <a href="https://commits.webkit.org/266019@main">https://commits.webkit.org/266019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/510a055f58826f848172d3083b5402c656a2a931

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14316 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14747 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11382 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11879 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11547 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15606 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1430 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->