### PR TITLE
CrashTracer: Safari at com.apple.WebKit: WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -118,7 +118,7 @@ void RemoteLayerTreeEventDispatcher::invalidate()
 {
     m_displayLinkClient->invalidate();
 
-    stopDisplayLinkObserver();
+    removeDisplayLinkClient();
 
     {
         Locker locker { m_scrollingTreeLock };
@@ -393,7 +393,7 @@ void RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver()
     if (!m_displayRefreshObserverID)
         return;
 
-    auto* displayLink = this->displayLink();
+    auto* displayLink = existingDisplayLink();
     if (!displayLink)
         return;
 


### PR DESCRIPTION
#### d7dc87868c78621c97034a644084cdbe65c61f53
<pre>
CrashTracer: Safari at com.apple.WebKit: WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink
<a href="https://bugs.webkit.org/show_bug.cgi?id=258976">https://bugs.webkit.org/show_bug.cgi?id=258976</a>
rdar://111348720

Reviewed by Simon Fraser.

At WebPageProxy::resetState() we are setting the drawing area
to nullptr with WebPageProxyArea::setDrawingArea(nullptr).

setDrawingArea(...) will delete m_scrollingCordinatorProxy, which destructor
is ~RemoteScrollingCoordinatorProxyMac(). This function will then try to
invalidate the wheel event dispatcher (m_wheelEventDispatcher-&gt;invalidate()). This is actually RemoteLayerTreeEventDispatcher::invalidate().

invalidate() calls stopDisplayLinkObserver() which needs to get a handle
of the the associated displayLink for doing that.

RemoteLayerTreeEventDispatcher::displayLink() returns early
if there is no m_scrollingCordinator, but we are exactly in the process
of deleting it. It then continues and tries to get the displayLink from the drawingArea (RemoteLayerTreeDrawingAreaProxyMac::displayLink()),
which will crash if there is no m_displayID set to the area.

I&apos;m not sure why, at this point, we don&apos;t have a m_displayID set to the
drawing area (it is set by windowScreenDidChange(id)). But, in any case,
I believe stopDisplayLinkObserver() should use existingDisplayLink()
instead of displayLink() because we shouldn`t need to stop observers
for a non existent displayLink.

Even better, in invalidate() we can replace stopDisplayLinkObserver() by
removeDisplayLinkClient(): Since we want to delete the displayLinkClient
at the end of invalidate() we can remove this client from the displayLink
map (removing all its observers in the process), which should happen
because the displayLinkClient is being deleted.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver):

Canonical link: <a href="https://commits.webkit.org/265862@main">https://commits.webkit.org/265862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23b0cfa99685de25a1f0157e973b2acd4a6cf4bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11630 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14326 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14210 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10315 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18062 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11395 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9538 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10799 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->