### PR TITLE
[macOS] Network connection logs should be silenced in Safari private browsing mode

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -377,6 +377,8 @@ public:
 #if PLATFORM(COCOA)
     void appPrivacyReportTestingData(PAL::SessionID, CompletionHandler<void(const AppPrivacyReportTestingData&)>&&);
     void clearAppPrivacyReportTestingData(PAL::SessionID, CompletionHandler<void()>&&);
+
+    bool isParentProcessFullWebBrowserOrRunningTest() const { return m_isParentProcessFullWebBrowserOrRunningTest; }
 #endif
 
 #if ENABLE(WEB_RTC)
@@ -577,6 +579,7 @@ private:
     bool m_didSyncCookiesForClose { false };
 #if PLATFORM(COCOA)
     int m_mediaStreamingActivitityToken { NOTIFY_TOKEN_INVALID };
+    bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -60,6 +60,7 @@ struct NetworkProcessCreationParameters {
     String uiProcessBundleIdentifier;
     RetainPtr<CFDataRef> networkATSContext;
     bool strictSecureDecodingForAllObjCEnabled { false };
+    bool isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
 
 #if USE(SOUP)

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -37,7 +37,8 @@ struct WebKit::NetworkProcessCreationParameters {
 #if PLATFORM(COCOA)
     String uiProcessBundleIdentifier
     RetainPtr<CFDataRef> networkATSContext
-    bool strictSecureDecodingForAllObjCEnabled;
+    bool strictSecureDecodingForAllObjCEnabled
+    bool isParentProcessFullWebBrowserOrRunningTest
 #endif
 
 #if USE(SOUP)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -78,6 +78,8 @@ static void initializeNetworkSettings()
 
 void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessCreationParameters& parameters)
 {
+    m_isParentProcessFullWebBrowserOrRunningTest = parameters.isParentProcessFullWebBrowserOrRunningTest;
+
     _CFNetworkSetATSContext(parameters.networkATSContext.get());
     IPC::setStrictSecureDecodingForAllObjCEnabled(parameters.strictSecureDecodingForAllObjCEnabled);
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1332,6 +1332,7 @@ void SessionWrapper::initialize(NSURLSessionConfiguration *configuration, Networ
 {
     UNUSED_PARAM(isNavigatingToAppBoundDomain);
 
+    // FIXME: The following `isParentProcessAFullWebBrowser` check is inaccurate in Safari on macOS.
     auto isFullBrowser = isParentProcessAFullWebBrowser(networkSession.networkProcess());
 #if PLATFORM(MAC)
     isFullBrowser = WebCore::MacApplication::isSafari();
@@ -1398,7 +1399,7 @@ NetworkSessionCocoa::NetworkSessionCocoa(NetworkProcess& networkProcess, const N
     sessionsCreated = true;
 #endif
 
-    NSURLSessionConfiguration *configuration = configurationForSessionID(m_sessionID, isParentProcessAFullWebBrowser(networkProcess));
+    auto configuration = configurationForSessionID(m_sessionID, networkProcess.isParentProcessFullWebBrowserOrRunningTest());
 
     if (!m_sessionID.isEphemeral())
         m_blobRegistry.setFileDirectory(FileSystem::createTemporaryDirectory(@"BlobRegistryFiles"));
@@ -1568,6 +1569,7 @@ SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(Navigati
 SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(WebPageProxyIdentifier webPageProxyID, const WebCore::ResourceRequest& request, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, std::optional<NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
 {
     auto shouldBeConsideredAppBound = isNavigatingToAppBoundDomain ? *isNavigatingToAppBoundDomain : NavigatingToAppBoundDomain::Yes;
+    // FIXME: The following `isParentProcessAFullWebBrowser` check is inaccurate in Safari on macOS.
     if (isParentProcessAFullWebBrowser(networkProcess()))
         shouldBeConsideredAppBound = NavigatingToAppBoundDomain::No;
 
@@ -2184,6 +2186,7 @@ void NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTime> modif
     }
 
     auto bundleID = WebCore::applicationBundleIdentifier();
+    // FIXME: The following `isParentProcessAFullWebBrowser` check is inaccurate in Safari on macOS.
     if (!isParentProcessAFullWebBrowser(networkProcess()) && !isActingOnBehalfOfAFullWebBrowser(bundleID))
         return completionHandler();
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -94,6 +94,7 @@
 #endif
 
 #if PLATFORM(COCOA)
+#include "DefaultWebBrowserChecks.h"
 #include "LegacyCustomProtocolManagerClient.h"
 #endif
 
@@ -227,6 +228,10 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 #endif
 
     parameters.allowedFirstPartiesForCookies = WebProcessProxy::allowedFirstPartiesForCookies();
+
+#if PLATFORM(COCOA)
+    parameters.isParentProcessFullWebBrowserOrRunningTest = isFullWebBrowserOrRunningTest();
+#endif
 
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(parameters), [weakThis = WeakPtr { *this }] {

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -92,36 +92,6 @@
     return evaluationResult.autorelease();
 }
 
-#if PLATFORM(MAC)
-
-// Note: this testing strategy makes a couple of assumptions:
-// 1. The network process hasn't already died and allowed the system to reuse the same PID.
-// 2. The API test did not take more than ~120 seconds to run.
-- (NSArray<NSString *> *)collectLogsForNewConnections
-{
-    auto predicate = [NSString stringWithFormat:@"subsystem == 'com.apple.network'"
-        " AND category == 'connection'"
-        " AND eventMessage endswith 'start'"
-        " AND processIdentifier == %d", self._networkProcessIdentifier];
-    RetainPtr pipe = [NSPipe pipe];
-    // FIXME: This is currently reliant on `NSTask`, which is absent on iOS. We should find a way to
-    // make this helper work on both platforms.
-    auto task = adoptNS([NSTask new]);
-    [task setLaunchPath:@"/usr/bin/log"];
-    [task setArguments:@[ @"show", @"--last", @"2m", @"--style", @"json", @"--predicate", predicate ]];
-    [task setStandardOutput:pipe.get()];
-    [task launch];
-    [task waitUntilExit];
-
-    auto rawData = [pipe fileHandleForReading].availableData;
-    auto messages = [NSMutableArray<NSString *> array];
-    for (id messageData in dynamic_objc_cast<NSArray>([NSJSONSerialization JSONObjectWithData:rawData options:0 error:nil]))
-        [messages addObject:dynamic_objc_cast<NSString>([messageData objectForKey:@"eventMessage"])];
-    return messages;
-}
-
-#endif // PLATFORM(MAC)
-
 @end
 
 namespace TestWebKitAPI {

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -152,6 +152,7 @@
 - (void)typeCharacter:(char)character modifiers:(NSEventModifierFlags)modifiers;
 - (void)typeCharacter:(char)character;
 - (void)setEventTimestampOffset:(NSTimeInterval)offset;
+@property (nonatomic, readonly) NSArray<NSString *> *collectLogsForNewConnections;
 @property (nonatomic, readonly) NSTimeInterval eventTimestamp;
 @property (nonatomic) BOOL forceWindowToBecomeKey;
 @end


### PR DESCRIPTION
#### 01329a31ae593125485a4f2bcac7d76981fbcf2f
<pre>
[macOS] Network connection logs should be silenced in Safari private browsing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=259022">https://bugs.webkit.org/show_bug.cgi?id=259022</a>
rdar://111586011

Reviewed by Youenn Fablet.

In Safari (and other browsers) on iOS, we avoid logging any information about network connections —
even with redaction — in private browsing (i.e. when using an ephemeral data store). We achieve this
by passing in `nw_context_privacy_level_silent` when configuring `NSURLSessionConfiguration` in the
network process.

However, this currently doesn&apos;t work on macOS because the logic for determining whether or not the
parent of the networking process is a full web browser (`isParentProcessAFullWebBrowser()`) only
takes the `com.apple.developer.web-browser` entitlement into account, which is iOS-specific.

In contrast, `isFullWebBrowserOrRunningTest()` (also implemented in `DefaultWebBrowserChecks.mm`)
uses the above entitlement check on iOS, and checks whether the application can open HTTP-family
URLs on macOS. Since this function is intended to be invoked from the application process, we add a
flag to `NetworkProcessCreationParameters` to compute and send this over to the network process upon
initialization.

Test: WKWebsiteDataStore.DoNotLogNetworkConnectionsInEphemeralSessions

* Source/WebKit/NetworkProcess/NetworkProcess.h:
(WebKit::NetworkProcess::isParentProcessFullWebBrowserOrRunningTest const):
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:

See above for more details.

* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::SessionWrapper::initialize):

Implement the main fix here — replace `isParentProcessAFullWebBrowser(networkProcess)` with
`networkProcess.isParentProcessFullWebBrowserOrRunningTest()`.

(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::NetworkSessionCocoa::sessionWrapperForTask):
(WebKit::NetworkSessionCocoa::removeNetworkWebsiteData):

Add a few FIXMEs referencing the fact that the other existing `isParentProcessAFullWebBrowser`
checks in this file don&apos;t work on macOS.

* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(-[TestWKWebView collectLogsForNewConnections]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:

Add an API test to verify that no network connection logging is saved when navigating in an
ephemeral session.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView collectLogsForNewConnections]):

Move this testing helper into `TestWKWebView`, so that we can invoke it from API tests across
different files.

Canonical link: <a href="https://commits.webkit.org/265904@main">https://commits.webkit.org/265904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3efbb58c0755981bb98e533d8e285b19e8c74ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14410 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14313 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18146 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14366 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11681 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9630 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10897 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2999 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11534 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->