### PR TITLE
[iPhone] 39miles.com link is rendered at single-column layout in private browsing mode

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5182,9 +5182,10 @@ FloatSize WebPage::screenSizeForFingerprintingProtections(const LocalFrame&, Flo
         return m_viewportConfiguration.minimumLayoutSize();
 
     static constexpr std::array fixedSizes {
-        FloatSize { 320,  568 },
-        FloatSize { 375,  667 },
-        FloatSize { 414,  736 },
+        FloatSize { 320, 568 },
+        FloatSize { 375, 667 },
+        FloatSize { 390, 844 },
+        FloatSize { 414, 896 },
     };
 
     for (auto fixedSize : fixedSizes) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -779,9 +779,10 @@ TEST(AdvancedPrivacyProtections, ClampScreenSizeToFixedValues)
         EXPECT_EQ(expectedSize.height, sizeForBindings.height);
     };
 
-    runTestWithScreenSize(CGSizeMake(393, 852), CGSizeMake(414, 736));
-    runTestWithScreenSize(CGSizeMake(320,  568), CGSizeMake(320,  568));
-    runTestWithScreenSize(CGSizeMake(440,  900), CGSizeMake(414,  736));
+    runTestWithScreenSize(CGSizeMake(320, 568), CGSizeMake(320, 568));
+    runTestWithScreenSize(CGSizeMake(388, 844), CGSizeMake(390, 844));
+    runTestWithScreenSize(CGSizeMake(390, 848), CGSizeMake(390, 844));
+    runTestWithScreenSize(CGSizeMake(440, 900), CGSizeMake(414, 896));
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 88351aff0eb23703afdc698fec358ee21fc4227d
<pre>
[iPhone] 39miles.com link is rendered at single-column layout in private browsing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=259129">https://bugs.webkit.org/show_bug.cgi?id=259129</a>
rdar://112105451

Reviewed by Aditya Keerthi.

Add a missing 390pt screen dimension breakpoint when advanced privacy protections are enabled;
currently, this causes some websites that rely on the screen width for layout to assume that the
width of the page is larger than it actually is.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::screenSizeForFingerprintingProtections const):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:

Also, augment an existing API test to verify that the new screen size breakpoint behaves as
expected.

Canonical link: <a href="https://commits.webkit.org/265979@main">https://commits.webkit.org/265979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/608d5da1ba9f051a195704eda3d33910d40712fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14210 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14655 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13375 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14636 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11286 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18379 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14638 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/11933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11171 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3063 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->