### PR TITLE
[MediaStream] enumerateDevices should not exposed devices that can not be used

### DIFF
--- a/LayoutTests/fast/mediastream/camera-invalid-device-expected.txt
+++ b/LayoutTests/fast/mediastream/camera-invalid-device-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Invalid cameras and microphones should not be exposed by enumerateDevices
+

--- a/LayoutTests/fast/mediastream/camera-invalid-device.html
+++ b/LayoutTests/fast/mediastream/camera-invalid-device.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>Test that invalid capture devices are not exposed by enumerateDevices.</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <video id='video'></video>
+    <script>
+    let setup = async (test) => {
+        if (!window.testRunner)
+            return Promise.reject('test requires internal API');
+
+        test.add_cleanup(() => { testRunner.resetMockMediaDevices(); });
+    }
+
+    async function getDeviceWithLabel(label)
+    {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        let deviceId = undefined;
+        devices.forEach(device => {
+            if (device.label === label)
+                deviceId = device.deviceId;
+        });
+
+        stream.getTracks().forEach(track => {
+            track.stop();
+        });
+
+        return deviceId;
+    }
+
+    promise_test(async (test) => {
+        await setup(test);
+
+        testRunner.addMockCameraDevice('BogusCamera', 'invalid camera', { invalid: 'true' });
+        let invalidDevice = await getDeviceWithLabel('invalid camera')
+        assert_equals(invalidDevice, undefined);
+
+        testRunner.resetMockMediaDevices();
+        testRunner.addMockMicrophoneDevice('BogusMicrophone', 'invalid microphone', { invalid: 'true' });
+        invalidDevice = await getDeviceWithLabel('invalid microphone')
+        assert_equals(invalidDevice, undefined);
+
+    }, 'Invalid cameras and microphones should not be exposed by enumerateDevices');
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -140,21 +140,22 @@ void RealtimeMediaSourceCenter::getMediaStreamDevices(CompletionHandler<void(Vec
     });
 }
 
-RealtimeMediaSourceCapabilities RealtimeMediaSourceCenter::getCapabilities(const CaptureDevice& device)
+std::optional<RealtimeMediaSourceCapabilities> RealtimeMediaSourceCenter::getCapabilities(const CaptureDevice& device)
 {
     if (device.type() == CaptureDevice::DeviceType::Camera) {
         auto source = videoCaptureFactory().createVideoCaptureSource({ device },  { "fake"_s, "fake"_s }, nullptr, { });
         if (!source)
-            return { };
+            return std::nullopt;
         return source.source()->capabilities();
     }
-    if (device.type() == CaptureDevice::DeviceType::Microphone) {
+    if (device.type() == CaptureDevice::DeviceType::Microphone || device.type() == CaptureDevice::DeviceType::Speaker) {
         auto source = audioCaptureFactory().createAudioCaptureSource({ device }, { "fake"_s, "fake"_s }, nullptr, { });
         if (!source)
-            return { };
+            return std::nullopt;
         return source.source()->capabilities();
     }
-    return { };
+
+    return std::nullopt;
 }
 
 static void addStringToSHA1(SHA1& sha1, const String& string)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -80,7 +80,7 @@ public:
     void createMediaStream(Ref<const Logger>&&, NewMediaStreamHandler&&, MediaDeviceHashSalts&&, CaptureDevice&& audioDevice, CaptureDevice&& videoDevice, const MediaStreamRequest&);
 
     WEBCORE_EXPORT void getMediaStreamDevices(CompletionHandler<void(Vector<CaptureDevice>&&)>&&);
-    WEBCORE_EXPORT RealtimeMediaSourceCapabilities getCapabilities(const CaptureDevice&);
+    WEBCORE_EXPORT std::optional<RealtimeMediaSourceCapabilities> getCapabilities(const CaptureDevice&);
 
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() { return m_supportedConstraints; }
 

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -58,14 +58,14 @@ namespace WebCore {
 static inline Vector<MockMediaDevice> defaultDevices()
 {
     return Vector<MockMediaDevice> {
-        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, false, MockMicrophoneProperties { 44100 } },
-        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, false,  MockMicrophoneProperties { 48000 } },
+        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, MockMicrophoneProperties { 44100 } },
+        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { },  MockMicrophoneProperties { 48000 } },
 
