### PR TITLE
Dictation glow can be rendered exceeding graphics context bounds

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -558,6 +558,7 @@ void Recorder::resetClip()
     currentState().clipBounds = m_initialClip;
 
     recordResetClip();
+    clip(m_initialClip);
 }
 
 void Recorder::clip(const FloatRect& rect)

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -286,7 +286,9 @@ struct ResetClipRect {
     static String description()
     {
         return R"DL(
-(reset-clip))DL"_s;
+(reset-clip)
+(clip
+  (rect at (0,0) size 77x88)))DL"_s;
     }
 };
 


### PR DESCRIPTION
#### c9f844d07498207a3163fdae7793db9577cf1d98
<pre>
Dictation glow can be rendered exceeding graphics context bounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=258960">https://bugs.webkit.org/show_bug.cgi?id=258960</a>
&lt;radar://111867549&gt;

Reviewed by Kimmo Kinnunen.

We should never set the clip rectangle to something larger than the
initial graphics context bounds, since we won&apos;t render to an area
larger than that and the contents will be left stale.

Correct this by clipping to the initial clip rectangle whenever the clip
rectangle is reset.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::resetClip):
We were already setting the clip bounds to this value a few lines above.

* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
Update test expectation.

Canonical link: <a href="https://commits.webkit.org/265851@main">https://commits.webkit.org/265851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863d1f4b2b1782b78f2f4394d8f9bc1241c9967f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12058 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13804 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14335 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14219 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10944 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18070 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11104 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14278 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9547 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10806 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2950 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15131 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->