### PR TITLE
Replace log object prewarming with call to topPrivatelyControlledDomain

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -89,6 +89,7 @@
 #import <WebCore/PlatformMediaSessionManager.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ProcessCapabilities.h>
+#import <WebCore/PublicSuffix.h>
 #import <WebCore/RuntimeApplicationChecks.h>
 #import <WebCore/SWContextManager.h>
 #import <WebCore/SystemBattery.h>
@@ -716,41 +717,22 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void deliberateCrashForTesting()
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 static void prewarmLogs()
 {
-    static std::array<std::pair<const char*, const char*>, 29> logs { {
+    // This call will create container manager log objects.
+    // FIXME: this can be removed if we move all calls to topPrivatelyControlledDomain out of the WebContent process.
+    // This would be desirable, since the WebContent process is blocking access to the container manager daemon.
+    topPrivatelyControlledDomain("apple.com"_s);
+
+    static std::array<std::pair<const char*, const char*>, 5> logs { {
         { "com.apple.CFBundle", "strings" },
-        { "com.apple.containermanager", "unspecified" },
-        { "com.apple.containermanager", "cache" },
-        { "com.apple.containermanager", "sandbox" },
-        { "com.apple.containermanager", "xpc" },
-        { "com.apple.containermanager", "query" },
-        { "com.apple.containermanager", "paths" },
-        { "com.apple.containermanager", "locking" },
-        { "com.apple.containermanager", "database" },
-        { "com.apple.containermanager", "upcall" },
-        { "com.apple.containermanager", "lifecycle" },
-        { "com.apple.containermanager", "fs" },
-        { "com.apple.containermanager", "startup" },
-        { "com.apple.containermanager", "test" },
-        { "com.apple.containermanager", "metadata" },
-        { "com.apple.containermanager", "codesignmapping" },
-        { "com.apple.containermanager", "longterm" },
-        { "com.apple.containermanager", "schema" },
-        { "com.apple.containermanager", "codesign" },
-        { "com.apple.containermanager", "repair" },
-        { "com.apple.containermanager", "disk" },
-        { "com.apple.containermanager", "persona" },
-        { "com.apple.containermanager", "command" },
-        { "com.apple.containermanager", "telemetry" },
         { "com.apple.network", "" },
         { "com.apple.CFNetwork", "ATS" },
-        { "com.apple.coremedia", "" },
         { "com.apple.coremedia", "" },
         { "com.apple.SafariShared", "Translation" },
     } };
 
     for (auto& log : logs) {
-        auto logHandle = os_log_create(log.first, log.second);
-        bool enabled = os_log_type_enabled(logHandle, OS_LOG_TYPE_ERROR);
+        auto logHandle = adoptOSObject(os_log_create(log.first, log.second));
+        bool enabled = os_log_type_enabled(logHandle.get(), OS_LOG_TYPE_ERROR);
         UNUSED_PARAM(enabled);
     }
 }


### PR DESCRIPTION
#### f51b379abd462bc5a9dff60c62468133bfa83303
<pre>
Replace log object prewarming with call to topPrivatelyControlledDomain
<a href="https://bugs.webkit.org/show_bug.cgi?id=258949">https://bugs.webkit.org/show_bug.cgi?id=258949</a>
rdar://111873538

Reviewed by Brent Fulgham.

Instead of directly creating and prewarming log objects, call topPrivatelyControlledDomain which will
cause the same container manager log objects to be created. This appears to be a further, small
improvement in page load performance.

* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::prewarmLogs):

Canonical link: <a href="https://commits.webkit.org/265838@main">https://commits.webkit.org/265838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4337a2255d36a62540c27013a854d8f24f526f1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14300 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14183 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10289 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18037 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11369 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14239 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9513 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15096 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1343 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->