### PR TITLE
[WPE][GTK] API test `TestUIClient` `/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check` is failing

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -148,7 +148,7 @@ std::optional<RealtimeMediaSourceCapabilities> RealtimeMediaSourceCenter::getCap
             return std::nullopt;
         return source.source()->capabilities();
     }
-    if (device.type() == CaptureDevice::DeviceType::Microphone || device.type() == CaptureDevice::DeviceType::Speaker) {
+    if (device.type() == CaptureDevice::DeviceType::Microphone) {
         auto source = audioCaptureFactory().createAudioCaptureSource({ device }, { "fake"_s, "fake"_s }, nullptr, { });
         if (!source)
             return std::nullopt;


### PR DESCRIPTION
#### 629234acc45038263f2874c6a47f02015ed6d27c
<pre>
[WPE][GTK] API test `TestUIClient` `/webkit/WebKitWebView/usermedia-enumeratedevices-permission-check` is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259109">https://bugs.webkit.org/show_bug.cgi?id=259109</a>

Reviewed by NOBODY (OOPS!).

We should not try to create an audio capture source from a speaker.

This regression was introduced in 265923@main

* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::getCapabilities):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/629234acc45038263f2874c6a47f02015ed6d27c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14124 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11909 "Failed to checkout and rebase branch from PR 15743") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12441 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12545 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13305 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10471 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14564 "Failed to checkout and rebase branch from PR 15743") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10588 "4 flakes 4 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11216 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18320 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11671 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11381 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11876 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9802 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->