### PR TITLE
[gtest][CMake] Compile the unified source gtest-all.cc

### DIFF
--- a/Source/ThirdParty/gtest/CMakeLists.txt
+++ b/Source/ThirdParty/gtest/CMakeLists.txt
@@ -10,15 +10,8 @@ set(GTEST_INCLUDE_DIRECTORIES
 )
 
 set(GTEST_SOURCES
-    ${GTEST_DIR}/src/gtest.cc
-    ${GTEST_DIR}/src/gtest-death-test.cc
-    ${GTEST_DIR}/src/gtest-filepath.cc
+    ${GTEST_DIR}/src/gtest-all.cc
     ${GTEST_DIR}/src/gtest_main.cc
-    ${GTEST_DIR}/src/gtest-matchers.cc
-    ${GTEST_DIR}/src/gtest-port.cc
-    ${GTEST_DIR}/src/gtest-printers.cc
-    ${GTEST_DIR}/src/gtest-test-part.cc
-    ${GTEST_DIR}/src/gtest-typed-test.cc
 )
 
 set(gtest_DEFINITIONS GTEST_HAS_RTTI=0)


### PR DESCRIPTION
#### 805f2b51a3510329657d290c42c01d175158b26e
<pre>
[gtest][CMake] Compile the unified source gtest-all.cc
<a href="https://bugs.webkit.org/show_bug.cgi?id=259090">https://bugs.webkit.org/show_bug.cgi?id=259090</a>

Reviewed by Yusuke Suzuki.

clang-cl reported the following warning for Windows port:
&gt; ThirdParty\gtest\src\gtest-filepath.cc(68,12): warning: unused variable &apos;kAlternatePathSeparatorString&apos; [-Wunused-const-variable]

clang-cl doesn&apos;t report this warning for the upstream google-test
because it&apos;s using gtest-all.cc. Let&apos;s use it in WebKit.

* Source/ThirdParty/gtest/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/266025@main">https://commits.webkit.org/266025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b818a4623fc13d0267ffed76dab9c8e26a8b69db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11857 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14482 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14506 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9756 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11042 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3092 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->