### PR TITLE
[iOS] Add support for simulating UITextChecker results in WebKitTestRunner

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1184,6 +1184,7 @@ typedef enum {
 - (id)_initWithAsynchronousLoading:(BOOL)asynchronousLoading;
 - (BOOL)_doneLoading;
 - (NSRange)rangeOfMisspelledWordInString:(NSString *)stringToCheck range:(NSRange)range startingAt:(NSInteger)startingOffset wrap:(BOOL)wrapFlag languages:(NSArray *)languagesArray;
+- (NSArray<NSTextAlternatives *> *)grammarAlternativesForString:(NSString *)string;
 @end
 
 @interface UIKeyboardInputMode : UITextInputMode <NSCopying>

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.h
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.h
@@ -50,7 +50,6 @@ public:
     double maximumZoomScale() const override;
     JSObjectRef contentVisibleRect() const override;
     void copyText(JSStringRef) override;
-    void setSpellCheckerResults(JSValueRef) override { }
 };
 
 }

--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.h
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.h
@@ -27,14 +27,18 @@
 #import <wtf/RetainPtr.h>
 
 #if PLATFORM(MAC)
-
 #import <AppKit/NSSpellChecker.h>
+using PlatformTextChecker = NSSpellChecker;
+#else
+#import <UIKit/UITextChecker.h>
+using PlatformTextChecker = UITextChecker;
+#endif
 
 @class LayoutTestTextCheckingResult;
 
 using TextCheckingResultsDictionary = NSDictionary<NSString *, NSArray<LayoutTestTextCheckingResult *> *>;
 
-@interface LayoutTestSpellChecker : NSSpellChecker {
+@interface LayoutTestSpellChecker : PlatformTextChecker {
 @private
     RetainPtr<TextCheckingResultsDictionary> _results;
     BOOL _spellCheckerLoggingEnabled;
@@ -47,5 +51,3 @@ using TextCheckingResultsDictionary = NSDictionary<NSString *, NSArray<LayoutTes
 @property (nonatomic, copy) TextCheckingResultsDictionary *results;
 @property (nonatomic) BOOL spellCheckerLoggingEnabled;
 @end
-
-#endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -27,6 +27,7 @@
 #import "TestController.h"
 
 #import "CrashReporterInfo.h"
+#import "LayoutTestSpellChecker.h"
 #import "Options.h"
 #import "PlatformWebView.h"
 #import "StringFunctions.h"
@@ -367,6 +368,8 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
         [platformView _resetNavigationGestureStateForTesting];
         [platformView.configuration.preferences setTextInteractionEnabled:options.textInteractionEnabled()];
     }
+
+    [LayoutTestSpellChecker uninstallAndReset];
 
     WebCoreTestSupport::setAdditionalSupportedImageTypesForTesting(String::fromLatin1(options.additionalSupportedImageTypes().c_str()));
 }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -84,6 +84,8 @@ private:
 #if ENABLE(IMAGE_ANALYSIS)
     uint64_t currentImageAnalysisRequestID() const final;
 #endif
+
+    void setSpellCheckerResults(JSValueRef) final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "UIScriptControllerCocoa.h"
 
+#import "LayoutTestSpellChecker.h"
 #import "PlatformWebView.h"
 #import "StringFunctions.h"
 #import "TestController.h"
@@ -311,5 +312,10 @@ uint64_t UIScriptControllerCocoa::currentImageAnalysisRequestID() const
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS)
+
+void UIScriptControllerCocoa::setSpellCheckerResults(JSValueRef results)
+{
+    [[LayoutTestSpellChecker checker] setResultsFromJSValue:results inContext:m_context->jsContext()];
+}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -152,7 +152,6 @@ private:
     void setAllowsViewportShrinkToFit(bool) override;
     void copyText(JSStringRef) override;
     void installTapGestureOnWindow(JSValueRef) override;
-    void setSpellCheckerResults(JSValueRef) override { }
     void setScrollViewKeyboardAvoidanceEnabled(bool) override;
 
     bool mayContainEditableElementsInRect(unsigned x, unsigned y, unsigned width, unsigned height) override;

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -171,8 +171,6 @@ void TestController::initializeTestPluginDirectory()
 
 bool TestController::platformResetStateToConsistentValues(const TestOptions& options)
 {
-    [LayoutTestSpellChecker uninstallAndReset];
-
     cocoaResetStateToConsistentValues(options);
 
     while ([NSApp nextEventMatchingMask:NSEventMaskGesture | NSEventMaskScrollWheel untilDate:nil inMode:NSDefaultRunLoopMode dequeue:YES]) {

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
@@ -60,7 +60,6 @@ private:
     NSView *platformContentView() const override;
     void clearAllCallbacks() override;
     void copyText(JSStringRef) override;
-    void setSpellCheckerResults(JSValueRef) override;
 
     void chooseMenuAction(JSStringRef, JSValueRef) override;
 

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -316,11 +316,6 @@ void UIScriptControllerMac::copyText(JSStringRef text)
     [pasteboard setString:text->string() forType:NSPasteboardTypeString];
 }
 
-void UIScriptControllerMac::setSpellCheckerResults(JSValueRef results)
-{
-    [[LayoutTestSpellChecker checker] setResultsFromJSValue:results inContext:m_context->jsContext()];
-}
-
 static NSString *const TopLevelEventInfoKey = @"events";
 static NSString *const EventTypeKey = @"type";
 static NSString *const ViewRelativeXPositionKey = @"viewX";


### PR DESCRIPTION
#### 250d336cc274116333d50d07264f76062116f1ad
<pre>
[iOS] Add support for simulating UITextChecker results in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=258990">https://bugs.webkit.org/show_bug.cgi?id=258990</a>
rdar://111404885

Reviewed by Tim Horton.

Add some test infrastructure that I&apos;ll be adopting as a part of a new layout test in a subsequent
patch. This refactors `UIScriptController::setSpellCheckerResults` (which is currently only
implemented on macOS) such that it is usable on iOS as well. See below for more details.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.h:
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.h:
* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:

Compile this on iOS as well, by subclassing `UITextChecker` instead of `NSSpellChecker`. Most of
the logic remains the same, but with a handful of minor differences.

(ensureGlobalLayoutTestSpellChecker):
(nsTextCheckingType):
(+[LayoutTestSpellChecker checker]):
(+[LayoutTestSpellChecker uninstallAndReset]):
(-[LayoutTestSpellChecker setResultsFromJSValue:inContext:]):
(stringForCorrectionResponse):
(swizzledGrammarDetailsForString):
(-[LayoutTestSpellChecker grammarAlternativesForString:]):

Implement this and intercept calls into `TextComposer` to grab grammar checking details over the
scope of this function call; this allows us to ensure that tapping on grammar checking ranges (blue
underlines on iOS) shows an edit menu with the appropriate text replacements.

(-[LayoutTestSpellChecker checkString:range:types:languages:options:]):
(-[LayoutTestSpellChecker _doneLoading]):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaResetStateToConsistentValues):

Move the call to `+[LayoutTestSpellChecker reset]` out of `TestControllerMac`, and into
`TestControllerCocoa` where it runs on both macOS and iOS.

* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::setSpellCheckerResults):

Move this logic out of `UIScriptControllerMac`, and into `UIScriptControllerCocoa` instead where it
can service both macOS and iOS testing.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.h:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::setSpellCheckerResults): Deleted.

Canonical link: <a href="https://commits.webkit.org/265869@main">https://commits.webkit.org/265869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c509cf3641e9bf55f24ec0e4ac9573a63f3953d6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14239 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18091 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14302 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9566 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10826 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2968 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->