### PR TITLE
Enable Web process cache on iOS

### DIFF
--- a/Source/WTF/wtf/RAMSize.cpp
+++ b/Source/WTF/wtf/RAMSize.cpp
@@ -40,6 +40,10 @@
 #include <bmalloc/bmalloc.h>
 #endif
 
+#if OS(DARWIN)
+#include <mach/mach.h>
+#endif
+
 namespace WTF {
 
 #if OS(WINDOWS)
@@ -81,5 +85,25 @@ size_t ramSize()
     });
     return ramSize;
 }
+
+#if OS(DARWIN)
+size_t ramSizeDisregardingJetsamLimit()
+{
+    host_basic_info_data_t hostInfo;
+
+    mach_port_t host = mach_host_self();
+    mach_msg_type_number_t count = HOST_BASIC_INFO_COUNT;
+    kern_return_t r = host_info(host, HOST_BASIC_INFO, (host_info_t)&hostInfo, &count);
+    if (mach_port_deallocate(mach_task_self(), host) != KERN_SUCCESS)
+        return 0;
+    if (r != KERN_SUCCESS)
+        return 0;
+
+    if (hostInfo.max_mem > std::numeric_limits<size_t>::max())
+        return std::numeric_limits<size_t>::max();
+
+    return static_cast<size_t>(hostInfo.max_mem);
+}
+#endif
 
 } // namespace WTF

--- a/Source/WTF/wtf/RAMSize.h
+++ b/Source/WTF/wtf/RAMSize.h
@@ -29,6 +29,10 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE size_t ramSize();
 
+#if OS(DARWIN)
+WTF_EXPORT_PRIVATE size_t ramSizeDisregardingJetsamLimit();
+#endif
+
 }
 
 using WTF::ramSize;

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -185,13 +185,20 @@ void WebProcessCache::updateCapacity(WebProcessPool& processPool)
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache is disabled because cache model is not PrimaryWebBrowser", 0);
         m_capacity = 0;
     } else {
-        size_t memorySize = ramSize() / GB;
+#if PLATFORM(IOS_FAMILY)
+        constexpr unsigned maxProcesses = 10;
+        size_t memorySize = WTF::ramSizeDisregardingJetsamLimit() / GB;
+#else
+        constexpr unsigned maxProcesses = 30;
+        size_t memorySize = WTF::ramSize() / GB;
+#endif
+        WEBPROCESSCACHE_RELEASE_LOG("memory size %zu GB", 0, memorySize);
         if (memorySize < 3) {
             m_capacity = 0;
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache is disabled because device does not have enough RAM", 0);
         } else {
-            // Allow 4 processes in the cache per GB of RAM, up to 30 processes.
-            m_capacity = std::min<unsigned>(memorySize * 4, 30);
+            // Allow 4 processes in the cache per GB of RAM, up to maxProcesses.
+            m_capacity = std::min<unsigned>(memorySize * 4, maxProcesses);
             WEBPROCESSCACHE_RELEASE_LOG("updateCapacity: Cache has a capacity of %u processes", 0, capacity());
         }
     }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -447,7 +447,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters)
             if (m_pagesInWindows.isEmpty() && critical == Critical::No)
                 critical = Critical::Yes;
 
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
             // If this is a process we keep around for performance, kill it on memory pressure instead of trying to free up its memory.
             if (!m_isSuspending && (m_processType == ProcessType::CachedWebContent || m_processType == ProcessType::PrewarmedWebContent || areAllPagesSuspended())) {
                 if (m_processType == ProcessType::CachedWebContent)
@@ -1607,14 +1607,6 @@ void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estim
     suspendAllMediaBuffering();
     if (auto* platformMediaSessionManager = PlatformMediaSessionManager::sharedManagerIfExists())
         platformMediaSessionManager->processWillSuspend();
-#endif
-
-#if !PLATFORM(MAC)
-    if (!m_suppressMemoryPressureHandler) {
-        MemoryPressureHandler::singleton().releaseMemory(Critical::Yes, Synchronous::Yes);
-        for (auto& page : m_pageMap.values())
-            page->releaseMemory(Critical::Yes);
-    }
 #endif
 
     freezeAllLayerTrees();


### PR DESCRIPTION
#### 7d015b7c0f7a00805f719bf96e04f2f33b2ff77d
<pre>
Enable Web process cache on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=258978">https://bugs.webkit.org/show_bug.cgi?id=258978</a>
rdar://111908431

Reviewed by Brent Fulgham.

Enable the Web process cache on iOS by addressing an issue where the physical memory size in GB is reported as zero,
causing the process cache capacity to be set to zero. This is because the jetsam limit is taken into consideration
in this computation on iOS. This patch adds a function that returns the memory size without considering the jetsam
limit of the calling process. This patch also delays releasing memory when preparing to suspend, since this is
further improving the page load speed when reusing a process from the cache. Releasing the memory is delayed until
we drop the last assertion, which will suspend the process. Until then, the process is running and able to respond
to memory pressure warnings from the system and releasing memory. Furthermore, the process is not added to the cache
if assertions are being held, preventing it from suspending. This is a fix for a regression in page load speed we
see on <a href="http://www.youtube.com">http://www.youtube.com</a> when adding it to the cache. This change is a speedup on page load benchmarks.

* Source/WTF/wtf/RAMSize.cpp:
(WTF::ramSizeDisregardingJetsamLimit):
* Source/WTF/wtf/RAMSize.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::updateCapacity):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
* Source/WebKit/WebProcess/WebProcess.cpp:

Canonical link: <a href="https://commits.webkit.org/266267@main">https://commits.webkit.org/266267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46fa1a4d4f97e4909d4be44b3144495699460fe9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12732 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15414 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15764 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12069 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11398 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12558 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12739 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13419 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12011 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3515 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3265 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16333 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13803 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12580 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3312 "Passed tests") | 
<!--EWS-Status-Bubble-End-->