### PR TITLE
[MediaStream] enumerateDevices should not expose devices that can not be used

### DIFF
--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -79,6 +79,11 @@ public:
     bool isEphemeral() const { return m_isEphemeral; }
     void setIsEphemeral(bool isEphemeral) { m_isEphemeral = isEphemeral; }
 
+    bool isInputDevice() const
+    {
+        return m_type == DeviceType::Microphone || m_type == DeviceType::Camera;
+    }
+
     explicit operator bool() const { return m_type != DeviceType::Unknown; }
 
     CaptureDevice isolatedCopy() &&;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -148,7 +148,7 @@ std::optional<RealtimeMediaSourceCapabilities> RealtimeMediaSourceCenter::getCap
             return std::nullopt;
         return source.source()->capabilities();
     }
-    if (device.type() == CaptureDevice::DeviceType::Microphone || device.type() == CaptureDevice::DeviceType::Speaker) {
+    if (device.type() == CaptureDevice::DeviceType::Microphone) {
         auto source = audioCaptureFactory().createAudioCaptureSource({ device }, { "fake"_s, "fake"_s }, nullptr, { });
         if (!source)
             return std::nullopt;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -819,12 +819,14 @@ void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool 
         for (auto& device : devices) {
             RealtimeMediaSourceCapabilities deviceCapabilities;
 
-            auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
-            if (!capabilities)
-                continue;
+            if (device.isInputDevice()) {
+                auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
+                if (!capabilities)
+                    continue;
 
-            if (revealIdsAndLabels)
-                deviceCapabilities = WTFMove(*capabilities);
+                if (revealIdsAndLabels)
+                    deviceCapabilities = WTFMove(*capabilities);
+            }
 
             devicesWithCapabilities.uncheckedAppend({ WTFMove(device), WTFMove(deviceCapabilities) });
         }

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp
@@ -73,12 +73,14 @@ void UserMediaCaptureManager::getMediaStreamDevices(bool revealIdsAndLabels, Get
         for (auto& device : devices) {
             RealtimeMediaSourceCapabilities deviceCapabilities;
 
-            auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
-            if (!capabilities)
-                continue;
+            if (device.isInputDevice()) {
+                auto capabilities = RealtimeMediaSourceCenter::singleton().getCapabilities(device);
+                if (!capabilities)
+                    continue;
 
-            if (revealIdsAndLabels)
-                deviceCapabilities = *capabilities;
+                if (revealIdsAndLabels)
+                    deviceCapabilities = *capabilities;
+            }
 
             devicesWithCapabilities.uncheckedAppend({ WTFMove(device), WTFMove(deviceCapabilities) });
         }


### PR DESCRIPTION
#### 33ede2d5891676cb59cdd61aa29ae5e82c60fc1b
<pre>
[MediaStream] enumerateDevices should not expose devices that can not be used
<a href="https://bugs.webkit.org/show_bug.cgi?id=258993">https://bugs.webkit.org/show_bug.cgi?id=258993</a>
rdar://110210394

Reviewed by Youenn Fablet.

Only include capabilities for InputDevices.

* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::isInputDevice):

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getCapabilities):

* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices):

* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::getMediaStreamDevices):

Canonical link: <a href="https://commits.webkit.org/265947@main">https://commits.webkit.org/265947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/793b0a06c66aee16206145ff41a3eec5cb168039

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14581 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14537 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11208 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->