### PR TITLE
[CSS] Allow empty font-family name

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3853,7 +3853,6 @@ webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/font-face-weig
 
 # Triaged css-fonts failures
 webkit.org/b/246564 imported/w3c/web-platform-tests/css/css-fonts/font-synthesis-small-caps-not-applied.html [ ImageOnlyFailure ]
-webkit.org/b/257092 imported/w3c/web-platform-tests/css/css-fonts/font-palette-empty-font-family.html [ ImageOnlyFailure ]
 webkit.org/b/246911 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-2.html [ ImageOnlyFailure ]
 
 # vert font feature in vertical-text

--- a/LayoutTests/fast/text/font-face-empty-string-expected.txt
+++ b/LayoutTests/fast/text/font-face-empty-string-expected.txt
@@ -15,7 +15,7 @@ PASS fontface.unicodeRange = '' threw exception SyntaxError: The string did not 
 PASS fontface = new FontFace('WebFont', 'url(\'asdf\')', {featureSettings: ''}) did not throw exception.
 PASS fontface.featureSettings is "normal"
 PASS fontface.featureSettings = '' threw exception SyntaxError: The string did not match the expected pattern..
-PASS fontface.family = '' threw exception SyntaxError: The string did not match the expected pattern..
+PASS fontface.family = '' did not throw exception.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/font-face-empty-string.html
+++ b/LayoutTests/fast/text/font-face-empty-string.html
@@ -21,7 +21,7 @@ shouldNotThrow("fontface = new FontFace('WebFont', 'url(\\\'asdf\\\')', {feature
 shouldBeEqualToString("fontface.featureSettings", "normal");
 shouldThrow("fontface.featureSettings = ''");
 
-shouldThrow("fontface.family = ''");
+shouldNotThrow("fontface.family = ''");
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that an empty font family name is handled correctly</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-family-2-desc">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that an empty font family name is handled correctly</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-family-2-desc">
+<style>
+@font-face {
+    font-family: "COLR-test-font";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values --MyPalette {
+    font-family: "COLR-test-font";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'COLR-test-font'; font-palette: --MyPalette;">A</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that a non-ident font family name is handled correctly</title>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-family-2-desc">
+<link rel="author" title="Matthieu Dubet" href="mailto:m_dubet@apple.com">
+<link rel="match" href="font-palette-non-ident-font-family-ref.html">
+<style>
+@font-face {
+    font-family: "foo bar";
+    src: url("resources/COLR-palettes-test-font.ttf") format("truetype");
+}
+
+@font-palette-values --MyPalette {
+    font-family: "foo bar";
+    base-palette: 1;
+}
+</style>
+</head>
+<body>
+<div style="font: 48px 'foo bar'; font-palette: --MyPalette;">A</div>
+</body>
+</html>

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -175,7 +175,7 @@ void CSSFontFaceSet::addToFacesLookupTable(CSSFontFace& face)
 
     for (auto& item : *families) {
         auto familyName = AtomString { CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item)) };
-        if (familyName.isEmpty())
+        if (familyName.isNull())
             continue;
 
         auto addResult = m_facesLookupTable.add(familyName, Vector<Ref<CSSFontFace>>());
@@ -223,7 +223,7 @@ void CSSFontFaceSet::removeFromFacesLookupTable(const CSSFontFace& face, const C
 {
     for (auto& item : familiesToSearchFor) {
         String familyName = CSSFontFaceSet::familyNameFromPrimitive(downcast<CSSPrimitiveValue>(item));
-        if (familyName.isEmpty())
+        if (familyName.isNull())
             continue;
 
         auto iterator = m_facesLookupTable.find(familyName);
@@ -399,7 +399,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
             familyAtom = familyString;
         });
 
-        if (!familyAtom.isEmpty() && uniqueFamilies.add(familyAtom).isNewEntry)
+        if (!familyAtom.isNull() && uniqueFamilies.add(familyAtom).isNewEntry)
             familyOrder.append(familyAtom);
     }
 

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -241,8 +241,14 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
 
 void CSSFontSelector::addFontPaletteValuesRule(const StyleRuleFontPaletteValues& fontPaletteValuesRule)
 {
-    AtomString fontFamily = fontPaletteValuesRule.fontFamily().isNull() ? emptyAtom() : fontPaletteValuesRule.fontFamily();
-    AtomString name = fontPaletteValuesRule.name().isNull() ? emptyAtom() : fontPaletteValuesRule.name();
+
+    auto& name = fontPaletteValuesRule.name();
+    ASSERT(!name.isNull());
+
+    auto& fontFamily = fontPaletteValuesRule.fontFamily();
+    if (fontFamily.isNull())
+        return;
+
     m_paletteMap.set(std::make_pair(fontFamily, name), fontPaletteValuesRule.fontPaletteValues());
 
     ++m_version;
@@ -351,6 +357,7 @@ const FontPaletteValues& CSSFontSelector::lookupFontPaletteValues(const AtomStri
     auto iterator = m_paletteMap.find(std::make_pair(familyName, paletteName));
     if (iterator == m_paletteMap.end())
         return emptyFontPaletteValues.get();
+
     return iterator->value;
 }
 
@@ -376,7 +383,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     AtomString familyForLookup = familyName;
     std::optional<FontDescription> overrideFontDescription;
     const FontDescription* fontDescriptionForLookup = &fontDescription;
-    auto resolveAndAssignGenericFamily = [&]() {
+    auto resolveAndAssignGenericFamily = [&] {
         if (auto genericFamilyOptional = resolveGenericFamily(fontDescription, familyName))
             familyForLookup = *genericFamilyOptional;
     };

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -177,7 +177,7 @@ FontFace::~FontFace()
 
 ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const String& family)
 {
-    if (family.isEmpty())
+    if (family.isNull())
         return Exception { SyntaxError };
     // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
     m_backing->setFamilies(CSSValueList::createCommaSeparated(context.cssValuePool().createFontFamilyValue(AtomString { family })));

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -811,7 +811,15 @@ RefPtr<StyleRuleFontPaletteValues> CSSParserImpl::consumeFontPaletteValuesRule(C
     auto declarations = consumeDeclarationListInNewNestingContext(block, StyleRuleType::FontPaletteValues);
     auto properties = createStyleProperties(declarations, m_context.mode);
 
-    AtomString fontFamily { properties->getPropertyValue(CSSPropertyFontFamily) };
+    auto fontFamily = [&] () -> AtomString {
+        auto cssFontFamily = properties->getPropertyCSSValue(CSSPropertyFontFamily);
+        if (!cssFontFamily)
+            return { };
+        auto cssPrimitiveFontFamily = dynamicDowncast<CSSPrimitiveValue>(*cssFontFamily);
+        if (!cssPrimitiveFontFamily || !cssPrimitiveFontFamily->isFontFamily())
+            return { };
+        return AtomString { cssPrimitiveFontFamily->stringValue() };
+    }();
 
     std::optional<FontPaletteIndex> basePalette;
     if (auto basePaletteValue = properties->getPropertyCSSValue(CSSPropertyBasePalette)) {

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -147,7 +147,7 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
     auto& fontCache = FontCache::forCurrentThread();
     while (index < description.effectiveFamilyCount()) {
         auto visitor = WTF::makeVisitor([&](const AtomString& family) -> FontRanges {
-            if (family.isEmpty())
+            if (family.isNull())
                 return FontRanges();
             if (fontSelector) {
                 auto ranges = fontSelector->fontRangesForFamily(description, family);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -996,7 +996,7 @@ inline void BuilderCustom::applyValueFontFamily(BuilderState& builderState, CSSV
                 isGenericFamily = true;
                 family = CSSPropertyParserHelpers::genericFontFamily(contentValue.valueID());
             }
-            if (family.isEmpty())
+            if (family.isNull())
                 continue;
             if (families.isEmpty())
                 fontDescription.setIsSpecifiedFont(!isGenericFamily);


### PR DESCRIPTION
#### 1bd647f19109a84e816403fa2ef37f49a3b77f0e
<pre>
[CSS] Allow empty font-family name
<a href="https://bugs.webkit.org/show_bug.cgi?id=257092">https://bugs.webkit.org/show_bug.cgi?id=257092</a>
rdar://109613703

Reviewed by Tim Nguyen.

We allow the empty string to be used as a font-family name per spec.
This also fixes a bug with non-ident family name (such as &quot;foo bar&quot;).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/font-palette-non-ident-font-family.html: Added.
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::addToFacesLookupTable):
(WebCore::CSSFontFaceSet::removeFromFacesLookupTable):
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontPaletteValuesRule):
(WebCore::CSSFontSelector::lookupFontPaletteValues):
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::setFamily):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeFontPaletteValuesRule):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFontFamily):

Canonical link: <a href="https://commits.webkit.org/265997@main">https://commits.webkit.org/265997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d9a4c100caa6337c746ff7f141639c5669fbdf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12570 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14677 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18418 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14681 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11197 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3076 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15543 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11828 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->