### PR TITLE
REGRESSION(257749@main): Copying table in Confluence on Safari doesn't copy header rows

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks-expected.txt
@@ -1,0 +1,43 @@
+This tests copying excludes content with user-select: none.
+To manually test, copy "hello world foo bar" below then paste.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getSelection().toString().includes("hello") is true
+PASS getSelection().toString().includes("world") is true
+PASS getSelection().toString().includes("WebKit") is true
+PASS getSelection().toString().includes("rocks") is true
+PASS getSelection().toString().includes("because") is true
+PASS getSelection().toString().includes("foo") is true
+PASS getSelection().toString().includes("bar") is true
+PASS event.clipboardData.getData("text/plain").includes("hello") is true
+PASS event.clipboardData.getData("text/plain").includes("world") is true
+PASS event.clipboardData.getData("text/plain").includes("WebKit") is true
+PASS event.clipboardData.getData("text/plain").includes("rocks") is true
+PASS event.clipboardData.getData("text/plain").includes("because") is true
+PASS event.clipboardData.getData("text/plain").includes("foo") is true
+PASS event.clipboardData.getData("text/plain").includes("bar") is true
+PASS event.clipboardData.getData("text/html").includes("hello") is true
+PASS event.clipboardData.getData("text/html").includes("world") is true
+PASS event.clipboardData.getData("text/html").includes("<i") is true
+PASS event.clipboardData.getData("text/html").includes("</i>") is true
+PASS event.clipboardData.getData("text/html").includes("WebKit") is true
+PASS event.clipboardData.getData("text/html").includes("<b ") is true
+PASS event.clipboardData.getData("text/html").includes("</b>") is true
+PASS event.clipboardData.getData("text/html").includes("rocks") is true
+PASS event.clipboardData.getData("text/html").includes("<q>") is true
+PASS event.clipboardData.getData("text/html").includes("</q>") is true
+PASS event.clipboardData.getData("text/html").includes("because") is true
+PASS event.clipboardData.getData("text/html").includes("<s>") is true
+PASS event.clipboardData.getData("text/html").includes("</s>") is true
+PASS event.clipboardData.getData("text/html").includes("<em>") is true
+PASS event.clipboardData.getData("text/html").includes("</em>") is true
+PASS event.clipboardData.getData("text/html").includes("foo") is true
+PASS event.clipboardData.getData("text/html").includes("bar") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+hello world WebKit rocks because foo bar
+hello world WebKit rocks because foo bar
+

--- a/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks.html
+++ b/LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="confluence-request-time" content="1689029750234">
+</head>
+<body>
+<div id="source">hello <span style="-webkit-user-select: none; user-select: none;"><i>world </i><b style="-webkit-user-select: initial;
+user-select: initial;">WebKit <span style="-webkit-user-select: none; user-select: none;"><q>rocks </q></span></b><font color="green" style="-webkit-user-select: none;
+user-select: none;"><s>because </s></font></span><span inert><em>foo </em></span></span>bar</div>
+<div id="destination" contenteditable></div>
+<pre id="output"></pre>
+</body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description(`This tests copying excludes content with user-select: none.<br>
+To manually test, copy "hello world foo bar" below then paste.`);
+
+jsTestIsAsync = true;
+getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+
+source.addEventListener("copy", () => {
+    shouldBeTrue('getSelection().toString().includes("hello")');
+    shouldBeTrue('getSelection().toString().includes("world")');
+    shouldBeTrue('getSelection().toString().includes("WebKit")');
+    shouldBeTrue('getSelection().toString().includes("rocks")');
+    shouldBeTrue('getSelection().toString().includes("because")');
+    shouldBeTrue('getSelection().toString().includes("foo")');
+    shouldBeTrue('getSelection().toString().includes("bar")');
+});
+
+destination.addEventListener("paste", () => {
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("hello")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("world")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("WebKit")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("rocks")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("because")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("foo")');
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("bar")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("hello")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("world")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<i")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</i>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("WebKit")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<b ")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</b>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("rocks")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<q>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</q>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("because")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<s>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</s>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("<em>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("</em>")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("foo")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("bar")');
+    finishJSTest();
+});
+
+if (window.testRunner) {
+    testRunner.execCommand("Copy");
+    destination.focus();
+    testRunner.execCommand("Paste");
+} else {
+    source.addEventListener("copy", () => {
+        setTimeout(() => destination.focus(), 0);
+    });
+}
+
+</script>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -88,6 +88,7 @@
 #include "Page.h"
 #include "PagePasteboardContext.h"
 #include "Pasteboard.h"
