### PR TITLE
[WPE] `WebKitWebResource/get-data-error` and `WebKitWebResource/get-data-empty` API tests are failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp
@@ -517,7 +517,7 @@ static void webViewLoadChanged(WebKitWebView* webView, WebKitLoadEvent loadEvent
 static void testWebResourceGetDataError(Test* test, gconstpointer)
 {
     GRefPtr<GMainLoop> mainLoop = adoptGRef(g_main_loop_new(nullptr, FALSE));
-    GRefPtr<WebKitWebView> webView = WEBKIT_WEB_VIEW(Test::createWebView(test->m_webContext.get()));
+    auto webView = Test::adoptView((Test::createWebView(test->m_webContext.get())));
     webkit_web_view_load_html(webView.get(), "<html></html>", nullptr);
     g_signal_connect(webView.get(), "load-changed", G_CALLBACK(webViewLoadChanged), mainLoop.get());
     g_main_loop_run(mainLoop.get());
@@ -539,7 +539,7 @@ static void testWebResourceGetDataError(Test* test, gconstpointer)
 static void testWebResourceGetDataEmpty(Test* test, gconstpointer)
 {
     GRefPtr<GMainLoop> mainLoop = adoptGRef(g_main_loop_new(nullptr, FALSE));
-    GRefPtr<WebKitWebView> webView = WEBKIT_WEB_VIEW(Test::createWebView(test->m_webContext.get()));
+    auto webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
     webkit_web_view_load_html(webView.get(), "", nullptr);
     g_signal_connect(webView.get(), "load-changed", G_CALLBACK(webViewLoadChanged), mainLoop.get());
     g_main_loop_run(mainLoop.get());

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -364,20 +364,6 @@
             }
         }
     },
-    "TestResources": {
-        "subtests": {
-            "/webkit/WebKitWebResource/get-data-error": {
-                "expected": {
-                    "wpe": {"status": ["FAIL"]}
-                }
-            },
-            "/webkit/WebKitWebResource/get-data-empty": {
-                "expected": {
-                    "wpe": {"status": ["FAIL"]}
-                }
-            }
-        }
-    },
     "TestJSC": {
         "subtests": {
             "/jsc/vm": {


### PR DESCRIPTION
#### ea9a3d02288cec38d705f5db245a432e45204726
<pre>
[WPE] `WebKitWebResource/get-data-error` and `WebKitWebResource/get-data-empty` API tests are failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=259103">https://bugs.webkit.org/show_bug.cgi?id=259103</a>

Reviewed by Miguel Gomez.

Similar to 265772@main, these tests must use
`Test::adapter View()` when creating a `WebKitWebView`.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestResources.cpp:
(testWebResourceGetDataError):
(testWebResourceGetDataEmpty):
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/265943@main">https://commits.webkit.org/265943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f964738e26108210d25b7f82f50145055d879f2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14565 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14520 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11077 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3036 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->