### PR TITLE
Fix WasmFaultSignalHandler.cpp doesn't compile on Windows

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -26,7 +26,8 @@
 #include "config.h"
 #include "WasmFaultSignalHandler.h"
 
-#if ENABLE(WEBASSEMBLY)
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=259108 Support signal handlers on Windows
+#if ENABLE(WEBASSEMBLY) && OS(UNIX)
 
 #include "ExecutableAllocator.h"
 #include "LLIntData.h"
@@ -132,5 +133,5 @@ void prepareSignalingMemory()
     
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY)
+#endif // ENABLE(WEBASSEMBLY) && OS(UNIX)
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -29,7 +29,7 @@ namespace JSC {
 
 namespace Wasm {
 
-#if ENABLE(WEBASSEMBLY)
+#if ENABLE(WEBASSEMBLY) && OS(UNIX)
 void activateSignalingMemory();
 void prepareSignalingMemory();
 #else

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <wtf/threads/Signals.h>
 
+// FIXME: https://bugs.webkit.org/show_bug.cgi?id=259108 Support signal handlers on Windows
 #if OS(UNIX)
 
 #if HAVE(MACH_EXCEPTIONS)


### PR DESCRIPTION
#### 62ac852fe74f53bfa9e969af61d7da3a5d740134
<pre>
Fix WasmFaultSignalHandler.cpp doesn&apos;t compile on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=258556">https://bugs.webkit.org/show_bug.cgi?id=258556</a>

Reviewed by Ross Kirsling.

WTF/wtf/threads/Signals.cpp assumes Unix platforms but
WasmFaultSignalHandler.cpp uses the signals API without checking the
platform.

This patch avoids setting the signal handlers not to use the signals
API so that it doesn&apos;t break Windows build.

This is a temporary fix. Signal handlers for WIndows are eventually
implemented at <a href="https://bugs.webkit.org/show_bug.cgi?id=259108">https://bugs.webkit.org/show_bug.cgi?id=259108</a>

* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:

Canonical link: <a href="https://commits.webkit.org/265964@main">https://commits.webkit.org/265964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/200507b9f40a808218e45ac522c16c311a984110

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11903 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14579 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14539 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18312 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10528 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11372 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14555 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11712 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11869 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9799 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12436 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11096 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3262 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3054 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15426 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12789 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11723 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3043 "Passed tests") | 
<!--EWS-Status-Bubble-End-->