### PR TITLE
ElementInternals.setFormValue(<nullish value>) doesn't clear submission value

### DIFF
--- a/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2-expected.txt
+++ b/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2-expected.txt
@@ -1,0 +1,29 @@
+
+Upgraded form-associated custom elements without an owner:
+PASS $("noowner-upgrade1").restoredState is undefined
+PASS $("noowner-upgrade2").restoredState is "bar"
+PASS $("noowner-upgrade3").restoredState is undefined
+PASS isFormDataEqual($("noowner-upgrade4").restoredState, __formData1) is true
+
+Upgraded form-associated custom elements with a form owner:
+PASS $("upgrade1").restoredState is undefined
+PASS $("upgrade2").restoredState is undefined
+PASS isFormDataEqual($("upgrade3").restoredState, __formData1) is true
+PASS $("upgrade4").restoredState is "bar"
+
+Predefined form-associated custom elements without an owner:
+PASS $("noowner-predefined1").restoredState is undefined
+PASS $("noowner-predefined2").restoredState is "bar"
+PASS $("noowner-predefined3").restoredState is undefined
+PASS isFormDataEqual($("noowner-predefined4").restoredState, __formData2) is true
+
+Predefined form-associated custom elements with a form owner:
+PASS $("predefined1").restoredState is undefined
+PASS isFormDataEqual($("predefined2").restoredState, __formData1) is true
+PASS $("predefined3").restoredState is undefined
+PASS $("predefined4").restoredState is "foo"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html
+++ b/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="resources/common.js"></script>
 </head>
 <body>
@@ -32,10 +32,7 @@ function getXFooConstructor() {
             const value = this._parseFormValue(this.dataset.submissionValue);
             const state = this._parseFormValue(this.dataset.state);
 
-            if (state == null)
-                this._internals.setFormValue(value);
-            else
-                this._internals.setFormValue(value, state);
+            this._internals.setFormValue(value, state);
         }
 
         formStateRestoreCallback(state) {
@@ -115,27 +112,27 @@ function runTest()
         makeForms(2);
 
         debug('\nUpgraded form-associated custom elements without an owner:');
-        shouldBeEqualToString('$("noowner-upgrade1").restoredState', 'foo');
+        shouldBe('$("noowner-upgrade1").restoredState', 'undefined');
         shouldBeEqualToString('$("noowner-upgrade2").restoredState', 'bar');
-        shouldBeTrue('isFormDataEqual($("noowner-upgrade3").restoredState, __formData2)');
+        shouldBe('$("noowner-upgrade3").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("noowner-upgrade4").restoredState, __formData1)');
 
         debug('\nUpgraded form-associated custom elements with a form owner:');
-        shouldBeTrue('isFormDataEqual($("upgrade1").restoredState, __formData2)');
-        shouldBeEqualToString('$("upgrade2").restoredState', 'foo');
+        shouldBe('$("upgrade1").restoredState', 'undefined');
+        shouldBe('$("upgrade2").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("upgrade3").restoredState, __formData1)');
         shouldBeEqualToString('$("upgrade4").restoredState', 'bar');
 
         debug('\nPredefined form-associated custom elements without an owner:');
-        shouldBeEqualToString('$("noowner-predefined1").restoredState', 'foo');
+        shouldBe('$("noowner-predefined1").restoredState', 'undefined');
         shouldBeEqualToString('$("noowner-predefined2").restoredState', 'bar');
-        shouldBeTrue('isFormDataEqual($("noowner-predefined3").restoredState, __formData1)');
+        shouldBe('$("noowner-predefined3").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("noowner-predefined4").restoredState, __formData2)');
 
         debug('\nPredefined form-associated custom elements with a form owner:');
-        shouldBeEqualToString('$("predefined1").restoredState', 'foo');
+        shouldBe('$("predefined1").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("predefined2").restoredState, __formData1)');
-        shouldBeEqualToString('$("predefined3").restoredState', 'bar');
+        shouldBe('$("predefined3").restoredState', 'undefined');
         shouldBeEqualToString('$("predefined4").restoredState', 'foo');
 
         $('parent').innerHTML = '';
@@ -145,5 +142,4 @@ function runTest()
 
 runTest();
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value-expected.txt
@@ -1,0 +1,4 @@
+
+PASS ElementInternals.setFormValue(null) clears submission value
+PASS ElementInternals.setFormValue(undefined) clears submission value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ElementInternals.setFormValue(nullish value) should clear submission value</title>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setformvalue">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        customElements.define("test-form-element", class extends HTMLElement {
+            static formAssociated = true;
+            constructor() {
+                super();
+                this.internals = this.attachInternals();
+            }
+        });
+    </script>
+</head>
+<body>
+    <form id="form-null">
+        <test-form-element id="input-null" name="input-null"></test-form-element>
+    </form>
+
+    <form id="form-undefined">
+        <test-form-element id="input-undefined" name="input-undefined"></test-form-element>
+    </form>
+
+    <script>
+      test(() => {
+        const input = document.getElementById("input-null");
+        input.internals.setFormValue("fail");
+        input.internals.setFormValue(null);
+        const formData = new FormData(document.getElementById("form-null"));
+        assert_false(formData.has("input-null"));
+      }, "ElementInternals.setFormValue(null) clears submission value");
+
+      test(() => {
+        const input = document.getElementById("input-undefined");
+        input.internals.setFormValue("fail");
+        input.internals.setFormValue(undefined);
+        const formData = new FormData(document.getElementById("form-undefined"));
+        assert_false(formData.has("input-undefined"));
+      }, "ElementInternals.setFormValue(undefined) clears submission value");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -391,6 +391,8 @@ void JSCustomElementInterface::invokeFormStateRestoreCallback(Element& element, 
             args.append(jsString(vm, state));
         }, [&](RefPtr<File>) {
             ASSERT_NOT_REACHED();
+        }, [](std::nullptr_t) {
+            ASSERT_NOT_REACHED();
         });
 
         args.append(jsNontrivialString(vm, "restore"_s));

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -31,12 +31,45 @@
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertSequences.h"
+#include "JSDOMFormData.h"
 #include "JSElement.h"
