### PR TITLE
Make SQLiteTransaction notify SQLiteDatabaseTracker on macOS

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteTransaction.cpp
+++ b/Source/WebCore/platform/sql/SQLiteTransaction.cpp
@@ -27,10 +27,7 @@
 #include "SQLiteTransaction.h"
 
 #include "SQLiteDatabase.h"
-
-#if PLATFORM(IOS_FAMILY)
 #include "SQLiteDatabaseTracker.h"
-#endif
 
 namespace WebCore {
 
@@ -58,18 +55,14 @@ void SQLiteTransaction::begin()
         // any statements. If that happens, this transaction will fail.
         // http://www.sqlite.org/lang_transaction.html
         // http://www.sqlite.org/lockingv3.html#locking
-#if PLATFORM(IOS_FAMILY)
         SQLiteDatabaseTracker::incrementTransactionInProgressCount();
-#endif
         if (m_readOnly)
             m_inProgress = m_db.executeCommand("BEGIN"_s);
         else
             m_inProgress = m_db.executeCommand("BEGIN IMMEDIATE"_s);
         m_db.m_transactionInProgress = m_inProgress;
-#if PLATFORM(IOS_FAMILY)
         if (!m_inProgress)
             SQLiteDatabaseTracker::decrementTransactionInProgressCount();
-#endif
     }
 }
 
@@ -79,10 +72,8 @@ void SQLiteTransaction::commit()
         ASSERT(m_db.m_transactionInProgress);
         m_inProgress = !m_db.executeCommand("COMMIT"_s);
         m_db.m_transactionInProgress = m_inProgress;
-#if PLATFORM(IOS_FAMILY)
         if (!m_inProgress)
             SQLiteDatabaseTracker::decrementTransactionInProgressCount();
-#endif
     }
 }
 
@@ -97,9 +88,7 @@ void SQLiteTransaction::rollback()
         m_db.executeCommand("ROLLBACK"_s);
         m_inProgress = false;
         m_db.m_transactionInProgress = false;
-#if PLATFORM(IOS_FAMILY)
         SQLiteDatabaseTracker::decrementTransactionInProgressCount();
-#endif
     }
 }
 
@@ -108,9 +97,7 @@ void SQLiteTransaction::stop()
     if (m_inProgress) {
         m_inProgress = false;
         m_db.m_transactionInProgress = false;
-#if PLATFORM(IOS_FAMILY)
         SQLiteDatabaseTracker::decrementTransactionInProgressCount();
-#endif
     }
 }
 


### PR DESCRIPTION
#### 722cf9996ceb152c7dfb9ba23235d0e456d29295
<pre>
Make SQLiteTransaction notify SQLiteDatabaseTracker on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=259062">https://bugs.webkit.org/show_bug.cgi?id=259062</a>
rdar://112027513

Reviewed by Chris Dumez and Brent Fulgham.

In 265791@main we enabled SQLiteDatabaseTracker on macOS, but it still does nothing because
SQLiteTransaction doesn&apos;t notify it. Change SQLiteTransaction to notify the tracker about ongoing
transactions on macOS as well.

* Source/WebCore/platform/sql/SQLiteTransaction.cpp:
(WebCore::SQLiteTransaction::begin):
(WebCore::SQLiteTransaction::commit):
(WebCore::SQLiteTransaction::rollback):
(WebCore::SQLiteTransaction::stop):

Canonical link: <a href="https://commits.webkit.org/265918@main">https://commits.webkit.org/265918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63729d530d691bec4bdd458f512c05652355e1b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11811 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14486 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14403 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11107 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18219 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14459 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11765 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10981 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->