### PR TITLE
REGRESSION(265596@main) Vertical WebVTT cues are laid out horizontally

### DIFF
--- a/LayoutTests/media/track/track-cue-vertical-style-expected.txt
+++ b/LayoutTests/media/track/track-cue-vertical-style-expected.txt
@@ -1,0 +1,13 @@
+
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(canplay)
+RUN(cue = new VTTCue(0, 1, "vertical"))
+RUN(textTrack.addCue(cue))
+EXPECTED (firstCueElement() != 'null') OK
+EXPECTED (window.getComputedStyle(firstCueElement()).writingMode == 'horizontal-tb') OK
+RUN(cue.vertical = "rl")
+EXPECTED (window.getComputedStyle(firstCueElement()).writingMode == 'vertical-rl') OK
+RUN(cue.vertical = "lr")
+EXPECTED (window.getComputedStyle(firstCueElement()).writingMode == 'vertical-lr') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-cue-vertical-style.html
+++ b/LayoutTests/media/track/track-cue-vertical-style.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>track-cue-vertical-style</title>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <script>
+    function firstCueElement() {
+        return internals.shadowRoot(video).querySelector('[pseudo="cue"]');
+    }
+
+    async function runTest() {
+        findMediaElement();
+        run('video.src = findMediaFile("video", "../content/test")');
+        await waitFor(video, 'canplay');
+
+        window.textTrack = video.addTextTrack("subtitles");
+        textTrack.mode = 'showing';
+
+        run('cue = new VTTCue(0, 1, "vertical")');
+        run('textTrack.addCue(cue)');
+
+        if (!window.testRunner) {
+            consoleWrite('Test requires internals; manually verify <code>vertical</code> cue is vertical.');
+            endTest();
+        }
+
+        await testExpectedEventually('firstCueElement()', null, '!=');
+
+        await testExpectedEventually(`window.getComputedStyle(firstCueElement()).writingMode`, 'horizontal-tb')
+
+        run('cue.vertical = "rl"');
+
+        await testExpectedEventually(`window.getComputedStyle(firstCueElement()).writingMode`, 'vertical-rl')
+
+        run('cue.vertical = "lr"');
+
+        await testExpectedEventually(`window.getComputedStyle(firstCueElement()).writingMode`, 'vertical-lr')
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -172,7 +172,6 @@ void VTTCueBox::applyCSSProperties()
 
     // the 'position' property must be set to 'absolute'
     // the 'unicode-bidi' property must be set to 'plaintext'
-    // the 'writing-mode' property must be set to writing-mode
     // the overflow-wrap property must be set to break-word
     // the text-wrap property must be set to balance [CSS-TEXT-4]
     // The color property on the (root) list of WebVTT Node Objects must be set
@@ -186,6 +185,9 @@ void VTTCueBox::applyCSSProperties()
     //   Let left be x-position vw and top be y-position vh.
     // Use 'cqh' and 'cqw' rather than 'vh' and 'vw' here, as the video viewport
     // is not a true viewport, but it is a container, so they serve the same purpose.
+
+    // the 'writing-mode' property must be set to writing-mode
+    setInlineStyleProperty(CSSPropertyWritingMode, cue->getCSSWritingMode(), false);
 
     // the 'top' property must be set to top
     std::visit(WTF::makeVisitor([&] (double top) {


### PR DESCRIPTION
#### c4d1167df42e2c76331e86877e086fa64dead53a
<pre>
REGRESSION(265596@main) Vertical WebVTT cues are laid out horizontally
<a href="https://bugs.webkit.org/show_bug.cgi?id=258980">https://bugs.webkit.org/show_bug.cgi?id=258980</a>
rdar://111909315

Reviewed by Eric Carlson.

Use the calculated value of `writing-mode` in applyCSSProperties() rather
than the default provided in the UA style sheet.

* LayoutTests/media/track/track-cue-vertical-style-expected.txt: Added.
* LayoutTests/media/track/track-cue-vertical-style.html: Added.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCueBox::applyCSSProperties):

Canonical link: <a href="https://commits.webkit.org/265860@main">https://commits.webkit.org/265860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9cf2291d8d82ced58c9a261681cad98612e4441

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13033 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14215 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18067 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11401 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14280 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9544 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10817 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->