### PR TITLE
[CSS Math Functions] Correctly serialize sin/cos/tan functions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize-expected.txt
@@ -1,42 +1,100 @@
 
-FAIL 'cos(0)' as a specified value should serialize as 'calc(1)'. assert_equals: 'cos(0)' and 'calc(1)' should serialize the same in specified values. expected "calc(1)" but got "cos(0)"
-FAIL 'scale(cos(0))' as a specified value should serialize as 'scale(calc(1))'. assert_equals: 'scale(cos(0))' and 'scale(calc(1))' should serialize the same in specified values. expected "scale(calc(1))" but got "scale(cos(0))"
-PASS 'cos(0)' as a computed value should serialize as '1'.
-PASS 'scale(cos(0))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
-FAIL 'sin(0)' as a specified value should serialize as 'calc(0)'. assert_equals: 'sin(0)' and 'calc(0)' should serialize the same in specified values. expected "calc(0)" but got "sin(0)"
-FAIL 'scale(sin(0))' as a specified value should serialize as 'scale(calc(0))'. assert_equals: 'scale(sin(0))' and 'scale(calc(0))' should serialize the same in specified values. expected "scale(calc(0))" but got "scale(sin(0))"
-PASS 'sin(0)' as a computed value should serialize as '0'.
-PASS 'scale(sin(0))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'.
-FAIL 'tan(0)' as a specified value should serialize as 'calc(0)'. assert_equals: 'tan(0)' and 'calc(0)' should serialize the same in specified values. expected "calc(0)" but got "tan(0)"
-FAIL 'scale(tan(0))' as a specified value should serialize as 'scale(calc(0))'. assert_equals: 'scale(tan(0))' and 'scale(calc(0))' should serialize the same in specified values. expected "scale(calc(0))" but got "scale(tan(0))"
-PASS 'tan(0)' as a computed value should serialize as '0'.
-PASS 'scale(tan(0))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'.
-PASS 'calc(sin(0) + cos(0) + tan(0))' as a specified value should serialize as 'calc(1)'.
-PASS 'scale(calc(sin(0) + cos(0) + tan(0)))' as a specified value should serialize as 'scale(calc(1))'.
-PASS 'calc(sin(0) + cos(0) + tan(0))' as a computed value should serialize as '1'.
-PASS 'scale(calc(sin(0) + cos(0) + tan(0)))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
-PASS 'calc(sin(0) + 0.5)' as a specified value should serialize as 'calc(0.5)'.
+PASS 'scale(cos(0))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(cos(0)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(sin(0))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(sin(0)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(tan(0))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(tan(0)))' as a specified value should serialize as 'scale(calc(0))'.
 PASS 'scale(calc(sin(0) + 0.5))' as a specified value should serialize as 'scale(calc(0.5))'.
-PASS 'calc(sin(0) + 0.5)' as a computed value should serialize as '0.5'.
-PASS 'scale(calc(sin(0) + 0.5))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'.
-PASS 'calc(cos(0) + 0.5)' as a specified value should serialize as 'calc(1.5)'.
+PASS 'scale(calc(calc(sin(0) + 0.5)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(0) + cos(0) + tan(0)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(calc(sin(0) + cos(0) + tan(0))))' as a specified value should serialize as 'scale(calc(1))'.
 PASS 'scale(calc(cos(0) + 0.5))' as a specified value should serialize as 'scale(calc(1.5))'.
-FAIL 'calc(cos(0) + 0.5)' as a computed value should serialize as '1.5'. assert_equals: '1.5' should round-trip exactly in computed values. expected "1.5" but got "1"
-PASS 'scale(calc(cos(0) + 0.5))' as a computed value should serialize as 'matrix(1.5, 0, 0, 1.5, 0, 0)'.
-PASS 'calc(tan(0) + 0.5)' as a specified value should serialize as 'calc(0.5)'.
+PASS 'scale(calc(calc(cos(0) + 0.5)))' as a specified value should serialize as 'scale(calc(1.5))'.
 PASS 'scale(calc(tan(0) + 0.5))' as a specified value should serialize as 'scale(calc(0.5))'.
