### PR TITLE
[macOS] Only disable the background responsiveness timer once the process has been suspended

### DIFF
--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -102,6 +102,11 @@ void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
 
     scheduleNextResponsivenessCheck();
 
+    // This shouldn't happen but still check to be 100% sure we don't report
+    // suspended processes as unresponsive.
+    if (m_webProcessProxy.throttler().isSuspended())
+        return;
+
     if (!m_isResponsive)
         return;
 
@@ -133,8 +138,10 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
 
 bool BackgroundProcessResponsivenessTimer::shouldBeActive() const
 {
-#if !USE(RUNNINGBOARD)
+#if !PLATFORM(IOS_FAMILY)
     if (m_webProcessProxy.visiblePageCount())
+        return false;
+    if (m_webProcessProxy.throttler().isSuspended())
         return false;
     if (m_webProcessProxy.isStandaloneServiceWorkerProcess())
         return true;

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -399,6 +399,8 @@ void ProcessThrottler::clearAssertion()
         PROCESSTHROTTLER_RELEASE_LOG("clearAssertion: Releasing near-suspended assertion");
         m_prepareToDropLastAssertionTimeoutTimer.stop();
         m_assertionToClearAfterPrepareToDropLastAssertion = nullptr;
+        if (!m_assertion)
+            m_process.didDropLastAssertion();
     });
 }
 

--- a/Source/WebKit/UIProcess/ProcessThrottlerClient.h
+++ b/Source/WebKit/UIProcess/ProcessThrottlerClient.h
@@ -44,6 +44,7 @@ public:
     virtual ASCIILiteral clientName() const = 0;
     virtual String environmentIdentifier() const { return emptyString(); }
     virtual void prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
+    virtual void didDropLastAssertion() { }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1726,6 +1726,12 @@ void WebProcessProxy::didChangeThrottleState(ProcessThrottleState type)
     }
 
     ASSERT(!m_backgroundToken || !m_foregroundToken);
+    m_backgroundResponsivenessTimer.updateState();
+}
+
+void WebProcessProxy::didDropLastAssertion()
+{
+    m_backgroundResponsivenessTimer.updateState();
 }
 
 void WebProcessProxy::prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -365,6 +365,7 @@ public:
     void sendProcessDidResume(ResumeReason) final;
     void didChangeThrottleState(ProcessThrottleState) final;
     void prepareToDropLastAssertion(CompletionHandler<void()>&&) final;
+    void didDropLastAssertion() final;
     ASCIILiteral clientName() const final { return "WebProcess"_s; }
     String environmentIdentifier() const final;
 


### PR DESCRIPTION
#### f008b08e638510b256b1cc0e07881cb292a60d74
<pre>
[macOS] Only disable the background responsiveness timer once the process has been suspended
<a href="https://bugs.webkit.org/show_bug.cgi?id=259115">https://bugs.webkit.org/show_bug.cgi?id=259115</a>
rdar://111702782

Reviewed by Ben Nham.

Only disable the background responsiveness timer once the process has been
suspended. We wait a long time on macOS to suspend background processes so the
background responsiveness timer still is useful during this &quot;running in the
background&quot; period.

The background responsiveness timer had very recently been disabled on macOS
in 265536@main.

* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::shouldBeActive const):
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::clearAssertion):
* Source/WebKit/UIProcess/ProcessThrottlerClient.h:
(WebKit::ProcessThrottlerClient::didDropLastAssertion):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::didDropLastAssertion):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/265958@main">https://commits.webkit.org/265958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6310664727682e743c8be41dcbc1522226a5fe9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11927 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14597 "127 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14567 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10600 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18333 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11683 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14579 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/11891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9815 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11121 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15452 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->