### PR TITLE
Fix unused field warning in RunLoopObserver for non-Cocoa platforms

### DIFF
--- a/Source/WebCore/platform/RunLoopObserver.h
+++ b/Source/WebCore/platform/RunLoopObserver.h
@@ -64,10 +64,16 @@ public:
 
     enum class Type : bool { Repeating, OneShot };
     RunLoopObserver(WellKnownOrder order, RunLoopObserverCallback&& callback, Type type = Type::Repeating)
-        : m_order(order)
-        , m_callback(WTFMove(callback))
+        : m_callback(WTFMove(callback))
         , m_type(type)
+#if USE(CF)
+        , m_order(order)
     { }
+#else
+    {
+        UNUSED_PARAM(order);
+    }
+#endif
 
     WEBCORE_EXPORT ~RunLoopObserver();
 
@@ -85,13 +91,12 @@ public:
 private:
     void runLoopObserverFired();
 
-    WellKnownOrder m_order { WellKnownOrder::GraphicsCommit };
     RunLoopObserverCallback m_callback;
+    Type m_type { Type::Repeating };
 #if USE(CF)
+    WellKnownOrder m_order { WellKnownOrder::GraphicsCommit };
     RetainPtr<PlatformRunLoopObserver> m_runLoopObserver;
 #endif
-    Type m_type { Type::Repeating };
 };
 
 } // namespace WebCore
-


### PR DESCRIPTION
#### 6a797e18d7692574c6c6432ae28dc824a1a4d6a2
<pre>
Fix unused field warning in RunLoopObserver for non-Cocoa platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=258996">https://bugs.webkit.org/show_bug.cgi?id=258996</a>

Reviewed by Wenson Hsieh.

Make `m_order` specific to `USE(CF)`.

* Source/WebCore/platform/RunLoopObserver.h:
(WebCore::RunLoopObserver::RunLoopObserver):

Canonical link: <a href="https://commits.webkit.org/265873@main">https://commits.webkit.org/265873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10540519e2af272265df221d96e3d89b8dc14edc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14364 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14255 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10363 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18101 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14312 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9579 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10840 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2970 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->