### PR TITLE
[GTK] Handle global modifiers state in the UI process only

### DIFF
--- a/Source/WebCore/platform/PlatformKeyboardEvent.h
+++ b/Source/WebCore/platform/PlatformKeyboardEvent.h
@@ -135,7 +135,6 @@ namespace WebCore {
         static String keyIdentifierForGdkKeyCode(unsigned);
         static int windowsKeyCodeForGdkKeyCode(unsigned);
         static String singleCharacterString(unsigned);
-        static bool modifiersContainCapsLock(unsigned);
 #endif
 
 #if USE(LIBWPE)

--- a/Source/WebCore/platform/gtk/GtkUtilities.cpp
+++ b/Source/WebCore/platform/gtk/GtkUtilities.cpp
@@ -221,4 +221,16 @@ bool shouldUseOverlayScrollbars()
     return !!overlayScrolling;
 }
 
+bool eventModifiersContainCapsLock(GdkEvent* event)
+{
+#if USE(GTK4)
+    auto* device = gdk_event_get_source_device(event);
+    if (!device || gdk_device_get_source(device) != GDK_SOURCE_KEYBOARD)
+        device = gdk_seat_get_keyboard(gdk_display_get_default_seat(gdk_event_get_display(event)));
+    return gdk_device_get_caps_lock_state(device);
+#else
+    return gdk_keymap_get_caps_lock_state(gdk_keymap_get_for_display(gdk_event_get_display(event)));
+#endif
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/gtk/GtkUtilities.h
+++ b/Source/WebCore/platform/gtk/GtkUtilities.h
@@ -59,4 +59,6 @@ void monitorWorkArea(GdkMonitor*, GdkRectangle*);
 
 bool shouldUseOverlayScrollbars();
 
+WEBCORE_EXPORT bool eventModifiersContainCapsLock(GdkEvent*);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/gtk/GtkVersioning.h
+++ b/Source/WebCore/platform/gtk/GtkVersioning.h
@@ -276,6 +276,12 @@ gtk_scrolled_window_new()
     return gtk_scrolled_window_new(nullptr, nullptr);
 }
 
+static inline GdkEvent*
+gtk_event_controller_get_current_event(GtkEventController*)
+{
+    return gtk_get_current_event();
+}
+
 static inline GdkModifierType
 gtk_event_controller_get_current_event_state(GtkEventController*)
 {
@@ -293,6 +299,12 @@ gtk_event_controller_get_current_event_time(GtkEventController*)
 static inline GtkIconTheme* gtk_icon_theme_get_for_display(GdkDisplay* display)
 {
     return gtk_icon_theme_get_for_screen(gdk_display_get_default_screen(display));
+}
+
+static inline GdkDisplay*
+gdk_event_get_display(GdkEvent* event)
+{
+    return event->any.window ? gdk_window_get_display(event->any.window) : gdk_display_get_default();
 }
 
 #endif // USE(GTK4)

--- a/Source/WebKit/Shared/gtk/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/gtk/WebEventFactory.cpp
@@ -69,7 +69,7 @@ static inline OptionSet<WebEventModifier> modifiersForEvent(const GdkEvent* even
         modifiers.add(WebEventModifier::AltKey);
     if (state & GDK_META_MASK)
         modifiers.add(WebEventModifier::MetaKey);
-    if (PlatformKeyboardEvent::modifiersContainCapsLock(state))
+    if (state & GDK_LOCK_MASK && eventModifiersContainCapsLock(const_cast<GdkEvent*>(event)))
         modifiers.add(WebEventModifier::CapsLockKey);
 
     GdkEventType type = gdk_event_get_event_type(const_cast<GdkEvent*>(event));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11756,8 +11756,12 @@ void WebPageProxy::getIsViewVisible(bool& result)
 
 void WebPageProxy::updateCurrentModifierState()
 {
+#if PLATFORM(COCOA) || PLATFORM(GTK)
 #if PLATFORM(COCOA)
     auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
+#elif PLATFORM(GTK)
+    auto modifiers = currentStateOfModifierKeys();
+#endif
     send(Messages::WebPage::UpdateCurrentModifierState(modifiers));
 #endif
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -169,6 +169,7 @@ enum class ModalContainerDecision : uint8_t;
 enum class MouseEventPolicy : uint8_t;
 enum class PermissionName : uint8_t;
 enum class PermissionState : uint8_t;
+enum class PlatformEventModifier : uint8_t;
 enum class PolicyAction : uint8_t;
 enum class ReasonForDismissingAlternativeText : uint8_t;
 enum class ReloadOption : uint8_t;
@@ -2523,6 +2524,7 @@ private:
 
 #if PLATFORM(GTK)
     void showEmojiPicker(const WebCore::IntRect&, CompletionHandler<void(String)>&&);
+    OptionSet<WebCore::PlatformEventModifier> currentStateOfModifierKeys();
 #endif
 
     // Popup Menu.


### PR DESCRIPTION
#### 02196ebd1929a498ae53c4b689d78312094cd0dc
<pre>
[GTK] Handle global modifiers state in the UI process only
<a href="https://bugs.webkit.org/show_bug.cgi?id=258965">https://bugs.webkit.org/show_bug.cgi?id=258965</a>

Reviewed by Michael Catanzaro.

The web process updates the global modifiers state on every key event
received and when the view gets focused.

* Source/WebCore/platform/PlatformKeyboardEvent.h:
* Source/WebCore/platform/gtk/GtkUtilities.cpp:
(WebCore::eventModifiersContainCapsLock):
* Source/WebCore/platform/gtk/GtkUtilities.h:
* Source/WebCore/platform/gtk/GtkVersioning.h:
(gtk_event_controller_get_current_event):
(gdk_event_get_display):
* Source/WebCore/platform/gtk/PlatformKeyboardEventGtk.cpp:
(WebCore::PlatformKeyboardEvent::currentStateOfModifierKeys):
(WebCore::PlatformKeyboardEvent::modifiersContainCapsLock): Deleted.
* Source/WebKit/Shared/gtk/WebEventFactory.cpp:
(WebKit::modifiersForEvent):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(modifiersForSynthesizedEvent):
(webkitWebViewBaseTouchRelease):
(webkitWebViewBaseTouchDragUpdate):
(webkitWebViewBaseTouchDragEnd):
(toWebKitModifiers):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateCurrentModifierState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp:
(WebKit::WebPageProxy::currentStateOfModifierKeys):

Canonical link: <a href="https://commits.webkit.org/266095@main">https://commits.webkit.org/266095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5afbb4b0ca19459fd9abfae6e137bfd795265db9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11613 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14309 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14193 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10920 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18047 "17 flakes 92 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14253 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9522 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15106 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1459 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->