### PR TITLE
[CSS Math Functions] min/max() with one argument should always collapse to calc()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/minmax-length-percent-serialize-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/minmax-length-percent-serialize-expected.txt
@@ -5,14 +5,14 @@ PASS 'min(1px)' as a used value should serialize as '1px'.
 PASS 'max(1px)' as a specified value should serialize as 'calc(1px)'.
 PASS 'max(1px)' as a computed value should serialize as '1px'.
 PASS 'max(1px)' as a used value should serialize as '1px'.
-FAIL 'min(1% + 1px)' as a specified value should serialize as 'calc(1% + 1px)'. assert_equals: 'min(1% + 1px)' and 'calc(1% + 1px)' should serialize the same in specified values. expected "calc(1% + 1px)" but got "min(1% + 1px)"
-FAIL 'min(1% + 1px)' as a computed value should serialize as 'calc(1% + 1px)'. assert_equals: 'min(1% + 1px)' and 'calc(1% + 1px)' should serialize the same in computed values. expected "calc(1% + 1px)" but got "min(1% + 1px)"
+PASS 'min(1% + 1px)' as a specified value should serialize as 'calc(1% + 1px)'.
+PASS 'min(1% + 1px)' as a computed value should serialize as 'calc(1% + 1px)'.
 PASS 'min(1% + 1px)' as a used value should serialize as '2px'.
-FAIL 'min(1px + 1%)' as a specified value should serialize as 'calc(1% + 1px)'. assert_equals: 'min(1px + 1%)' and 'calc(1% + 1px)' should serialize the same in specified values. expected "calc(1% + 1px)" but got "min(1% + 1px)"
-FAIL 'min(1px + 1%)' as a computed value should serialize as 'calc(1% + 1px)'. assert_equals: 'min(1px + 1%)' and 'calc(1% + 1px)' should serialize the same in computed values. expected "calc(1% + 1px)" but got "min(1% + 1px)"
+PASS 'min(1px + 1%)' as a specified value should serialize as 'calc(1% + 1px)'.
+PASS 'min(1px + 1%)' as a computed value should serialize as 'calc(1% + 1px)'.
 PASS 'min(1px + 1%)' as a used value should serialize as '2px'.
-FAIL 'max(1px + 1%)' as a specified value should serialize as 'calc(1% + 1px)'. assert_equals: 'max(1px + 1%)' and 'calc(1% + 1px)' should serialize the same in specified values. expected "calc(1% + 1px)" but got "max(1% + 1px)"
-FAIL 'max(1px + 1%)' as a computed value should serialize as 'calc(1% + 1px)'. assert_equals: 'max(1px + 1%)' and 'calc(1% + 1px)' should serialize the same in computed values. expected "calc(1% + 1px)" but got "max(1% + 1px)"
+PASS 'max(1px + 1%)' as a specified value should serialize as 'calc(1% + 1px)'.
+PASS 'max(1px + 1%)' as a computed value should serialize as 'calc(1% + 1px)'.
 PASS 'max(1px + 1%)' as a used value should serialize as '2px'.
 PASS 'min(1px, 2px)' as a specified value should serialize as 'calc(1px)'.
 PASS 'min(1px, 2px)' as a computed value should serialize as '1px'.

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -904,9 +904,10 @@ Ref<CSSCalcExpressionNode> CSSCalcOperationNode::simplifyNode(Ref<CSSCalcExpress
             if (depth)
                 return true;
             
-            if (parent.isNonCalcFunction() && is<CSSCalcPrimitiveValueNode>(parent.children()[0])) {
+            if (parent.isNonCalcFunction() && (parent.isIdentity() || is<CSSCalcPrimitiveValueNode>(parent.children()[0]))) {
                 parent.makeTopLevelCalc();
-                return false;
+                if (is<CSSCalcPrimitiveValueNode>(parent.children()[0]))
+                    return false;
             }
 
             // At the root, preserve the root function by only merging nodes with the same function.


### PR DESCRIPTION
#### 70fc9b224798486c83adc8a9e34a0ba266ab1e70
<pre>
[CSS Math Functions] min/max() with one argument should always collapse to calc()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259037">https://bugs.webkit.org/show_bug.cgi?id=259037</a>
rdar://111986569

Reviewed by Darin Adler.

`min(10px + 10%)` &amp; `max(10px + 10%)` currently don&apos;t collapse to `calc(10px + 10%)` because (10px + 10%) does not generate a
`CSSCalcPrimitiveValueNode` but a `CSSCalcOperationNode` due to the sum of pixels and percentages that can&apos;t be simplified.
Add an identity check (min/max with 1 argument) to collapse them.

In the identity case, we also want to try and combine the parent with the child when relevant to avoid getting `calc((10px + 10%))`
(with the double parentheses) when serializing, so we don&apos;t return false early from the lambda.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/minmax-length-percent-serialize-expected.txt:
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::simplifyNode):

Canonical link: <a href="https://commits.webkit.org/265893@main">https://commits.webkit.org/265893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/166daef75edb32a77a8204f5d6d96e75abc1863a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14433 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10315 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14341 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11708 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10925 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2988 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->