-PASS 'calc(tan(0) + 0.5)' as a computed value should serialize as '0.5'.
-PASS 'scale(calc(tan(0) + 0.5))' as a computed value should serialize as 'matrix(0.5, 0, 0, 0.5, 0, 0)'.
-PASS 'calc(sin(infinity))' as a specified value should serialize as 'calc(NaN)'.
+PASS 'scale(calc(calc(tan(0) + 0.5)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(0deg))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(cos(0deg)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(sin(0deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(sin(0deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(tan(0deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(tan(0deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(sin(30deg))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(30deg)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(sin(0.523599))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(0.523599)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(sin(0.523599rad))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(0.523599rad)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(sin(33.333333grad))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(33.333333grad)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(sin(0.08333333turn))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(sin(0.08333333turn)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(60deg))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(cos(60deg)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(66.66666666grad))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(cos(66.66666666grad)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(1.047197551))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(cos(1.047197551)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(1.047197551rad))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(cos(1.047197551rad)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(cos(0.16666666666turn))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(calc(cos(0.16666666666turn)))' as a specified value should serialize as 'scale(calc(0.5))'.
+PASS 'scale(tan(45deg))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(tan(45deg)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(tan(50grad))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(tan(50grad)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(tan(0.78539816))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(tan(0.78539816)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(tan(0.78539816rad))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(tan(0.78539816rad)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(tan(0.125turn))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(tan(0.125turn)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(tan(90deg))' as a specified value should serialize as 'scale(calc(infinity))'.
+PASS 'scale(calc(tan(90deg)))' as a specified value should serialize as 'scale(calc(infinity))'.
+PASS 'scale(tan(-90deg))' as a specified value should serialize as 'scale(calc(-infinity))'.
+PASS 'scale(calc(tan(-90deg)))' as a specified value should serialize as 'scale(calc(-infinity))'.
+PASS 'scale(sin(180deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(sin(180deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(cos(180deg))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(calc(cos(180deg)))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(tan(180deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(tan(180deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(sin(270deg))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(calc(sin(270deg)))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(cos(270deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(cos(270deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(tan(270deg))' as a specified value should serialize as 'scale(calc(-infinity))'.
+PASS 'scale(calc(tan(270deg)))' as a specified value should serialize as 'scale(calc(-infinity))'.
+PASS 'scale(sin(-180deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(sin(-180deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(cos(-180deg))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(calc(cos(-180deg)))' as a specified value should serialize as 'scale(calc(-1))'.
+PASS 'scale(tan(-180deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(tan(-180deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(sin(-270deg))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(calc(sin(-270deg)))' as a specified value should serialize as 'scale(calc(1))'.
+PASS 'scale(cos(-270deg))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(calc(cos(-270deg)))' as a specified value should serialize as 'scale(calc(0))'.
+PASS 'scale(tan(-270deg))' as a specified value should serialize as 'scale(calc(infinity))'.
+PASS 'scale(calc(tan(-270deg)))' as a specified value should serialize as 'scale(calc(infinity))'.
+PASS 'scale(calc(sin(30deg) + cos(60deg) + tan(45deg)))' as a specified value should serialize as 'scale(calc(2))'.
+PASS 'scale(calc(calc(sin(30deg) + cos(60deg) + tan(45deg))))' as a specified value should serialize as 'scale(calc(2))'.
 PASS 'scale(calc(sin(infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(sin(infinity))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(sin(infinity)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
-PASS 'calc(cos(infinity))' as a specified value should serialize as 'calc(NaN)'.
+PASS 'scale(calc(calc(sin(infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
 PASS 'scale(calc(cos(infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(cos(infinity))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(cos(infinity)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
-PASS 'calc(tan(infinity))' as a specified value should serialize as 'calc(NaN)'.
+PASS 'scale(calc(calc(cos(infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
 PASS 'scale(calc(tan(infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(tan(infinity))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(tan(infinity)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
+PASS 'scale(calc(calc(tan(infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(sin(-infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(sin(-infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(cos(-infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(cos(-infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(tan(-infinity)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(tan(-infinity))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(sin(NaN)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(sin(NaN))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(cos(NaN)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(cos(NaN))))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(tan(NaN)))' as a specified value should serialize as 'scale(calc(NaN))'.
+PASS 'scale(calc(calc(tan(NaN))))' as a specified value should serialize as 'scale(calc(NaN))'.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize.html
@@ -1,61 +1,73 @@
 <!DOCTYPE html>
-<link rel="help" href="https://drafts.csswg.org/css-values-4/#comp-func">
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#trig-funcs">
 <link rel="help" href="https://drafts.csswg.org/css-values-4/#numbers">
 <link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-serialize">
 <link rel="author" title="Apple Inc">
+<link rel="author" title="Seokho Song" href="seokho@chromium.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../support/serialize-testcommon.js"></script>
 <div id=target></div>
 <script>
