### PR TITLE
[CSS Math Functions] Correctly serialize mod/rem/clamp root nodes

### DIFF
--- a/LayoutTests/fast/css/calc-parsing-expected.txt
+++ b/LayoutTests/fast/css/calc-parsing-expected.txt
@@ -21,23 +21,23 @@ PASS element.style['width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "200px"
 
 element.style["width"] = "clamp(100px,123px,200px)"
-PASS element.style['width'] is "clamp(100px, 123px, 200px)"
+PASS element.style['width'] is "calc(123px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "123px"
 
 element.style["width"] = "clamp(100px,300px,200px)"
-PASS element.style['width'] is "clamp(100px, 300px, 200px)"
+PASS element.style['width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "200px"
 
 element.style["width"] = "clamp(200px,300px,100px)"
-PASS element.style['width'] is "clamp(200px, 300px, 100px)"
+PASS element.style['width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "200px"
 
 element.style["width"] = "clamp((50px + 50px),40px,200px)"
-PASS element.style['width'] is "clamp(100px, 40px, 200px)"
+PASS element.style['width'] is "calc(100px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "100px"
 
 element.style["width"] = "clamp(50px + 50px,40px,200px)"
-PASS element.style['width'] is "clamp(100px, 40px, 200px)"
+PASS element.style['width'] is "calc(100px)"
 PASS getComputedStyle(element).getPropertyValue('width') is "100px"
 
 element.style["width"] = "min(100px,0%)"
@@ -308,23 +308,23 @@ PASS element.style['min-width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "200px"
 
 element.style["min-width"] = "clamp(100px,123px,200px)"
-PASS element.style['min-width'] is "clamp(100px, 123px, 200px)"
+PASS element.style['min-width'] is "calc(123px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "123px"
 
 element.style["min-width"] = "clamp(100px,300px,200px)"
-PASS element.style['min-width'] is "clamp(100px, 300px, 200px)"
+PASS element.style['min-width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "200px"
 
 element.style["min-width"] = "clamp(200px,300px,100px)"
-PASS element.style['min-width'] is "clamp(200px, 300px, 100px)"
+PASS element.style['min-width'] is "calc(200px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "200px"
 
 element.style["min-width"] = "clamp((50px + 50px),40px,200px)"
-PASS element.style['min-width'] is "clamp(100px, 40px, 200px)"
+PASS element.style['min-width'] is "calc(100px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "100px"
 
 element.style["min-width"] = "clamp(50px + 50px,40px,200px)"
-PASS element.style['min-width'] is "clamp(100px, 40px, 200px)"
+PASS element.style['min-width'] is "calc(100px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "100px"
 
 element.style["min-width"] = "min(100px,0%)"

--- a/LayoutTests/fast/css/calc-parsing.html
+++ b/LayoutTests/fast/css/calc-parsing.html
@@ -34,11 +34,11 @@
                 testExpression('max(100px + 200px)', 'calc(300px)', '300px');
                 testExpression('max(100px , 200px)', 'calc(200px)', '200px');
                 testExpression('max(100px,200px)', 'calc(200px)', '200px');
-                testExpression('clamp(100px,123px,200px)', 'clamp(100px, 123px, 200px)', '123px');
-                testExpression('clamp(100px,300px,200px)', 'clamp(100px, 300px, 200px)', '200px');
-                testExpression('clamp(200px,300px,100px)', 'clamp(200px, 300px, 100px)', '200px');
-                testExpression('clamp((50px + 50px),40px,200px)', 'clamp(100px, 40px, 200px)', '100px');
-                testExpression('clamp(50px + 50px,40px,200px)', 'clamp(100px, 40px, 200px)', '100px');
+                testExpression('clamp(100px,123px,200px)', 'calc(123px)', '123px');
+                testExpression('clamp(100px,300px,200px)', 'calc(200px)', '200px');
+                testExpression('clamp(200px,300px,100px)', 'calc(200px)', '200px');
+                testExpression('clamp((50px + 50px),40px,200px)', 'calc(100px)', '100px');
+                testExpression('clamp(50px + 50px,40px,200px)', 'calc(100px)', '100px');
                 testExpression('min(100px,0%)', 'min(100px, 0%)', propertyName == 'width' ? '0px' : "min(100px, 0%)");
                 testExpression('max(100px,0%)', 'max(100px, 0%)', propertyName == 'width' ? '100px' : "max(100px, 0%)");
                 testExpression('clamp(100px,0%,1%)', 'clamp(100px, 0%, 1%)', propertyName == 'width' ? '100px' : "clamp(100px, 0%, 1%)");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize-expected.txt
@@ -1,4 +1,6 @@
 
 PASS e.style['letter-spacing'] = "clamp(1px, 2px, 3px)" should set the property value
-FAIL e.style['letter-spacing'] = "clamp(1px, 2px, clamp(2px, 3px, 4px))" should set the property value assert_equals: serialization should be canonical expected "clamp(1px, 2px, clamp(2px, 3px, 4px))" but got "clamp(1px, 2px, 3px)"
+PASS e.style['letter-spacing'] = "calc(clamp(1px, 2px, 3px))" should set the property value
+PASS e.style['letter-spacing'] = "clamp(1px, 2px, clamp(2px, 3px, 4px))" should set the property value
+PASS e.style['letter-spacing'] = "calc(clamp(1px, 2px, clamp(2px, 3px, 4px)))" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize.html
@@ -7,9 +7,10 @@
 <script>
 function test_valid_length(value, expected) {
   test_valid_value('letter-spacing', value, expected);
+  test_valid_value('letter-spacing', `calc(${value})`, expected);
 }
 
-test_valid_length('clamp(1px, 2px, 3px)', 'clamp(1px, 2px, 3px)');
-test_valid_length('clamp(1px, 2px, clamp(2px, 3px, 4px))', 'clamp(1px, 2px, clamp(2px, 3px, 4px))');
+test_valid_length('clamp(1px, 2px, 3px)', 'calc(2px)');
+test_valid_length('clamp(1px, 2px, clamp(2px, 3px, 4px))', 'calc(2px)');
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize-expected.txt
@@ -3,24 +3,24 @@ FAIL 'round(1.1,1)' as a specified value should serialize as 'calc(1)'. assert_e
 FAIL 'scale(round(1.1,1))' as a specified value should serialize as 'scale(calc(1))'. assert_equals: 'scale(round(1.1,1))' and 'scale(calc(1))' should serialize the same in specified values. expected "scale(calc(1))" but got "scale(round(nearest, 1.1, 1))"
 PASS 'round(1.1,1)' as a computed value should serialize as '1'.
 PASS 'scale(round(1.1,1))' as a computed value should serialize as 'matrix(1, 0, 0, 1, 0, 0)'.
-FAIL 'mod(1,1)' as a specified value should serialize as 'calc(0)'. assert_equals: 'mod(1,1)' and 'calc(0)' should serialize the same in specified values. expected "calc(0)" but got "mod(1, 1)"
-FAIL 'scale(mod(1,1))' as a specified value should serialize as 'scale(calc(0))'. assert_equals: 'scale(mod(1,1))' and 'scale(calc(0))' should serialize the same in specified values. expected "scale(calc(0))" but got "scale(mod(1, 1))"
+PASS 'mod(1,1)' as a specified value should serialize as 'calc(0)'.
+PASS 'scale(mod(1,1))' as a specified value should serialize as 'scale(calc(0))'.
 PASS 'mod(1,1)' as a computed value should serialize as '0'.
 PASS 'scale(mod(1,1))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'.
-FAIL 'rem(1,1)' as a specified value should serialize as 'calc(0)'. assert_equals: 'rem(1,1)' and 'calc(0)' should serialize the same in specified values. expected "calc(0)" but got "rem(1, 1)"
-FAIL 'scale(rem(1,1))' as a specified value should serialize as 'scale(calc(0))'. assert_equals: 'scale(rem(1,1))' and 'scale(calc(0))' should serialize the same in specified values. expected "scale(calc(0))" but got "scale(rem(1, 1))"
+PASS 'rem(1,1)' as a specified value should serialize as 'calc(0)'.
+PASS 'scale(rem(1,1))' as a specified value should serialize as 'scale(calc(0))'.
 PASS 'rem(1,1)' as a computed value should serialize as '0'.
 PASS 'scale(rem(1,1))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'.
 PASS 'calc(round(1,0))' as a specified value should serialize as 'calc(NaN)'.
 PASS 'scale(calc(round(1,0)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(round(1,0))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(round(1,0)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
+FAIL 'calc(round(1,0))' as a computed value should serialize as '0'. assert_equals: 'calc(round(1,0))' and '0' should serialize the same in computed values. expected "0" but got "1"
+FAIL 'scale(calc(round(1,0)))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'. assert_equals: 'scale(calc(round(1,0)))' and 'matrix(0, 0, 0, 0, 0, 0)' should serialize the same in computed values. expected "matrix(0, 0, 0, 0, 0, 0)" but got "matrix3d(infinity, NaN, NaN, NaN, NaN, infinity, NaN, NaN, 0, 0, 1, 0, 0, 0, 0, 1)"
 PASS 'calc(mod(1,0))' as a specified value should serialize as 'calc(NaN)'.
 PASS 'scale(calc(mod(1,0)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(mod(1,0))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(mod(1,0)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
+FAIL 'calc(mod(1,0))' as a computed value should serialize as '0'. assert_equals: 'calc(mod(1,0))' and '0' should serialize the same in computed values. expected "0" but got "1"
+FAIL 'scale(calc(mod(1,0)))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'. assert_equals: 'scale(calc(mod(1,0)))' and 'matrix(0, 0, 0, 0, 0, 0)' should serialize the same in computed values. expected "matrix(0, 0, 0, 0, 0, 0)" but got "matrix3d(infinity, NaN, NaN, NaN, NaN, infinity, NaN, NaN, 0, 0, 1, 0, 0, 0, 0, 1)"
 PASS 'calc(rem(1,0))' as a specified value should serialize as 'calc(NaN)'.
 PASS 'scale(calc(rem(1,0)))' as a specified value should serialize as 'scale(calc(NaN))'.
-FAIL 'calc(rem(1,0))' as a computed value should serialize as 'NaN'. assert_equals: 'NaN' should round-trip exactly in computed values. expected "NaN" but got "1"
-FAIL 'scale(calc(rem(1,0)))' as a computed value should serialize as 'matrix(NaN, 0, 0, NaN, 0, 0)'. assert_equals: 'matrix(NaN, 0, 0, NaN, 0, 0)' should round-trip exactly in computed values. expected "matrix(NaN, 0, 0, NaN, 0, 0)" but got "none"
+FAIL 'calc(rem(1,0))' as a computed value should serialize as '0'. assert_equals: 'calc(rem(1,0))' and '0' should serialize the same in computed values. expected "0" but got "1"
+FAIL 'scale(calc(rem(1,0)))' as a computed value should serialize as 'matrix(0, 0, 0, 0, 0, 0)'. assert_equals: 'scale(calc(rem(1,0)))' and 'matrix(0, 0, 0, 0, 0, 0)' should serialize the same in computed values. expected "matrix(0, 0, 0, 0, 0, 0)" but got "matrix3d(infinity, NaN, NaN, NaN, NaN, infinity, NaN, NaN, 0, 0, 1, 0, 0, 0, 0, 1)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize.html
@@ -11,7 +11,7 @@
 <script>
 function test_serialization(t,s,c) {
     test_specified_serialization('opacity', t, s);
-    test_specified_serialization('transform', `scale(${t})`, `scale(calc(${c}))`);
+    test_specified_serialization('transform', `scale(${t})`, `scale(${s})`);
     test_computed_serialization('opacity', t, c);
     test_computed_serialization('transform', `scale(${t})`, `matrix(${c}, 0, 0, ${c}, 0, 0)`);
 }
@@ -32,13 +32,13 @@ test_serialization(
 test_serialization(
     'calc(round(1,0))',
     'calc(NaN)',
-    'NaN');
+    '0');
 test_serialization(
     'calc(mod(1,0))',
     'calc(NaN)',
-    'NaN');
+    '0');
 test_serialization(
     'calc(rem(1,0))',
     'calc(NaN)',
-    'NaN');
+    '0');
 </script>

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -71,7 +71,7 @@ public:
     bool isHypotNode() const { return m_operator == CalcOperator::Hypot; }
     bool isSqrtNode() const { return m_operator == CalcOperator::Sqrt; }
     bool isPowOrSqrtNode() const { return m_operator == CalcOperator::Pow || isSqrtNode(); }
-    bool shouldPreserveFunction() const { return isSteppedNode() || isRoundOperation() || isClampNode(); }
+    bool shouldPreserveFunction() const { return isRoundOperation(); }
     bool isClampNode() const { return m_operator == CalcOperator::Clamp; }
 
     void hoistChildrenWithOperator(CalcOperator);
@@ -145,7 +145,7 @@ private:
     }
 
     void makeTopLevelCalc();
-    bool shouldNotPreserveFunction() const { return isSignNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isPowOrSqrtNode() || isInverseTrigNode() || isAtan2Node() || isTrigNode(); }
+    bool shouldNotPreserveFunction() const { return isSignNode() || isClampNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isSteppedNode() || isPowOrSqrtNode() || isInverseTrigNode() || isAtan2Node() || isTrigNode(); }
     static double evaluateOperator(CalcOperator, const Vector<double>&);
     static Ref<CSSCalcExpressionNode> simplifyNode(Ref<CSSCalcExpressionNode>&&, int depth);
     static Ref<CSSCalcExpressionNode> simplifyRecursive(Ref<CSSCalcExpressionNode>&&, int depth);


### PR DESCRIPTION
#### 29ee9a1e18c5829eeac46896a5807b4516b8913f
<pre>
[CSS Math Functions] Correctly serialize mod/rem/clamp root nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=259020">https://bugs.webkit.org/show_bug.cgi?id=259020</a>
rdar://111960904

Reviewed by Darin Adler.

From the spec <a href="https://drafts.csswg.org/css-values-4/#calc-simplification">https://drafts.csswg.org/css-values-4/#calc-simplification</a>:

&gt; If root is an operator node that’s not one of the calc-operator nodes, and all of its calculation children are numeric values with enough information to compute the operation root represents, return the result of running root’s operation using its children, expressed in the result’s canonical unit.

We now always try to resolve the top-level mod/rem/clamp, e.g. clamp(1px, 2px, 3px) now gives calc(2px) instead of clamp(1px, 2px, 3px).
This is consistent with calc(clamp(1px, 2px, 3px)) being serialized as calc(2px).

* LayoutTests/fast/css/calc-parsing-expected.txt:
* LayoutTests/fast/css/calc-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/clamp-length-serialize.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-serialize.html:
* Source/WebCore/css/calc/CSSCalcOperationNode.h:

Canonical link: <a href="https://commits.webkit.org/265886@main">https://commits.webkit.org/265886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f93e8f31d0c32b4d2a10b911910f7c23a27058bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12517 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12321 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14318 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11035 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11194 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11686 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10902 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/10910 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15228 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->