### PR TITLE
Add variable swatches to color picker

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1781,6 +1781,8 @@ localizedStrings["Valid From"] = "Valid From";
 localizedStrings["Valid Until"] = "Valid Until";
 localizedStrings["Value"] = "Value";
 localizedStrings["Variables"] = "Variables";
+/* Title of swatches section in Color Picker */
+localizedStrings["Variables @ Color Picker"] = "Variables";
 /* Section title for font variation properties. */
 localizedStrings["Variation Properties @ Font Details Sidebar Section"] = "Variation Properties";
 localizedStrings["Verbose"] = "Verbose";

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -26,7 +26,6 @@
 .color-picker {
     position: relative;
     width: var(--color-picker-width);
-    height: 236px;
     padding: 5px;
 
     --color-picker-hue-offset-start: 41px;
@@ -107,4 +106,34 @@
 
 .color-picker > .color-inputs-wrapper > .pick-color-from-screen.active {
     color: var(--glyph-color-active);
+}
+
+.color-picker > .variable-color-swatches {
+    padding: 8px 0 0;
+}
+
+.color-picker > .variable-color-swatches > ul{
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 2px;
+    padding: 0;
+    margin: 2px 0 0;
+    max-height: 45px;
+    overflow-y: auto;
+}
+
+.color-picker > .variable-color-swatches > ul > li {
+    height: 1em;
+}
+
+.color-picker > .variable-color-swatches > ul > li > .inline-swatch {
+    --inline-swatch-margin-right-override: 0;
+    --inline-swatch-vertical-align-override: 0;
+}
+
+.color-picker > .variable-color-swatches > h2 {
+    margin: 0;
+    font-size: 1.15em;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
@@ -29,11 +29,14 @@
     position: relative;
     width: 1em;
     height: 1em;
-    margin-right: 3px;
-    vertical-align: -2px;
+    margin-right: var(--inline-swatch-margin-right-override, var(--inline-swatch-margin-right-default));
+    vertical-align: var(--inline-swatch-vertical-align-override, var(--inline-swatch-vertical-align-default));
     border-radius: 2px;
     overflow: hidden;
     cursor: default;
+
+    --inline-swatch-margin-right-default: 3px;
+    --inline-swatch-vertical-align-override: -2px;
 }
 
 .inline-swatch:not(.box-shadow),


### PR DESCRIPTION
#### 3afcee6932b3b4ddb02e3b3551fb600d8c727633
<pre>
Add variable swatches to color picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=259120">https://bugs.webkit.org/show_bug.cgi?id=259120</a>
rdar://112099603

Reviewed by Devin Rousso.

Include known color variables within the color picker. Select variables based on selected element and sort them based on the HSL values. The colors are shown using the InlineSwatch class allowing developers to quickly select variable colors.

Utilize the node styles of an element to gather color variable information and sort based on visual appearance. Future work could aggregate more sources of color data and add new sorting patterns.

Rewrote InlineSwatch to allow swapping between multiple swatch types. Added ColorSwatchDisplay to show all swatches. Altered ColorPicker communication pattern with InlineSwatch.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker):
(.color-picker &gt; .variable-color-swatches):
(.color-picker &gt; .variable-color-swatches &gt; ul):
(.color-picker &gt; .variable-color-swatches &gt; ul &gt; li):
(.color-picker &gt; .variable-color-swatches &gt; ul &gt; li &gt; .inline-swatch):
(.color-picker &gt; .variable-color-swatches &gt; h2):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.prototype.async colorInputsWrapperElement):
(WI.ColorPicker.sortColorVariables.visualAppeal):
(WI.ColorPicker.sortColorVariables):
(WI.ColorPicker.prototype._updateColorForVariable):
(WI.ColorPicker):
(WI.ColorPicker.get element): Deleted.
(WI.ColorPicker.get colorSquare): Deleted.
(WI.ColorPicker.set opacity): Deleted.
(WI.ColorPicker.get color): Deleted.
(WI.ColorPicker.set color): Deleted.
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css:
(.inline-swatch):
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
(WI.InlineSwatch.prototype.switch):
(WI.InlineSwatch.prototype._updateSwatch):
(WI.InlineSwatch.prototype._valueEditorValueDidChange):
(WI.InlineSwatch.prototype._findMatchingColorVariable):
(WI.InlineSwatch):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.inlineSwatchGetColorVariables):
(WI.SpreadsheetStyleProperty.prototype._createInlineSwatch):
(WI.SpreadsheetStyleProperty.prototype._addVariableTokens):

Canonical link: <a href="https://commits.webkit.org/266794@main">https://commits.webkit.org/266794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dc161dcdd4062dd50af613057332994a0277f37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16537 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15195 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17271 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13344 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16746 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14056 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13347 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3564 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->