### PR TITLE
[Cocoa] ::cue background-color not changed unless "allow video to override" unchecked

### DIFF
--- a/LayoutTests/media/track/track-user-stylesheet-override-expected.txt
+++ b/LayoutTests/media/track/track-user-stylesheet-override-expected.txt
@@ -1,0 +1,10 @@
+Test that caption styles override UA provided styles
+
+RUN(internals.setCaptionsStyleSheetOverride('::cue { color: blue; background-color: yellow; }'))
+EVENT(canplaythrough)
+EVENT(seeked)
+EXPECTED (firstCueElement() != 'null') OK
+EXPECTED (window.getComputedStyle(firstCueElement()).color == 'rgb(0, 0, 255)') OK
+EXPECTED (window.getComputedStyle(firstCueElement()).backgroundColor == 'rgb(255, 255, 0)') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-user-stylesheet-override.html
+++ b/LayoutTests/media/track/track-user-stylesheet-override.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+        <script src=../media-file.js></script>
+        <script src=../video-test.js></script>
+
+        <script>
+            function firstCueElement() {
+                return internals.shadowRoot(video).querySelector('[pseudo="cue"]');
+            }
+
+            async function runTest()
+            {
+                consoleWrite("");
+                run("internals.setCaptionsStyleSheetOverride('::cue { color: blue; background-color: yellow; }')");
+
+                findMediaElement();
+
+                video.src = findMediaFile('video', '../content/test');
+                waitFor(video, 'error').then(failTest);
+
+                await waitFor(video, 'canplaythrough');
+                video.textTracks[0].mode = 'showing';
+
+                video.currentTime = 0.5;
+                await waitFor(video, 'seeked');
+
+
+                await testExpectedEventually('firstCueElement()', null, '!=');
+                await testExpectedEventually(`window.getComputedStyle(firstCueElement()).color`, 'rgb(0, 0, 255)', '==', 100);
+                await testExpectedEventually(`window.getComputedStyle(firstCueElement()).backgroundColor`, 'rgb(255, 255, 0)', '==', 100);
+            }
+
+            window.addEventListener('load', event => {
+                runTest().catch(failTest).then(endTest);
+            }, {once: true})
+
+        </script>
+    </head>
+    <body>
+        <span>Test that caption styles override UA provided styles</span>
+        <video controls >
+            <track src="captions-webvtt/styling.vtt" kind="captions">
+        </video>
+    </body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -51,12 +51,12 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 /* https://w3c.github.io/webvtt/#applying-css-properties
    7.4. Applying CSS properties to WebVTT Node Objects */
 
-video::cue {
+::cue {
     background-color: rgba(0, 0, 0, 0.8);
     overflow: visible;
 }
 
-video::-webkit-media-text-track-display {
+::-webkit-media-text-track-display {
     position: absolute;
     unicode-bidi: plaintext;
     overflow: visible;
@@ -65,17 +65,17 @@ video::-webkit-media-text-track-display {
     white-space: pre-line;
 }
 
-video::-webkit-media-text-track-display {
+::-webkit-media-text-track-display {
     white-space: pre-wrap;
     box-sizing: border-box;
     font: 22px sans-serif; /* Keep in sync with `DEFAULTCAPTIONFONTSIZE`. */
 }
 
-video::-webkit-media-text-track-display-backdrop {
+::-webkit-media-text-track-display-backdrop {
     display: inline-block;
 }
 
-video::cue(:future) {
+::cue(:future) {
     color: gray;
 }
 


### PR DESCRIPTION
#### bb909a8331522160a271cc9943fa804d4b1c8a5c
<pre>
[Cocoa] ::cue background-color not changed unless &quot;allow video to override&quot; unchecked
<a href="https://bugs.webkit.org/show_bug.cgi?id=259121">https://bugs.webkit.org/show_bug.cgi?id=259121</a>
rdar://112100260

Reviewed by Andy Estes.

The `text-tracks.css` UA style sheet sets default styles for VTT cues by setting
a style on `video::cue`. However that has a higher specificity than the styles generated
by the platform, which use `::cue`. This means, in effect, that the system provided
styles (as specified by the user) are ignored unless they are accompanied by a &apos;!important&apos;
rule, which means those rules also cannot be overridden by page provided styles.

Move from `video::cue` to `::cue` in the UA provided styles, allowing both the platform
and the page to override them.

* LayoutTests/media/track/track-user-stylesheet-override-expected.txt: Added.
* LayoutTests/media/track/track-user-stylesheet-override.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
(::cue):
(::-webkit-media-text-track-display):
(::-webkit-media-text-track-display-backdrop):
(::cue(:future)):
(video::cue): Deleted.
(video::-webkit-media-text-track-display): Deleted.
(video::-webkit-media-text-track-display-backdrop): Deleted.
(video::cue(:future)): Deleted.

Canonical link: <a href="https://commits.webkit.org/265975@main">https://commits.webkit.org/265975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb6ea4f9403feaac23edc8671ff597d330d4e15e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15190 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13342 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14595 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18356 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11909 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11123 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3058 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15474 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->