### PR TITLE
[GStreamer][GL] Missing support for P010 video format

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
@@ -47,6 +47,8 @@ struct DMABufFormat {
 
         R8 = DMABufFormatImpl::createFourCC('R', '8', ' ', ' '),
         GR88 = DMABufFormatImpl::createFourCC('G', 'R', '8', '8'),
+        R16 = DMABufFormatImpl::createFourCC('R', '1', '6', ' '),
+        GR32 = DMABufFormatImpl::createFourCC('G', 'R', '3', '2'),
 
         XRGB8888 = DMABufFormatImpl::createFourCC('X', 'R', '2', '4'),
         XBGR8888 = DMABufFormatImpl::createFourCC('X', 'B', '2', '4'),
@@ -75,6 +77,9 @@ struct DMABufFormat {
         Y444 = DMABufFormatImpl::createFourCC('Y', '4', '4', '4'),
         Y41B = DMABufFormatImpl::createFourCC('Y', '4', '1', 'B'),
         Y42B = DMABufFormatImpl::createFourCC('Y', '4', '2', 'B'),
+
+        P010 = DMABufFormatImpl::createFourCC('P', '0', '1', '0'),
+        P016 = DMABufFormatImpl::createFourCC('P', '0', '1', '6'),
     };
 
     enum class Modifier : uint64_t {
@@ -114,11 +119,11 @@ struct DMABufFormat {
     struct Plane {
         Plane() = default;
 
-        template<typename PlaneDefitionType>
-        Plane(const PlaneDefitionType&)
-            : fourcc(PlaneDefitionType::fourcc)
-            , horizontalSubsampling(PlaneDefitionType::horizontalSubsampling)
-            , verticalSubsampling(PlaneDefitionType::verticalSubsampling)
+        template<typename PlaneDefinitionType>
+        Plane(const PlaneDefinitionType&)
+            : fourcc(PlaneDefinitionType::fourcc)
+            , horizontalSubsampling(PlaneDefinitionType::horizontalSubsampling)
+            , verticalSubsampling(PlaneDefinitionType::verticalSubsampling)
         { }
 
         FourCC fourcc { FourCC::Invalid };
@@ -320,6 +325,22 @@ inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::Y42B>()
         PlaneDefinition<FourCC::R8, 1, 0>>();
 }
 
+template<>
+inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::P010>()
+{
+    return DMABufFormat::instantiate<FourCC::P010,
+        PlaneDefinition<FourCC::R16, 0, 0>,
+        PlaneDefinition<FourCC::GR32, 1, 1>>();
+}
+
+template<>
+inline DMABufFormat DMABufFormat::create<DMABufFormat::FourCC::P016>()
+{
+    return DMABufFormat::instantiate<FourCC::P010,
+        PlaneDefinition<FourCC::R16, 0, 0>,
+        PlaneDefinition<FourCC::GR32, 1, 1>>();
+}
+
 inline DMABufFormat DMABufFormat::create(uint32_t fourccValue)
 {
 #define CREATE_FORMAT_FOR_FOURCC(FourCCValue) \
@@ -349,6 +370,8 @@ inline DMABufFormat DMABufFormat::create(uint32_t fourccValue)
     CREATE_FORMAT_FOR_FOURCC(Y444);
     CREATE_FORMAT_FOR_FOURCC(Y41B);
     CREATE_FORMAT_FOR_FOURCC(Y42B);
+    CREATE_FORMAT_FOR_FOURCC(P010);
+    CREATE_FORMAT_FOR_FOURCC(P016);
     default:
         break;
     }

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -68,6 +68,8 @@ static inline bool isBufferFormatSupported(const DMABufFormat& format)
     case DMABufFormat::FourCC::Y444:
     case DMABufFormat::FourCC::Y41B:
     case DMABufFormat::FourCC::Y42B:
+    case DMABufFormat::FourCC::P010:
+    case DMABufFormat::FourCC::P016:
         return true;
     default:
         return false;

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -47,7 +47,7 @@ struct _WebKitDMABufVideoSinkPrivate {
 GST_DEBUG_CATEGORY_STATIC(webkit_dmabuf_video_sink_debug);
 #define GST_CAT_DEFAULT webkit_dmabuf_video_sink_debug
 
-#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA }"
+#define GST_WEBKIT_DMABUF_SINK_CAPS_FORMAT_LIST "{ RGBA, RGBx, BGRA, BGRx, I420, YV12, A420, NV12, NV21, Y444, Y41B, Y42B, VUYA, P010_10LE, P010_10BE, P016_LE, P016BE }"
 static GstStaticPadTemplate sinkTemplate = GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
 // TODO: this is a list of remaining YUV formats we want to support, but don't currently work (due to improper handling in TextureMapper):

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3317,6 +3317,12 @@ static uint32_t fourccValue(GstVideoFormat format)
         return uint32_t(DMABufFormat::FourCC::BGRA8888);
     case GST_VIDEO_FORMAT_ABGR:
         return uint32_t(DMABufFormat::FourCC::RGBA8888);
+    case GST_VIDEO_FORMAT_P010_10LE:
+    case GST_VIDEO_FORMAT_P010_10BE:
+        return uint32_t(DMABufFormat::FourCC::P010);
+    case GST_VIDEO_FORMAT_P016_LE:
+    case GST_VIDEO_FORMAT_P016_BE:
+        return uint32_t(DMABufFormat::FourCC::P016);
     default:
         break;
     }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -266,6 +266,14 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
         texmapGL.drawTexturePackedYUV(data.texture[0],
             yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
         break;
+    case DMABufFormat::FourCC::P010:
+    case DMABufFormat::FourCC::P016:
+        // These HDR formats have 10 bits color depth, but since we support only 8 bits color depth, we
+        // threat it as a regular semi-planar YUV format, thus ignoring the two least significant
+        // bits when rendering.
+        texmapGL.drawTextureSemiPlanarYUV(std::array<GLuint, 2> { data.texture[0], data.texture[1] },
+            false, yuvToRGB, m_flags, IntSize(data.width, data.height), targetRect, modelViewMatrix, opacity);
+        break;
     default:
         break;
     }


### PR DESCRIPTION
#### ff57fb336bb501c2d8d318ccfe8124678439fccc
<pre>
[GStreamer][GL] Missing support for P010 video format
<a href="https://bugs.webkit.org/show_bug.cgi?id=259031">https://bugs.webkit.org/show_bug.cgi?id=259031</a>

Reviewed by Žan Doberšek.

The DMABuf sink can now negotiate P010 and P016 formats with upstream video decoders, such as
vah265dec. This makes hevc playback smooth on capable Intel GPUs at least.

* Source/WebCore/platform/graphics/gbm/DMABufFormat.h:
(WebCore::DMABufFormat::Plane::Plane):
(WebCore::DMABufFormat::create&lt;DMABufFormat::FourCC::P010&gt;):
(WebCore::DMABufFormat::create&lt;DMABufFormat::FourCC::P016&gt;):
(WebCore::DMABufFormat::create):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::isBufferFormatSupported):
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::fourccValue):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):

Canonical link: <a href="https://commits.webkit.org/265896@main">https://commits.webkit.org/265896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572a9a942cfeffc1e1686e58a64ac9182233a02f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14425 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14385 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10917 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2991 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->