### PR TITLE
[LibWPE] Fix click count logic

### DIFF
--- a/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
+++ b/Source/WebKit/Shared/libwpe/WebEventFactory.cpp
@@ -160,13 +160,13 @@ static inline short pressedMouseButtons(uint32_t modifiers)
 static inline unsigned clickCount(struct wpe_input_pointer_event* event)
 {
     static const uint32_t doubleClickTime = 500; // Milliseconds.
-    static const unsigned pixelThreshold = 5;
+    static const int pixelThreshold = 5;
     static struct wpe_input_pointer_event gLastClickEvent = { };
     static unsigned gLastClickCount = 1;
 
     bool cancelPreviousClick = (event->time - gLastClickEvent.time) > doubleClickTime
-        || abs(event->x == gLastClickEvent.x) > pixelThreshold
-        || abs(event->y == gLastClickEvent.y) > pixelThreshold;
+        || std::abs(event->x - gLastClickEvent.x) > pixelThreshold
+        || std::abs(event->y - gLastClickEvent.y) > pixelThreshold;
 
     if (event->type == wpe_input_pointer_event_type_button && event->state) {
         if (!cancelPreviousClick && (event->button == gLastClickEvent.button))


### PR DESCRIPTION
#### 4776b34f03c78abda6801614775b8c468f6a5a27
<pre>
[LibWPE] Fix click count logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=259000">https://bugs.webkit.org/show_bug.cgi?id=259000</a>

Reviewed by Michael Catanzaro.

When comparing screen coordinates for a click `==` was used instead of
a subtraction. Also modify the threshold to be an int so there isn&apos;t
a type warning since `std::abs` outputs an `int` not an `unsigned`.

* Source/WebKit/Shared/libwpe/WebEventFactory.cpp:
(WebKit::clickCount):

Canonical link: <a href="https://commits.webkit.org/265874@main">https://commits.webkit.org/265874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d531ec4e3f48c5ce84e6c08dd72a2aa05f8a37b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14257 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10357 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18103 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11137 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14317 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10842 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15168 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->