### PR TITLE
Simulator should have a 48-bit address space

### DIFF
--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -37,7 +37,7 @@ class Structure;
 #if CPU(ADDRESS64)
 
 // We would like to define this value in PlatformEnable.h, but it is not possible since the following is relying on MACH_VM_MAX_ADDRESS.
-#if CPU(ARM64) && OS(DARWIN)
+#if CPU(ARM64) && OS(DARWIN) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 #if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
 #define ENABLE_STRUCTURE_ID_WITH_SHIFT 1
 static_assert(MACH_VM_MAX_ADDRESS_RAW == MACH_VM_MAX_ADDRESS);

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -30,6 +30,7 @@
 #include <wtf/Forward.h>
 #include <wtf/GetPtr.h>
 #include <wtf/HashFunctions.h>
+#include <wtf/Platform.h>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/StdLibExtras.h>
 
@@ -40,7 +41,7 @@
 namespace WTF {
 
 #if CPU(ADDRESS64)
-#if CPU(ARM64) && OS(DARWIN)
+#if CPU(ARM64) && OS(DARWIN) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 #if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
 #define HAVE_36BIT_ADDRESS 1
 #endif

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -52,6 +52,17 @@
 #define HAVE_ARM_IDIV_INSTRUCTIONS 1
 #endif
 
+#if CPU(ADDRESS64)
+#if OS(DARWIN) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH (WTF::getMSBSetConstexpr(MACH_VM_MAX_ADDRESS) + 1)
+#else
+/* We strongly assume that effective address width is <= 48 in 64bit architectures (e.g. NaN boxing). */
+#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH 48
+#endif
+#else
+#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH 32
+#endif
+
 #if PLATFORM(COCOA)
 #define HAVE_AUDIT_TOKEN 1
 #endif

--- a/Source/WTF/wtf/PlatformOS.h
+++ b/Source/WTF/wtf/PlatformOS.h
@@ -133,19 +133,6 @@
 #define WTF_OS_UNIX 1
 #endif
 
-
-#if CPU(ADDRESS64)
-#if OS(DARWIN)
-#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH (WTF::getMSBSetConstexpr(MACH_VM_MAX_ADDRESS) + 1)
-#else
-/* We strongly assume that effective address width is <= 48 in 64bit architectures (e.g. NaN boxing). */
-#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH 48
-#endif
-#else
-#define WTF_OS_CONSTANT_EFFECTIVE_ADDRESS_WIDTH 32
-#endif
-
-
 /* Asserts, invariants for macro definitions */
 
 #define WTF_OS_WIN ERROR "USE WINDOWS WITH OS NOT WIN"

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -297,7 +297,7 @@
 #endif
 
 #if BCPU(ADDRESS64)
-#if BOS(DARWIN)
+#if BOS(DARWIN) && !BPLATFORM(IOS_FAMILY_SIMULATOR)
 #define BOS_EFFECTIVE_ADDRESS_WIDTH (bmalloc::getMSBSetConstexpr(MACH_VM_MAX_ADDRESS) + 1)
 #else
 /* We strongly assume that effective address width is <= 48 in 64bit architectures (e.g. NaN boxing). */

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -397,7 +397,7 @@ pas_root* pas_root_ensure_for_libmalloc_enumeration(void)
 #define PAS_SYSTEM_COMPACT_POINTER_SIZE 4
 
 #if PAS_CPU(ADDRESS64)
-#if PAS_ARM64 && PAS_OS(DARWIN)
+#if PAS_ARM64 && PAS_OS(DARWIN) && !PAS_PLATFORM(IOS_FAMILY_SIMULATOR)
 #if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
 #define PAS_HAVE_36BIT_ADDRESS 1
 #endif


### PR DESCRIPTION
#### fa76f5ed3119f79bbbcd597e446cf201183b33b4
<pre>
Simulator should have a 48-bit address space
<a href="https://bugs.webkit.org/show_bug.cgi?id=258999">https://bugs.webkit.org/show_bug.cgi?id=258999</a>
rdar://111137299

Reviewed by Yusuke Suzuki.

If you allocate a lot of memory in the simulator, eventually you will
fail one of the CompactPtr assertions because the simulator actually
acts like macOS with respect to virtual memory.

Mach&apos;s max address size is defined incorrectly for this case, so we guard
against that on our side.

* Source/JavaScriptCore/runtime/StructureID.h:
* Source/WTF/wtf/CompactPtr.h:
* Source/WTF/wtf/PlatformHave.h:
* Source/WTF/wtf/PlatformOS.h:
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/libpas/src/libpas/pas_root.c:

Canonical link: <a href="https://commits.webkit.org/265930@main">https://commits.webkit.org/265930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7695d3cff6f03270720dfbc102d7d45432fdfb55

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14036 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14524 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14456 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11141 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10456 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11600 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14492 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11635 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/11799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9739 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12360 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3248 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15351 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12707 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3026 "Passed tests") | 
<!--EWS-Status-Bubble-End-->