### PR TITLE
Attachment: Correct display of RTL labels

### DIFF
--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -54,6 +54,7 @@
 #include "SharedBuffer.h"
 #include "UserAgentStyleSheets.h"
 #include <pal/FileSizeFormatter.h>
+#include <unicode/ubidi.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/UUID.h>
 #include <wtf/URLParser.h>
@@ -225,10 +226,13 @@ void HTMLAttachmentElement::ensureWideLayoutShadowTree(ShadowRoot& root)
     m_informationBlock = createContainedElement<HTMLDivElement>(informationArea, attachmentInformationBlockIdentifier());
 
     m_actionTextElement = createContainedElement<HTMLDivElement>(*m_informationBlock, attachmentActionIdentifier(), String { attachmentActionForDisplay() });
+    m_actionTextElement->setAttributeWithoutSynchronization(HTMLNames::dirAttr, autoAtom());
 
     m_titleElement = createContainedElement<HTMLDivElement>(*m_informationBlock, attachmentTitleIdentifier(), String { attachmentTitleForDisplay() });
+    m_titleElement->setAttributeWithoutSynchronization(HTMLNames::dirAttr, autoAtom());
 
     m_subtitleElement = createContainedElement<HTMLDivElement>(*m_informationBlock, attachmentSubtitleIdentifier(), String { attachmentSubtitleForDisplay() });
+    m_subtitleElement->setAttributeWithoutSynchronization(HTMLNames::dirAttr, autoAtom());
 
     updateSaveButton(!attributeWithoutSynchronization(saveAttr).isNull());
 }
@@ -522,13 +526,31 @@ String HTMLAttachmentElement::attachmentTitleForDisplay() const
     if (indexOfLastDot == notFound)
         return title;
 
+    auto filename = StringView(title).left(indexOfLastDot);
+    auto extension = StringView(title).substring(indexOfLastDot);
+
+    if (isWideLayout() && !filename.is8Bit() && ubidi_getBaseDirection(filename.characters16(), filename.length()) == UBIDI_RTL) {
+        // The filename is deemed RTL, it should be exposed as RTL overall, but keeping the extension to the right.
+        return makeString(
+            rightToLeftMark, // Make this whole text appear as RTL, the element's `dir="auto"` will right-align and put ellipsis on the left (if needed)
+            leftToRightIsolate, // Isolate the filename+extension, and force LTR to ensure that the extension always stays on the right.
+            firstStrongIsolate, // Isolate the filename.
+            filename, // Note: The filename contains its own bidi characters.
+            popDirectionalIsolate, // End isolation of the filename.
+            zeroWidthSpace, // Add a preferred breakpoint before the extension when word-wrapping (so the extension doesn't get split).
+            extension,
+            popDirectionalIsolate // And end the filename+extension LTR isolation.
+        );
+    }
+
+    // Non-RTL or narrow layout: Keep the extension to the right, but the overall direction doesn't need to be exposed.
     return makeString(
-        leftToRightMark,
-        firstStrongIsolate,
-        StringView(title).left(indexOfLastDot),
-        popDirectionalIsolate,
-        zeroWidthSpace,
-        StringView(title).substring(indexOfLastDot)
+        leftToRightMark, // Force LTR to ensure that the extension always stays on the right.
+        firstStrongIsolate, // Isolate the filename.
+        filename, // Note: The filename contains its own bidi characters.
+        popDirectionalIsolate, // End isolation of the filename.
+        zeroWidthSpace, // Add a preferred breakpoint before the extension when word-wrapping (so the extension doesn't get split).
+        extension
     );
 }
 


### PR DESCRIPTION
#### 36e066b5f3e20eaa6fe432d0220e45a96c7ad129
<pre>
Attachment: Correct display of RTL labels
<a href="https://bugs.webkit.org/show_bug.cgi?id=259027">https://bugs.webkit.org/show_bug.cgi?id=259027</a>
rdar://108566229

Reviewed by Alan Baradlay.

To let the shadow DOM CSS correctly align and cut too-long labels, the elements need to have a `dir=&quot;auto&quot;`
attribute, and titles with RTL filenames should add an outer right-to-left mark so that the automatic
direction works as expected.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::HTMLAttachmentElement::attachmentTitleForDisplay const):

Canonical link: <a href="https://commits.webkit.org/265989@main">https://commits.webkit.org/265989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f6276ef3ba70ae8a27e37667b9a7844cd3d162

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11980 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12833 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14669 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12648 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14651 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18392 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14654 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9872 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11186 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3073 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->