### PR TITLE
Potential crash under NetworkDataTaskBlob::dispatchDidReceiveResponse()

### DIFF
--- a/Source/WebCore/platform/network/BlobResourceHandle.h
+++ b/Source/WebCore/platform/network/BlobResourceHandle.h
@@ -78,7 +78,7 @@ private:
 
     void doStart();
     void getSizeForNext();
-    void seek();
+    std::optional<Error> seek();
     void consumeData(const uint8_t* data, int bytesRead);
     void failed(Error);
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -164,7 +164,10 @@ void NetworkDataTaskBlob::getSizeForNext()
 
     // Do we finish validating and counting size for all items?
     if (m_sizeItemCount >= m_blobData->items().size()) {
-        seek();
+        if (auto error = seek()) {
+            didFail(*error);
+            return;
+        }
         dispatchDidReceiveResponse();
         return;
     }
@@ -186,6 +189,7 @@ void NetworkDataTaskBlob::getSizeForNext()
 void NetworkDataTaskBlob::didGetSize(long long size)
 {
     ASSERT(RunLoop::isMain());
+    Ref protectedThis { *this };
 
     if (m_state == State::Canceling || m_state == State::Completed || (!m_client && !isDownload())) {
         clearStream();
@@ -214,23 +218,21 @@ void NetworkDataTaskBlob::didGetSize(long long size)
     getSizeForNext();
 }
 
-void NetworkDataTaskBlob::seek()
+auto NetworkDataTaskBlob::seek() -> std::optional<Error>
 {
     ASSERT(RunLoop::isMain());
 
     // Bail out if the range is not provided.
     if (!m_isRangeRequest)
-        return;
+        return std::nullopt;
 
     // Adjust m_rangeStart / m_rangeEnd
     if (m_rangeStart == kPositionNotSpecified) {
         m_rangeStart = m_totalSize - m_rangeEnd;
         m_rangeEnd = m_rangeStart + m_rangeEnd - 1;
     } else {
-        if (m_rangeStart >= m_totalSize) {
-            didFail(Error::RangeError);
-            return;
-        }
+        if (m_rangeStart >= m_totalSize)
+            return Error::RangeError;
         if (m_rangeEnd == kPositionNotSpecified || m_rangeEnd >= m_totalSize)
             m_rangeEnd = m_totalSize - 1;
     }
@@ -247,6 +249,7 @@ void NetworkDataTaskBlob::seek()
     long long rangeSize = m_rangeEnd - m_rangeStart + 1;
     if (m_totalRemainingSize > rangeSize)
         m_totalRemainingSize = rangeSize;
+    return std::nullopt;
 }
 
 void NetworkDataTaskBlob::dispatchDidReceiveResponse()

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -84,7 +84,7 @@ private:
     void clearStream();
     void getSizeForNext();
     void dispatchDidReceiveResponse();
-    void seek();
+    std::optional<Error> seek();
     void consumeData(const uint8_t* data, int bytesRead);
     void read();
     void readData(const WebCore::BlobDataItem&);


### PR DESCRIPTION
#### d7832a4e54aded809a7ea2d90b9d014d882e0e71
<pre>
Potential crash under NetworkDataTaskBlob::dispatchDidReceiveResponse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258951">https://bugs.webkit.org/show_bug.cgi?id=258951</a>
rdar://111798349

Reviewed by Youenn Fablet.

In getSizeForNext(), we call seek() and then dispatchDidReceiveResponse().
After 261968@main, seek() could call fail internally and call didFail().
However, we could still call dispatchDidReceiveResponse() right after in
case of failure.

We now propagate the error state out of seek() and have the caller call
didFail() and then early return instead of calling dispatchDidReceiveResponse().

* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::getSizeForNext):
(WebKit::NetworkDataTaskBlob::seek):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h:

Canonical link: <a href="https://commits.webkit.org/265848@main">https://commits.webkit.org/265848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ae9c4cd9efb75475bf63695cf8022a674f66e04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14332 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14213 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10938 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11398 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10801 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2949 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->