### PR TITLE
AR View closes instead of showing 3D asset - MobileSafari Crashing at -[_WKSystemPreviewDataTaskDelegate dataTask:didCompleteWithError:] + 32

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -273,6 +273,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
         return nil;
 
     _previewController = previewController;
+    _fileHandle = FileSystem::invalidPlatformFileHandle;
     return self;
 }
 
@@ -346,6 +347,7 @@ static NSString * const _WKARQLWebsiteURLParameterKey = @"ARQLWebsiteURLParamete
 
 - (void)completeLoad
 {
+    ASSERT(_fileHandle != FileSystem::invalidPlatformFileHandle);
     size_t byteCount = FileSystem::writeToFile(_fileHandle, [_data bytes], [_data length]);
     FileSystem::closeFile(_fileHandle);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html
@@ -6,3 +6,6 @@
 <a id="badlink" rel="ar" href="BadLink.usdz">
     <img>
 </a>
+<a id="bloblink" rel="ar" href="blob:foo">
+    <img>
+</a>


### PR DESCRIPTION
#### c7ca29832dcbf36dc2c8ee92f42b7c3aae2abf9e
<pre>
AR View closes instead of showing 3D asset - MobileSafari Crashing at -[_WKSystemPreviewDataTaskDelegate dataTask:didCompleteWithError:] + 32
<a href="https://bugs.webkit.org/show_bug.cgi?id=258957">https://bugs.webkit.org/show_bug.cgi?id=258957</a>
rdar://110671973

Reviewed by Tim Horton.

When we try to load a `blob:` URL, the WKDataTask instantly fails. This
causes us to try to close a file handle that hasn&apos;t been initialised.
Add a check to make sure that doesn&apos;t happen.

There is still the bigger bug of needing to actually load blob URLs.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SystemPreview.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/system-preview.html:

Canonical link: <a href="https://commits.webkit.org/266048@main">https://commits.webkit.org/266048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdf85f39b8be1369c7a370f8c8f207cd8169b7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12132 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14859 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18555 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14838 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/11368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3111 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->