### PR TITLE
Wide-layout attachments: Fix baseline computation

### DIFF
--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -9,9 +9,9 @@ layer at (0,0) size 800x98
             RenderImage {IMG} at (14,14) size 52x52
           RenderFlexibleBox {DIV} at (70,0) size 172x80
             RenderGrid {DIV} at (0,40) size 172x0
-      RenderText {#text} at (268,51) size 4x18
-        text run at (268,51) width 4: " "
-      RenderImage {IMG} at (272,45) size 20x20
+      RenderText {#text} at (268,52) size 4x18
+        text run at (268,52) width 4: " "
+      RenderImage {IMG} at (272,46) size 20x20
       RenderText {#text} at (0,0) size 0x0
 layer at (9,9) size 266x80
   RenderBlock (relative positioned) {DIV} at (0,0) size 266x80 [color=#00000000]

--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x813
+layer at (0,0) size 800x777
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x813
-  RenderBlock {HTML} at (0,0) size 800x813
-    RenderBody {BODY} at (8,8) size 784x797
+layer at (0,0) size 800x777
+  RenderBlock {HTML} at (0,0) size 800x777
+    RenderBody {BODY} at (8,8) size 784x761
       RenderBlock {DIV} at (0,0) size 784x94
         RenderText {#text} at (0,67) size 47x19
           text run at (0,67) width 47: "Blank: "
@@ -51,18 +51,18 @@ layer at (0,0) size 800x813
                 RenderBlock {DIV} at (190,0) size 40x40
                   RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#7676801F]
                     RenderBlock (anonymous) at (11,0) size 18x40
-      RenderBlock {DIV} at (0,470) size 784x109
-        RenderText {#text} at (0,0) size 97x19
-          text run at (0,0) width 97: "Zero progress: "
-        RenderAttachment {ATTACHMENT} at (97,16) size 339x92 [color=#007AFF]
+      RenderBlock {DIV} at (0,470) size 784x97
+        RenderText {#text} at (0,77) size 97x19
+          text run at (0,77) width 97: "Zero progress: "
+        RenderAttachment {ATTACHMENT} at (97,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
             RenderFlexibleBox {DIV} at (82,0) size 230x92
               RenderGrid {DIV} at (0,37) size 230x18
-      RenderBlock {DIV} at (0,579) size 784x109
-        RenderText {#text} at (0,0) size 96x19
-          text run at (0,0) width 96: "75% progress: "
-        RenderAttachment {ATTACHMENT} at (96,16) size 339x92 [color=#007AFF]
+      RenderBlock {DIV} at (0,567) size 784x97
+        RenderText {#text} at (0,77) size 96x19
+          text run at (0,77) width 96: "75% progress: "
+        RenderAttachment {ATTACHMENT} at (96,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
@@ -70,10 +70,10 @@ layer at (0,0) size 800x813
                   RenderText at (0,0) size 0x0
             RenderFlexibleBox {DIV} at (82,0) size 230x92
               RenderGrid {DIV} at (0,37) size 230x18
-      RenderBlock {DIV} at (0,688) size 784x109
-        RenderText {#text} at (0,0) size 104x19
-          text run at (0,0) width 104: "100% progress: "
-        RenderAttachment {ATTACHMENT} at (104,16) size 339x92 [color=#007AFF]
+      RenderBlock {DIV} at (0,664) size 784x97
+        RenderText {#text} at (0,77) size 104x19
+          text run at (0,77) width 104: "100% progress: "
+        RenderAttachment {ATTACHMENT} at (104,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 82x92
               RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
@@ -125,22 +125,22 @@ layer at (131,419) size 118x24 backgroundClip at (131,419) size 117x24 clip at (
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (131,443) size 118x8 backgroundClip at (131,443) size 117x8 clip at (131,443) size 117x8
   RenderDeprecatedFlexibleBox {DIV} at (0,32) size 118x8 [color=#3C3C4399]
-layer at (188,532) size 230x17
+layer at (188,517) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (187,641) size 230x17
+layer at (187,614) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (195,750) size 230x17
+layer at (195,711) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (332,411) size 18x40
   RenderBlock {DIV} at (0,0) size 18x40 [bgcolor=#007AFF]
-layer at (116,504) size 72x72
+layer at (116,489) size 72x72
   RenderBlock {DIV} at (10,10) size 72x72 [bgcolor=#000000]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x714
+layer at (0,0) size 785x678
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x714
-  RenderBlock {HTML} at (0,0) size 785x714
-    RenderBody {BODY} at (8,8) size 769x698
+layer at (0,0) size 785x678
+  RenderBlock {HTML} at (0,0) size 785x678
+    RenderBody {BODY} at (8,8) size 769x662
       RenderBlock {DIV} at (0,0) size 769x82
         RenderText {#text} at (0,52) size 47x18
           text run at (0,52) width 47: "Blank: "
@@ -51,18 +51,18 @@ layer at (0,0) size 785x714
                 RenderBlock {DIV} at (144,0) size 28x28
                   RenderButton {BUTTON} at (0,0) size 28x28 [color=#00000019] [border: (1px solid #00000019)]
                     RenderBlock (anonymous) at (7,3) size 14x21
-      RenderBlock {DIV} at (0,410) size 769x96
-        RenderText {#text} at (0,0) size 97x18
-          text run at (0,0) width 97: "Zero progress: "
-        RenderAttachment {ATTACHMENT} at (97,15) size 267x80
+      RenderBlock {DIV} at (0,410) size 769x84
+        RenderText {#text} at (0,66) size 97x18
+          text run at (0,66) width 97: "Zero progress: "
+        RenderAttachment {ATTACHMENT} at (97,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
             RenderFlexibleBox {DIV} at (70,0) size 172x80
               RenderGrid {DIV} at (0,32) size 172x16
-      RenderBlock {DIV} at (0,506) size 769x96
-        RenderText {#text} at (0,0) size 96x18
-          text run at (0,0) width 96: "75% progress: "
-        RenderAttachment {ATTACHMENT} at (96,15) size 267x80
+      RenderBlock {DIV} at (0,494) size 769x84
+        RenderText {#text} at (0,66) size 96x18
+          text run at (0,66) width 96: "75% progress: "
+        RenderAttachment {ATTACHMENT} at (96,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
@@ -70,10 +70,10 @@ layer at (0,0) size 785x714
                   RenderText at (0,0) size 0x0
             RenderFlexibleBox {DIV} at (70,0) size 172x80
               RenderGrid {DIV} at (0,32) size 172x16
-      RenderBlock {DIV} at (0,602) size 769x96
-        RenderText {#text} at (0,0) size 104x18
-          text run at (0,0) width 104: "100% progress: "
-        RenderAttachment {ATTACHMENT} at (104,15) size 267x80
+      RenderBlock {DIV} at (0,578) size 769x84
+        RenderText {#text} at (0,66) size 104x18
+          text run at (0,66) width 104: "100% progress: "
+        RenderAttachment {ATTACHMENT} at (104,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 66x80
               RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
@@ -125,22 +125,22 @@ layer at (119,367) size 95x20 backgroundClip at (119,367) size 94x20 clip at (11
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (119,387) size 95x4 backgroundClip at (119,387) size 94x4 clip at (119,387) size 94x4
   RenderDeprecatedFlexibleBox {DIV} at (0,24) size 95x4 [color=#0000007F]
-layer at (176,465) size 172x16
+layer at (176,451) size 172x16
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
     RenderBlock (anonymous) at (0,0) size 172x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (175,561) size 172x16
+layer at (175,535) size 172x16
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
     RenderBlock (anonymous) at (0,0) size 172x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (183,657) size 172x16
+layer at (183,619) size 172x16
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
     RenderBlock (anonymous) at (0,0) size 172x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (270,366) size 14x21
   RenderBlock {DIV} at (0,0) size 14x21 [bgcolor=#0000007F]
-layer at (120,447) size 52x52
+layer at (120,433) size 52x52
   RenderBlock {DIV} at (14,14) size 52x52 [bgcolor=#000000D8]

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -97,16 +97,15 @@ void RenderAttachment::layout()
         layoutShadowContent(newIntrinsicSize);
 }
 
-LayoutUnit RenderAttachment::baselinePosition(FontBaseline fontBaseline, bool firstLine, LineDirectionMode lineDirectionMode, LinePositionMode linePositionMode) const
+LayoutUnit RenderAttachment::baselinePosition(FontBaseline, bool, LineDirectionMode, LinePositionMode) const
 {
     if (auto* baselineElement = attachmentElement().wideLayoutImageElement()) {
-        bool unusedIsReplaced;
-        auto attachmentRect = attachmentElement().renderRect(&unusedIsReplaced);
-        auto baselineElementRect = baselineElement->renderRect(&unusedIsReplaced);
-        auto baselineElementTop = baselineElementRect.y() - attachmentRect.y();
-        if (auto* baselineElementRenderBox = baselineElement->renderBoxModelObject())
-            return baselineElementTop + baselineElementRenderBox->baselinePosition(fontBaseline, firstLine, lineDirectionMode, linePositionMode);
-        return baselineElementTop + baselineElementRect.height();
+        if (auto* baselineElementRenderBox = baselineElement->renderBox()) {
+            // This is the bottom of the image assuming it is vertically centered.
+            return (height() + baselineElementRenderBox->height()) / 2;
+        }
+        // Fallback to the bottom of the attachment if there is no image.
+        return height();
     }
 
     return theme().attachmentBaseline(*this);


### PR DESCRIPTION
#### 28021b9b53fe677af02c6099ef04bfc612d6f673
<pre>
Wide-layout attachments: Fix baseline computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259039">https://bugs.webkit.org/show_bug.cgi?id=259039</a>
rdar://problem/111991128

Reviewed by Tim Nguyen.

The previous computation used `renderRect`s, which relied on the baseline, modifying the baseline again
and again.
Instead, assume that the image is vertically centred, so it&apos;s just a matter of adding half-heights to find
the bottom of that image. (Fallback to the full attachment height alone in case the inner element doesn&apos;t
have its height yet.)

* LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt:
* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::baselinePosition const):

Canonical link: <a href="https://commits.webkit.org/265894@main">https://commits.webkit.org/265894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab36b2f28f074884911cc9749745a446032f8020

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11758 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12545 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14346 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18173 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9660 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10930 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11567 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->