+#include "Quirks.h"
 #include "Range.h"
 #include "RemoveFormatCommand.h"
 #include "RenderBlock.h"
@@ -3473,12 +3474,18 @@ void Editor::changeSelectionAfterCommand(const VisibleSelection& newSelection, O
 
 String Editor::selectedText() const
 {
-    return selectedText({ TextIteratorBehavior::TraversesFlatTree, TextIteratorBehavior::IgnoresUserSelectNone });
+    auto options = OptionSet { TextIteratorBehavior::TraversesFlatTree };
+    if (!m_document.quirks().needsToCopyUserSelectNoneQuirk())
+        options.add(TextIteratorBehavior::IgnoresUserSelectNone);
+    return selectedText(options);
 }
 
 String Editor::selectedTextForDataTransfer() const
 {
-    return selectedText(OptionSet { TextIteratorBehavior::EmitsImageAltText, TextIteratorBehavior::TraversesFlatTree, TextIteratorBehavior::IgnoresUserSelectNone });
+    auto options = OptionSet { TextIteratorBehavior::EmitsImageAltText, TextIteratorBehavior::TraversesFlatTree };
+    if (!m_document.quirks().needsToCopyUserSelectNoneQuirk())
+        options.add(TextIteratorBehavior::IgnoresUserSelectNone);
+    return selectedText(options);
 }
 
 String Editor::selectedText(TextIteratorBehaviors behaviors) const

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -70,6 +70,7 @@
 #include "Page.h"
 #include "PageConfiguration.h"
 #include "PasteboardItemInfo.h"
+#include "Quirks.h"
 #include "Range.h"
 #include "RenderBlock.h"
 #include "ScriptWrappableInlines.h"
@@ -438,7 +439,7 @@ inline StyledMarkupAccumulator::StyledMarkupAccumulator(const Position& start, c
     , m_annotate(annotate)
     , m_highestNodeToBeSerialized(highestNodeToBeSerialized)
     , m_useComposedTree(serializeComposedTree == SerializeComposedTree::Yes)
-    , m_ignoresUserSelectNone(ignoreUserSelectNone == IgnoreUserSelectNone::Yes)
+    , m_ignoresUserSelectNone(ignoreUserSelectNone == IgnoreUserSelectNone::Yes && !start.document()->quirks().needsToCopyUserSelectNoneQuirk())
     , m_needsPositionStyleConversion(needsPositionStyleConversion)
     , m_standardFontFamilySerializationMode(standardFontFamilySerializationMode)
     , m_shouldPreserveMSOList(msoListMode == MSOListMode::Preserve)

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -38,6 +38,7 @@
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
 #include "NodeName.h"
+#include "Quirks.h"
 #include "RenderStyle.h"
 #include "Settings.h"
 #include "StyleResolveForDocument.h"
@@ -185,6 +186,8 @@ void HTMLMetaElement::process()
 #endif
     else if (equalLettersIgnoringASCIICase(nameValue, "referrer"_s))
         document().processReferrerPolicy(contentValue, ReferrerPolicySource::MetaTag);
+    else if (equalLettersIgnoringASCIICase(nameValue, "confluence-request-time"_s))
+        document().quirks().setNeedsToCopyUserSelectNoneQuirk();
 }
 
 const AtomString& HTMLMetaElement::content() const

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -35,6 +35,7 @@
 #include "Editing.h"
 #include "FrameSelection.h"
 #include "LocalFrame.h"
+#include "Quirks.h"
 #include "Range.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
@@ -510,12 +511,17 @@ String DOMSelection::toString() const
     auto frame = this->frame();
     if (!frame)
         return String();
+
+    OptionSet<TextIteratorBehavior> options;
+    if (!frame->document()->quirks().needsToCopyUserSelectNoneQuirk())
+        options.add(TextIteratorBehavior::IgnoresUserSelectNone);
+
     if (frame->settings().liveRangeSelectionEnabled()) {
         auto range = frame->selection().selection().range();
-        return range ? plainText(*range, TextIteratorBehavior::IgnoresUserSelectNone) : emptyString();
+        return range ? plainText(*range, options) : emptyString();
     }
     auto range = frame->selection().selection().firstRange();
-    return range ? plainText(*range, TextIteratorBehavior::IgnoresUserSelectNone) : emptyString();
+    return range ? plainText(*range, options) : emptyString();
 }
 
 RefPtr<Node> DOMSelection::shadowAdjustedNode(const Position& position) const

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -170,6 +170,10 @@ public:
     void setNeedsConfigurableIndexedPropertiesQuirk() { m_needsConfigurableIndexedPropertiesQuirk = true; }
     bool needsConfigurableIndexedPropertiesQuirk() const;
 
