### PR TITLE
REGRESSION(265043@main): Fullscreen mode only shows video in some part of the screen on Twitter

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-containing-block-change-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-containing-block-change-expected.txt
@@ -1,0 +1,7 @@
+Test passes if the lightgreen area fills the screen after going fullscreen.
+
+Go fullscreen
+EXPECTED (target.offsetWidth > 400 == 'true') OK
+EXPECTED (target.offsetHeight > 400 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-containing-block-change.html
+++ b/LayoutTests/fullscreen/fullscreen-containing-block-change.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that containing block changes are reflected when going fullscreen</title>
+</head>
+<body>
+    <!-- will-change: transform creates a containing-block for fixed positioned elements, but the top layer overrides it --->
+    <div style="height: 400px; width: 400px; will-change: transform;">
+        <!-- container-type: size triggers layout during style resolution -->
+        <div style="container-type: size; background-color: lightgreen; width: 100%; height: 100%;" id="target">
+            <p>Test passes if the green area fills the screen after going fullscreen.</p>
+            <button onclick="target.requestFullscreen()">Go fullscreen</button>
+            <!-- Add extra positioned child to make sure descendants are also properly laid out-->
+            <div style="position: absolute; left: 0; right: 0; top: 100px; bottom: 0; background-color: greenyellow;"></div>
+        </div>
+    </div>
+    <script src="full-screen-test.js"></script>
+    <script>
+        async function test() {
+            await new Promise((resolve) => {
+                addEventListener("fullscreenchange", resolve, { once: true });
+                runWithKeyDown(() => {
+                    target.requestFullscreen();
+                });
+            });
+
+            testExpected("target.offsetWidth > 400", true);
+            testExpected("target.offsetHeight > 400", true);
+            endTest();
+        }
+
+        test();
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -56,6 +56,7 @@
     pointer-events: inherit;
     -webkit-cursor-visibility: inherit;
     position: relative;
+    container-type: size; /* Used by WebVTT & visionOS controls */
     will-change: z-index;
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -23,12 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Enable container queries */
-
-.media-controls-container {
-    container-type: size;
-}
-
 /* Default values for some constants */
 
 .media-controls.vision,


### PR DESCRIPTION
#### 5198e14b51f73c112c7f28c80558a9e491190810
<pre>
REGRESSION(265043@main): Fullscreen mode only shows video in some part of the screen on Twitter
<a href="https://bugs.webkit.org/show_bug.cgi?id=258907">https://bugs.webkit.org/show_bug.cgi?id=258907</a>
rdar://111095697

Reviewed by NOBODY (OOPS!).

265043@main started to use container queries in the video shadow root. As a side effect, this caused every call to
Document::resolveStyle() to start laying out the whole document (through frameView.layoutContext().layout()).

Adding to top layer &amp; removing from top layer requires layout when the containing block changes.

We haven&apos;t really hit any problem with not marking for layout until now, because usually we apply the pseudo element styles
which include `position: fixed;` and other things, at the same time as adding to top layer, which marks them for layout anyway.

In the fullscreen case, we have a slightly different series:
```
ancestor-&gt;setFullscreenFlag(true); &lt;- applies pseudo class styles (hence dirtying layout)

ancestor-&gt;document().resolveStyle(Document::ResolveStyleType::Rebuild); &lt;- runs layout (clearing dirty layout)

ancestor-&gt;addToTopLayer(); &lt;- changes the containing block without marking renderer for layout

// No layout!!
```

Add a special case in addToTopLayer/removeFromTopLayer, for cases where we don&apos;t process pseudo class style changes and containing block changes
under the same layout.

Also make it clear in the media-controls CSS that container queries are needed on all platforms (not just visionOS), since
WebVTT relies on it.

* LayoutTests/fullscreen/fullscreen-containing-block-change-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-containing-block-change.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(.media-controls-container):
* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls-container): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addToTopLayer):
(WebCore::Element::removeFromTopLayer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5198e14b51f73c112c7f28c80558a9e491190810

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14557 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14513 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10559 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11188 "7 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18293 "2 flakes 119 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11642 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11353 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14535 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11844 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9775 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11070 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11059 "Exiting early after 10 failures. 10 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->