### PR TITLE
Fix clang-cl warnings of WebCore for Windows port

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -156,7 +156,7 @@ void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destinati
                 return;
 
             Ref itemTypeLoader { *weakItemTypeLoader };
-#if !COMPILER(MSVC)
+#if !(COMPILER(MSVC) && !COMPILER(CLANG))
             ASSERT_UNUSED(this, notFound != m_itemTypeLoaders.findIf([&] (auto& loader) { return loader.ptr() == itemTypeLoader.ptr(); }));
 #endif
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -297,6 +297,9 @@ void FullscreenManager::cancelFullscreen()
     m_pendingExitFullscreen = true;
 
     m_document.eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, topDocument = WTFMove(topDocument), identifier = LOGIDENTIFIER] {
+#if RELEASE_LOG_DISABLED
+        UNUSED_PARAM(this);
+#endif
         if (!weakThis)
             return;
 

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -245,6 +245,8 @@ std::unique_ptr<GLContext> GLContext::createWindowContext(GLNativeWindowType win
     case PlatformDisplay::Type::Surfaceless:
         RELEASE_ASSERT_NOT_REACHED();
         break;
+    default:
+        break;
     }
 
     if (surface == EGL_NO_SURFACE) {
@@ -377,6 +379,8 @@ std::unique_ptr<GLContext> GLContext::createOffscreen(PlatformDisplay& platformD
             // Do not fallback to pbuffers.
             WTFLogAlways("Could not create EGL surfaceless context: %s.", lastErrorString());
             return nullptr;
+        default:
+            break;
         }
     }
     if (!context) {
@@ -424,6 +428,8 @@ std::unique_ptr<GLContext> GLContext::createSharing(PlatformDisplay& platformDis
             // Do not fallback to pbuffers.
             WTFLogAlways("Could not create EGL surfaceless context: %s.", lastErrorString());
             return nullptr;
+        default:
+            break;
         }
     }
     if (!context) {

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -138,7 +138,6 @@ static Vector<unsigned> stringIndicesFromClusters(const Vector<WORD>& clusters, 
     BidiRange<unsigned> stringIndicesRange(stringIndices, isLTR);
     auto glyphIndex = stringIndicesRange.begin();
     unsigned stringIndex = 0;
-    int i = 0;
     for (;;) {
         auto startStringIndex = stringIndex;
         auto startGlyphIndex = clusters[stringIndex];

--- a/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
+++ b/Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp
@@ -63,6 +63,8 @@ public:
     {
     }
 
+    virtual ~AsyncCallback() { }
+
     HRESULT STDMETHODCALLTYPE QueryInterface(_In_ REFIID riid, __RPC__deref_out void __RPC_FAR *__RPC_FAR *ppvObject) override
     {
         static const QITAB qit[] = {
@@ -2831,7 +2833,6 @@ void MediaPlayerPrivateMediaFoundation::Direct3DPresenter::paintCurrentFrame(Web
 
         ASSERT(cairoFormat != CAIRO_FORMAT_INVALID);
 
-        cairo_surface_t* image = nullptr;
         if (cairoFormat != CAIRO_FORMAT_INVALID) {
             auto surface = adoptRef(cairo_image_surface_create_for_data(static_cast<unsigned char*>(data), cairoFormat, width, height, pitch));
             auto image = NativeImage::create(WTFMove(surface));

--- a/Source/WebCore/platform/win/KeyEventWin.cpp
+++ b/Source/WebCore/platform/win/KeyEventWin.cpp
@@ -230,15 +230,15 @@ static WindowsKeyNames& windowsKeyNames()
 
 PlatformKeyboardEvent::PlatformKeyboardEvent(HWND, WPARAM code, LPARAM keyData, Type type, bool systemKey)
     : PlatformEvent(type, GetKeyState(VK_SHIFT) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_CONTROL) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, false, WallTime::fromRawSeconds(::GetTickCount() * 0.001))
+    , m_autoRepeat(HIWORD(keyData) & KF_REPEAT)
+    , m_isKeypad(isKeypadEvent(code, keyData, type))
+    , m_isSystemKey(systemKey)
     , m_text((type == PlatformEvent::Type::Char) ? singleCharacterString(code) : String())
     , m_unmodifiedText((type == PlatformEvent::Type::Char) ? singleCharacterString(code) : String())
     , m_key(type == PlatformEvent::Type::Char ? windowsKeyNames().domKeyFromChar(code) : windowsKeyNames().domKeyFromParams(code, keyData))
     , m_code(windowsKeyNames().domCodeFromLParam(keyData))
     , m_keyIdentifier((type == PlatformEvent::Type::Char) ? String() : keyIdentifierForWindowsKeyCode(code))
     , m_windowsVirtualKeyCode((type == Type::RawKeyDown || type == Type::KeyUp) ? windowsKeycodeWithLocation(code, keyData) : 0)
-    , m_autoRepeat(HIWORD(keyData) & KF_REPEAT)
-    , m_isKeypad(isKeypadEvent(code, keyData, type))
-    , m_isSystemKey(systemKey)
 {
 }
 

--- a/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
+++ b/Source/WebCore/platform/win/PlatformMouseEventWin.cpp
@@ -83,9 +83,9 @@ PlatformMouseEvent::PlatformMouseEvent(HWND hWnd, UINT message, WPARAM wParam, L
     : PlatformEvent(messageToEventType(message), wParam & MK_SHIFT, wParam & MK_CONTROL, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, WallTime::now())
     , m_position(positionForEvent(hWnd, lParam))
     , m_globalPosition(globalPositionForEvent(hWnd, lParam))
-    , m_buttons(buttonsForEvent(wParam))
     , m_clickCount(0)
     , m_modifierFlags(wParam)
+    , m_buttons(buttonsForEvent(wParam))
     , m_didActivateWebView(didActivateWebView)
 {
     switch (message) {

--- a/Source/WebCore/platform/win/WheelEventWin.cpp
+++ b/Source/WebCore/platform/win/WheelEventWin.cpp
@@ -76,7 +76,6 @@ PlatformWheelEvent::PlatformWheelEvent(HWND hWnd, WPARAM wParam, LPARAM lParam, 
     : PlatformEvent(PlatformEvent::Type::Wheel, wParam & MK_SHIFT, wParam & MK_CONTROL, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, GetKeyState(VK_MENU) & HIGH_BIT_MASK_SHORT, WallTime::fromRawSeconds(::GetTickCount() * 0.001))
     , m_position(positionForEvent(hWnd, lParam))
     , m_globalPosition(globalPositionForEvent(hWnd, lParam))
-    , m_directionInvertedFromDevice(false)
 {
     float scaleFactor = deviceScaleFactorForWindow(hWnd);
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h
@@ -30,6 +30,7 @@
 
 #include "RenderBoxInlines.h"
 #include "RenderMathMLBlock.h"
+#include "RenderTableInlines.h"
 #include "StyleInheritedData.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### afbcfab2cefd87cd5534a9a3086efc21e97cd727
<pre>
Fix clang-cl warnings of WebCore for Windows port
<a href="https://bugs.webkit.org/show_bug.cgi?id=259100">https://bugs.webkit.org/show_bug.cgi?id=259100</a>

Reviewed by Ross Kirsling.

clang-cl reported the following warnings:

&gt; platform\graphics\win\ComplexTextControllerUniscribe.cpp(141,9): warning: unused variable &apos;i&apos; [-Wunused-variable]
&gt; platform\graphics\egl\GLContext.cpp(228,29): warning: enumeration value &apos;Windows&apos; not handled in switch [-Wswitch]
&gt; platform\graphics\egl\GLContext.cpp(359,33): warning: enumeration value &apos;Windows&apos; not handled in switch [-Wswitch]
&gt; platform\graphics\egl\GLContext.cpp(406,33): warning: enumeration value &apos;Windows&apos; not handled in switch [-Wswitch]
&gt; platform\win\KeyEventWin.cpp(238,7): warning: field &apos;m_windowsVirtualKeyCode&apos; will be initialized after field &apos;m_autoRepeat&apos; [-Wreorder-ctor]
&gt; platform\win\PlatformMouseEventWin.cpp(86,7): warning: field &apos;m_buttons&apos; will be initialized after field &apos;m_clickCount&apos; [-Wreorder-ctor]
&gt; platform\win\WheelEventWin.cpp(78,7): warning: field &apos;m_globalPosition&apos; will be initialized after field &apos;m_directionInvertedFromDevice&apos; [-Wreorder-ctor]
&gt; platform\graphics\win\MediaPlayerPrivateMediaFoundation.cpp(84,13): warning: delete called on non-final &apos;WebCore::MediaPlayerPrivateMediaFoundation::AsyncCallback&apos; that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
&gt; platform\graphics\win\MediaPlayerPrivateMediaFoundation.cpp(2834,26): warning: unused variable &apos;image&apos; [-Wunused-variable]
&gt; Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp(154,31): warning: lambda capture &apos;this&apos; is not used [-Wunused-lambda-capture]
&gt; dom/FullscreenManager.cpp(299,65): warning: lambda capture &apos;this&apos; is not used [-Wunused-lambda-capture]
&gt; rendering\RenderTable.h(66,23): warning: inline function &apos;WebCore::RenderTable::borderTop&apos; is not defined [-Wundefined-inline]
&gt; rendering\RenderTable.h(67,23): warning: inline function &apos;WebCore::RenderTable::borderBottom&apos; is not defined [-Wundefined-inline]

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::cancelFullscreen):
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::createWindowContext):
(WebCore::GLContext::createOffscreen):
(WebCore::GLContext::createSharing):
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::stringIndicesFromClusters):
* Source/WebCore/platform/graphics/win/MediaPlayerPrivateMediaFoundation.cpp:
(WebCore::MediaPlayerPrivateMediaFoundation::AsyncCallback::~AsyncCallback):
(WebCore::MediaPlayerPrivateMediaFoundation::Direct3DPresenter::paintCurrentFrame):
* Source/WebCore/platform/win/KeyEventWin.cpp:
(WebCore::PlatformKeyboardEvent::PlatformKeyboardEvent):
* Source/WebCore/platform/win/PlatformMouseEventWin.cpp:
(WebCore::PlatformMouseEvent::PlatformMouseEvent):
* Source/WebCore/platform/win/WheelEventWin.cpp:
(WebCore::PlatformWheelEvent::PlatformWheelEvent):
* Source/WebCore/rendering/mathml/RenderMathMLBlockInlines.h:

Canonical link: <a href="https://commits.webkit.org/266001@main">https://commits.webkit.org/266001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba133432e4b45afe891ab8920204efa66fe9f07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14688 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14670 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18411 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15536 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1410 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->