-        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, false,  MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
-        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, false,  MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },
-        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 3"_s, false,  MockSpeakerProperties { String { }, 48000 } },
+        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, { },  MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
+        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, { },  MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },
+        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 3"_s, { },  MockSpeakerProperties { String { }, 48000 } },
 
-        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 1"_s, false,
+        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 1"_s, { },
             MockCameraProperties {
                 30,
                 VideoFacingMode::User, {
@@ -77,7 +77,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 Color::black,
             } },
 
-        MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, false,
+        MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, { },
             MockCameraProperties {
                 15,
                 VideoFacingMode::Environment, {
@@ -93,11 +93,11 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 Color::darkGray,
             } },
 
-        MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, false, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },
-        MockMediaDevice { "SCREEN-2"_s, "Mock screen device 2"_s, false, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::yellow, { 3840, 2160 } } },
+        MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },
+        MockMediaDevice { "SCREEN-2"_s, "Mock screen device 2"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::yellow, { 3840, 2160 } } },
 
-        MockMediaDevice { "WINDOW-1"_s, "Mock window device 1"_s, false, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 241, 181 }, { 640, 480 } } },
-        MockMediaDevice { "WINDOW-2"_s, "Mock window device 2"_s, false, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 208, 181 }, { 1280, 600 } } },
+        MockMediaDevice { "WINDOW-1"_s, "Mock window device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 241, 181 }, { 640, 480 } } },
+        MockMediaDevice { "WINDOW-2"_s, "Mock window device 2"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 208, 181 }, { 1280, 600 } } },
     };
 }
 
@@ -108,6 +108,11 @@ public:
         ASSERT(device.type() == CaptureDevice::DeviceType::Camera);
         if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(CaptureDevice::DeviceType::Camera, device.persistentId()))
             return { "Unable to find mock camera device with given persistentID"_s };
+
+        auto mock = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(device.persistentId());
+        ASSERT(mock);
+        if (mock->flags.contains(MockMediaDevice::Flag::Invalid))
+            return { "Invalid mock camera device"_s };
 
         return MockRealtimeVideoSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalts), constraints, pageIdentifier);
     }
@@ -215,9 +220,14 @@ class MockRealtimeAudioSourceFactory final : public AudioCaptureFactory {
 public:
     CaptureSourceOrError createAudioCaptureSource(const CaptureDevice& device, MediaDeviceHashSalts&& hashSalts, const MediaConstraints* constraints, PageIdentifier pageIdentifier) final
     {
-        ASSERT(device.type() == CaptureDevice::DeviceType::Microphone);
-        if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(CaptureDevice::DeviceType::Microphone, device.persistentId()))
-            return { "Unable to find mock microphone device with given persistentID"_s };
+        ASSERT(device.type() == CaptureDevice::DeviceType::Microphone || device.type() == CaptureDevice::DeviceType::Speaker);
+        if (!MockRealtimeMediaSourceCenter::captureDeviceWithPersistentID(device.type(), device.persistentId()))
+            return { "Unable to find mock microphone or speaker device with given persistentID"_s };
+
+        auto mock = MockRealtimeMediaSourceCenter::mockDeviceWithPersistentID(device.persistentId());
+        ASSERT(mock);
+        if (mock->flags.contains(MockMediaDevice::Flag::Invalid))
+            return { "Invalid mock microphone or speaker device"_s };
 
         return MockRealtimeAudioSource::create(String { device.persistentId() }, AtomString { device.label() }, WTFMove(hashSalts), constraints, pageIdentifier);
     }