+#include "JSFile.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 
 namespace WebCore {
 using namespace JSC;
+
+JSValue JSElementInternals::setFormValue(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame)
+{
+    using JSCustomElementFormValue = IDLUnion<IDLNull, IDLInterface<File>, IDLUSVString, IDLInterface<DOMFormData>>;
+
+    auto& vm = lexicalGlobalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(callFrame.argumentCount() < 1)) {
+        throwException(&lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(&lexicalGlobalObject));
+        return { };
+    }
+
+    EnsureStillAliveScope argument0 = callFrame.uncheckedArgument(0);
+    auto value = convert<JSCustomElementFormValue>(lexicalGlobalObject, argument0.value());
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    std::optional<CustomElementFormValue> state;
+    if (callFrame.argumentCount() > 1) {
+        EnsureStillAliveScope argument1 = callFrame.argument(1);
+        state = convert<JSCustomElementFormValue>(lexicalGlobalObject, argument1.value());
+        RETURN_IF_EXCEPTION(throwScope, { });
+    }
+
+    auto result = wrapped().setFormValue(WTFMove(value), WTFMove(state));
+    if (UNLIKELY(result.hasException())) {
+        propagateException(lexicalGlobalObject, throwScope, result.releaseException());
+        return { };
+    }
+
+    return jsUndefined();
+}
 
 static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElementInternals& thisObject, const QualifiedName& attributeName)
 {

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -61,7 +61,7 @@ ExceptionOr<RefPtr<HTMLFormElement>> ElementInternals::form() const
     return Exception { NotSupportedError };
 }
 
