### PR TITLE
Add scrollbar width style to ScrollableAreaParameters

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -946,6 +946,7 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(Scrolling
     scrollParameters.horizontalNativeScrollbarVisibility = scrollableArea.horizontalNativeScrollbarVisibility();
     scrollParameters.verticalNativeScrollbarVisibility = scrollableArea.verticalNativeScrollbarVisibility();
     scrollParameters.useDarkAppearanceForScrollbars = scrollableArea.useDarkAppearanceForScrollbars();
+    scrollParameters.scrollbarWidthStyle = scrollableArea.scrollbarWidthStyle();
 
     scrollingNode->setScrollableAreaParameters(scrollParameters);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -89,6 +89,8 @@ struct ScrollableAreaParameters {
 
     bool useDarkAppearanceForScrollbars { false };
 
+    ScrollbarWidth scrollbarWidthStyle { ScrollbarWidth::Auto };
+
     bool operator==(const ScrollableAreaParameters& other) const
     {
         return horizontalScrollElasticity == other.horizontalScrollElasticity
@@ -101,7 +103,8 @@ struct ScrollableAreaParameters {
             && allowsVerticalScrolling == other.allowsVerticalScrolling
             && horizontalNativeScrollbarVisibility == other.horizontalNativeScrollbarVisibility
             && verticalNativeScrollbarVisibility == other.verticalNativeScrollbarVisibility
-            && useDarkAppearanceForScrollbars == other.useDarkAppearanceForScrollbars;
+            && useDarkAppearanceForScrollbars == other.useDarkAppearanceForScrollbars
+            && scrollbarWidthStyle == other.scrollbarWidthStyle;
     }
 };
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -130,7 +130,9 @@ public:
     
     OverscrollBehavior horizontalOverscrollBehavior() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior; }
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
-    
+
+    ScrollbarWidth scrollbarWidthStyle() const { return m_scrollableAreaParameters.scrollbarWidthStyle; }
+
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
     
     void scrollbarVisibilityDidChange(ScrollbarOrientation, bool);

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -262,8 +262,7 @@ bool ScrollerPairMac::useDarkAppearance() const
 
 ScrollbarWidth ScrollerPairMac::scrollbarWidthStyle() const
 {
-    // FIXME: This should be based on the element style. See <https://webkit.org/b/257430>
-    return ScrollbarWidth::Auto;
+    return m_scrollingNode.scrollbarWidthStyle();
 }
 
 ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientation orientation)

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -422,4 +422,13 @@ template<> struct EnumTraits<WebCore::ScrollbarOrientation> {
         WebCore::ScrollbarOrientation::Vertical
     >;
 };
+
+template<> struct EnumTraits<WebCore::ScrollbarWidth> {
+    using values = EnumValues<
+        WebCore::ScrollbarWidth,
+        WebCore::ScrollbarWidth::Auto,
+        WebCore::ScrollbarWidth::Thin,
+        WebCore::ScrollbarWidth::None
+    >;
+};
 } // namespace WTF

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1980,6 +1980,13 @@ header: <WebCore/ScrollTypes.h>
     ReplacedByCustomScrollbar
 };
 
+header: <WebCore/ScrollTypes.h>
+[CustomHeader] enum class WebCore::ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None
+};
+
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollableAreaParameters {
     WebCore::ScrollElasticity horizontalScrollElasticity;
@@ -1993,6 +2000,7 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
     WebCore::NativeScrollbarVisibility horizontalNativeScrollbarVisibility;
     WebCore::NativeScrollbarVisibility verticalNativeScrollbarVisibility;
     bool useDarkAppearanceForScrollbars;
+    WebCore::ScrollbarWidth scrollbarWidthStyle;
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>


### PR DESCRIPTION
#### 4a4b3254505852dd5204ff5c5b6d4882143175eb
<pre>
Add scrollbar width style to ScrollableAreaParameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=259017">https://bugs.webkit.org/show_bug.cgi?id=259017</a>

Reviewed by Simon Fraser.

This patch adds scrollbarWidthStyle to ScrollableAreaParameters.
This is wired up to ScrollerPairMac to replace the hardcoded ScrollbarWidth::Auto.
This will allow a follow up to fix the thin value having no affect with composited scrolling.

This patch has no behaviour changes.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::ScrollableAreaParameters::operator== const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::scrollbarWidthStyle const):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/265907@main">https://commits.webkit.org/265907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72e150e08b42094374dbde57663c9a65d769f771

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12168 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14303 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18143 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14362 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9622 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10887 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->