### PR TITLE
FileSystemWin.cpp: warning: unused function 'getFileSizeFromFindData' and 'fileModificationTimeFromFindData'

### DIFF
--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -58,19 +58,6 @@ static bool getFindData(String path, WIN32_FIND_DATAW& findData)
     return true;
 }
 
-static bool getFileSizeFromFindData(const WIN32_FIND_DATAW& findData, long long& size)
-{
-    ULARGE_INTEGER fileSize;
-    fileSize.HighPart = findData.nFileSizeHigh;
-    fileSize.LowPart = findData.nFileSizeLow;
-
-    if (fileSize.QuadPart > static_cast<ULONGLONG>(std::numeric_limits<long long>::max()))
-        return false;
-
-    size = fileSize.QuadPart;
-    return true;
-}
-
 static std::optional<uint64_t> getFileSizeFromByHandleFileInformationStructure(const BY_HANDLE_FILE_INFORMATION& fileInformation)
 {
     ULARGE_INTEGER fileSize;
@@ -93,16 +80,6 @@ static void fileCreationTimeFromFindData(const WIN32_FIND_DATAW& findData, time_
     time = fileTime.QuadPart / 10000000 - kSecondsFromFileTimeToTimet;
 }
 
-
-static void fileModificationTimeFromFindData(const WIN32_FIND_DATAW& findData, time_t& time)
-{
-    ULARGE_INTEGER fileTime;
-    fileTime.HighPart = findData.ftLastWriteTime.dwHighDateTime;
-    fileTime.LowPart = findData.ftLastWriteTime.dwLowDateTime;
-
-    // Information about converting time_t to FileTime is available at http://msdn.microsoft.com/en-us/library/ms724228%28v=vs.85%29.aspx
-    time = fileTime.QuadPart / 10000000 - kSecondsFromFileTimeToTimet;
-}
 
 std::optional<uint64_t> fileSize(PlatformFileHandle fileHandle)
 {


### PR DESCRIPTION
#### e57a429e193977681da5e369136b92bc0031ef1a
<pre>
FileSystemWin.cpp: warning: unused function &apos;getFileSizeFromFindData&apos; and &apos;fileModificationTimeFromFindData&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=259098">https://bugs.webkit.org/show_bug.cgi?id=259098</a>

Reviewed by Don Olmstead.

clang-cl reported warnings for Windows port:

&gt; wtf\win\FileSystemWin.cpp(61,13): warning: unused function &apos;getFileSizeFromFindData&apos; [-Wunused-function]
&gt; wtf\win\FileSystemWin.cpp(97,13): warning: unused function &apos;fileModificationTimeFromFindData&apos; [-Wunused-function]

They are unused since 237444@main (bug#225362). Removed them.

* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::getFileSizeFromFindData): Deleted.
(WTF::FileSystemImpl::fileModificationTimeFromFindData): Deleted.

Canonical link: <a href="https://commits.webkit.org/265961@main">https://commits.webkit.org/265961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/764549b83585753b5f1bcd3e88c42c5e9c846f4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14507 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18291 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10499 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11349 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14533 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11680 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9772 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12404 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11064 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3257 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15394 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12757 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1384 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11691 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3038 "Passed tests") | 
<!--EWS-Status-Bubble-End-->