### PR TITLE
Resolve WebCodecsVideoEncoder::isConfigSupported promise when createVideoEncoderConfig does not support the input parameters

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt
@@ -5,11 +5,11 @@ PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode
 PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
 PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters assert_false: expected false got true
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
+PASS VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
 FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt
@@ -5,11 +5,11 @@ PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Width is 
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:Height is 0
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayWidth is 0
 PASS Test that VideoEncoder.isConfigSupported() rejects invalid config:displayHeight is 0
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode promise_test: Unhandled rejection with value: object "TypeError: Scalabilty mode is not supported"
+PASS VideoEncoder.isConfigSupported() doesn't support config:Invalid scalability mode
 PASS VideoEncoder.isConfigSupported() doesn't support config:Width is too large
 PASS VideoEncoder.isConfigSupported() doesn't support config:Height is too large
 FAIL VideoEncoder.isConfigSupported() doesn't support config:Too strenuous accelerated encoding parameters assert_false: expected false got true
-FAIL VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264 assert_false: expected false got true
+PASS VideoEncoder.isConfigSupported() doesn't support config:Odd sized frames for H264
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"avc1.42001E","hardwareAcceleration":"no-preference","width":640,"height":480,"bitrate":5000000,"framerate":24,"avc":{"format":"annexb"},"futureConfigFeature":"foo"}
 FAIL VideoEncoder.isConfigSupported() supports:{"codec":"vp8","hardwareAcceleration":"no-preference","width":800,"height":600,"bitrate":7000000,"bitrateMode":"variable","framerate":60,"scalabilityMode":"L1T2","futureConfigFeature":"foo","latencyMode":"quality","avc":{"format":"annexb"}} assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
 PASS VideoEncoder.isConfigSupported() supports:{"codec":"vp09.00.10.08","hardwareAcceleration":"no-preference","width":1280,"height":720,"bitrate":7000000,"bitrateMode":"constant","framerate":25,"futureConfigFeature":"foo","latencyMode":"realtime","alpha":"discard"}


### PR DESCRIPTION
#### e99a99cea11288498936429a46434c1ec9d0b6df
<pre>
Resolve WebCodecsVideoEncoder::isConfigSupported promise when createVideoEncoderConfig does not support the input parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=259047">https://bugs.webkit.org/show_bug.cgi?id=259047</a>
rdar://112005870

Reviewed by Eric Carlson.

Update the implementation according the spec, by resolving with false when the given parameters are not supported.
We also pass the input parameters as per spec.
We add a H.264 specific check for odd size video frames, which is consistent with Chrome.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/video-encoder-config.https.any.worker-expected.txt:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::isConfigSupported):

Canonical link: <a href="https://commits.webkit.org/265900@main">https://commits.webkit.org/265900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8eea1db180cf9813b7e594c52938eb53006743a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12845 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14359 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11071 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18184 "4 flakes 145 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14413 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10943 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2997 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11580 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->