### PR TITLE
Add WebCodecs HEVC support

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5083,15 +5083,15 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/wide-gamut-canvas/2d.color
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [ Failure ]
 
-# HEVC support
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_hevc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_hevc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_annexb [ Skip ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_hevc [ Skip ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_annexb [ Skip ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_hevc [ Skip ]
+# HEVC support may not be available to all platforms.
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_hevc [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_hevc [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_hevc [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_annexb [ Pass Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_hevc [ Pass Failure ]
 
 webkit.org/b/226942 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/active-processing.https.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
-FAIL Encoding and decoding cycle w/ stripped color space promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
-FAIL Encoding and decoding cycle w/ stripped color space promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
-FAIL Encoding and decoding cycle w/ stripped color space promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Encoding and decoding cycle promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
-FAIL Encoding and decoding cycle w/ stripped color space promise_test: Unhandled rejection with value: object "InvalidStateError: VideoDecoder is not configured"
+PASS Encoding and decoding cycle
+PASS Encoding and decoding cycle w/ stripped color space
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_annexb-expected.txt
@@ -1,20 +1,20 @@
 
-NOTRUN Test isConfigSupported() hev1.1.6.L60.90 unsupported
-NOTRUN Test isConfigSupported() with 1080p crop hev1.1.6.L60.90 unsupported
-NOTRUN Test that isConfigSupported() returns a parsed configuration hev1.1.6.L60.90 unsupported
-NOTRUN Test invalid configs hev1.1.6.L60.90 unsupported
-NOTRUN Test configure() hev1.1.6.L60.90 unsupported
-NOTRUN Decode a key frame hev1.1.6.L60.90 unsupported
-NOTRUN Decode a non key frame first fails hev1.1.6.L60.90 unsupported
-NOTRUN Verify reset() suppresses outputs hev1.1.6.L60.90 unsupported
-NOTRUN Test unconfigured VideoDecoder operations hev1.1.6.L60.90 unsupported
-NOTRUN Test closed VideoDecoder operations hev1.1.6.L60.90 unsupported
-NOTRUN Decode empty frame hev1.1.6.L60.90 unsupported
-NOTRUN Decode corrupt frame hev1.1.6.L60.90 unsupported
-NOTRUN Close while decoding corrupt frame hev1.1.6.L60.90 unsupported
-NOTRUN Test decoding after flush hev1.1.6.L60.90 unsupported
-NOTRUN Test decoding a with negative timestamp hev1.1.6.L60.90 unsupported
-NOTRUN Test reset during flush hev1.1.6.L60.90 unsupported
-NOTRUN Test low-latency decoding hev1.1.6.L60.90 unsupported
-NOTRUN VideoDecoder decodeQueueSize test hev1.1.6.L60.90 unsupported
+PASS Test isConfigSupported()
+PASS Test isConfigSupported() with 1080p crop
+PASS Test that isConfigSupported() returns a parsed configuration
+PASS Test invalid configs
+PASS Test configure()
+PASS Decode a key frame
+PASS Decode a non key frame first fails
+PASS Verify reset() suppresses outputs
+PASS Test unconfigured VideoDecoder operations
+PASS Test closed VideoDecoder operations
+PASS Decode empty frame
+PASS Decode corrupt frame
+PASS Close while decoding corrupt frame
+PASS Test decoding after flush
+PASS Test decoding a with negative timestamp
+PASS Test reset during flush
+PASS Test low-latency decoding
+PASS VideoDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_hevc-expected.txt
@@ -1,22 +1,20 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
-FAIL Decode a key frame promise_test: Unhandled rejection with value: object "EncodingError: Decoder failure"
+PASS Decode a key frame
 PASS Decode a non key frame first fails
-TIMEOUT Verify reset() suppresses outputs Test timed out
-NOTRUN Test unconfigured VideoDecoder operations
-NOTRUN Test closed VideoDecoder operations
-NOTRUN Decode empty frame
-NOTRUN Decode corrupt frame
-NOTRUN Close while decoding corrupt frame
-NOTRUN Test decoding after flush
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test reset during flush
-NOTRUN Test low-latency decoding
-NOTRUN VideoDecoder decodeQueueSize test
+PASS Verify reset() suppresses outputs
+PASS Test unconfigured VideoDecoder operations
+PASS Test closed VideoDecoder operations
+PASS Decode empty frame
+PASS Decode corrupt frame
+PASS Close while decoding corrupt frame
+PASS Test decoding after flush
+PASS Test decoding a with negative timestamp
+PASS Test reset during flush
+PASS Test low-latency decoding
+PASS VideoDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_annexb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_annexb-expected.txt
@@ -1,20 +1,20 @@
 
-NOTRUN Test isConfigSupported() hev1.1.6.L60.90 unsupported
-NOTRUN Test isConfigSupported() with 1080p crop hev1.1.6.L60.90 unsupported
-NOTRUN Test that isConfigSupported() returns a parsed configuration hev1.1.6.L60.90 unsupported
-NOTRUN Test invalid configs hev1.1.6.L60.90 unsupported
-NOTRUN Test configure() hev1.1.6.L60.90 unsupported
-NOTRUN Decode a key frame hev1.1.6.L60.90 unsupported
-NOTRUN Decode a non key frame first fails hev1.1.6.L60.90 unsupported
-NOTRUN Verify reset() suppresses outputs hev1.1.6.L60.90 unsupported
-NOTRUN Test unconfigured VideoDecoder operations hev1.1.6.L60.90 unsupported
-NOTRUN Test closed VideoDecoder operations hev1.1.6.L60.90 unsupported
-NOTRUN Decode empty frame hev1.1.6.L60.90 unsupported
-NOTRUN Decode corrupt frame hev1.1.6.L60.90 unsupported
-NOTRUN Close while decoding corrupt frame hev1.1.6.L60.90 unsupported
-NOTRUN Test decoding after flush hev1.1.6.L60.90 unsupported
-NOTRUN Test decoding a with negative timestamp hev1.1.6.L60.90 unsupported
-NOTRUN Test reset during flush hev1.1.6.L60.90 unsupported
-NOTRUN Test low-latency decoding hev1.1.6.L60.90 unsupported
-NOTRUN VideoDecoder decodeQueueSize test hev1.1.6.L60.90 unsupported
+PASS Test isConfigSupported()
+PASS Test isConfigSupported() with 1080p crop
+PASS Test that isConfigSupported() returns a parsed configuration
+PASS Test invalid configs
+PASS Test configure()
+PASS Decode a key frame
+PASS Decode a non key frame first fails
+PASS Verify reset() suppresses outputs
+PASS Test unconfigured VideoDecoder operations
+PASS Test closed VideoDecoder operations
+PASS Decode empty frame
+PASS Decode corrupt frame
+PASS Close while decoding corrupt frame
+PASS Test decoding after flush
+PASS Test decoding a with negative timestamp
+PASS Test reset during flush
+PASS Test low-latency decoding
+PASS VideoDecoder decodeQueueSize test
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_hevc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_hevc-expected.txt
@@ -1,22 +1,20 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test isConfigSupported()
 PASS Test isConfigSupported() with 1080p crop
 PASS Test that isConfigSupported() returns a parsed configuration
 PASS Test invalid configs
 PASS Test configure()
-FAIL Decode a key frame promise_test: Unhandled rejection with value: object "EncodingError: Decoder failure"
+PASS Decode a key frame
 PASS Decode a non key frame first fails
-TIMEOUT Verify reset() suppresses outputs Test timed out
-NOTRUN Test unconfigured VideoDecoder operations
-NOTRUN Test closed VideoDecoder operations
-NOTRUN Decode empty frame
-NOTRUN Decode corrupt frame
-NOTRUN Close while decoding corrupt frame
-NOTRUN Test decoding after flush
-NOTRUN Test decoding a with negative timestamp
-NOTRUN Test reset during flush
-NOTRUN Test low-latency decoding
-NOTRUN VideoDecoder decodeQueueSize test
+PASS Verify reset() suppresses outputs
+PASS Test unconfigured VideoDecoder operations
+PASS Test closed VideoDecoder operations
+PASS Decode empty frame
+PASS Decode corrupt frame
+PASS Close while decoding corrupt frame
+PASS Test decoding after flush
+PASS Test decoding a with negative timestamp
+PASS Test reset during flush
+PASS Test low-latency decoding
+PASS VideoDecoder decodeQueueSize test
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1125,6 +1125,16 @@ imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?h
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
 
+# HEVC support
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_annexb [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h265_hevc [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_annexb [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h265_hevc [ Failure ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_annexb [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h265_hevc [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_annexb [ Skip ]
+imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h265_hevc [ Skip ]
+
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
 # Likely bugs related with dav1ddec.

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm
@@ -107,6 +107,7 @@
 - (void)setLowLatency:(bool)lowLatencyEnabled {
     if (m_h264Encoder)
         [m_h264Encoder setH264LowLatencyEncoderEnabled:lowLatencyEnabled];
+    [m_h265Encoder setLowLatency:lowLatencyEnabled];
 }
 
 - (void)setUseAnnexB:(bool)useAnnexB {

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm
@@ -138,6 +138,10 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
     _error = noErr;
     return WEBRTC_VIDEO_CODEC_ERROR;
   }
+  if (!data || !size) {
+    RTC_LOG(LS_WARNING) << "Empty frame.";
+    return WEBRTC_VIDEO_CODEC_ERROR;
+  }
 
   rtc::ScopedCFTypeRef<CMVideoFormatDescriptionRef> inputFormat =
       rtc::ScopedCF(webrtc::CreateH265VideoFormatDescription(
@@ -223,7 +227,7 @@ CMSampleBufferRef H265BufferToCMSampleBuffer(const uint8_t* buffer, size_t buffe
     &kCFTypeDictionaryValueCallBacks);
 
   CMVideoFormatDescriptionRef videoFormatDescription = nullptr;
-  auto err = CMVideoFormatDescriptionCreate(NULL, kCMVideoCodecType_H264, width, height, extensionsDict, &videoFormatDescription);
+  auto err = CMVideoFormatDescriptionCreate(NULL, kCMVideoCodecType_HEVC, width, height, extensionsDict, &videoFormatDescription);
   CFRelease(codecConfig);
   CFRelease(atomsDict);
   CFRelease(extensionsDict);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH265.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH265.h
@@ -19,6 +19,7 @@ __attribute__((objc_runtime_name("WK_RTCVideoEncoderH265")))
 @interface RTCVideoEncoderH265 : NSObject <RTCVideoEncoder>
 
 - (instancetype)initWithCodecInfo:(RTCVideoCodecInfo *)codecInfo;
+- (void)setLowLatency:(bool)enabled;
 - (void)setUseAnnexB:(bool)useAnnexB;
 - (void)setDescriptionCallback:(RTCVideoEncoderDescriptionCallback)callback;
 - (void)flush;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -93,7 +93,9 @@ std::optional<VideoCodecType> LibWebRTCCodecs::videoCodecTypeFromWebCodec(const 
     if (codec.startsWith("avc1."_s))
         return VideoCodecType::H264;
 
-    // FIXME: Expose H265 if available.
+    if (codec.startsWith("hev1."_s) || codec.startsWith("hvc1."_s))
+        return VideoCodecType::H265;
+
     return { };
 }
 


### PR DESCRIPTION
#### 532dd9a010f0b915d8e2f2e20d33f0384870bb97
<pre>
Add WebCodecs HEVC support
<a href="https://bugs.webkit.org/show_bug.cgi?id=259102">https://bugs.webkit.org/show_bug.cgi?id=259102</a>
rdar://112067287

Reviewed by Eric Carlson.

Update H265 RTC encoder to properly handle webcodecs.
In particular, we add some nullptr checks, as well as fixing init data in case AVC format is used.
We also set low latency mode according what webcodecs gives us.

Skipping tests in GLib until it gets implemented.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker_h265_hevc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any_h265_hevc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker_h265_hevc-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_annexb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any_h265_hevc-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/WebKit/WebKitEncoder.mm:
(-[WK_RTCLocalVideoH264H265Encoder setLowLatency:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoDecoderH265.mm:
(-[RTCVideoDecoderH265 decodeData:size:timeStamp:]):
(-[RTCVideoDecoderH265 setAVCFormat:size:width:height:]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH265.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_codec/RTCVideoEncoderH265.mm:
(-[RTCVideoEncoderH265 initWithCodecInfo:]):
(-[RTCVideoEncoderH265 setLowLatency:]):
(-[RTCVideoEncoderH265 resetCompressionSession]):
(-[RTCVideoEncoderH265 configureCompressionSession]):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::videoCodecTypeFromWebCodec):

Canonical link: <a href="https://commits.webkit.org/266044@main">https://commits.webkit.org/266044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2e77f4afcf73a7140d6bb43ce638e8511feb722

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12085 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14797 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18510 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9982 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11313 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->