-ExceptionOr<void> ElementInternals::setFormValue(std::optional<CustomElementFormValue>&& value, std::optional<CustomElementFormValue>&& state)
+ExceptionOr<void> ElementInternals::setFormValue(CustomElementFormValue&& value, std::optional<CustomElementFormValue>&& state)
 {
     if (RefPtr element = elementAsFormAssociatedCustom()) {
         element->setFormValue(WTFMove(value), WTFMove(state));

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -51,7 +51,7 @@ public:
 
     ExceptionOr<RefPtr<HTMLFormElement>> form() const;
 
-    ExceptionOr<void> setFormValue(std::optional<CustomElementFormValue>&&, std::optional<CustomElementFormValue>&& = std::nullopt);
+    ExceptionOr<void> setFormValue(CustomElementFormValue&&, std::optional<CustomElementFormValue>&& state);
 
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     ExceptionOr<bool> willValidate() const;

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (File or USVString or DOMFormData) FormValue;
-
 [
     GenerateIsReachable=ImplElementRoot,
     GenerateAddOpaqueRoot=element,
@@ -33,7 +31,7 @@ typedef (File or USVString or DOMFormData) FormValue;
 ] interface ElementInternals {
     readonly attribute ShadowRoot? shadowRoot;
 
-    undefined setFormValue(FormValue? value, optional FormValue? state);
+    [Custom] undefined setFormValue(any value, optional any state);
 
     readonly attribute HTMLFormElement? form;
 

--- a/Source/WebCore/html/CustomElementFormValue.h
+++ b/Source/WebCore/html/CustomElementFormValue.h
@@ -31,6 +31,6 @@
 
 namespace WebCore {
 
-using CustomElementFormValue = std::variant<RefPtr<File>, String, RefPtr<DOMFormData>>;
+using CustomElementFormValue = std::variant<std::nullptr_t, RefPtr<File>, String, RefPtr<DOMFormData>>;
 
 } // namespace WebCore

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -88,13 +88,11 @@ ALWAYS_INLINE static CustomElementFormValue cloneIfIsFormData(CustomElementFormV
     });
 }
 
-void FormAssociatedCustomElement::setFormValue(std::optional<CustomElementFormValue>&& submissionValue, std::optional<CustomElementFormValue>&& state)
+void FormAssociatedCustomElement::setFormValue(CustomElementFormValue&& submissionValue, std::optional<CustomElementFormValue>&& state)
 {
     ASSERT(m_element->isPrecustomizedOrDefinedCustomElement());
 
-    if (submissionValue.has_value())
-        m_submissionValue = cloneIfIsFormData(WTFMove(submissionValue.value()));
-
+    m_submissionValue = cloneIfIsFormData(WTFMove(submissionValue));
     m_state = state.has_value() ? cloneIfIsFormData(WTFMove(state.value())) : m_submissionValue;
 }
 
@@ -114,10 +112,7 @@ bool FormAssociatedCustomElement::appendFormData(DOMFormData& formData)
 {
     ASSERT(m_element->isDefinedCustomElement());
 
-    if (!m_submissionValue.has_value())
-        return false;
-
-    WTF::switchOn(m_submissionValue.value(), [&](RefPtr<DOMFormData> value) {
+    WTF::switchOn(m_submissionValue, [&](RefPtr<DOMFormData> value) {
         for (const auto& item : value->items()) {
             WTF::switchOn(item.data, [&](const String& value) {
                 formData.append(item.name, value);
@@ -131,6 +126,8 @@ bool FormAssociatedCustomElement::appendFormData(DOMFormData& formData)
     }, [&](RefPtr<File> value) {
         if (!name().isEmpty())
             formData.append(name(), *value);
+    }, [](std::nullptr_t) {
+        // do nothing
     });
 
     return true;
@@ -226,33 +223,33 @@ FormControlState FormAssociatedCustomElement::saveFormControlState() const
 
     FormControlState savedState;
 
-    if (m_state.has_value()) {
-        // FIXME: Support File when saving / restoring state.
-        // https://bugs.webkit.org/show_bug.cgi?id=249895
-        bool didLogMessage = false;
-        auto logUnsupportedFileWarning = [&](RefPtr<File>) {
-            auto& document = asHTMLElement().document();
-            if (document.frame() && !didLogMessage) {
-                document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
-                didLogMessage = true;
-            }
-        };
+    // FIXME: Support File when saving / restoring state.
+    // https://bugs.webkit.org/show_bug.cgi?id=249895
+    bool didLogMessage = false;
+    auto logUnsupportedFileWarning = [&](RefPtr<File>) {
+        auto& document = asHTMLElement().document();
+        if (document.frame() && !didLogMessage) {
+            document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
+            didLogMessage = true;
+        }
+    };
 
-        WTF::switchOn(m_state.value(), [&](RefPtr<DOMFormData> state) {
-            savedState.reserveInitialCapacity(state->items().size() * 2);
+    WTF::switchOn(m_state, [&](RefPtr<DOMFormData> state) {
+        savedState.reserveInitialCapacity(state->items().size() * 2);
 
-            for (const auto& item : state->items()) {
-                WTF::switchOn(item.data, [&](const String& value) {
-                    savedState.append(item.name);
-                    savedState.append(value);
-                }, logUnsupportedFileWarning);
-            }
+        for (const auto& item : state->items()) {
+            WTF::switchOn(item.data, [&](const String& value) {
+                savedState.append(item.name);
+                savedState.append(value);
+            }, logUnsupportedFileWarning);
+        }
 
-            savedState.shrinkToFit();
-        }, [&](const String& state) {
-            savedState.append(state);
-        }, logUnsupportedFileWarning);
-    }
+        savedState.shrinkToFit();
+    }, [&](const String& state) {
+        savedState.append(state);
+    }, [](std::nullptr_t) {
+        // do nothing
+    }, logUnsupportedFileWarning);
 
     return savedState;
 }

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -55,7 +55,7 @@ public:
     void reset() final;
     bool isEnumeratable() const final;
 
-    void setFormValue(std::optional<CustomElementFormValue>&& submissionValue, std::optional<CustomElementFormValue>&& state);
+    void setFormValue(CustomElementFormValue&& submissionValue, std::optional<CustomElementFormValue>&& state);
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     String validationMessage() const final;
 
@@ -97,8 +97,8 @@ private:
     WeakPtr<HTMLMaybeFormAssociatedCustomElement, WeakPtrImplWithEventTargetData> m_element;
     ValidityStateFlags m_validityStateFlags;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_validationAnchor { nullptr };
-    std::optional<CustomElementFormValue> m_submissionValue;
-    std::optional<CustomElementFormValue> m_state;
+    CustomElementFormValue m_submissionValue { nullptr };
+    CustomElementFormValue m_state { nullptr };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b691e0b9a450ba727548c89af3a44b011deae058
<pre>
ElementInternals.setFormValue(&lt;nullish value&gt;) doesn&apos;t clear submission value
<a href="https://bugs.webkit.org/show_bug.cgi?id=258870">https://bugs.webkit.org/show_bug.cgi?id=258870</a>
&lt;rdar://problem/111802198&gt;

Reviewed by Ryosuke Niwa.

With current bindings implementation, given an optional nullish interface / union type without default value,
it&apos;s impossible to distiungish in DOM code whether a null / undefined was passed or an argument was missing:
both compile to std::nullopt.

This was causing two bugs in ElementInternals.setFormValue() [1]:
  1) nullish `value` parameter was not clearing the submission value;
  2) nullish `state` parameter was perceived as missing and the `value` was used instead.

On one hand, we could revise all WebIDL files with optional nullish interface / union types to ensure that
we don&apos;t have extra / missing default values (oftentimes we do), and then make ones without defaults values
compile to std::nullopt (for missing argument) / std::nullptr_t (for nullish argument).

On the other, that would be quite massive change and this distinction isn&apos;t current needed anywhere but
ElementInternals.setFormValue(), so this change hand-rolls custom bindings just for this method, fixing
both issues by checking argument count and leveraging std::nullptr_t.

[1] <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setformvalue">https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setformvalue</a>

* LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2-expected.txt: Added.
* LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html: Added.
* LayoutTests/fast/forms/state-restore-form-associated-custom-elements.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html: Added.
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::invokeFormStateRestoreCallback):
* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp:
(WebCore::JSElementInternals::setFormValue):
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::setFormValue):
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/ElementInternals.idl:
* Source/WebCore/html/CustomElementFormValue.h:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::setFormValue):
(WebCore::FormAssociatedCustomElement::appendFormData):
(WebCore::FormAssociatedCustomElement::saveFormControlState const):
* Source/WebCore/html/FormAssociatedCustomElement.h:

Canonical link: <a href="https://commits.webkit.org/266126@main">https://commits.webkit.org/266126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0869d43d073c41dd4e9d0deaf8b4ceeb48250cf2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12975 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15076 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15164 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18796 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11042 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15110 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12283 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10259 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13022 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11597 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3419 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3175 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15950 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13397 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12210 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3213 "Passed tests") | 
<!--EWS-Status-Bubble-End-->