### PR TITLE
Keep attachment save icon size even with using larger accessibility text

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -50,7 +50,7 @@ layer at (0,0) size 800x777
               RenderGrid {DIV} at (0,26) size 230x40
                 RenderBlock {DIV} at (190,0) size 40x40
                   RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#7676801F]
-                    RenderBlock (anonymous) at (11,0) size 18x40
+                    RenderBlock (anonymous) at (0,0) size 40x40
       RenderBlock {DIV} at (0,470) size 784x97
         RenderText {#text} at (0,77) size 97x19
           text run at (0,77) width 97: "Zero progress: "
@@ -140,8 +140,8 @@ layer at (195,711) size 230x17
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (332,411) size 18x40
-  RenderBlock (generated) at (0,0) size 18x40 [bgcolor=#007AFF]
+layer at (321,411) size 40x40
+  RenderBlock (generated) at (0,0) size 40x40 [bgcolor=#007AFF]
     RenderText at (0,0) size 0x0
 layer at (116,489) size 72x72
   RenderBlock {DIV} at (10,10) size 72x72 [bgcolor=#000000]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -50,7 +50,7 @@ layer at (0,0) size 785x678
               RenderGrid {DIV} at (0,26) size 172x28
                 RenderBlock {DIV} at (144,0) size 28x28
                   RenderButton {BUTTON} at (0,0) size 28x28 [color=#00000019] [border: (1px solid #00000019)]
-                    RenderBlock (anonymous) at (7,3) size 14x21
+                    RenderBlock (anonymous) at (1,1) size 26x26
       RenderBlock {DIV} at (0,410) size 769x84
         RenderText {#text} at (0,66) size 97x18
           text run at (0,66) width 97: "Zero progress: "
@@ -140,8 +140,8 @@ layer at (183,619) size 172x16
     RenderBlock (anonymous) at (0,0) size 172x16
       RenderText {#text} at (0,0) size 56x16
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (270,366) size 14x21
-  RenderBlock (generated) at (0,0) size 14x21 [bgcolor=#0000007F]
+layer at (264,364) size 26x26
+  RenderBlock (generated) at (0,0) size 26x26 [bgcolor=#0000007F]
     RenderText at (0,0) size 0x0
 layer at (120,433) size 52x52
   RenderBlock {DIV} at (14,14) size 52x52 [bgcolor=#000000D8]

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -165,6 +165,7 @@ button#attachment-save-button {
     border: 1px solid;
 #endif
     border-radius: 50%;
+    padding: 0;
     pointer-events: initial;
 }
 
@@ -178,8 +179,10 @@ button#attachment-save-button::before {
     width: 100%;
     height: 100%;
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+    mask-size: 18px;
     background-color: -apple-system-blue;
 #else
+    mask-size: 14px;
     background-color: -apple-system-secondary-label;
 #endif
 }


### PR DESCRIPTION
#### beecadc714145c68516ae171b97e4c7924ace7a0
<pre>
Keep attachment save icon size even with using larger accessibility text
<a href="https://bugs.webkit.org/show_bug.cgi?id=259101">https://bugs.webkit.org/show_bug.cgi?id=259101</a>
rdar://112060938

Reviewed by Tim Nguyen.

When larger text size is used, the default button CSS padding becomes enormous and squashed the save SVG
icon into nothing. This patch removes the excessive padding, and forces the expected icon size.

* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(button#attachment-save-button):
(div#attachment-save-icon):

Canonical link: <a href="https://commits.webkit.org/265945@main">https://commits.webkit.org/265945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a9076237f1cd556b1ad7f9977607be35ccb0e7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14570 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14525 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18305 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14548 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9786 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11082 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3039 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->