+    // webkit.org/b/259091.
+    bool needsToCopyUserSelectNoneQuirk() const { return m_needsToCopyUserSelectNoneQuirk; }
+    void setNeedsToCopyUserSelectNoneQuirk() { m_needsToCopyUserSelectNoneQuirk = true; }
+
 private:
     bool needsQuirks() const;
 
@@ -232,6 +236,7 @@ private:
     mutable std::optional<bool> m_shouldAdvertiseSupportForHLSSubtitleTypes;
 #endif
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
+    bool m_needsToCopyUserSelectNoneQuirk { false };
 };
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm
@@ -172,4 +172,14 @@ TEST(CopyRTF, StripsUserSelectNone)
     EXPECT_WK_STREQ([attributedString string].UTF8String, "hello WebKit bar");
 }
 
+TEST(CopyRTF, StripsUserSelectNoneQuirks)
+{
+    auto attributedString = copyAttributedStringFromHTML(@"<meta name='confluence-request-time' content='1689029750234'>"
+        "hello <span style='-webkit-user-select: none; user-select: none;'>world "
+        "<span style='-webkit-user-select: initial; user-select: initial;'>WebKit </span></span>"
+        "<div style='-webkit-user-select: none; user-select: none;'>some<br>user-select-none<br>content</div><span inert>foo </span>bar", false);
+
+    EXPECT_WK_STREQ([attributedString string].UTF8String, "hello world WebKit\nsome\nuser-select-none\ncontent\nfoo bar");
+}
+
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 6f132509a670a1b3e8ef9aa552736926b456e8ee
<pre>
REGRESSION(257749@main): Copying table in Confluence on Safari doesn&apos;t copy header rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=259091">https://bugs.webkit.org/show_bug.cgi?id=259091</a>

Reviewed by Wenson Hsieh.

Add a Confluence specific quirk to copy `-webkit-user-select: none` contents.

* LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-content-with-user-select-none-quirks.html: Added.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectedText const):
(WebCore::Editor::selectedTextForDataTransfer const):
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::HTMLConverter):
(HTMLConverter::_enterElement):
(HTMLConverter::_processText):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::StyledMarkupAccumulator):
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::process):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::toString const):
* Source/WebCore/page/Quirks.h:
(WebCore::Quirks::needsToCopyUserSelectNoneQuirk const):
(WebCore::Quirks::setNeedsToCopyUserSelectNoneQuirk):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyRTF.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/265939@main">https://commits.webkit.org/265939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f905973ab0e74a137cfbc3fd5c8d84b7ecd4822a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12328 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12681 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14545 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14492 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10546 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11171 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14518 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9762 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11045 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15380 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1377 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11678 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->