### PR TITLE
[CSS Math Functions] REGRESSION(265879@main): signs-abs-computed.html WPT crashes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3700,7 +3700,6 @@ webkit.org/b/259025 imported/w3c/web-platform-tests/css/css-values/ch-unit-018.h
 webkit.org/b/259025 imported/w3c/web-platform-tests/css/css-values/ic-unit-015.html [ ImageOnlyFailure ]
 webkit.org/b/214466 imported/w3c/web-platform-tests/css/css-values/ex-unit-004.html [ ImageOnlyFailure ]
 webkit.org/b/242467 imported/w3c/web-platform-tests/css/css-values/calc-text-indent-intrinsic-1.html [ ImageOnlyFailure ]
-webkit.org/b/259026 imported/w3c/web-platform-tests/css/css-values/signs-abs-computed.html [ Skip ]
 
 # wpt css-sizing failures
 webkit.org/b/203509 imported/w3c/web-platform-tests/css/css-sizing/auto-scrollbar-inside-stf-abspos.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt
@@ -13,8 +13,19 @@ PASS calc(abs(sign(0.1) + 0.2) / 2) should be used-value-equivalent to 0.6
 PASS calc(abs(0.1 + 0.2) * -2) should be used-value-equivalent to -0.6
 PASS calc(sign(0.1 - 0.2) - 0.05) should be used-value-equivalent to -1.05
 PASS calc(sign(1) + sign(1) - 0.05) should be used-value-equivalent to 1.95
-PASS calc(sign(-0)) should be used-value-equivalent to -0
-PASS calc(sign(0)) should be used-value-equivalent to 0
+PASS abs(10px) should be used-value-equivalent to 10px
+PASS abs(10%) should be used-value-equivalent to 10px
+PASS abs(10px + 10%) should be used-value-equivalent to 20px
+PASS calc(10px + abs(10%)) should be used-value-equivalent to 20px
+PASS abs(-10px) should be used-value-equivalent to 10px
+PASS abs(-10%) should be used-value-equivalent to 10px
+PASS calc(calc(sign(-0))) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(calc(sign(-0)))), 1) should be used-value-equivalent to -1
+PASS calc(calc(sign(0))) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(calc(sign(0)))), 1) should be used-value-equivalent to 1
+PASS abs(infinity) should be used-value-equivalent to calc(infinity)
+PASS abs(-infinity) should be used-value-equivalent to calc(infinity)
+FAIL abs(NaN) should be used-value-equivalent to calc(NaN) assert_equals: abs(NaN) and calc(NaN) serialize to the same thing in used values. expected "matrix3d(infinity, NaN, NaN, NaN, NaN, infinity, NaN, NaN, 0, 0, 1, 0, 0, 0, 0, 1)" but got "matrix3d(NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, 0, 0, 1, 0, 0, 0, 0, 1)"
 PASS sign(1px) should be used-value-equivalent to 1
 PASS sign(1cm) should be used-value-equivalent to 1
 PASS sign(1mm) should be used-value-equivalent to 1
@@ -57,48 +68,90 @@ PASS sign(-1deg) should be used-value-equivalent to -1
 PASS sign(-1grad) should be used-value-equivalent to -1
 PASS sign(-1rad) should be used-value-equivalent to -1
 PASS sign(-1turn) should be used-value-equivalent to -1
