### PR TITLE
[WebGL] Speculative fix for crash in WebGLRenderingContextBase::reshape

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -383,10 +383,10 @@ RefPtr<WebGLTexture> WebGL2RenderingContext::validateTextureStorage2DBinding(con
     RefPtr<WebGLTexture> texture;
     switch (target) {
     case GraphicsContextGL::TEXTURE_2D:
-        texture = m_textureUnits[m_activeTextureUnit].texture2DBinding;
+        texture = activeTextureUnitState().texture2DBinding;
         break;
     case GraphicsContextGL::TEXTURE_CUBE_MAP:
-        texture = m_textureUnits[m_activeTextureUnit].textureCubeMapBinding;
+        texture = activeTextureUnitState().textureCubeMapBinding;
         break;
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid texture target");
@@ -403,10 +403,10 @@ RefPtr<WebGLTexture> WebGL2RenderingContext::validateTexture3DBinding(const char
     RefPtr<WebGLTexture> texture;
     switch (target) {
     case GraphicsContextGL::TEXTURE_2D_ARRAY:
-        texture = m_textureUnits[m_activeTextureUnit].texture2DArrayBinding;
+        texture = activeTextureUnitState().texture2DArrayBinding;
         break;
     case GraphicsContextGL::TEXTURE_3D:
-        texture = m_textureUnits[m_activeTextureUnit].texture3DBinding;
+        texture = activeTextureUnitState().texture3DBinding;
         break;
     default:
         synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid texture target");
@@ -3115,9 +3115,9 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     case GraphicsContextGL::SAMPLER_BINDING:
         return m_boundSamplers[m_activeTextureUnit];
     case GraphicsContextGL::TEXTURE_BINDING_2D_ARRAY:
-        return m_textureUnits[m_activeTextureUnit].texture2DArrayBinding;
+        return activeTextureUnitState().texture2DArrayBinding;
     case GraphicsContextGL::TEXTURE_BINDING_3D:
-        return m_textureUnits[m_activeTextureUnit].texture3DBinding;
+        return activeTextureUnitState().texture3DBinding;
     case GraphicsContextGL::TRANSFORM_FEEDBACK_ACTIVE:
         return getBooleanParameter(pname);
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_BINDING:

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1074,6 +1074,14 @@ protected:
     // Returns true if underlying context had errors.
     bool updateErrors();
 
+protected:
+    TextureUnitState& activeTextureUnitState()
+    {
+        RELEASE_ASSERT_WITH_MESSAGE(m_activeTextureUnit < m_textureUnits.size(),
+            "active texture unit %lu >= texture unit count %zu", m_activeTextureUnit, m_textureUnits.size());
+        return m_textureUnits[m_activeTextureUnit];
+    }
+
 private:
     void scheduleTaskToDispatchContextLostEvent();
     // Helper for restoration after context lost.


### PR DESCRIPTION
#### 3b7df736c09c1ee209d55e710e6ed2780f11e09b
<pre>
[WebGL] Speculative fix for crash in WebGLRenderingContextBase::reshape
<a href="https://bugs.webkit.org/show_bug.cgi?id=258958">https://bugs.webkit.org/show_bug.cgi?id=258958</a>
rdar://111695432

Reviewed by NOBODY (OOPS!).

We are seeing invalid indexing into m_textureUnits in the wild. m_textureUnits
is validated in initializeNewContext(), so assume that m_activeTextureUnit is
invalid.

Check m_activeTextureUnit is in bounds of m_textureUnits and signal that the
context is lost for internal inconsistent state instead of crashing in Release.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateTextureStorage2DBinding):
(WebCore::WebGL2RenderingContext::validateTexture3DBinding):
(WebCore::WebGL2RenderingContext::getParameter):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::reshape):
(WebCore::WebGLRenderingContextBase::bindTexture):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::validateTextureBinding):
(WebCore::WebGLRenderingContextBase::validateTexture2DBinding):
(WebCore::WebGLRenderingContextBase::restoreCurrentTexture2D):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::activeTextureUnitState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b7df736c09c1ee209d55e710e6ed2780f11e09b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13770 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14301 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14184 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11371 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14243 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9514 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10773 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->