### PR TITLE
[MSE] Reuse "fudge factor" when samples are removed

### DIFF
--- a/Source/WebCore/html/TimeRanges.cpp
+++ b/Source/WebCore/html/TimeRanges.cpp
@@ -100,9 +100,9 @@ unsigned TimeRanges::length() const
     return m_ranges.length();
 }
 
-void TimeRanges::add(double start, double end)
+void TimeRanges::add(double start, double end, AddTimeRangeOption addTimeRangeOption)
 {
-    m_ranges.add(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end));
+    m_ranges.add(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end), addTimeRangeOption);
 }
 
 bool TimeRanges::contain(double time) const

--- a/Source/WebCore/html/TimeRanges.h
+++ b/Source/WebCore/html/TimeRanges.h
@@ -46,7 +46,7 @@ public:
     
     WEBCORE_EXPORT unsigned length() const;
 
-    WEBCORE_EXPORT void add(double start, double end);
+    WEBCORE_EXPORT void add(double start, double end, AddTimeRangeOption = AddTimeRangeOption::None);
     bool contain(double time) const;
     
     size_t find(double time) const;

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -36,6 +36,11 @@ class PrintStream;
 
 namespace WebCore {
 
+enum class AddTimeRangeOption : uint8_t {
+    None,
+    EliminateSmallGaps,
+};
+
 class WEBCORE_EXPORT PlatformTimeRanges final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -45,6 +50,7 @@ public:
     PlatformTimeRanges copyWithEpsilon(const MediaTime&) const;
 
     static const PlatformTimeRanges& emptyRanges();
+    static MediaTime timeFudgeFactor();
 
     MediaTime start(unsigned index) const;
     MediaTime start(unsigned index, bool& valid) const;
@@ -62,7 +68,7 @@ public:
 
     unsigned length() const { return m_ranges.size(); }
 
-    void add(const MediaTime& start, const MediaTime& end);
+    void add(const MediaTime& start, const MediaTime& end, AddTimeRangeOption = AddTimeRangeOption::None);
     void clear();
     
     bool contain(const MediaTime&) const;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1218,18 +1218,8 @@ void SourceBufferPrivate::processMediaSample(Ref<MediaSample>&& sample)
             resetTimestampOffsetInTrackBuffers();
         }
 
-        // Eliminate small gaps between buffered ranges by coalescing
-        // disjoint ranges separated by less than a "fudge factor".
         auto presentationEndTime = presentationTimestamp + frameDuration;
-        auto nearestToPresentationStartTime = trackBuffer.buffered().nearest(presentationTimestamp);
-        if (nearestToPresentationStartTime.isValid() && (presentationTimestamp - nearestToPresentationStartTime).isBetween(MediaTime::zeroTime(), timeFudgeFactor()))
-            presentationTimestamp = nearestToPresentationStartTime;
-
-        auto nearestToPresentationEndTime = trackBuffer.buffered().nearest(presentationEndTime);
-        if (nearestToPresentationEndTime.isValid() && (nearestToPresentationEndTime - presentationEndTime).isBetween(MediaTime::zeroTime(), timeFudgeFactor()))
-            presentationEndTime = nearestToPresentationEndTime;
-
-        trackBuffer.addBufferedRange(presentationTimestamp, presentationEndTime);
+        trackBuffer.addBufferedRange(presentationTimestamp, presentationEndTime, AddTimeRangeOption::EliminateSmallGaps);
         m_client->sourceBufferPrivateDidParseSample(frameDuration.toDouble());
 
         break;

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -162,7 +162,7 @@ protected:
 
     virtual void appendInternal(Ref<SharedBuffer>&&) = 0;
     virtual void resetParserStateInternal() = 0;
-    virtual MediaTime timeFudgeFactor() const { return { 2002, 24000 }; }
+    virtual MediaTime timeFudgeFactor() const { return PlatformTimeRanges::timeFudgeFactor(); }
     virtual bool isActive() const { return false; }
     virtual bool isSeeking() const { return false; }
     virtual MediaTime currentMediaTime() const { return { }; }

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -67,9 +67,9 @@ MediaTime TrackBuffer::maximumBufferedTime() const
     return m_buffered.maximumBufferedTime();
 }
 
