### PR TITLE
VideoFrame buffer constructor doesn't respect codedWidth if visibleRect is present

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/videoFrame-with-stride-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-with-stride-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Creating video frames Creating video frames Creating video frames with codedWidth differing from visibleWidthh
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-with-stride.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-with-stride.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='/webcodecs/videoFrame-utils.js'></script>
+</head>
+<body>
+<canvas id=canvas width=100px hwight=100px></canvas>
+<script>
+function createVideoFrame(stride)
+{
+    const width = 16;
+    const height = 16;
+    const size = stride * height;
+    const buf = new ArrayBuffer(size * 1.5);
+    const bytesY = new Uint8Array(buf, 0, size * 1.0);
+    const bytesU = new Uint8Array(buf, size * 1.0, size * 0.25);
+    const bytesV = new Uint8Array(buf, size * 1.25, size * 0.25);
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++)
+            bytesY[y * stride + x] = (y << 4) | x;
+    }
+    bytesU.fill(128);
+    bytesV.fill(128);
+
+    return new VideoFrame(buf, {
+      format: "I420",
+      codedWidth: stride,
+      codedHeight: height,
+      timestamp: 0,
+      visibleRect: {
+        x: 0,
+        y: 0,
+        width: width,
+        height: height
+      },
+      colorSpace: {
+        primaries: 'bt709',
+        transfer: 'bt709',
+        matrix: 'bt709',
+        fullRange: true,
+      }
+    });
+}
+
+test(t => {
+     const frame1 = createVideoFrame(16);
+     t.add_cleanup(() => frame1.close());
+     const frame2 = createVideoFrame(32);
+     t.add_cleanup(() => frame2.close());
+
+     canvas.getContext('2d').drawImage(frame1, 0, 0);
+     const data1 = canvas.getContext('2d').getImageData(0, 0, 4, 2).data;
+
+     canvas.getContext('2d').drawImage(frame2, 0, 0);
+     const data2 = canvas.getContext('2d').getImageData(0, 0, 4, 2).data;
+
+     assert_array_equals(data1, data2);
+}, 'Creating video frames Creating video frames Creating video frames with codedWidth differing from visibleWidthh');
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -280,7 +280,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
         return parsedRectOrExtension.releaseException();
 
     auto parsedRect = parsedRectOrExtension.releaseReturnValue();
-    auto layoutOrException = computeLayoutAndAllocationSize(parsedRect, init.layout, init.format);
+    auto layoutOrException = computeLayoutAndAllocationSize(defaultRect, init.layout, init.format);
     if (layoutOrException.hasException())
         return layoutOrException.releaseException();
     


### PR DESCRIPTION
#### e919dcfad3da7a2f20efe34b6e810761ddd64204
<pre>
VideoFrame buffer constructor doesn&apos;t respect codedWidth if visibleRect is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=256848">https://bugs.webkit.org/show_bug.cgi?id=256848</a>
rdar://109724698

Reviewed by Eric Carlson.

Use codedWidth and codedHeight instead of parsedRect.
This is coherent with the rest of the algorithm like checking the array size and is consistent with what Chrome does.
I filed <a href="https://github.com/w3c/webcodecs/issues/702">https://github.com/w3c/webcodecs/issues/702</a> to update the spec.

* LayoutTests/http/wpt/webcodecs/videoFrame-with-stride-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-with-stride.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):

Canonical link: <a href="https://commits.webkit.org/265844@main">https://commits.webkit.org/265844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e81ff738b97e363d1ac83059ee2d9d245a4fbcc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14312 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14196 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18049 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9525 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10798 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11422 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->