-PASS sign(0px) should be used-value-equivalent to 0
-PASS sign(0cm) should be used-value-equivalent to 0
-PASS sign(0mm) should be used-value-equivalent to 0
-PASS sign(0Q) should be used-value-equivalent to 0
-PASS sign(0in) should be used-value-equivalent to 0
-PASS sign(0pc) should be used-value-equivalent to 0
-PASS sign(0pt) should be used-value-equivalent to 0
-PASS sign(0em) should be used-value-equivalent to 0
-PASS sign(0ex) should be used-value-equivalent to 0
-PASS sign(0ch) should be used-value-equivalent to 0
-PASS sign(0rem) should be used-value-equivalent to 0
-PASS sign(0vh) should be used-value-equivalent to 0
-PASS sign(0vw) should be used-value-equivalent to 0
-PASS sign(0vmin) should be used-value-equivalent to 0
-PASS sign(0vmax) should be used-value-equivalent to 0
-PASS sign(-0px) should be used-value-equivalent to -0
-PASS sign(-0cm) should be used-value-equivalent to -0
-PASS sign(-0mm) should be used-value-equivalent to -0
-PASS sign(-0Q) should be used-value-equivalent to -0
-PASS sign(-0in) should be used-value-equivalent to -0
-PASS sign(-0pc) should be used-value-equivalent to -0
-PASS sign(-0pt) should be used-value-equivalent to -0
-PASS sign(-0em) should be used-value-equivalent to -0
-PASS sign(-0ex) should be used-value-equivalent to -0
-PASS sign(-0ch) should be used-value-equivalent to -0
-PASS sign(-0rem) should be used-value-equivalent to -0
-PASS sign(-0vh) should be used-value-equivalent to -0
-PASS sign(-0vw) should be used-value-equivalent to -0
-PASS sign(-0vmin) should be used-value-equivalent to -0
-PASS sign(-0vmax) should be used-value-equivalent to -0
-PASS sign(0s) should be used-value-equivalent to 0
-PASS sign(0ms) should be used-value-equivalent to 0
-PASS sign(-0s) should be used-value-equivalent to 0
-PASS sign(-0ms) should be used-value-equivalent to 0
-PASS sign(0deg) should be used-value-equivalent to 0
-PASS sign(0grad) should be used-value-equivalent to 0
-PASS sign(0rad) should be used-value-equivalent to 0
-PASS sign(0turn) should be used-value-equivalent to 0
-PASS sign(-0deg) should be used-value-equivalent to -0
-PASS sign(-0grad) should be used-value-equivalent to -0
-PASS sign(-0rad) should be used-value-equivalent to -0
-PASS sign(-0turn) should be used-value-equivalent to -0
+PASS calc(sign(0px)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0px))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0cm)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0cm))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0mm)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0mm))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0Q)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0Q))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0in)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0in))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0pc)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0pc))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0pt)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0pt))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0em)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0em))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0ex)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0ex))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0ch)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0ch))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0rem)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0rem))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0vh)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0vh))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0vw)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0vw))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0vmin)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0vmin))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0vmax)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0vmax))), 1) should be used-value-equivalent to 1
+PASS calc(sign(-0px)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0px))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0cm)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0cm))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0mm)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0mm))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0Q)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0Q))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0in)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0in))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0pc)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0pc))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0pt)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0pt))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0em)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0em))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0ex)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0ex))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0ch)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0ch))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0rem)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0rem))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0vh)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0vh))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0vw)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0vw))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0vmin)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0vmin))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0vmax)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0vmax))), 1) should be used-value-equivalent to -1
+PASS calc(sign(0s)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0s))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0ms)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0ms))), 1) should be used-value-equivalent to 1
+PASS calc(sign(-0s)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0s))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0ms)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0ms))), 1) should be used-value-equivalent to -1
+PASS calc(sign(0deg)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0deg))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0grad)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0grad))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0rad)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0rad))), 1) should be used-value-equivalent to 1
+PASS calc(sign(0turn)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(0turn))), 1) should be used-value-equivalent to 1
+PASS calc(sign(-0deg)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0deg))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0grad)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0grad))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0rad)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0rad))), 1) should be used-value-equivalent to -1
+PASS calc(sign(-0turn)) should be used-value-equivalent to 0
+PASS clamp(-1, calc( 1 / sign(sign(-0turn))), 1) should be used-value-equivalent to -1
 PASS abs(1px) should be used-value-equivalent to 1px
 PASS abs(1cm) should be used-value-equivalent to 1cm
 PASS abs(1mm) should be used-value-equivalent to 1mm
@@ -141,4 +194,6 @@ PASS abs(-1deg) should be used-value-equivalent to 1deg
 PASS abs(-1grad) should be used-value-equivalent to 1grad
 PASS abs(-1rad) should be used-value-equivalent to 1rad
 PASS abs(-1turn) should be used-value-equivalent to 1turn
+FAIL sign(10px - 1em) should be used-value-equivalent to 0; fontSize=10px assert_equals: sign(10px - 1em) and 0 serialize to the same thing in used values. expected "0" but got "1"
+FAIL sign(10px - 2em) should be used-value-equivalent to -1; fontSize=10px assert_equals: sign(10px - 2em) and -1 serialize to the same thing in used values. expected "-1" but got "1"
 

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -662,11 +662,9 @@ void CSSCalcOperationNode::combineChildren()
             m_children.clear();
             m_children.append(WTFMove(newChild));
         }
