### PR TITLE
Use Ref<> for MatchedProperties::properties instead of RefPtr<>

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -147,7 +147,7 @@ inline void ElementRuleCollector::addElementStyleProperties(const StylePropertie
     if (!isCacheable)
         m_result->isCacheable = false;
 
-    auto matchedProperty = MatchedProperties { propertySet };
+    auto matchedProperty = MatchedProperties { *propertySet };
     matchedProperty.cascadeLayerPriority = priority;
     matchedProperty.fromStyleAttribute = fromStyleAttribute;
     addMatchedProperties(WTFMove(matchedProperty), DeclarationOrigin::Author);
@@ -262,7 +262,7 @@ void ElementRuleCollector::transferMatchedRules(DeclarationOrigin declarationOri
         }
 
         addMatchedProperties({
-            &matchedRule.ruleData->styleRule().properties(),
+            matchedRule.ruleData->styleRule().properties(),
             static_cast<uint8_t>(matchedRule.ruleData->linkMatchType()),
             matchedRule.ruleData->propertyAllowlist(),
             matchedRule.styleScopeOrdinal,
@@ -611,7 +611,7 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
             auto result = downcast<HTMLElement>(styledElement).directionalityIfDirIsAuto();
             auto& properties = result.value_or(TextDirection::LTR) == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
             if (result)
-                addMatchedProperties({ &properties }, DeclarationOrigin::Author);
+                addMatchedProperties({ properties }, DeclarationOrigin::Author);
         }
     }
     
@@ -666,7 +666,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
         if (matchedProperties.styleScopeOrdinal != ScopeOrdinal::Element)
             return false;
 
-        for (auto current : *matchedProperties.properties) {
+        for (auto current : matchedProperties.properties.get()) {
             // Currently the property cache only copy the non-inherited values and resolve
             // the inherited ones.
             // Here we define some exception were we have to resolve some properties that are not inherited
@@ -699,7 +699,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 void ElementRuleCollector::addAuthorKeyframeRules(const StyleRuleKeyframe& keyframe)
 {
     ASSERT(m_result->authorDeclarations.isEmpty());
-    m_result->authorDeclarations.append({ &keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlistForPseudoId(m_pseudoElementRequest.pseudoId) });
+    m_result->authorDeclarations.append({ keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlistForPseudoId(m_pseudoElementRequest.pseudoId) });
 }
 
 }

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -36,7 +36,7 @@ namespace WebCore::Style {
 enum class FromStyleAttribute : bool { No, Yes };
 
 struct MatchedProperties {
-    RefPtr<const StyleProperties> properties;
+    Ref<const StyleProperties> properties;
     uint8_t linkMatchType { SelectorChecker::MatchAll };
     PropertyAllowlist allowlistType { PropertyAllowlist::None };
     ScopeOrdinal styleScopeOrdinal { ScopeOrdinal::Element };
@@ -65,7 +65,7 @@ inline bool operator==(const MatchResult& a, const MatchResult& b)
 
 inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
 {
-    return a.properties == b.properties
+    return a.properties.ptr() == b.properties.ptr()
         && a.linkMatchType == b.linkMatchType
         && a.allowlistType == b.allowlistType
         && a.styleScopeOrdinal == b.styleScopeOrdinal
@@ -76,7 +76,7 @@ inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
 inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
 {
     add(hasher,
-        matchedProperties.properties.get(),
+        matchedProperties.properties.ptr(),
         matchedProperties.linkMatchType,
         matchedProperties.allowlistType,
         matchedProperties.styleScopeOrdinal,

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -87,7 +87,7 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
 
     m_result.authorDeclarations.reserveCapacity(m_result.authorDeclarations.size() + matchedPageRules.size());
     for (auto* pageRule : matchedPageRules)
-        m_result.authorDeclarations.uncheckedAppend({ &pageRule->properties() });
+        m_result.authorDeclarations.uncheckedAppend({ pageRule->properties() });
 }
 
 static bool checkPageSelectorComponents(const CSSSelector* selector, bool isLeftPage, bool isFirstPage, const String& pageName)

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -196,7 +196,7 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
     auto propertyAllowlist = matchedProperties.allowlistType;
     bool hasImportantProperties = false;
 
-    for (auto current : *matchedProperties.properties) {
+    for (auto current : matchedProperties.properties.get()) {
         if (current.isImportant())
             hasImportantProperties = true;
         if (important != current.isImportant())
@@ -337,7 +337,7 @@ void PropertyCascade::addImportantMatches(CascadeLevel cascadeLevel)
     for (unsigned i = 0; i < matchedDeclarations.size(); ++i) {
         const MatchedProperties& matchedProperties = matchedDeclarations[i];
 
-        if (!hasImportantProperties(*matchedProperties.properties))
+        if (!hasImportantProperties(matchedProperties.properties))
             continue;
 
         importantMatches.append({ i, matchedProperties.styleScopeOrdinal, matchedProperties.cascadeLayerPriority, matchedProperties.fromStyleAttribute });


### PR DESCRIPTION
#### f1c09f61e0a00983a3f6d6c7feda17866e1d7490
<pre>
Use Ref&lt;&gt; for MatchedProperties::properties instead of RefPtr&lt;&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=259092">https://bugs.webkit.org/show_bug.cgi?id=259092</a>

Reviewed by Tim Nguyen.

Use Ref&lt;&gt; for MatchedProperties::properties instead of RefPtr&lt;&gt;, to make it
clear it cannot be null.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addElementStyleProperties):
(WebCore::Style::ElementRuleCollector::transferMatchedRules):
(WebCore::Style::ElementRuleCollector::matchAllRules):
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
(WebCore::Style::ElementRuleCollector::addAuthorKeyframeRules):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::operator==):
(WebCore::Style::add):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::PageRuleCollector::matchPageRules):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::addImportantMatches):

Canonical link: <a href="https://commits.webkit.org/265936@main">https://commits.webkit.org/265936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77c05f25058d27f40735840920e7303fdb16833b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14064 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14540 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13257 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14483 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11165 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11625 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14507 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11819 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11043 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3032 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->