### PR TITLE
[git-webkit] Enable secret scanning on public forks

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.1',
+    version='6.6.2',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 1)
+version = Version(6, 6, 2)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -37,6 +37,7 @@ class GitHub(bmocks.GitHub):
         self, remote='github.example.com/WebKit/WebKit', datafile=None,
         default_branch='main', git_svn=False, environment=None,
         releases=None, issues=None, projects=None, labels=None,
+        private=False,
     ):
         if not scmremote.GitHub.is_webserver('https://{}'.format(remote)):
             raise ValueError('"{}" is not a valid GitHub remote'.format(remote))
@@ -44,6 +45,7 @@ class GitHub(bmocks.GitHub):
         self.default_branch = default_branch
         self.remote = remote
         self.forks = []
+        self.private = private
 
         super(GitHub, self).__init__(remote, environment=environment, issues=issues, projects=projects, labels=labels)
 
@@ -122,11 +124,16 @@ class GitHub(bmocks.GitHub):
             'name': self.remote.split('/')[2],
             'url': url,
             'default_branch': self.default_branch,
+            'visibility': 'private' if self.private else 'public',
             'owner': {
                 'login': self.remote.split('/')[1],
             }, 'organization': {
                 'login': self.remote.split('/')[1],
             }, 'html_url': self.remote,
+            'security_and_analysis': {
+                'secret_scanning': dict(status='disabled'),
+                'secret_scanning_push_protection': dict(status='disabled'),
+            },
         }, url=url)
 
     def _list_refs_response(self, url, type):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -70,8 +70,10 @@ class TestSetup(testing.PathTestCase):
             captured.root.log.getvalue(),
             '''Saving GitHub credentials in system credential store...
 GitHub credentials saved via Keyring!
+https://github.example.com/WebKit/WebKit is public, enabling secret scanning on fork
 Verifying user owned fork...
 Created a private fork of 'WebKit' belonging to 'username'!
+Enabled secret scanning on https://github.example.com/username/WebKit!
 ''',
         )
 
@@ -118,6 +120,7 @@ Set git editor to 'SVN_LOG_EDITOR' for this repository
         )
 
     def test_github_checkout(self):
+        self.maxDiff = None
         with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub() as remote, \
             MockTerminal.input('n', 'n', 'committer@webkit.org', 'n', 'Committer', 's', 'overwrite', 'y', 'disabled', '1', 'y'), \
             mocks.local.Git(self.path, remote='https://{}.git'.format(remote.remote)) as repo, \
@@ -181,8 +184,10 @@ Setting git editor for {repository}...
 Using the default git editor for this repository
 Saving GitHub credentials in system credential store...
 GitHub credentials saved via Keyring!
+https://github.example.com/WebKit/WebKit is public, enabling secret scanning on fork
 Verifying user owned fork...
 Created a private fork of 'WebKit' belonging to 'username'!
+Enabled secret scanning on https://github.example.com/username/WebKit!
 Adding forked remote as 'fork'...
 Added remote 'fork'
 Fetching 'fork'

--- a/metadata/git_config_extension
+++ b/metadata/git_config_extension
@@ -8,12 +8,15 @@
 [webkitscmpy "remotes.origin"]
         url = git@github.com:WebKit/WebKit.git
         security-level = 0
+        secrets-scanning = true
 [webkitscmpy "remotes.security"]
         url = git@github.com:WebKit/WebKit-security.git
         security-level = 1
+        secrets-scanning = false
 [webkitscmpy "remotes.apple"]
         url = git@github.com:apple/WebKit.git
         security-level = 2
+        secrets-scanning = false
 [webkitscmpy "access"]
         apple = apple/teams/WebKit
         security = WebKit/teams/security


### PR DESCRIPTION
#### 5ad05b63a0df53bbdf8aa2812dde51b4cd3f1bfc
<pre>
[git-webkit] Enable secret scanning on public forks
<a href="https://bugs.webkit.org/show_bug.cgi?id=258982">https://bugs.webkit.org/show_bug.cgi?id=258982</a>
rdar://111909822

Rubber-stamped by Aakash Jain.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py:
(GitHub.__init__): Allow caller to specify that the repository is private.
(GitHub._api_response): Include secret scanning and visibility data.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.block_secrets): Enable secret scanning and block the pushing of secrets.
(Setup.github): When validating an existing fork or creating a new one, enable
secret scanning and blocking if caller requests it.
(Setup.git): Consult configuration data to see if secret scanning should be enabled
in forks.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py:
* metadata/git_config_extension: Enable secret scanning for WebKit forks, but disable
it for private forks.

Canonical link: <a href="https://commits.webkit.org/265868@main">https://commits.webkit.org/265868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46e7fc08835044f56bf5c22c43a79b0d892371e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12102 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/12448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13848 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14864 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/12463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12266 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14264 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/12196 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/10992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/11635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/12463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/11992 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10849 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1351 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->