### PR TITLE
font-tech() should not validate descriptor for any invalid item

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
@@ -24,6 +24,8 @@ PASS Check that src: url("foo.ttf") tech(initial) is invalid
 PASS Check that src: url("foo.ttf") tech(none) is invalid
 PASS Check that src: url("foo.ttf") tech(normal) is invalid
 PASS Check that src: url("foo.ttf") tech(xyzzy) is invalid
+PASS Check that src: url("foo.ttf") tech(xyzzy, features-opentype) is invalid
+PASS Check that src: url("foo.ttf") tech(features-opentype, xyzzy) is invalid
 PASS Check that src: url("foo.ttf") format(opentype) tech(features-opentype) is valid
 PASS Check that src: url("foo.ttf") tech(features-opentype) format(opentype) is invalid
 PASS Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech.html
@@ -39,6 +39,8 @@
     { src: 'url("foo.ttf") tech(none)', valid: false },
     { src: 'url("foo.ttf") tech(normal)', valid: false },
     { src: 'url("foo.ttf") tech(xyzzy)', valid: false },
+    { src: 'url("foo.ttf") tech(xyzzy, features-opentype)', valid: false },
+    { src: 'url("foo.ttf") tech(features-opentype, xyzzy)', valid: false },
     // format() function must precede tech() if both are present
     { src: 'url("foo.ttf") format(opentype) tech(features-opentype)', valid: true },
     { src: 'url("foo.ttf") tech(features-opentype) format(opentype)', valid: false },

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8239,8 +8239,9 @@ Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleVa
         if (arg.type() != IdentToken)
             return { };
         auto technology = fromCSSValueID<FontTechnology>(arg.id());
-        if (technology != FontTechnology::Invalid)
-            technologies.append(technology);
+        if (technology == FontTechnology::Invalid)
+            return { };
+        technologies.append(technology);
     } while (consumeCommaIncludingWhitespace(args) && !singleValue);
     if (!args.atEnd())
         return { };


### PR DESCRIPTION
#### 165f4f7106fc71ccbe3ed921e7fa1ea048339b49
<pre>
font-tech() should not validate descriptor for any invalid item
<a href="https://bugs.webkit.org/show_bug.cgi?id=258948">https://bugs.webkit.org/show_bug.cgi?id=258948</a>
rdar://112020474

Reviewed by Cameron McCormack.

If any value in font-tech() list is not valid we should invalidate the src
item. Before we were invalidating it only if all values were not valid.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech.html:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontTech):

Canonical link: <a href="https://commits.webkit.org/266032@main">https://commits.webkit.org/266032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e13ef9d25dfcdf36d01d6b57573c52080462f4b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11448 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14810 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->