-void TrackBuffer::addBufferedRange(const MediaTime& start, const MediaTime& end)
+void TrackBuffer::addBufferedRange(const MediaTime& start, const MediaTime& end, AddTimeRangeOption addTimeRangeOption)
 {
-    m_buffered.add(start, end);
+    m_buffered.add(start, end, addTimeRangeOption);
 }
 
 void TrackBuffer::addSample(MediaSample& sample)
@@ -198,7 +198,7 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
 
         auto startTime = sample->presentationTime();
         auto endTime = startTime + sample->duration();
-        erasedRanges.add(startTime, endTime);
+        erasedRanges.add(startTime, endTime, AddTimeRangeOption::EliminateSmallGaps);
 
 #if !RELEASE_LOG_DISABLED
         bytesRemoved += startBufferSize - m_samples.sizeInBytes();

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -49,7 +49,7 @@ public:
     static UniqueRef<TrackBuffer> create(RefPtr<MediaDescription>&&, const MediaTime&);
     
     MediaTime maximumBufferedTime() const;
-    void addBufferedRange(const MediaTime& start, const MediaTime& end);
+    void addBufferedRange(const MediaTime& start, const MediaTime& end, AddTimeRangeOption = AddTimeRangeOption::None);
     void addSample(MediaSample&);
     
     bool updateMinimumUpcomingPresentationTime();

--- a/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp
@@ -287,5 +287,34 @@ TEST(TimeRanges, IntersectWith_Gaps3)
     ASSERT_RANGE("{ [1,5) [6,9) }", rangesB);
 }
 
+TEST(TimeRanges, Add_SmallGaps)
+{
+    RefPtr<TimeRanges> ranges = TimeRanges::create();
+
+    const MediaTime duration { MediaTime::createWithDouble(1.0) };
+    const double smallGap { 0.001 };
+    const unsigned numberOfSamples { 10 };
+
+    for (unsigned i = 0; i < numberOfSamples; ++i) {
+        const double start = duration.toDouble() * i;
+        const double end = start + duration.toDouble() - smallGap;
+
+        ranges->add(start, end, AddTimeRangeOption::None);
+    }
+
+    EXPECT_EQ(numberOfSamples, ranges->length());
+
+    ranges = TimeRanges::create();
+
+    for (unsigned i = 0; i < numberOfSamples; ++i) {
+        const double start = duration.toDouble() * i;
+        const double end = start + duration.toDouble() - smallGap;
+
+        ranges->add(start, end, AddTimeRangeOption::EliminateSmallGaps);
+    }
+
+    EXPECT_EQ(1u, ranges->length());
+}
+
 }
 


### PR DESCRIPTION
#### c3bf8dd554481b04a008756c79c53040279ca936
<pre>
[MSE] Reuse &quot;fudge factor&quot; when samples are removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=258869">https://bugs.webkit.org/show_bug.cgi?id=258869</a>

Reviewed by Xabier Rodriguez-Calvar.

Currently when TrackBuffer::removeSamples is called and erasedRanged is created from the samples,
removing small gaps between samples is not done. It causes that in some cases many separated ranges
are created which has impact on performance of removing samples.

Reusing &quot;eliminate small gap&quot; mechanism from SourceBufferPrivate::processMediaSample solves the problem.

* Source/WebCore/html/TimeRanges.cpp:
(WebCore::TimeRanges::add):
* Source/WebCore/html/TimeRanges.h:
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::timeFudgeFactor):
(WebCore::PlatformTimeRanges::add):
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::timeFudgeFactor const):
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::addBufferedRange):
(WebCore::TrackBuffer::removeSamples):
* Source/WebCore/platform/graphics/TrackBuffer.h:
* Tools/TestWebKitAPI/Tests/WebCore/TimeRanges.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/266357@main">https://commits.webkit.org/266357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97749ea501e048f8b3a4133691bf34044b085c46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15630 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16061 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11715 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12290 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19327 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15664 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10862 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12244 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16574 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->