### PR TITLE
RemoteInspectorSocketWin.cpp: warning: cast from 'struct sockaddr *' to 'struct sockaddr_in *' increases required alignment from 2 to 4

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/socket/win/RemoteInspectorSocketWin.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/win/RemoteInspectorSocketWin.cpp
@@ -169,7 +169,7 @@ std::optional<PlatformSocketType> connect(const char* serverAddress, uint16_t se
         hints.ai_socktype = SOCK_STREAM;
         hints.ai_family = AF_INET;
         if (!getaddrinfo(serverAddress, 0, &hints, &res)) {
-            address.sin_addr = ((struct sockaddr_in*)(res->ai_addr))->sin_addr;
+            address.sin_addr = reinterpret_cast<struct sockaddr_in*>(res->ai_addr)->sin_addr;
             freeaddrinfo(res);
         }
     }


### PR DESCRIPTION
#### f43f814b129e0da721ae11915c42e4e73d3607a1
<pre>
RemoteInspectorSocketWin.cpp: warning: cast from &apos;struct sockaddr *&apos; to &apos;struct sockaddr_in *&apos; increases required alignment from 2 to 4
<a href="https://bugs.webkit.org/show_bug.cgi?id=259096">https://bugs.webkit.org/show_bug.cgi?id=259096</a>

Reviewed by Ross Kirsling.

clang-cl reported the following warning for Windows port.

&gt; JavaScriptCore\inspector\remote\socket\win\RemoteInspectorSocketWin.cpp(172,33): warning: cast from &apos;struct sockaddr *&apos; to &apos;struct sockaddr_in *&apos; increases required alignment from 2 to 4 [-Wcast-align]
&gt;             address.sin_addr = ((struct sockaddr_in*)(res-&gt;ai_addr))-&gt;sin_addr;
&gt;                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Source/JavaScriptCore/inspector/remote/socket/win/RemoteInspectorSocketWin.cpp:
(Inspector::Socket::connect): Use reinterpret_cast instead of C style cast to suppress the warning.

Canonical link: <a href="https://commits.webkit.org/265984@main">https://commits.webkit.org/265984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f2e92710d57d85e86ce26eb0389688faf6124c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14082 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14551 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14504 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18287 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11635 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11346 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14528 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9768 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12401 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11061 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3254 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15391 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12754 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1397 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11688 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3035 "Passed tests") | 
<!--EWS-Status-Bubble-End-->