### PR TITLE
Add assertions to in IPC::Connection to make sure we have an error if decoder is null

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -315,7 +315,9 @@ public:
         DecoderOrError(Error inError)
             : decoder(nullptr)
             , error(inError)
-        { }
+        {
+            ASSERT(error != Error::NoError);
+        }
     };
 
     static RefPtr<Connection> connection(UniqueID);
@@ -703,8 +705,10 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
 
     // Now send the message and wait for a reply.
     auto replyDecoderOrError = sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, sendSyncOptions);
-    if (!replyDecoderOrError.decoder)
+    if (!replyDecoderOrError.decoder) {
+        ASSERT(replyDecoderOrError.error != Error::NoError);
         return { nullptr, std::nullopt, replyDecoderOrError.error };
+    }
 
     SendSyncResult<T> result;
     *replyDecoderOrError.decoder >> result.replyArguments;


### PR DESCRIPTION
#### 19cf6854df35ef31db52e6223c919a7658f1737c
<pre>
Add assertions to in IPC::Connection to make sure we have an error if decoder is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=259006">https://bugs.webkit.org/show_bug.cgi?id=259006</a>

Reviewed by Dan Glastonbury.

Add assertions to in IPC::Connection to make sure we have an error if decoder
is null, since we&apos;ve had a recent bug in this area (265736@main).

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::DecoderOrError::DecoderOrError):
(IPC::Connection::sendSync):

Canonical link: <a href="https://commits.webkit.org/265925@main">https://commits.webkit.org/265925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf6fef817f2a67cbdfc132b8918711daced79730

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11682 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14267 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10364 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18111 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11637 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10852 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3022 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->