### PR TITLE
REGRESSION(265827@main): Variable reference in matched declarations cache can not be overridden

### DIFF
--- a/LayoutTests/fast/css/variables/variable-reference-override-cached-expected.html
+++ b/LayoutTests/fast/css/variables/variable-reference-override-cached-expected.html
@@ -1,0 +1,8 @@
+<style>
+div {
+    background-color:green;
+    width:100px;
+    height:100px;
+}
+</style>
+<div></div>

--- a/LayoutTests/fast/css/variables/variable-reference-override-cached.html
+++ b/LayoutTests/fast/css/variables/variable-reference-override-cached.html
@@ -1,0 +1,12 @@
+<style>
+div {
+    --a:red;
+    background-color:var(--a);
+    width:100px;
+    height:100px;
+}
+div {
+    background-color:green;
+}
+</style>
+<div><div></div></div>

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -90,6 +90,7 @@ private:
     void setDeferred(CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
     static void setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, CascadeLevel);
 
+    bool hasProperty(CSSPropertyID, const CSSValue&);
 
     unsigned deferredPropertyIndex(CSSPropertyID) const;
     void setDeferredPropertyIndex(CSSPropertyID, unsigned);


### PR DESCRIPTION
#### 58d11893af8926dc0092a858dab48021353d7535
<pre>
REGRESSION(265827@main): Variable reference in matched declarations cache can not be overridden
<a href="https://bugs.webkit.org/show_bug.cgi?id=259112">https://bugs.webkit.org/show_bug.cgi?id=259112</a>
rdar://111924949

Reviewed by Myles C. Maxfield.

A normal non-inherited value overriding a variable reference may not be applied correctly.

* LayoutTests/fast/css/variables/variable-reference-override-cached-expected.html: Added.
* LayoutTests/fast/css/variables/variable-reference-override-cached.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::hasProperty):
(WebCore::Style::PropertyCascade::addMatch):
(WebCore::Style::PropertyCascade::shouldApplyAfterAnimation):

The cached variable reference case needs the same already-applied check as the after-animation case.
Move the check to addMatch.

* Source/WebCore/style/PropertyCascade.h:

Canonical link: <a href="https://commits.webkit.org/265985@main">https://commits.webkit.org/265985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a354d3e90128090a85c358139831b2c6835030b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14593 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14603 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11232 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18363 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14618 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11888 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9813 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11103 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3066 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->