### PR TITLE
Begin implementing redirect handling for site-isolation

### DIFF
--- a/Source/WebKit/Shared/LocalFrameCreationParameters.h
+++ b/Source/WebKit/Shared/LocalFrameCreationParameters.h
@@ -31,7 +31,7 @@
 namespace WebKit {
 
 struct LocalFrameCreationParameters {
-    WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier;
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LocalFrameCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/LocalFrameCreationParameters.serialization.in
@@ -21,5 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 struct WebKit::LocalFrameCreationParameters {
-    WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier;
+    std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier;
 };

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -26,30 +26,9 @@
 #include "config.h"
 #include "ProvisionalFrameProxy.h"
 
-#include "APIWebsitePolicies.h"
-#include "DrawingAreaProxy.h"
-#include "FrameInfoData.h"
-#include "HandleMessage.h"
-#include "LoadParameters.h"
-#include "LoadedWebArchive.h"
-#include "LocalFrameCreationParameters.h"
-#include "MessageSenderInlines.h"
-#include "NetworkProcessMessages.h"
-#include "RemotePageProxy.h"
-#include "VisitedLinkStore.h"
-#include "WebFrameProxy.h"
-#include "WebPageMessages.h"
-#include "WebPageProxy.h"
-#include "WebPageProxyMessages.h"
-#include "WebProcessMessages.h"
-#include "WebProcessProxy.h"
-
-#include <WebCore/FrameIdentifier.h>
-#include <WebCore/ShouldTreatAsContinuingLoad.h>
-
 namespace WebKit {
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProcessProxy>&& process, const WebCore::ResourceRequest& request)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProcessProxy>&& process)
     : m_frame(frame)
     , m_process(WTFMove(process))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
@@ -59,32 +38,10 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProces
 {
     m_process->markProcessAsRecentlyUsed();
     m_process->addProvisionalFrameProxy(*this);
-
-    ASSERT(frame.page());
-
-    LoadParameters loadParameters;
-    loadParameters.request = request;
-    loadParameters.shouldTreatAsContinuingLoad = WebCore::ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision;
-    loadParameters.frameIdentifier = frame.frameID();
-    // FIXME: Add more parameters as appropriate.
-
-    LocalFrameCreationParameters localFrameCreationParameters {
-        m_layerHostingContextIdentifier
-    };
-
-    // FIXME: This gives too much cookie access. This should be removed after putting the entire frame tree in all web processes.
-    auto giveAllCookieAccess = LoadedWebArchive::Yes;
-    WebCore::RegistrableDomain domain { request.url() };
-    m_process->addAllowedFirstPartyForCookies(domain);
-    frame.page()->websiteDataStore().networkProcess().sendWithAsyncReply(Messages::NetworkProcess::AddAllowedFirstPartyForCookies(m_process->coreProcessIdentifier(), domain, giveAllCookieAccess), [process = m_process, loadParameters = WTFMove(loadParameters), localFrameCreationParameters = WTFMove(localFrameCreationParameters), pageID = m_pageID] () mutable {
-        process->send(Messages::WebPage::TransitionFrameToLocal(localFrameCreationParameters, *loadParameters.frameIdentifier), pageID);
-        process->send(Messages::WebPage::LoadRequest(loadParameters), pageID);
-    });
 }
 
 ProvisionalFrameProxy::~ProvisionalFrameProxy()
 {
-    m_process->removeVisitedLinkStoreUser(m_visitedLinkStore.get(), m_webPageID);
     m_process->removeProvisionalFrameProxy(*this);
 }
 

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -31,10 +31,6 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/WeakPtr.h>
 
-namespace WebCore {
-class ResourceRequest;
-}
-
 namespace WebKit {
 
 class VisitedLinkStore;
@@ -44,7 +40,7 @@ class WebProcessProxy;
 class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
+    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&);
     ~ProvisionalFrameProxy();
 
     WebProcessProxy& process() { return m_process.get(); }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -151,7 +151,7 @@ public:
     void disconnect();
     void didCreateSubframe(WebCore::FrameIdentifier);
     ProcessID processID() const;
-    void swapToProcess(Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
+    void prepareForProvisionalNavigationInProcess(WebProcessProxy&, CompletionHandler<void()>&&);
 
     void commitProvisionalFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
     void setRemotePageProxy(RemotePageProxy&);


### PR DESCRIPTION
#### 77585442bf6a0acc7af584f838acd4653918b7e9
<pre>
Begin implementing redirect handling for site-isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259133">https://bugs.webkit.org/show_bug.cgi?id=259133</a>
rdar://112109909

Reviewed by J Pascoe.

When a same-site redirect was received when navigating an iframe, we would
resend the TransitionToLocal message causing an assertion.  This message is
not needed if there is already a local frame in the process.

I also moved a lot of the process preparation code from ProvisionalFrameProxy&apos;s
constructor and WebPageProxy to a new-ish function prepareForProvisionalNavigationInProcess
which is just expanding what used to be called &quot;swapToProcess&quot; to handle more cases.

* Source/WebKit/Shared/LocalFrameCreationParameters.h:
* Source/WebKit/Shared/LocalFrameCreationParameters.serialization.in:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
(WebKit::ProvisionalFrameProxy::~ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalNavigationInProcess):
(WebKit::WebFrameProxy::swapToProcess): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/265982@main">https://commits.webkit.org/265982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec5cf4959df78e9612d0c581af75f103bffc03ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14216 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14662 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13378 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14642 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11290 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14643 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11177 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15507 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->