### PR TITLE
Tune font prewarming

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -967,21 +967,34 @@ void FontCache::prewarmGlobally()
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure())
         return;
 
-    Vector<String> families {
-#if PLATFORM(MAC) || PLATFORM(MACCATALYST)
-        ".SF NS Text"_s,
-        ".SF NS Display"_s,
-#endif
+    Vector<String> seenFamilies {
+        "Apple SD Gothic Neo"_s,
         "Arial"_s,
+        "Geeza Pro"_s,
+        "Georgia"_s,
         "Helvetica"_s,
         "Helvetica Neue"_s,
+        "Hiragino Sans"_s,
         "Lucida Grande"_s,
+        "Menlo"_s,
+        "PingFang SC"_s,
         "Times"_s,
+        "Times New Roman"_s,
+        "Trebuchet MS"_s,
+        "Verdana"_s,
+    };
+    Vector<String> systemFallbackFamilies {
+        "Arial"_s,
+        "Arial Bold"_s,
+        "Helvetica"_s,
+        "Helvetica Neue Bold"_s,
+        "System Font Regular"_s,
         "Times New Roman"_s,
     };
 
     FontCache::PrewarmInformation prewarmInfo;
-    prewarmInfo.seenFamilies = WTFMove(families);
+    prewarmInfo.seenFamilies = WTFMove(seenFamilies);
+    prewarmInfo.fontNamesRequiringSystemFallback = WTFMove(systemFallbackFamilies);
     FontCache::forCurrentThread().prewarm(WTFMove(prewarmInfo));
 #endif
 }


### PR DESCRIPTION
#### fab41033635650c94233962299f3382f4c1ff7c0
<pre>
Tune font prewarming
<a href="https://bugs.webkit.org/show_bug.cgi?id=259001">https://bugs.webkit.org/show_bug.cgi?id=259001</a>
rdar://problem/112291907

Reviewed by Brent Fulgham.

Tune font prewarming to improve page load performance.

* Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp:
(WebCore::FontCache::prewarmGlobally):

Canonical link: <a href="https://commits.webkit.org/266188@main">https://commits.webkit.org/266188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89c2e92fa210fcb474bed3ba807260f59101f32e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11119 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11874 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18934 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12041 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12525 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11795 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3222 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->