### PR TITLE
Attachments: Tap to download looks huge on visionOS

### DIFF
--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -5,13 +5,13 @@ layer at (0,0) size 800x98
     RenderBody {BODY} at (8,8) size 784x82
       RenderAttachment {ATTACHMENT} at (1,1) size 266x80
         RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-          RenderGrid {DIV} at (0,0) size 66x80
-            RenderImage {IMG} at (14,14) size 52x52
-          RenderFlexibleBox {DIV} at (70,0) size 172x80
-            RenderGrid {DIV} at (0,40) size 172x0
-      RenderText {#text} at (268,52) size 4x18
-        text run at (268,52) width 4: " "
-      RenderImage {IMG} at (272,46) size 20x20
+          RenderGrid {DIV} at (14,14) size 0x52
+            RenderImage {IMG} at (0,26) size 0x0
+          RenderFlexibleBox {DIV} at (32,0) size 210x80
+            RenderGrid {DIV} at (0,40) size 210x0
+      RenderText {#text} at (268,26) size 4x18
+        text run at (268,26) width 4: " "
+      RenderImage {IMG} at (272,20) size 20x20
       RenderText {#text} at (0,0) size 0x0
 layer at (9,9) size 266x80
   RenderBlock (relative positioned) {DIV} at (0,0) size 266x80 [color=#00000000]

--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -4,51 +4,51 @@ layer at (0,0) size 800x777
   RenderBlock {HTML} at (0,0) size 800x777
     RenderBody {BODY} at (8,8) size 784x761
       RenderBlock {DIV} at (0,0) size 784x94
-        RenderText {#text} at (0,67) size 47x19
-          text run at (0,67) width 47: "Blank: "
+        RenderText {#text} at (0,31) size 47x19
+          text run at (0,31) width 47: "Blank: "
         RenderAttachment {ATTACHMENT} at (47,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,46) size 230x0
+            RenderGrid {DIV} at (10,10) size 0x72
+              RenderImage {IMG} at (0,36) size 0x0
+            RenderFlexibleBox {DIV} at (20,0) size 292x92
+              RenderGrid {DIV} at (0,46) size 292x0
       RenderBlock {DIV} at (0,94) size 784x94
-        RenderText {#text} at (0,67) size 39x19
-          text run at (0,67) width 39: "Title: "
+        RenderText {#text} at (0,31) size 39x19
+          text run at (0,31) width 39: "Title: "
         RenderAttachment {ATTACHMENT} at (39,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,31) size 230x30
+            RenderGrid {DIV} at (10,10) size 0x72
+              RenderImage {IMG} at (0,36) size 0x0
+            RenderFlexibleBox {DIV} at (20,0) size 292x92
+              RenderGrid {DIV} at (0,31) size 292x30
       RenderBlock {DIV} at (0,188) size 784x94
-        RenderText {#text} at (0,67) size 83x19
-          text run at (0,67) width 83: "and subtitle: "
+        RenderText {#text} at (0,31) size 83x19
+          text run at (0,31) width 83: "and subtitle: "
         RenderAttachment {ATTACHMENT} at (83,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,31) size 230x30
+            RenderGrid {DIV} at (10,10) size 0x72
+              RenderImage {IMG} at (0,36) size 0x0
+            RenderFlexibleBox {DIV} at (20,0) size 292x92
+              RenderGrid {DIV} at (0,31) size 292x30
       RenderBlock {DIV} at (0,282) size 784x94
-        RenderText {#text} at (0,67) size 52x19
-          text run at (0,67) width 52: "Action: "
+        RenderText {#text} at (0,31) size 52x19
+          text run at (0,31) width 52: "Action: "
         RenderAttachment {ATTACHMENT} at (52,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,22) size 230x48
+            RenderGrid {DIV} at (10,10) size 0x72
+              RenderImage {IMG} at (0,36) size 0x0
+            RenderFlexibleBox {DIV} at (20,0) size 292x92
+              RenderGrid {DIV} at (0,22) size 292x48
       RenderBlock {DIV} at (0,376) size 784x94
-        RenderText {#text} at (0,67) size 40x19
-          text run at (0,67) width 40: "Save: "
+        RenderText {#text} at (0,31) size 40x19
+          text run at (0,31) width 40: "Save: "
         RenderAttachment {ATTACHMENT} at (40,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderImage {IMG} at (10,10) size 72x72
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,26) size 230x40
-                RenderBlock {DIV} at (190,0) size 40x40
+            RenderGrid {DIV} at (10,10) size 0x72
+              RenderImage {IMG} at (0,36) size 0x0
+            RenderFlexibleBox {DIV} at (20,0) size 292x92
+              RenderGrid {DIV} at (0,26) size 292x40
+                RenderBlock {DIV} at (252,0) size 40x40
                   RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#7676801F]
                     RenderBlock (anonymous) at (0,0) size 40x40
       RenderBlock {DIV} at (0,470) size 784x97
@@ -56,92 +56,92 @@ layer at (0,0) size 800x777
           text run at (0,77) width 97: "Zero progress: "
         RenderAttachment {ATTACHMENT} at (97,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,37) size 230x18
+            RenderGrid {DIV} at (10,10) size 54x72
+            RenderFlexibleBox {DIV} at (74,0) size 238x92
+              RenderGrid {DIV} at (0,37) size 238x18
       RenderBlock {DIV} at (0,567) size 784x97
         RenderText {#text} at (0,77) size 96x19
           text run at (0,77) width 96: "75% progress: "
         RenderAttachment {ATTACHMENT} at (96,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
-                RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+            RenderGrid {DIV} at (10,10) size 54x72
+              RenderBlock {DIV} at (0,9) size 54x54 [color=#3C3C4399]
+                RenderBlock (generated) at (0,0) size 54x54 [border: (4px solid #3C3C4399)]
                   RenderText at (0,0) size 0x0
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,37) size 230x18
+            RenderFlexibleBox {DIV} at (74,0) size 238x92
+              RenderGrid {DIV} at (0,37) size 238x18
       RenderBlock {DIV} at (0,664) size 784x97
         RenderText {#text} at (0,77) size 104x19
           text run at (0,77) width 104: "100% progress: "
         RenderAttachment {ATTACHMENT} at (104,1) size 339x92 [color=#007AFF]
           RenderFlexibleBox {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
-            RenderGrid {DIV} at (0,0) size 82x92
-              RenderBlock {DIV} at (10,10) size 72x72 [color=#3C3C4399]
-                RenderBlock (generated) at (0,0) size 72x72 [border: (4px solid #3C3C4399)]
+            RenderGrid {DIV} at (10,10) size 54x72
+              RenderBlock {DIV} at (0,9) size 54x54 [color=#3C3C4399]
+                RenderBlock (generated) at (0,0) size 54x54 [border: (4px solid #3C3C4399)]
                   RenderText at (0,0) size 0x0
-            RenderFlexibleBox {DIV} at (82,0) size 230x92
-              RenderGrid {DIV} at (0,37) size 230x18
-layer at (129,134) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+            RenderFlexibleBox {DIV} at (74,0) size 238x92
+              RenderGrid {DIV} at (0,37) size 238x18
+layer at (67,134) size 292x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 292x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 292x17
       RenderText {#text} at (0,0) size 29x17
         text run at (0,0) width 29: "Title"
-layer at (129,151) size 230x13
-  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x13 [color=#3C3C4399]
-    RenderBlock (anonymous) at (0,0) size 230x13
+layer at (67,151) size 292x13
+  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 292x13 [color=#3C3C4399]
+    RenderBlock (anonymous) at (0,0) size 292x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (174,228) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (112,228) size 292x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 292x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 292x17
       RenderText {#text} at (0,0) size 29x17
         text run at (0,0) width 29: "Title"
-layer at (174,245) size 230x13
-  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x13 [color=#3C3C4399]
-    RenderBlock (anonymous) at (0,0) size 230x13
+layer at (112,245) size 292x13
+  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 292x13 [color=#3C3C4399]
+    RenderBlock (anonymous) at (0,0) size 292x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (143,314) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#3C3C4399]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (81,314) size 292x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 292x17 [color=#3C3C4399]
+    RenderBlock (anonymous) at (0,0) size 292x17
       RenderText {#text} at (0,0) size 106x17
         text run at (0,0) width 106: "Tap to download"
-layer at (143,331) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (81,331) size 292x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,17) size 292x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 292x17
       RenderText {#text} at (0,0) size 52x17
         text run at (0,0) width 52: "\x{200E}\x{2068}Title\x{2069}\x{200B}.txt"
-layer at (143,348) size 230x13
-  RenderDeprecatedFlexibleBox {DIV} at (0,34) size 230x13 [color=#3C3C4399]
-    RenderBlock (anonymous) at (0,0) size 230x13
+layer at (81,348) size 292x13
+  RenderDeprecatedFlexibleBox {DIV} at (0,34) size 292x13 [color=#3C3C4399]
+    RenderBlock (anonymous) at (0,0) size 292x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (131,411) size 118x8 backgroundClip at (131,411) size 117x8 clip at (131,411) size 117x8
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 118x8 [color=#3C3C4399]
-layer at (131,419) size 118x24 backgroundClip at (131,419) size 117x24 clip at (131,419) size 117x24
-  RenderDeprecatedFlexibleBox {DIV} at (0,7) size 118x26 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 118x17
+layer at (69,411) size 149x8 backgroundClip at (69,411) size 148x8 clip at (69,411) size 148x8
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 149x8 [color=#3C3C4399]
+layer at (69,419) size 149x24 backgroundClip at (69,419) size 148x24 clip at (69,419) size 148x24
+  RenderDeprecatedFlexibleBox {DIV} at (0,7) size 149x26 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 149x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (131,443) size 118x8 backgroundClip at (131,443) size 117x8 clip at (131,443) size 117x8
-  RenderDeprecatedFlexibleBox {DIV} at (0,32) size 118x8 [color=#3C3C4399]
-layer at (188,517) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (69,443) size 149x8 backgroundClip at (69,443) size 148x8 clip at (69,443) size 148x8
+  RenderDeprecatedFlexibleBox {DIV} at (0,32) size 149x8 [color=#3C3C4399]
+layer at (180,517) size 238x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 238x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 238x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (187,614) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (179,614) size 238x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 238x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 238x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (195,711) size 230x17
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
-    RenderBlock (anonymous) at (0,0) size 230x17
+layer at (187,711) size 238x17
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 238x17 [color=#000000]
+    RenderBlock (anonymous) at (0,0) size 238x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (321,411) size 40x40
   RenderBlock (generated) at (0,0) size 40x40 [bgcolor=#007AFF]
     RenderText at (0,0) size 0x0
-layer at (116,489) size 72x72
-  RenderBlock {DIV} at (10,10) size 72x72 [bgcolor=#000000]
+layer at (116,498) size 54x54
+  RenderBlock {DIV} at (0,9) size 54x54 [bgcolor=#000000]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -4,51 +4,51 @@ layer at (0,0) size 785x678
   RenderBlock {HTML} at (0,0) size 785x678
     RenderBody {BODY} at (8,8) size 769x662
       RenderBlock {DIV} at (0,0) size 769x82
-        RenderText {#text} at (0,52) size 47x18
-          text run at (0,52) width 47: "Blank: "
+        RenderText {#text} at (0,26) size 47x18
+          text run at (0,26) width 47: "Blank: "
         RenderAttachment {ATTACHMENT} at (47,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,40) size 172x0
+            RenderGrid {DIV} at (14,14) size 0x52
+              RenderImage {IMG} at (0,26) size 0x0
+            RenderFlexibleBox {DIV} at (32,0) size 210x80
+              RenderGrid {DIV} at (0,40) size 210x0
       RenderBlock {DIV} at (0,82) size 769x82
-        RenderText {#text} at (0,52) size 39x18
-          text run at (0,52) width 39: "Title: "
+        RenderText {#text} at (0,26) size 39x18
+          text run at (0,26) width 39: "Title: "
         RenderAttachment {ATTACHMENT} at (39,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,26) size 172x28
+            RenderGrid {DIV} at (14,14) size 0x52
+              RenderImage {IMG} at (0,26) size 0x0
+            RenderFlexibleBox {DIV} at (32,0) size 210x80
+              RenderGrid {DIV} at (0,26) size 210x28
       RenderBlock {DIV} at (0,164) size 769x82
-        RenderText {#text} at (0,52) size 83x18
-          text run at (0,52) width 83: "and subtitle: "
+        RenderText {#text} at (0,26) size 83x18
+          text run at (0,26) width 83: "and subtitle: "
         RenderAttachment {ATTACHMENT} at (83,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,26) size 172x28
+            RenderGrid {DIV} at (14,14) size 0x52
+              RenderImage {IMG} at (0,26) size 0x0
+            RenderFlexibleBox {DIV} at (32,0) size 210x80
+              RenderGrid {DIV} at (0,26) size 210x28
       RenderBlock {DIV} at (0,246) size 769x82
-        RenderText {#text} at (0,52) size 52x18
-          text run at (0,52) width 52: "Action: "
+        RenderText {#text} at (0,26) size 52x18
+          text run at (0,26) width 52: "Action: "
         RenderAttachment {ATTACHMENT} at (52,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,18) size 172x44
+            RenderGrid {DIV} at (14,14) size 0x52
+              RenderImage {IMG} at (0,26) size 0x0
+            RenderFlexibleBox {DIV} at (32,0) size 210x80
+              RenderGrid {DIV} at (0,18) size 210x44
       RenderBlock {DIV} at (0,328) size 769x82
-        RenderText {#text} at (0,52) size 40x18
-          text run at (0,52) width 40: "Save: "
+        RenderText {#text} at (0,26) size 40x18
+          text run at (0,26) width 40: "Save: "
         RenderAttachment {ATTACHMENT} at (40,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderImage {IMG} at (14,14) size 52x52
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,26) size 172x28
-                RenderBlock {DIV} at (144,0) size 28x28
+            RenderGrid {DIV} at (14,14) size 0x52
+              RenderImage {IMG} at (0,26) size 0x0
+            RenderFlexibleBox {DIV} at (32,0) size 210x80
+              RenderGrid {DIV} at (0,26) size 210x28
+                RenderBlock {DIV} at (182,0) size 28x28
                   RenderButton {BUTTON} at (0,0) size 28x28 [color=#00000019] [border: (1px solid #00000019)]
                     RenderBlock (anonymous) at (1,1) size 26x26
       RenderBlock {DIV} at (0,410) size 769x84
@@ -56,92 +56,92 @@ layer at (0,0) size 785x678
           text run at (0,66) width 97: "Zero progress: "
         RenderAttachment {ATTACHMENT} at (97,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,32) size 172x16
+            RenderGrid {DIV} at (14,14) size 39x52
+            RenderFlexibleBox {DIV} at (71,0) size 171x80
+              RenderGrid {DIV} at (0,32) size 171x16
       RenderBlock {DIV} at (0,494) size 769x84
         RenderText {#text} at (0,66) size 96x18
           text run at (0,66) width 96: "75% progress: "
         RenderAttachment {ATTACHMENT} at (96,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
-                RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
+            RenderGrid {DIV} at (14,14) size 39x52
+              RenderBlock {DIV} at (0,6) size 39x40 [color=#0000007F]
+                RenderBlock (generated) at (0,0) size 39x39 [border: (4px solid #0000007F)]
                   RenderText at (0,0) size 0x0
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,32) size 172x16
+            RenderFlexibleBox {DIV} at (71,0) size 171x80
+              RenderGrid {DIV} at (0,32) size 171x16
       RenderBlock {DIV} at (0,578) size 769x84
         RenderText {#text} at (0,66) size 104x18
           text run at (0,66) width 104: "100% progress: "
         RenderAttachment {ATTACHMENT} at (104,1) size 267x80
           RenderFlexibleBox {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
-            RenderGrid {DIV} at (0,0) size 66x80
-              RenderBlock {DIV} at (14,14) size 52x52 [color=#0000007F]
-                RenderBlock (generated) at (0,0) size 52x52 [border: (4px solid #0000007F)]
+            RenderGrid {DIV} at (14,14) size 39x52
+              RenderBlock {DIV} at (0,6) size 39x40 [color=#0000007F]
+                RenderBlock (generated) at (0,0) size 39x39 [border: (4px solid #0000007F)]
                   RenderText at (0,0) size 0x0
-            RenderFlexibleBox {DIV} at (70,0) size 172x80
-              RenderGrid {DIV} at (0,32) size 172x16
-layer at (117,117) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+            RenderFlexibleBox {DIV} at (71,0) size 171x80
+              RenderGrid {DIV} at (0,32) size 171x16
+layer at (79,117) size 210x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 210x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 210x16
       RenderText {#text} at (0,0) size 29x16
         text run at (0,0) width 29: "Title"
-layer at (117,133) size 172x12
-  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 172x12 [color=#0000007F]
-    RenderBlock (anonymous) at (0,0) size 172x12
+layer at (79,133) size 210x12
+  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 210x12 [color=#0000007F]
+    RenderBlock (anonymous) at (0,0) size 210x12
       RenderText {#text} at (0,0) size 38x12
         text run at (0,0) width 38: "Subtitle"
-layer at (162,199) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (124,199) size 210x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 210x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 210x16
       RenderText {#text} at (0,0) size 29x16
         text run at (0,0) width 29: "Title"
-layer at (162,215) size 172x12
-  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 172x12 [color=#0000007F]
-    RenderBlock (anonymous) at (0,0) size 172x12
+layer at (124,215) size 210x12
+  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 210x12 [color=#0000007F]
+    RenderBlock (anonymous) at (0,0) size 210x12
       RenderText {#text} at (0,0) size 38x12
         text run at (0,0) width 38: "Subtitle"
-layer at (131,273) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#0000007F]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (93,273) size 210x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 210x16 [color=#0000007F]
+    RenderBlock (anonymous) at (0,0) size 210x16
       RenderText {#text} at (0,0) size 106x16
         text run at (0,0) width 106: "Tap to download"
-layer at (131,289) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (93,289) size 210x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,16) size 210x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 210x16
       RenderText {#text} at (0,0) size 52x16
         text run at (0,0) width 52: "\x{200E}\x{2068}Title\x{2069}\x{200B}.txt"
-layer at (131,305) size 172x12
-  RenderDeprecatedFlexibleBox {DIV} at (0,32) size 172x12 [color=#0000007F]
-    RenderBlock (anonymous) at (0,0) size 172x12
+layer at (93,305) size 210x12
+  RenderDeprecatedFlexibleBox {DIV} at (0,32) size 210x12 [color=#0000007F]
+    RenderBlock (anonymous) at (0,0) size 210x12
       RenderText {#text} at (0,0) size 38x12
         text run at (0,0) width 38: "Subtitle"
-layer at (119,363) size 95x4 backgroundClip at (119,363) size 94x4 clip at (119,363) size 94x4
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 95x4 [color=#0000007F]
-layer at (119,367) size 95x20 backgroundClip at (119,367) size 94x20 clip at (119,367) size 94x20
-  RenderDeprecatedFlexibleBox {DIV} at (0,4) size 95x20 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 95x16
+layer at (81,363) size 114x4 backgroundClip at (81,363) size 113x4 clip at (81,363) size 113x4
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 114x4 [color=#0000007F]
+layer at (81,367) size 114x20 backgroundClip at (81,367) size 113x20 clip at (81,367) size 113x20
+  RenderDeprecatedFlexibleBox {DIV} at (0,4) size 114x20 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 114x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (119,387) size 95x4 backgroundClip at (119,387) size 94x4 clip at (119,387) size 94x4
-  RenderDeprecatedFlexibleBox {DIV} at (0,24) size 95x4 [color=#0000007F]
-layer at (176,451) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (81,387) size 114x4 backgroundClip at (81,387) size 113x4 clip at (81,387) size 113x4
+  RenderDeprecatedFlexibleBox {DIV} at (0,24) size 114x4 [color=#0000007F]
+layer at (177,451) size 171x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 171x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 171x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (175,535) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (176,535) size 171x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 171x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 171x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (183,619) size 172x16
-  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 172x16 [color=#000000D8]
-    RenderBlock (anonymous) at (0,0) size 172x16
+layer at (184,619) size 171x16
+  RenderDeprecatedFlexibleBox {DIV} at (0,0) size 171x16 [color=#000000D8]
+    RenderBlock (anonymous) at (0,0) size 171x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
 layer at (264,364) size 26x26
   RenderBlock (generated) at (0,0) size 26x26 [bgcolor=#0000007F]
     RenderText at (0,0) size 0x0
-layer at (120,433) size 52x52
-  RenderBlock {DIV} at (14,14) size 52x52 [bgcolor=#000000D8]
+layer at (120,440) size 39x39
+  RenderBlock {DIV} at (0,6) size 39x40 [bgcolor=#000000D8]

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -74,6 +74,14 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLAttachmentElement);
 
 using namespace HTMLNames;
 
+#if PLATFORM(VISION)
+constexpr float attachmentIconSize = 40;
+#elif PLATFORM(IOS_FAMILY)
+constexpr float attachmentIconSize = 72;
+#else
+constexpr float attachmentIconSize = 52;
+#endif
+
 HTMLAttachmentElement::HTMLAttachmentElement(const QualifiedName& tagName, Document& document)
     : HTMLElement(tagName, document)
 {
@@ -178,6 +186,12 @@ static const AtomString& attachmentSaveButtonIdentifier()
     return identifier;
 }
 
+static const AtomString& attachmentIconSizeProperty()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("--icon-size"_s);
+    return identifier;
+}
+
 static const AtomString& saveAtom()
 {
     static MainThreadNeverDestroyed<const AtomString> identifier("save"_s);
@@ -208,6 +222,7 @@ void HTMLAttachmentElement::ensureWideLayoutShadowTree(ShadowRoot& root)
 
     m_containerElement = HTMLDivElement::create(document());
     m_containerElement->setIdAttribute(attachmentContainerIdentifier());
+    m_containerElement->setInlineStyleCustomProperty(attachmentIconSizeProperty(), makeString(attachmentIconSize, "px"_s));
     root.appendChild(*m_containerElement);
 
     auto previewArea = createContainedElement<HTMLDivElement>(*m_containerElement, attachmentPreviewAreaIdentifier());
@@ -682,14 +697,9 @@ void HTMLAttachmentElement::requestWideLayoutIconIfNeeded()
     if (!m_imageElement || !document().page() || !document().page()->attachmentElementClient())
         return;
 
-    bool unusedIsReplaced;
-    auto rect = m_imageElement->renderRect(&unusedIsReplaced);
-    if (rect.isEmpty())
-        return;
-
     m_needsWideLayoutIconRequest = false;
 
-    document().page()->attachmentElementClient()->requestAttachmentIcon(uniqueIdentifier(), FloatSize(rect.width().toFloat(), rect.height().toFloat()));
+    document().page()->attachmentElementClient()->requestAttachmentIcon(uniqueIdentifier(), FloatSize(attachmentIconSize, attachmentIconSize));
 }
 
 void HTMLAttachmentElement::requestIconWithSize(const FloatSize& size) const

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -24,14 +24,18 @@
 
 div#attachment-container {
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-    --icon-size: 72px;
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    --icon-margin: 8px;
+    --information-margin-end: 8px;
+    width: 187px;
+#else
     --icon-margin: 10px;
-    gap: 0;
     --information-margin-end: 26px;
     width: 338px;
+#endif
+    gap: 0;
     background-color: -apple-system-quaternary-fill;
 #else
-    --icon-size: 52px;
     --icon-margin: 14px;
     gap: 4px;
     --information-margin-end: 24px;
@@ -48,22 +52,30 @@ div#attachment-container {
 }
 
 div#attachment-preview-area {
-    width: calc(var(--icon-size) + var(--icon-margin));
     display: grid;
     align-items: center;
     justify-items: end;
     flex-shrink: 0;
+    margin: var(--icon-margin);
 }
 
 img#attachment-icon,
 div#attachment-placeholder,
 div#attachment-progress {
     grid-area: 1 / 1;
-    width: var(--icon-size);
-    aspect-ratio: 1;
+    align-self: center;
+    justify-self: center;
+}
+
+div#attachment-placeholder,
+div#attachment-progress {
+    width: calc(3/4 * var(--icon-size));
+    height: calc(3/4 * var(--icon-size));
 }
 
 img#attachment-icon {
+    max-width: var(--icon-size);
+    max-height: var(--icon-size);
     object-fit: contain;
 }
 
@@ -105,10 +117,14 @@ div#attachment-information-block {
 }
 
 div#attachment-action {
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    font-size: x-small;
+#else
+    font-size: small;
+#endif
     grid-row: 1;
     grid-column: 1;
     justify-self: stretch;
-    font-size: small;
     font-weight: bold;
     color: -apple-system-secondary-label;
     display: -webkit-box;
@@ -118,10 +134,14 @@ div#attachment-action {
 }
 
 div#attachment-title {
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    font-size: x-small;
+#else
+    font-size: small;
+#endif
     grid-row: 2;
     grid-column: 1;
     justify-self: stretch;
-    font-size: small;
     font-weight: bold;
     color: -apple-system-label;
     overflow-wrap: anywhere;
@@ -132,10 +152,14 @@ div#attachment-title {
 }
 
 div#attachment-subtitle {
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    font-size: xx-small;
+#else
+    font-size: x-small;
+#endif
     grid-row: 3;
     grid-column: 1;
     justify-self: stretch;
-    font-size: x-small;
     color: -apple-system-secondary-label;
     display: -webkit-box;
     -webkit-line-clamp: 1;
@@ -153,8 +177,13 @@ div#attachment-save-area {
 
 button#attachment-save-button {
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    width: 28px;
+    height: 28px;
+#else
     width: 40px;
     height: 40px;
+#endif
     background-color: -apple-system-tertiary-fill;
     border: 0;
 #else
@@ -170,6 +199,17 @@ button#attachment-save-button {
 }
 
 button#attachment-save-button::before {
+#if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+#if (defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION)
+    mask-size: 14px;
+#else
+    mask-size: 18px;
+#endif
+    background-color: -apple-system-blue;
+#else
+    mask-size: 14px;
+    background-color: -apple-system-secondary-label;
+#endif
     content: "";
     display: block;
     /* SF Symbol square-and-arrow-down from https://copysfsymbols.apple.com/bold.html */
@@ -178,11 +218,4 @@ button#attachment-save-button::before {
     mask-position: center;
     width: 100%;
     height: 100%;
-#if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-    mask-size: 18px;
-    background-color: -apple-system-blue;
-#else
-    mask-size: 14px;
-    background-color: -apple-system-secondary-label;
-#endif
 }


### PR DESCRIPTION
#### 5a50cf705fe831dbdf8333b654234d3256b114ef
<pre>
Attachments: Tap to download looks huge on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=259094">https://bugs.webkit.org/show_bug.cgi?id=259094</a>
rdar://109599374

Reviewed by Tim Nguyen.

Adjust the size of the attachment element components to compensate for the scale difference of visionOS.

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::attachmentIconSizeProperty):
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::HTMLAttachmentElement::requestWideLayoutIconIfNeeded):
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
(img#attachment-icon,):
(div#attachment-action):
(div#attachment-title):
(div#attachment-subtitle):
(button#attachment-save-button):

Canonical link: <a href="https://commits.webkit.org/266038@main">https://commits.webkit.org/266038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/413c403d6132b30f45066997dd420272c7f86082

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18498 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14768 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11298 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->