### PR TITLE
Add more assertions to guard against re-entrency in MatchedDeclarationsCache

### DIFF
--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -66,6 +66,7 @@ private:
     HashMap<unsigned, Entry, AlreadyHashed> m_entries;
     Timer m_sweepTimer;
     unsigned m_additionsSinceLastSweep { 0 };
+    bool m_isMutating { false };
 };
 
 }


### PR DESCRIPTION
#### 0a94a553d7db484185c24b09a7bc424ad2d36f23
<pre>
Add more assertions to guard against re-entrency in MatchedDeclarationsCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=259125">https://bugs.webkit.org/show_bug.cgi?id=259125</a>
rdar://107338197

Reviewed by NOBODY (OOPS!).

Add more assertions to guard against re-entrency in MatchedDeclarationsCache.
It may help find the root cause of &lt;rdar://107338197&gt;.

* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::find):
(WebCore::Style::MatchedDeclarationsCache::add):
(WebCore::Style::MatchedDeclarationsCache::remove):
(WebCore::Style::MatchedDeclarationsCache::invalidate):
(WebCore::Style::MatchedDeclarationsCache::clearEntriesAffectedByViewportUnits):
(WebCore::Style::MatchedDeclarationsCache::sweep):
* Source/WebCore/style/MatchedDeclarationsCache.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a94a553d7db484185c24b09a7bc424ad2d36f23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14694 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14676 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18417 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11488 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14680 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9897 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->