@@ -410,7 +420,10 @@ void MockRealtimeMediaSourceCenter::setDeviceIsEphemeral(const String& persisten
         return;
 
     MockMediaDevice device = iterator->value;
-    device.isEphemeral = isEphemeral;
+    if (isEphemeral)
+        device.flags.add(MockMediaDevice::Flag::Ephemeral);
+    else
+        device.flags.remove(MockMediaDevice::Flag::Ephemeral);
 
     removeDevice(persistentId);
     addDevice(device);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4348,6 +4348,12 @@ class WebCore::RealtimeMediaSourceCapabilities {
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 
+header: <WebCore/MockMediaDevice.h>
+[Nested, OptionSet] enum class WebCore::MockMediaDevice::Flag : uint8_t {
+    Ephemeral
+    Invalid
+};
+
 #endif
 
 enum class WebCore::PlatformVideoColorPrimaries : uint8_t {

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
@@ -63,7 +63,16 @@ void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStri
     else if (typeString != "microphone"_s)
         return;
 
-    toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), false, WTFMove(deviceProperties) });
+    WebCore::MockMediaDevice::Flags flags;
+    if (properties) {
+        auto invalidKey = adoptWK(WKStringCreateWithUTF8CString("invalid"));
+        if (auto invalid = WKDictionaryGetItemForKey(properties, invalidKey.get())) {
+            if (WKStringIsEqualToUTF8CString(static_cast<WKStringRef>(invalid), "true"))
+                flags.add(WebCore::MockMediaDevice::Flag::Invalid);
+        }
+    }
+
+    toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), flags, WTFMove(deviceProperties) });
 #endif
 }
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -813,13 +813,23 @@ static inline bool haveMicrophoneDevice(const Vector<CaptureDeviceWithCapabiliti
 void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
     RealtimeMediaSourceCenter::singleton().getMediaStreamDevices([revealIdsAndLabels, completionHandler = WTFMove(completionHandler)](auto&& devices) mutable {
-        auto deviceWithCapabilities = map(devices, [revealIdsAndLabels](auto&& device) -> CaptureDeviceWithCapabilities {
-            RealtimeMediaSourceCapabilities capabilities;
+        Vector<CaptureDeviceWithCapabilities> devicesWithCapabilities;
+
+        devicesWithCapabilities.reserveInitialCapacity(devices.size());
+        for (auto& device : devices) {
+            RealtimeMediaSourceCapabilities deviceCapabilities;
+
+            auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
+            if (!capabilities)
+                continue;
+
             if (revealIdsAndLabels)
-                capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
-            return { WTFMove(device), WTFMove(capabilities) };
-        });
-        completionHandler(WTFMove(deviceWithCapabilities));
+                deviceCapabilities = WTFMove(*capabilities);
+
+            devicesWithCapabilities.uncheckedAppend({ WTFMove(device), WTFMove(deviceCapabilities) });
+        }
+
+        completionHandler(WTFMove(devicesWithCapabilities));
     });
 }
 #endif

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -67,13 +67,23 @@ void UserMediaCaptureManager::validateUserMediaRequestConstraints(WebCore::Media
 void UserMediaCaptureManager::getMediaStreamDevices(bool revealIdsAndLabels, GetMediaStreamDevicesCallback&& completionHandler)
 {
     RealtimeMediaSourceCenter::singleton().getMediaStreamDevices([completionHandler = WTFMove(completionHandler), revealIdsAndLabels](auto&& devices) mutable {
-        auto deviceWithCapabilities = map(devices, [revealIdsAndLabels](auto&& device) -> CaptureDeviceWithCapabilities {
-            RealtimeMediaSourceCapabilities capabilities;
+        Vector<CaptureDeviceWithCapabilities> devicesWithCapabilities;
+
+        devicesWithCapabilities.reserveInitialCapacity(devices.size());
+        for (auto& device : devices) {
+            RealtimeMediaSourceCapabilities deviceCapabilities;
+
+            auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
+            if (!capabilities)
+                continue;
+
             if (revealIdsAndLabels)
-                capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
-            return { WTFMove(device), WTFMove(capabilities) };
-        });
-        completionHandler(WTFMove(deviceWithCapabilities));
+                deviceCapabilities = *capabilities;
+
+            devicesWithCapabilities.uncheckedAppend({ WTFMove(device), WTFMove(deviceCapabilities) });
+        }
+
+        completionHandler(WTFMove(devicesWithCapabilities));
     });
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -403,7 +403,7 @@ interface TestRunner {
     undefined installFakeHelvetica(DOMString configuration);
 
     undefined addMockCameraDevice(DOMString persistentId, DOMString label, object properties);
-    undefined addMockMicrophoneDevice(DOMString persistentId, DOMString label);
+    undefined addMockMicrophoneDevice(DOMString persistentId, DOMString label, object properties);
     undefined addMockScreenDevice(DOMString persistentId, DOMString label);
     undefined clearMockMediaDevices();
     undefined removeMockMediaDevice(DOMString persistentId);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1884,7 +1884,7 @@ void TestRunner::addMockMediaDevice(JSStringRef persistentId, JSStringRef label,
     }));
 }
 