-function test_serialization(t,s,c) {
-    test_specified_serialization('opacity', t, s);
-    test_specified_serialization('transform', `scale(${t})`, `scale(calc(${c}))`);
-    test_computed_serialization('opacity', t, c);
-    test_computed_serialization('transform', `scale(${t})`, `matrix(${c}, 0, 0, ${c}, 0, 0)`);
+function test_serialization(specified, expected, {prop="transform"}={}) {
+    test_specified_serialization(prop, `scale(${specified})`, `scale(${expected})`)
+}
+//TEST CASE                                            | EXPECTED
+var test_map = {
+    "cos(0)"                                           :"calc(1)",
+    "sin(0)"                                           :"calc(0)",
+    "tan(0)"                                           :"calc(0)",
+    "calc(sin(0) + 0.5)"                               :"calc(0.5)",
+    "calc(sin(0) + cos(0) + tan(0))"                   :"calc(1)",
+    "calc(cos(0) + 0.5)"                               :"calc(1.5)",
+    "calc(tan(0) + 0.5)"                               :"calc(0.5)",
+    "cos(0deg)"                                        :"calc(1)",
+    "sin(0deg)"                                        :"calc(0)",
+    "tan(0deg)"                                        :"calc(0)",
+    "sin(30deg)"                                       :"calc(0.5)",
+    "sin(0.523599)"                                    :"calc(0.5)",
+    "sin(0.523599rad)"                                 :"calc(0.5)",
+    "sin(33.333333grad)"                               :"calc(0.5)",
+    "sin(0.08333333turn)"                              :"calc(0.5)",
+    "cos(60deg)"                                       :"calc(0.5)",
+    "cos(66.66666666grad)"                             :"calc(0.5)",
+    "cos(1.047197551)"                                 :"calc(0.5)",
+    "cos(1.047197551rad)"                              :"calc(0.5)",
+    "cos(0.16666666666turn)"                           :"calc(0.5)",
+    "tan(45deg)"                                       :"calc(1)",
+    "tan(50grad)"                                      :"calc(1)",
+    "tan(0.78539816)"                                  :"calc(1)",
+    "tan(0.78539816rad)"                               :"calc(1)",
+    "tan(0.125turn)"                                   :"calc(1)",
+    "tan(90deg)"                                       :"calc(infinity)",
+    "tan(-90deg)"                                      :"calc(-infinity)",
+    "sin(180deg)"                                      :"calc(0)",
+    "cos(180deg)"                                      :"calc(-1)",
+    "tan(180deg)"                                      :"calc(0)",
+    "sin(270deg)"                                      :"calc(-1)",
+    "cos(270deg)"                                      :"calc(0)",
+    "tan(270deg)"                                      :"calc(-infinity)",
+    "sin(-180deg)"                                     :"calc(0)",
+    "cos(-180deg)"                                     :"calc(-1)",
+    "tan(-180deg)"                                     :"calc(0)",
+    "sin(-270deg)"                                     :"calc(1)",
+    "cos(-270deg)"                                     :"calc(0)",
+    "tan(-270deg)"                                     :"calc(infinity)",
+    "calc(sin(30deg) + cos(60deg) + tan(45deg))"       :"calc(2)",
+    "calc(sin(infinity))"                              :"calc(NaN)",
+    "calc(cos(infinity))"                              :"calc(NaN)",
+    "calc(tan(infinity))"                              :"calc(NaN)",
+    "calc(sin(-infinity))"                             :"calc(NaN)",
+    "calc(cos(-infinity))"                             :"calc(NaN)",
+    "calc(tan(-infinity))"                             :"calc(NaN)",
+    "calc(sin(NaN))"                                   :"calc(NaN)",
+    "calc(cos(NaN))"                                   :"calc(NaN)",
+    "calc(tan(NaN))"                                   :"calc(NaN)",
+};
+
+for (var exp in test_map) {
+    test_serialization(exp, test_map[exp]);
+    test_serialization(`calc(${exp})`, test_map[exp]);
 }
 
-test_serialization(
-    'cos(0)',
-    'calc(1)',
-    '1');
-test_serialization(
-    'sin(0)',
-    'calc(0)',
-    '0');
-test_serialization(
-    'tan(0)',
-    'calc(0)',
-    '0');
-
-test_serialization(
-    'calc(sin(0) + cos(0) + tan(0))',
-    'calc(1)',
-    '1');
-
-test_serialization(
-    'calc(sin(0) + 0.5)',
-    'calc(0.5)',
-    '0.5');
-test_serialization(
-    'calc(cos(0) + 0.5)',
-    'calc(1.5)',
-    '1.5');
-test_serialization(
-    'calc(tan(0) + 0.5)',
-    'calc(0.5)',
-    '0.5');
-
-test_serialization(
-    'calc(sin(infinity))',
-    'calc(NaN)',
-    'NaN');
-test_serialization(
-    'calc(cos(infinity))',
-    'calc(NaN)',
-    'NaN');
-test_serialization(
-    'calc(tan(infinity))',
-    'calc(NaN)',
-    'NaN');
 </script>

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -37,6 +37,7 @@
 #include "Logging.h"
 #include <wtf/Algorithms.h>
 #include <wtf/ListHashSet.h>
+#include <wtf/MathExtras.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -1369,7 +1370,16 @@ double CSSCalcOperationNode::evaluateOperator(CalcOperator op, const Vector<doub
     case CalcOperator::Tan: {
         if (children.size() != 1)
             return std::numeric_limits<double>::quiet_NaN();
-        return std::tan(children[0]);
+        double x = std::fmod(children[0], piDouble * 2);
+        // std::fmod can return negative values.
+        x = x < 0 ? piDouble * 2 + x : x;
+        ASSERT(!(x < 0));
+        ASSERT(!(x > piDouble * 2));
+        if (x == piOverTwoDouble)
+            return std::numeric_limits<double>::infinity();
+        if (x == 3 * piOverTwoDouble)
+            return -std::numeric_limits<double>::infinity();
+        return std::tan(x);
     }
     case CalcOperator::Log: {
         if (children.size() != 1 && children.size() != 2)

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -71,7 +71,7 @@ public:
     bool isHypotNode() const { return m_operator == CalcOperator::Hypot; }
     bool isSqrtNode() const { return m_operator == CalcOperator::Sqrt; }
     bool isPowOrSqrtNode() const { return m_operator == CalcOperator::Pow || isSqrtNode(); }
-    bool shouldPreserveFunction() const { return isTrigNode() || isInverseTrigNode() || isAtan2Node() || isSteppedNode() || isRoundOperation() || isClampNode(); }
+    bool shouldPreserveFunction() const { return isInverseTrigNode() || isAtan2Node() || isSteppedNode() || isRoundOperation() || isClampNode(); }
     bool isClampNode() const { return m_operator == CalcOperator::Clamp; }
 
     void hoistChildrenWithOperator(CalcOperator);
@@ -145,7 +145,7 @@ private:
     }
 
     void makeTopLevelCalc();
-    bool shouldNotPreserveFunction() const { return isSignNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isPowOrSqrtNode(); }
+    bool shouldNotPreserveFunction() const { return isSignNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isPowOrSqrtNode() || isTrigNode(); }
     static double evaluateOperator(CalcOperator, const Vector<double>&);
     static Ref<CSSCalcExpressionNode> simplifyNode(Ref<CSSCalcExpressionNode>&&, int depth);
     static Ref<CSSCalcExpressionNode> simplifyRecursive(Ref<CSSCalcExpressionNode>&&, int depth);

--- a/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
@@ -27,6 +27,7 @@
 #include "CalcExpressionOperation.h"
 
 #include <cmath>
+#include <wtf/MathExtras.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -132,7 +133,16 @@ float CalcExpressionOperation::evaluate(float maxValue) const
     case CalcOperator::Tan: {
         if (m_children.size() != 1)
             return std::numeric_limits<double>::quiet_NaN();
-        return std::tan(m_children[0]->evaluate(maxValue));
+        double x = std::fmod(m_children[0]->evaluate(maxValue), piDouble * 2);
+        // std::fmod can return negative values.
+        x = x < 0 ? piDouble * 2 + x : x;
+        ASSERT(!(x < 0));
+        ASSERT(!(x > piDouble * 2));
+        if (x == piOverTwoDouble)
+            return std::numeric_limits<double>::infinity();
+        if (x == 3 * piOverTwoDouble)
+            return -std::numeric_limits<double>::infinity();
+        return std::tan(x);
     }
     case CalcOperator::Log: {
         if (m_children.size() != 1 && m_children.size() != 2)


### PR DESCRIPTION
#### 15a8c32776708f07ae1c3b9539640cb00ae1e6a8
<pre>
[CSS Math Functions] Correctly serialize sin/cos/tan functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=259011">https://bugs.webkit.org/show_bug.cgi?id=259011</a>
rdar://111947212

Reviewed by Darin Adler.

There are 2 main changes:

- We now always try to resolve top level sin/cos/tan functions, cos(0) will serialize as calc(1) instead of cos(0) for instance. This is consistent with how calc(cos(0)) is serialized.

From the spec <a href="https://drafts.csswg.org/css-values-4/#calc-simplification">https://drafts.csswg.org/css-values-4/#calc-simplification</a>:

&gt; If root is an operator node that’s not one of the calc-operator nodes, and all of its calculation children are numeric values with enough information to compute the operation root represents, return the result of running root’s operation using its children, expressed in the result’s canonical unit.

- tan(90deg) &amp; tan(-90deg) now return respectively calc(infinity) &amp; calc(-infinity)

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/sin-cos-tan-serialize.html:

Update these tests from upstream WPT.

* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::evaluateOperator):
* Source/WebCore/css/calc/CSSCalcOperationNode.h:
* Source/WebCore/platform/calc/CalcExpressionOperation.cpp:
(WebCore::CalcExpressionOperation::evaluate const):

Canonical link: <a href="https://commits.webkit.org/265881@main">https://commits.webkit.org/265881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ca55ae3b118c372985062c3d8a126ddfca4afa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12499 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12302 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13109 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10395 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/11019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11476 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10884 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/10894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15210 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1355 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->