### PR TITLE
[JSC] Update ArrayBuffer#resize's detach check timing

### DIFF
--- a/JSTests/stress/arraybuffer-resizable-resize-update.js
+++ b/JSTests/stress/arraybuffer-resizable-resize-update.js
@@ -1,0 +1,24 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+let buffer = new ArrayBuffer(16, {maxByteLength: 16});
+shouldThrow(() => {
+    buffer.resize({
+        valueOf() {
+            $.detachArrayBuffer(buffer);
+            return 0;
+        }
+    });
+}, `TypeError: Receiver is detached`);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp
@@ -278,11 +278,11 @@ JSC_DEFINE_HOST_FUNCTION(arrayBufferProtoFuncResize, (JSGlobalObject* globalObje
     if (UNLIKELY(!thisObject->impl()->isResizableOrGrowableShared()))
         return throwVMTypeError(globalObject, scope, "ArrayBuffer is not resizable"_s);
 
-    if (UNLIKELY(thisObject->impl()->isDetached()))
-        return throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
-
     double newLength = callFrame->argument(0).toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
+
+    if (UNLIKELY(thisObject->impl()->isDetached()))
+        return throwVMTypeError(globalObject, scope, "Receiver is detached"_s);
 
     if (!std::isfinite(newLength) || newLength < 0)
         return throwVMRangeError(globalObject, scope, "new length is out of range"_s);


### PR DESCRIPTION
#### ee334fb70f71d5d522f3d2d93d922bc44419cca9
<pre>
[JSC] Update ArrayBuffer#resize&apos;s detach check timing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259076">https://bugs.webkit.org/show_bug.cgi?id=259076</a>
rdar://112041092

Reviewed by Mark Lam.

Change the order of detach check according to the latest spec[1],
but this only changes the type of error (from RangeError to TypeError).

[1]: <a href="https://github.com/tc39/ecma262/pull/3116">https://github.com/tc39/ecma262/pull/3116</a>

* JSTests/stress/arraybuffer-resizable-resize-update.js: Added.
(shouldThrow):
* Source/JavaScriptCore/runtime/JSArrayBufferPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/265935@main">https://commits.webkit.org/265935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b04e3ad114be74322ed44beefcdb0bf898fada5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11838 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14519 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14455 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18253 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10455 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14489 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11634 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9738 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12359 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11018 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3247 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15350 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12706 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11652 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3025 "Passed tests") | 
<!--EWS-Status-Bubble-End-->