### PR TITLE
[WebRTC] webrtc/multi-video.html can potentially overflow payload types

### DIFF
--- a/LayoutTests/webrtc/multi-video.html
+++ b/LayoutTests/webrtc/multi-video.html
@@ -65,6 +65,11 @@ promise_test((test) => {
                 firstConnection.addTrack(track4, newStream);
                 firstConnection.addTrack(track5, newStream);
                 firstConnection.addTrack(track6, newStream);
+
+                // Restrict each transceiver to one codec (H.264) to prevent payload types from overflowing in SDP offer.
+                const codecs = RTCRtpSender.getCapabilities("video").codecs;
+                const h264Codec = codecs.filter(codec => { return codec.mimeType === "video/H264"; })[0];
+                firstConnection.getTransceivers().forEach((transceiver) => { transceiver.setCodecPreferences([h264Codec]); });
             }, (secondConnection) => {
                 secondConnection.ontrack = (trackEvent) => {
                     resolve(trackEvent.streams[0]);


### PR DESCRIPTION
#### dbbc3bcdfc29ad33a3b6a431747eedf2080be849
<pre>
[WebRTC] webrtc/multi-video.html can potentially overflow payload types
<a href="https://bugs.webkit.org/show_bug.cgi?id=258979">https://bugs.webkit.org/show_bug.cgi?id=258979</a>

Reviewed by Xabier Rodriguez-Calvar.

Restrict each transceiver to one codec (H.264) to prevent payload types from overflowing in SDP
offer.

* LayoutTests/webrtc/multi-video.html:

Canonical link: <a href="https://commits.webkit.org/265944@main">https://commits.webkit.org/265944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c513ce9be93f4cc189566c8a13e2cbae167de4fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11886 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14567 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14522 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11197 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14545 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9783 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->