### PR TITLE
SQLiteDatabase should try to set RunningBoard file attribute on all database files, not just the main one

### DIFF
--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -49,10 +49,6 @@
 #define ENABLE_SQLITE_FAST_MALLOC (BENABLE(MALLOC_SIZE) && BENABLE(MALLOC_GOOD_SIZE))
 #endif
 
-#if PLATFORM(COCOA)
-#include <sys/xattr.h>
-#endif
-
 namespace WebCore {
 
 static const char notOpenErrorMessage[] = "database is not open";
@@ -159,15 +155,10 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
         int result = SQLITE_OK;
         {
             SQLiteTransactionInProgressAutoCounter transactionCounter;
-            auto fsFilename = FileSystem::fileSystemRepresentation(filename);
-            result = sqlite3_open_v2(fsFilename.data(), &m_db, flags, nullptr);
+            result = sqlite3_open_v2(FileSystem::fileSystemRepresentation(filename).data(), &m_db, flags, nullptr);
 #if PLATFORM(COCOA)
-            if (result == SQLITE_OK && options.contains(OpenOptions::CanSuspendWhileLocked)) {
-                char excluded = 0xff;
-                auto err = setxattr(fsFilename.data(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
-                if (err < 0)
-                    RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::open: setxattr failed: %" PUBLIC_LOG_STRING, strerror(errno));
-            }
+            if (result == SQLITE_OK && options.contains(OpenOptions::CanSuspendWhileLocked))
+                SQLiteFileSystem::setCanSuspendLockedFileAttribute(filename);
 #else
             UNUSED_PARAM(options);
 #endif

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -41,6 +41,10 @@
 #include <pal/spi/ios/SQLite3SPI.h>
 #endif
 
+#if PLATFORM(COCOA)
+#include <sys/xattr.h>
+#endif
+
 namespace WebCore {
 
 static constexpr std::array<const char *, 3> databaseFileSuffixes { "", "-shm", "-wal" };
@@ -90,6 +94,19 @@ bool SQLiteFileSystem::deleteDatabaseFile(const String& filePath)
 
     return !fileExists;
 }
+
+#if PLATFORM(COCOA)
+void SQLiteFileSystem::setCanSuspendLockedFileAttribute(const String& filePath)
+{
+    for (const auto* suffix : databaseFileSuffixes) {
+        String path = filePath + suffix;
+        char excluded = 0xff;
+        auto result = setxattr(FileSystem::fileSystemRepresentation(path).data(), "com.apple.runningboard.can-suspend-locked", &excluded, sizeof(excluded), 0, 0);
+        if (result < 0 && !strcmp(suffix, ""))
+            RELEASE_LOG_ERROR(SQLDatabase, "SQLiteFileSystem::setCanSuspendLockedFileAttribute: setxattr failed: %" PUBLIC_LOG_STRING, strerror(errno));
+    }
+}
+#endif
 
 bool SQLiteFileSystem::moveDatabaseFile(const String& oldFilePath, const String& newFilePath)
 {

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.h
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.h
@@ -80,6 +80,10 @@ public:
     // fileName - The file name.
     WEBCORE_EXPORT static bool deleteDatabaseFile(const String& filePath);
 
+#if PLATFORM(COCOA)
+    static void setCanSuspendLockedFileAttribute(const String& filePath);
+#endif
+
     // Moves a database file to a new place.
     WEBCORE_EXPORT static bool moveDatabaseFile(const String& oldFilePath, const String& newFilePath);
     WEBCORE_EXPORT static String computeHashForFileName(StringView filePath);


### PR DESCRIPTION
#### b182e96083de03417b61e77e60483b4a47c8eef7
<pre>
SQLiteDatabase should try to set RunningBoard file attribute on all database files, not just the main one
<a href="https://bugs.webkit.org/show_bug.cgi?id=259117">https://bugs.webkit.org/show_bug.cgi?id=259117</a>
rdar://97212284

Reviewed by Ben Nham.

SQLiteDatabase should try to set RunningBoard file attribute on all database
files, not just the main one.

This is a follow-up to 265951@main. This is not perfect this we don&apos;t control
when the `-shm` file will be created for example. However, this is a best
effort until we have something better (like an API from SQLite).

* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::open):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::setCanSuspendLockedFileAttribute):
* Source/WebCore/platform/sql/SQLiteFileSystem.h:

Canonical link: <a href="https://commits.webkit.org/265962@main">https://commits.webkit.org/265962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1cbc0f800092a6ba6780674bb91e96ac0c98079

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14147 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14600 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14570 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18335 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14584 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11893 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11124 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3051 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->