### PR TITLE
Restore missing CommonIdentifiers to avoid memory regression

### DIFF
--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -70,6 +70,7 @@
     macro(__lookupGetter__) \
     macro(__lookupSetter__) \
     macro(add) \
+    macro(additionalJettisonReason) \
     macro(anonymous) \
     macro(arguments) \
     macro(as) \
@@ -78,6 +79,10 @@
     macro(bind) \
     macro(byteLength) \
     macro(byteOffset) \
+    macro(bytecode) \
+    macro(bytecodeIndex) \
+    macro(bytecodes) \
+    macro(bytecodesID) \
     macro(calendar) \
     macro(callee) \
     macro(caller) \
@@ -86,10 +91,14 @@
     macro(clear) \
     macro(collation) \
     macro(column) \
+    macro(compilationKind) \
+    macro(compilationUID) \
+    macro(compilations) \
     macro(compile) \
     macro(configurable) \
     macro(constructor) \
     macro(count) \
+    macro(counters) \
     macro(dateStyle) \
     macro(day) \
     macro(days) \
@@ -98,6 +107,7 @@
     macro(defineProperty) \
     macro(deref) \
     macro(description) \
+    macro(descriptions) \
     macro(detail) \
     macro(displayName) \
     macro(done) \
@@ -107,7 +117,10 @@
     macro(eraYear) \
     macro(errors) \
     macro(eval) \
+    macro(events) \
     macro(exec) \
+    macro(executionCount) \
+    macro(exitKind) \
     macro(exports) \
     macro(fallback) \
     macro(flags) \
@@ -143,6 +156,7 @@
     macro(ignorePunctuation) \
     macro(index) \
     macro(indices) \
+    macro(inferredName) \
     macro(input) \
     macro(isoDay) \
     macro(isoHour) \
@@ -153,12 +167,15 @@
     macro(isoNanosecond) \
     macro(isoSecond) \
     macro(isoYear) \
+    macro(instructionCount) \
     macro(isArray) \
     macro(isEnabled) \
     macro(isPrototypeOf) \
     macro(isView) \
+    macro(isWatchpoint) \
     macro(isWellFormed) \
     macro(isWordLike) \
+    macro(jettisonReason) \
     macro(join) \
     macro(language) \
     macro(languageDisplay) \
@@ -195,14 +212,22 @@
     macro(nanosecondsDisplay) \
     macro(next) \
     macro(now) \
+    macro(numInlinedCalls) \
+    macro(numInlinedGetByIds) \
+    macro(numInlinedPutByIds) \
     macro(numberingSystem) \
     macro(numeric) \
     macro(of) \
+    macro(opcode) \
+    macro(origin) \
+    macro(osrExitSites) \
+    macro(osrExits) \
     macro(overflow) \
     macro(ownKeys) \
     macro(parse) \
     macro(parseInt) \
     macro(parseFloat) \
+    macro(profiledBytecodes) \
     macro(propertyIsEnumerable) \
     macro(prototype) \
     macro(raw) \
@@ -226,12 +251,14 @@
     macro(slice) \
     macro(smallestUnit) \
     macro(source) \
+    macro(sourceCode) \
     macro(sourceURL) \
     macro(stack) \
     macro(stackTraceLimit) \
     macro(sticky) \
     macro(style) \
     macro(subarray) \
+    macro(summary) \
     macro(target) \
     macro(test) \
     macro(then) \
@@ -251,6 +278,7 @@
     macro(trailingZeroDisplay) \
     macro(transfer) \
     macro(type) \
+    macro(uid) \
     macro(unicode) \
     macro(unicodeSets) \
     macro(unit) \


### PR DESCRIPTION
#### 58021e6dc89cc38cc40c7e9bab8afb23c7ca8fd7
<pre>
Restore missing CommonIdentifiers to avoid memory regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=259118">https://bugs.webkit.org/show_bug.cgi?id=259118</a>
rdar://111588835

Reviewed by Yusuke Suzuki.

For some reason, removing these unused common identifiers resulted in a .8% RAMification regression. This patch restores the removed identifiers to avoid this regression. Original change was <a href="https://commits.webkit.org/265586@main">https://commits.webkit.org/265586@main</a>

* Source/JavaScriptCore/runtime/CommonIdentifiers.h:

Canonical link: <a href="https://commits.webkit.org/265968@main">https://commits.webkit.org/265968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566c40f530c6066c13a1a5bcc4a89d76e3f330a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14616 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14586 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11243 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10568 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14601 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11756 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9826 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12482 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11137 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3271 "Found 1 jsc stress test failure: microbenchmarks/sorting-benchmark.js.no-cjit-collect-continuously") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15466 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12836 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11759 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3057 "Passed tests") | 
<!--EWS-Status-Bubble-End-->