-void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties)
+static WKRetainPtr<WKDictionaryRef> captureDeviceProperties(JSValueRef properties)
 {
     auto context = mainFrameJSContext();
 
@@ -1899,10 +1899,10 @@ void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label
         for (size_t i = 0; i < length; ++i) {
             JSStringRef jsPropertyName = JSPropertyNameArrayGetNameAtIndex(propertyNameArray, i);
             auto jsPropertyValue = JSObjectGetProperty(context, object, jsPropertyName, 0);
-            
+
             auto propertyName = toWK(jsPropertyName);
             auto propertyValue = toWKString(context, jsPropertyValue);
-            
+
             keys.append(propertyName.get());
             values.append(propertyValue.get());
             strings.append(WTFMove(propertyName));
@@ -1911,13 +1911,17 @@ void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label
         JSPropertyNameArrayRelease(propertyNameArray);
     }
 
-    auto wkProperties = adoptWK(WKDictionaryCreate(keys.data(), values.data(), keys.size()));
-    addMockMediaDevice(persistentId, label, "camera", wkProperties.get());
+    return adoptWK(WKDictionaryCreate(keys.data(), values.data(), keys.size()));
 }
 
-void TestRunner::addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label)
+void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties)
 {
-    addMockMediaDevice(persistentId, label, "microphone", nullptr);
+    addMockMediaDevice(persistentId, label, "camera", captureDeviceProperties(properties).get());
+}
+
+void TestRunner::addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties)
+{
+    addMockMediaDevice(persistentId, label, "microphone", captureDeviceProperties(properties).get());
 }
 
 void TestRunner::addMockScreenDevice(JSStringRef persistentId, JSStringRef label)

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -518,7 +518,7 @@ public:
     bool shouldDumpAllHTTPRedirectedResponseHeaders() const { return m_dumpAllHTTPRedirectedResponseHeaders; }
 
     void addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties);
-    void addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label);
+    void addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label, JSValueRef propertie);
     void addMockScreenDevice(JSStringRef persistentId, JSStringRef label);
     void clearMockMediaDevices();
     void removeMockMediaDevice(JSStringRef persistentId);


### PR DESCRIPTION
#### f4537682e879e9aa3c5b76de6c4d547015e3993d
<pre>
[MediaStream] enumerateDevices should not exposed devices that can not be used
<a href="https://bugs.webkit.org/show_bug.cgi?id=258993">https://bugs.webkit.org/show_bug.cgi?id=258993</a>
rdar://110210394

Reviewed by Jer Noble and Youenn Fablet.

`enumerateDevices` should only include devices that are available for capture, so
make sure each device can be instantiated before including it.

* LayoutTests/fast/mediastream/camera-invalid-device-expected.txt: Added.
* LayoutTests/fast/mediastream/camera-invalid-device.html: Added.

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getCapabilities): Change to return a std::optional&lt;&gt;
so it can signal failure.
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:

* Source/WebCore/platform/mock/MockMediaDevice.h:
(WebCore::MockMediaDevice::captureDevice const): Combine the existing `IsEphemeral` bool
with the new `Invalid` flag into a &quot;Flags&quot; bitfield.
(WebCore::MockMediaDevice::encode const): Encode the new flags variable.
(WebCore::MockMediaDevice::decodeMockMediaDevice): Decode it.
(WebCore::MockMediaDevice::decode): Ditto.

* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::defaultDevices): Update for the struct change.
(WebCore::MockRealtimeMediaSourceCenter::setDeviceIsEphemeral): Ditto.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Define the new bitfield.

* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp:
(WKAddMockMediaDevice): Both mock camera and microphone can now have properties.

* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices): Don&apos;t include
a device if `RealtimeMediaSourceCenter::getCapabilities` returns null.

* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::captureDeviceProperties): Convert the properties JS object to a WKDictionaryRef.
(WTR::TestRunner::addMockCameraDevice): Call captureDeviceProperties.
(WTR::TestRunner::addMockMicrophoneDevice): Add a properties parameter, call
captureDeviceProperties to parse it.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:

Canonical link: <a href="https://commits.webkit.org/265923@main">https://commits.webkit.org/265923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/407f039770f253040e9880fa5ef82a3e75549d02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14015 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14505 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14435 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10502 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11122 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11583 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11286 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11787 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9726 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3019 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->