### PR TITLE
[run-benchmark] Linux driver executes the browser capturing stdout/stderr but never checks it

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -106,10 +106,12 @@ class LinuxBrowserDriver(BrowserDriver):
             self.browser_args = []
         exec_args = [self.process_name] + self.browser_args + self._default_browser_arguments
         _log.info('Executing: {browser_cmdline}'.format(browser_cmdline=' '.join(exec_args)))
+        # The browser process is not expected to exit on its own, it gets killed when the benchmark ends
+        # and at that time is already too late to read the stdour/stderr pipes when there is lot of text
+        # because if the pipe gets full then the browser process gets frozen.
+        # So do not capture stdout/stderr, let the subprocess flush it to the default stdout/stderr.
         self._browser_process = subprocess.Popen(
             exec_args, env=self._test_environ,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
             **(dict(encoding='utf-8') if sys.version_info >= (3, 6) else dict())
         )
 


### PR DESCRIPTION
#### 0f3437e25ccfb415fb96a2f1da498a001ad00960
<pre>
[run-benchmark] Linux driver executes the browser capturing stdout/stderr but never checks it
<a href="https://bugs.webkit.org/show_bug.cgi?id=258968">https://bugs.webkit.org/show_bug.cgi?id=258968</a>

Reviewed by Carlos Garcia Campos.

The Linux driver of run-benchmark was capturing stdout and stderr of the
browser subprocess but never checking it. So this caused that when the browser
prints lot of text the pipe gets full and the browser process gets frozen.

This caused timeouts with Cog and the jsbench benchmark. I reported this
originally at <a href="https://github.com/Igalia/cog/issues/589">https://github.com/Igalia/cog/issues/589</a> thinking it was a
bug on Cog, but is a bug on the run-benchmark tool.

This patch just changes the way of executing the browser, to not capture stdout
or stderr and just let the browser print the output to the standard stdout/stderr.

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py:
(LinuxBrowserDriver.launch_url):

Canonical link: <a href="https://commits.webkit.org/265839@main">https://commits.webkit.org/265839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e1df3d5d6647fff3268b05b6c7610fc156163d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14318 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14201 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/12136 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18053 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14261 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9530 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10790 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15114 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1345 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->