### PR TITLE
PutStack sinking phase inserts PutStack with wrong value

### DIFF
--- a/JSTests/stress/PutStack-sinking-through-DeadFlush-unification.js
+++ b/JSTests/stress/PutStack-sinking-through-DeadFlush-unification.js
@@ -1,0 +1,30 @@
+function test(a, flag, flag2, bailout) {
+    a = 3333
+    if (flag) {
+        if (flag2) {
+            a = 1111;
+            Object.toString();
+        } else {
+            a = 2222;
+            Object.toString();
+        }
+        Object.toString();
+    }
+    Object.toString();
+    bailout ++;
+    return a;
+}
+
+function main() {
+    for(let i = 0; i < 1000; i ++) {
+        test(0, true, true, 0);
+        test(0, true, false, 0);
+        test(0, false, true, 0);
+        test(0, false, false, 0);
+    }
+    
+    let result = test(0, true, true, 0x7fffffff);
+    if (result !== 1111)
+        throw 'Expected test() to return 1111, got ' + result;
+}
+main()

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -372,6 +372,8 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         RUN_PHASE(performSSALowering);
         
         // Ideally, these would be run to fixpoint with the object allocation sinking phase.
+        if (Options::usePutStackSinking())
+            RUN_PHASE(performPutStackSinking);
         RUN_PHASE(performArgumentsElimination);
         if (Options::usePutStackSinking())
             RUN_PHASE(performPutStackSinking);

--- a/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
@@ -504,8 +504,11 @@ public:
                         Node* incoming = mapping.operand(operand);
                         DFG_ASSERT(m_graph, node, incoming);
                     
+                        // If we are sinking a PutStack to before an ExitOK, it
+                        // should be ExitInvalid like the other preceding nodes.
+                        auto origin = node->op() == ExitOK ? node->origin.withInvalidExit() : node->origin;
                         insertionSet.insertNode(
-                            nodeIndex, SpecNone, PutStack, node->origin,
+                            nodeIndex, SpecNone, PutStack, origin,
                             OpInfo(m_graph.m_stackAccessData.add(operand, format)),
                             Edge(incoming, uncheckedUseKindFor(format)));
                     


### PR DESCRIPTION
#### 8495ff2f3399f19ca2f88fa53c77ab00d83ce692
<pre>
PutStack sinking phase inserts PutStack with wrong value
<a href="https://bugs.webkit.org/show_bug.cgi?id=256872">https://bugs.webkit.org/show_bug.cgi?id=256872</a>
rdar://109752832

Reviewed by Keith Miller.

Fixes a bug where the DFG PutStack sinking phase would put the wrong
value to the stack. This is due to the PutStack sinking phase doing its
own SSA calculation to determine the correct locations to insert
PutStacks, which is not necessarily the same as correctly tracking the
values that should belong in each PutStack (which is just SSA conversion).

This patch adds an additional PutStack node after each Phi inserted in
SSA conversion. As a result, when PutStack sinking interprets each block
to map each variable to its current value, it correctly associates
existing Phis with their variables, even if the PutStack sinking phase&apos;s
SSA calculation would not insert a Phi there.

One concern with this patch is performance - specifically, adding
additional PutStacks might pessimize arguments elimination. To address
this, this patch runs PutStack sinking both before and after arguments
elimination, so we reduce spurious PutStacking before eliminating
arguments, and re-run it after to exploit any opportunities created by
the existing phase ordering. Testing on both Speedometer 2 and JetStream
2, there is no significant change in score with this patch.

* JSTests/stress/PutStack-sinking-through-DeadFlush-unification.js: Added.
(test):
(main):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
(JSC::DFG::SSAConversionPhase::run):

Canonical link: <a href="https://commits.webkit.org/265866@main">https://commits.webkit.org/265866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec76b60d384ea34ee1b9efdcb341b7ccf9715344

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11590 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14165 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18022 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11054 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14223 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11361 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9501 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12088 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10756 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15080 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12425 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11393 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2991 "Passed tests") | 
<!--EWS-Status-Bubble-End-->