-        if (isSignNode() || (isHypotNode() && canCombineAllChildren())) {
-            auto combinedUnitType = m_children[0]->primitiveType();
-            if (calcOperator() == CalcOperator::Sign)
-                combinedUnitType = CSSUnitType::CSS_NUMBER;
+        if ((isAbsOrSignNode() || isHypotNode()) && canCombineAllChildren()) {
             double resolvedValue = doubleValue(m_children[0]->primitiveType());
+            auto combinedUnitType = isSignNode() ? CSSUnitType::CSS_NUMBER : m_children[0]->primitiveType();
             auto newChild = CSSCalcPrimitiveValueNode::create(CSSPrimitiveValue::create(resolvedValue, combinedUnitType));
             m_children.clear();
             m_children.append(WTFMove(newChild));
@@ -1037,9 +1035,7 @@ double CSSCalcOperationNode::doubleValue(CSSUnitType unitType) const
             childType = CSSUnitType::CSS_RAD;
         if (isInverseTrigNode())
             childType = CSSUnitType::CSS_NUMBER;
-        if (isAtan2Node())
-            childType = child->primitiveType();
-        if (isSignNode())
+        if (isAtan2Node() || isAbsOrSignNode())
             childType = child->primitiveType();
         return child->doubleValue(childType);
     }));

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.h
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.h
@@ -63,7 +63,8 @@ public:
     bool isExpNode() const { return m_operator == CalcOperator::Exp || m_operator == CalcOperator::Log; }
     bool isInverseTrigNode() const { return m_operator == CalcOperator::Asin || m_operator == CalcOperator::Acos || m_operator == CalcOperator::Atan; }
     bool isAtan2Node() const { return m_operator == CalcOperator::Atan2; }
-    bool isSignNode() const { return m_operator == CalcOperator::Abs || m_operator == CalcOperator::Sign; }
+    bool isSignNode() const { return m_operator == CalcOperator::Sign; }
+    bool isAbsOrSignNode() const { return m_operator == CalcOperator::Abs || isSignNode(); }
     bool shouldSortChildren() const { return isCalcSumNode() || isCalcProductNode(); }
     bool isSteppedNode() const { return m_operator == CalcOperator::Mod || m_operator == CalcOperator::Rem || m_operator == CalcOperator::Round; }
     bool isRoundOperation() const { return m_operator == CalcOperator::Down || m_operator == CalcOperator::Up || m_operator == CalcOperator::ToZero || m_operator == CalcOperator::Nearest; }
@@ -145,7 +146,7 @@ private:
     }
 
     void makeTopLevelCalc();
-    bool shouldNotPreserveFunction() const { return isSignNode() || isClampNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isSteppedNode() || isPowOrSqrtNode() || isInverseTrigNode() || isAtan2Node() || isTrigNode(); }
+    bool shouldNotPreserveFunction() const { return isAbsOrSignNode() || isClampNode() || isMinOrMaxNode() || isExpNode() || isHypotNode() || isSteppedNode() || isPowOrSqrtNode() || isInverseTrigNode() || isAtan2Node() || isTrigNode(); }
     static double evaluateOperator(CalcOperator, const Vector<double>&);
     static Ref<CSSCalcExpressionNode> simplifyNode(Ref<CSSCalcExpressionNode>&&, int depth);
     static Ref<CSSCalcExpressionNode> simplifyRecursive(Ref<CSSCalcExpressionNode>&&, int depth);


### PR DESCRIPTION
#### dbc3feeb46ccfff61a83151b3066d3fe0e2ac710
<pre>
[CSS Math Functions] REGRESSION(265879@main): signs-abs-computed.html WPT crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=259026">https://bugs.webkit.org/show_bug.cgi?id=259026</a>
rdar://111965838

Reviewed by Darin Adler.

The crash was found after re-importing WPT (in 265887@main).

265879@main collapses the root node (e.g. abs(-10) to calc(10)), but it was also too eager when collapsing.

The code attempted to collapse abs(10px + 10%), which is not possible at parse-time, since percentages cannot be resolved then.
To address this, condition the collapsing on `canCombineAllChildren()`.

Also tidy the code a bit.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/signs-abs-computed-expected.txt:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::combineChildren):
(WebCore::CSSCalcOperationNode::doubleValue const):
* Source/WebCore/css/calc/CSSCalcOperationNode.h:

Canonical link: <a href="https://commits.webkit.org/265889@main">https://commits.webkit.org/265889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/581951fc2346b70770b5134d4b65b6a23cb6be43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14422 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14328 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18158 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11205 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9645 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10912 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->