### PR TITLE
[GLib] API test `/webkit/WebKitSettings/webkit-settings` is failing

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -213,6 +213,7 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
 {
     WebKitSettings* settings = WEBKIT_SETTINGS(object);
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     switch (propId) {
     case PROP_ENABLE_JAVASCRIPT:
         webkit_settings_set_enable_javascript(settings, g_value_get_boolean(value));
@@ -416,12 +417,14 @@ static void webKitSettingsSetProperty(GObject* object, guint propId, const GValu
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
     }
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
 {
     WebKitSettings* settings = WEBKIT_SETTINGS(object);
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     switch (propId) {
     case PROP_ENABLE_JAVASCRIPT:
         g_value_set_boolean(value, webkit_settings_get_enable_javascript(settings));
@@ -622,6 +625,7 @@ static void webKitSettingsGetProperty(GObject* object, guint propId, GValue* val
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
         break;
     }
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 static void webkit_settings_class_init(WebKitSettingsClass* klass)
@@ -677,7 +681,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             _("Load icons ignoring image load setting"),
             _("Whether to load site icons ignoring image load setting."),
             FALSE,
-            readWriteConstructParamFlags);
+            static_cast<GParamFlags>(readWriteConstructParamFlags | G_PARAM_DEPRECATED));
 
     /**
      * WebKitSettings:enable-offline-web-application-cache:
@@ -787,7 +791,7 @@ static void webkit_settings_class_init(WebKitSettingsClass* klass)
             _("Enable Java"),
             _("Whether Java support should be enabled."),
             FALSE,
-            readWriteConstructParamFlags);
+            static_cast<GParamFlags>(readWriteConstructParamFlags | G_PARAM_DEPRECATED));
 #endif
 
     /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -112,10 +112,10 @@ WEBKIT_API void
 webkit_settings_set_auto_load_images                           (WebKitSettings *settings,
                                                                 gboolean        enabled);
 
-WEBKIT_API gboolean
+WEBKIT_DEPRECATED gboolean
 webkit_settings_get_load_icons_ignoring_image_load_setting     (WebKitSettings *settings);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED void
 webkit_settings_set_load_icons_ignoring_image_load_setting     (WebKitSettings *settings,
                                                                 gboolean        enabled);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -53,10 +53,15 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_auto_load_images(settings, FALSE);
     g_assert_false(webkit_settings_get_auto_load_images(settings));
 
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // load-icons-ignoring-image-load-setting is deprecated and always false.
+    // Make warnings non-fatal for this test to make it pass.
+    Test::removeLogFatalFlag(G_LOG_LEVEL_WARNING);
     g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings));
     webkit_settings_set_load_icons_ignoring_image_load_setting(settings, TRUE);
     g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings));
+    Test::addLogFatalFlag(G_LOG_LEVEL_WARNING);
+    ALLOW_DEPRECATED_DECLARATIONS_END
     
     // Offline application cache is true by default.
     g_assert_true(webkit_settings_get_enable_offline_web_application_cache(settings));
@@ -392,13 +397,10 @@ void testWebKitSettingsNewWithSettings(Test* test, gconstpointer)
     GRefPtr<WebKitSettings> settings = adoptGRef(webkit_settings_new_with_settings(
         "enable-javascript", FALSE,
         "auto-load-images", FALSE,
-        "load-icons-ignoring-image-load-setting", TRUE,
         nullptr));
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(settings.get()));
     g_assert_false(webkit_settings_get_enable_javascript(settings.get()));
     g_assert_false(webkit_settings_get_auto_load_images(settings.get()));
-    // load-icons-ignoring-image-load-setting is deprecated and always false.
-    g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings.get()));
 }
 
 void testWebKitFeatures(Test* test, gconstpointer)

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -62,12 +62,6 @@
         "subtests": {
             "/webkit/WebKitSettings/javascript-markup": {
                 "expected": {"all@Debug": {"status": ["CRASH"], "bug": "webkit.org/b/221119"}}
-            },
-            "/webkit/WebKitSettings/webkit-settings": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}}
-            },
-            "/webkit/WebKitSettings/new-with-settings": {
-                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}}
             }
         }
     },


### PR DESCRIPTION
#### 1ba6a9fa393e478b5aafa4a0519287bb0ccb7f8d
<pre>
[GLib] API test `/webkit/WebKitSettings/webkit-settings` is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259049">https://bugs.webkit.org/show_bug.cgi?id=259049</a>

Reviewed by Michael Catanzaro.

The test was failing because
`webkit_settings_get_load_icons_ignoring_image_load_setting()` and
`webkit_settings_set_load_icons_ignoring_image_load_setting()` are
deprecated and issue a `g_warning()` which is fatal by default in
Glib tests.

The solution is to temporarily remove `G_LOG_LEVEL_WARNING` from fatals.

Also, unlike some other similar deprecated API functions, these two were
not marked as `WEBKIT_DEPRECATED`.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsSetProperty):
(webKitSettingsGetProperty):
(webkit_settings_class_init):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):
(testWebKitSettingsNewWithSettings):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265946@main">https://commits.webkit.org/265946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f113469f44bed52033c718ec82be09bf60cc76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14471 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13182 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11089 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18206 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14436 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9691 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10966 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->