### PR TITLE
"undefined symbol: JSC::Structure::create" for Windows clang-cl build

### DIFF
--- a/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
+++ b/Source/JavaScriptCore/API/JSAPIGlobalObject.cpp
@@ -28,6 +28,7 @@
 
 #include "GlobalObjectMethodTable.h"
 #include "JSCellInlines.h"
+#include "StructureInlines.h"
 
 namespace JSC {
 

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -35,6 +35,7 @@
 #include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/URL.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.cpp
@@ -27,6 +27,7 @@
 #include "CacheStorageConnection.h"
 
 #include "FetchResponse.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
@@ -36,6 +36,7 @@
 #include "Supplementable.h"
 #include "WorkerCacheStorageConnection.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -28,6 +28,7 @@
 #include "FetchBodySource.h"
 
 #include "FetchResponse.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchLoader.cpp
+++ b/Source/WebCore/Modules/fetch/FetchLoader.cpp
@@ -43,6 +43,7 @@
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
 #include "ThreadableBlobRegistry.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -40,6 +40,7 @@
 #include "ResourceError.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursorWithValue.cpp
@@ -27,6 +27,7 @@
 #include "IDBCursorWithValue.h"
 
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -39,6 +39,7 @@
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp
@@ -28,6 +28,7 @@
 
 #include "IDBConnectionProxy.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBIndex.cpp
@@ -36,6 +36,7 @@
 #include "Logging.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -38,6 +38,7 @@
 #include "IDBVersionChangeEvent.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IDBRequestCompletionEvent.h"
 
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
@@ -36,6 +36,7 @@
 #include "Page.h"
 #include "Supplementable.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -38,6 +38,7 @@
 #include "IDBResultData.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MainThread.h>
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -37,6 +37,7 @@
 #include "Logging.h"
 #include "SecurityOrigin.h"
 #include "TransactionOperation.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MainThread.h>
 

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
@@ -28,6 +28,7 @@
 
 #include "IDBCursor.h"
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp
@@ -29,6 +29,7 @@
 #include "IDBDatabase.h"
 #include "IDBTransaction.h"
 #include "IndexedDB.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp
@@ -29,6 +29,7 @@
 #include "IDBConnectionToServer.h"
 #include "IDBDatabase.h"
 #include "IDBOpenDBRequest.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
@@ -29,6 +29,7 @@
 #include "IDBConnectionToClient.h"
 #include "IDBConnectionToServer.h"
 #include "IDBRequest.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/MainThread.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp
@@ -27,6 +27,7 @@
 #include "IDBTransactionInfo.h"
 
 #include "IDBTransaction.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -62,6 +62,7 @@
 #include "VTTCue.h"
 #include "VoidCallback.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <variant>
 #include <wtf/Function.h>
 #include <wtf/JSONValues.h>

--- a/Source/WebCore/Modules/push-api/PushMessageData.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageData.cpp
@@ -34,6 +34,7 @@
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -29,6 +29,7 @@
 #include "JSReadableStream.h"
 #include "JSReadableStreamSource.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMGlobalObject.h"
 #include "ReadableStream.h"
 #include "SharedBuffer.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/Uint8Array.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockRegistry.cpp
@@ -28,6 +28,7 @@
 #include "Exception.h"
 #include "WebLockManager.h"
 #include "WebLockManagerSnapshot.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/MarkedBlockInlines.h>
 #include <JavaScriptCore/SlotVisitorInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/VM.h>
 

--- a/Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp
@@ -30,6 +30,7 @@
 #include "JSRange.h"
 #include "JSStaticRange.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp
@@ -42,6 +42,7 @@
 #include "JSCSSUnparsedValue.h"
 #include "JSDOMWrapperCache.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSDOMConstructorWithDocument.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConstructorWithDocument.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "JSDOMConstructorWithDocument.h"
 
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -30,6 +30,7 @@
 #include "WebCoreTypedArrayController.h"
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
 

--- a/Source/WebCore/bindings/js/JSMutationRecordCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMutationRecordCustom.cpp
@@ -27,6 +27,7 @@
 #include "JSMutationRecord.h"
 
 #include "MutationRecord.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRangeCustom.cpp
@@ -27,6 +27,7 @@
 #include "JSRange.h"
 
 #include "Range.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSStaticRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSStaticRangeCustom.cpp
@@ -27,6 +27,7 @@
 #include "JSStaticRange.h"
 
 #include "StaticRange.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bridge/runtime_root.cpp
+++ b/Source/WebCore/bridge/runtime_root.cpp
@@ -30,6 +30,7 @@
 #include "runtime_object.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/HashSet.h>

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -26,6 +26,7 @@
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryListEvent.h"
 #include "MediaQueryParser.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -29,6 +29,7 @@
 #include "AbortSignal.h"
 #include "DOMException.h"
 #include "JSDOMException.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -36,6 +36,7 @@
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/JSCast.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -36,6 +36,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/HashMap.h>
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -36,6 +36,7 @@
 #include "EventNames.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -37,6 +37,7 @@
 #include "Event.h"
 #include "EventTarget.h"
 #include "JSEventListener.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -48,6 +48,7 @@
 #include "SimpleRange.h"
 #include "TextBoundaries.h"
 #include "TextIterator.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 namespace FragmentDirectiveRangeFinder {

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -37,6 +37,7 @@
 #include "WebCoreOpaqueRoot.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Lock.h>

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -30,6 +30,7 @@
 #include "JSDOMPromise.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include <JavaScriptCore/Strong.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
 #include <JavaScriptCore/WeakInlines.h>

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1684,6 +1684,7 @@ END
 #include "NodeName.h"
 #include "Settings.h"
 #include "TagName.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -72,6 +72,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "VisibleUnits.h"
 #include "markup.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashSet.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -82,6 +82,7 @@
 #include "VisibleSelection.h"
 #include "VisibleUnits.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -35,6 +35,7 @@
 #include "HTMLObjectElement.h"
 #include "IdTargetObserver.h"
 #include "LocalFrame.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -31,6 +31,7 @@
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
 #include "HTMLOptionElement.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -53,6 +53,7 @@
 #include "ShadowRoot.h"
 #include "SharedBuffer.h"
 #include "UserAgentStyleSheets.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <pal/FileSizeFormatter.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/UUID.h>

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -26,6 +26,7 @@
 #include "CachedHTMLCollectionInlines.h"
 #include "HTMLNames.h"
 #include "NodeRareDataInlines.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -38,6 +38,7 @@
 #include "RenderWidget.h"
 #include "Settings.h"
 #include "SubframeLoader.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>
 

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -36,6 +36,7 @@
 #include "RenderElement.h"
 #include "ScriptDisallowedScope.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -61,6 +61,7 @@
 #include "SubmitEvent.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UserGestureIndicator.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <limits>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -42,6 +42,7 @@
 #include "NodeName.h"
 #include "RenderFrameSet.h"
 #include "Text.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -66,6 +66,7 @@
 #include "StyleScope.h"
 #include "StyleSheetContents.h"
 #include "SubresourceIntegrity.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>
 #include <wtf/Scope.h>

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -33,6 +33,7 @@
 #include "HTMLObjectElement.h"
 #include "NodeRareData.h"
 #include "NodeTraversal.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -48,6 +48,7 @@
 #include "SubframeLoader.h"
 #include "Text.h"
 #include "Widget.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>
 #include <wtf/RobinHoodHashSet.h>

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -33,6 +33,7 @@
 #include "RequestPriority.h"
 #include "Settings.h"
 #include "Text.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -49,6 +49,7 @@
 #include "RawDataDocumentParser.h"
 #include "RenderElement.h"
 #include "Settings.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -38,6 +38,7 @@
 #include "PluginViewBase.h"
 #include "RawDataDocumentParser.h"
 #include "RenderEmbeddedObject.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -32,6 +32,7 @@
 #include "HTMLObjectElement.h"
 #include "LiveNodeListInlines.h"
 #include "NodeRareData.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "CSSPreloadScanner.h"
 
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/SetForScope.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -46,6 +46,7 @@
 #include "SecurityPolicy.h"
 #include "Settings.h"
 #include "SizesAttributeParser.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/MainThread.h>
 #include <wtf/SortedArrayMap.h>
 

--- a/Source/WebCore/inspector/CommandLineAPIModule.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIModule.cpp
@@ -31,6 +31,7 @@
 #include "WebInjectedScriptManager.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/InjectedScript.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp
@@ -34,6 +34,7 @@
 #include <JavaScriptCore/InjectedScriptManager.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp
@@ -37,6 +37,7 @@
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/InjectedScript.h>
 #include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp
@@ -40,6 +40,7 @@
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "ViolationReportType.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/persistence/PersistentCoders.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -95,6 +95,7 @@
 #include "UserContentProvider.h"
 #include "UserContentURLPattern.h"
 #include "ViolationReportType.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/Assertions.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -83,6 +83,7 @@
 #include "VisitedLinkStore.h"
 #include "WebRTCProvider.h"
 #include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <pal/SessionID.h>
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -51,6 +51,7 @@
 #include "SharedStringHash.h"
 #include "ShouldTreatAsContinuingLoad.h"
 #include "VisitedLinkStore.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/text/CString.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -62,6 +62,7 @@
 #include "Settings.h"
 #include "SizesAttributeParser.h"
 #include "StyleResolver.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -49,6 +49,7 @@
 #include "Logging.h"
 #include "ThreadableBlobRegistry.h"
 #include "URLKeepingBlobAlive.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CompletionHandler.h>
 
 #if USE(QUICK_LOOK)

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -35,6 +35,7 @@
 #include "ScheduledAction.h"
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashMap.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -32,6 +32,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -29,7 +29,7 @@
 #include "HTMLAnchorElement.h"
 #include "SVGAElement.h"
 #include "SVGElementTypeHelpers.h"
-
+#include <JavaScriptCore/StructureInlines.h>
 
 #if ENABLE(DRAG_SUPPORT)
 #include "CachedImage.h"

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -45,6 +45,7 @@
 #include "SharedBuffer.h"
 #include "TextResourceDecoder.h"
 #include "ThreadableLoader.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/SetForScope.h>
 #include <wtf/text/StringToIntegerConversion.h>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -63,6 +63,7 @@
 #include "ShadowRoot.h"
 #include "SpatialNavigation.h"
 #include "Widget.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <limits>
 #include <wtf/Ref.h>
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -123,6 +123,7 @@
 #include "VelocityData.h"
 #include "VisualViewport.h"
 #include "WheelEventTestMonitor.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/HexNumber.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MemoryPressureHandler.h>

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -61,6 +61,7 @@
 #include "StyleRule.h"
 #include "StyleSheetContents.h"
 #include "Text.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -36,6 +36,7 @@
 #include "SerializedScriptValue.h"
 #include "WorkerGlobalScope.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/UserMessageHandlerDescriptor.cpp
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(USER_MESSAGE_HANDLERS)
 
 #include "DOMWrapperWorld.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/UserMessageHandlersNamespace.cpp
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.cpp
@@ -34,6 +34,7 @@
 #include "Page.h"
 #include "UserContentController.h"
 #include "UserMessageHandler.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -34,6 +34,7 @@
 #include "StructuredSerializeOptions.h"
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -27,6 +27,7 @@
 
 #include "HTTPParsers.h"
 #include "JSFetchReferrerPolicy.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
+++ b/Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp
@@ -39,6 +39,7 @@
 #include "MediaEncodingConfiguration.h"
 #include "MediaEncodingType.h"
 #include "VideoConfiguration.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/JSONValues.h>
 
 namespace WebCore {

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -53,6 +53,7 @@
 #include "UserGestureIndicator.h"
 #include "VisibleUnits.h"
 #include "XLinkNames.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -56,6 +56,7 @@
 #include "SystemFontDatabase.h"
 #include "Text.h"
 #include "TextRun.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/StackStats.h>
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -81,6 +81,7 @@
 #include "StyleResolver.h"
 #include "Styleable.h"
 #include "TiledBacking.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -61,6 +61,7 @@
 #include "SVGElement.h"
 #include "StyleSheetContents.h"
 #include "UserAgentStyleSheets.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -60,6 +60,7 @@
 #include "StyleAdjuster.h"
 #include "StyleResolver.h"
 #include "XMLNames.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/HashMap.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -53,6 +53,7 @@
 #include "SVGViewSpec.h"
 #include "StaticNodeList.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -38,6 +38,7 @@
 #include "ShadowRoot.h"
 #include "StyleInheritedData.h"
 #include "Text.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -48,6 +48,7 @@
 #include "SVGURIReference.h"
 #include "SVGUseElement.h"
 #include "XLinkNames.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MathExtras.h>
 #include <wtf/RobinHoodHashSet.h>

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -44,6 +44,7 @@
 #include "StructuredSerializeOptions.h"
 #include "Worker.h"
 #include "WorkerObjectProxy.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -35,6 +35,7 @@
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerType.h"
 #include <JavaScriptCore/RuntimeFlags.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/text/AtomStringHash.h>

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -71,6 +71,7 @@
 #include "WorkerThread.h"
 #include <JavaScriptCore/ScriptArguments.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Lock.h>
 #include <wtf/WorkQueue.h>

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSRunLoopTimer.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 #if USE(GLIB)
 #include <glib.h>

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -34,6 +34,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerScriptFetcher.h"
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/SetForScope.h>
 #include <wtf/Threading.h>
 

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMPromise.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/Microtask.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/service/NavigationPreloadManager.cpp
+++ b/Source/WebCore/workers/service/NavigationPreloadManager.cpp
@@ -30,6 +30,7 @@
 
 #include "ServiceWorkerContainer.h"
 #include "ServiceWorkerRegistration.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -43,6 +43,7 @@
 #include "StructuredSerializeOptions.h"
 #include "WorkerSWClientConnection.h"
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
@@ -33,6 +33,7 @@
 #include "ServiceWorkerThread.h"
 #include "SharedWorkerThread.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
@@ -35,6 +35,7 @@
 #include "WorkerFetchResult.h"
 #include "WorkerInitializationData.h"
 #include "WorkerScriptLoader.h"
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -49,6 +49,7 @@
 #include "WorkerInitializationData.h"
 #include "WorkerThread.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
+#include <JavaScriptCore/StructureInlines.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### b364f323f70b816fa5f50da3ce75f3eb7e5dc47b
<pre>
&quot;undefined symbol: JSC::Structure::create&quot; for Windows clang-cl build
<a href="https://bugs.webkit.org/show_bug.cgi?id=259119">https://bugs.webkit.org/show_bug.cgi?id=259119</a>

Reviewed by NOBODY (OOPS!).

clang-cl reported the following linkage error for Windows Release builds:

&gt; lld-link: error: undefined symbol: public: static class JSC::Structure * __cdecl JSC::Structure::create(class JSC::VM &amp;, class JSC::JSGlobalObject *, class JSC::JSValue, class JSC::TypeInfo const &amp;, struct JSC::ClassInfo const *, unsigned char, unsigned int)

Added #include &lt;JavaScriptCore/StructureInlines.h&gt;.

* Source/JavaScriptCore/API/JSAPIGlobalObject.cpp:
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
* Source/WebCore/Modules/cache/CacheStorageConnection.cpp:
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp:
* Source/WebCore/Modules/fetch/FetchBodySource.cpp:
* Source/WebCore/Modules/fetch/FetchLoader.cpp:
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
* Source/WebCore/Modules/indexeddb/IDBCursorWithValue.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
* Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.cpp:
* Source/WebCore/Modules/indexeddb/IDBIndex.cpp:
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
* Source/WebCore/Modules/indexeddb/IDBRequestCompletionEvent.cpp:
* Source/WebCore/Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
* Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBCursorInfo.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBRequestData.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBTransactionInfo.cpp:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
* Source/WebCore/Modules/push-api/PushMessageData.cpp:
* Source/WebCore/Modules/streams/ReadableStream.cpp:
* Source/WebCore/Modules/streams/ReadableStreamSink.cpp:
* Source/WebCore/Modules/web-locks/WebLockRegistry.cpp:
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
* Source/WebCore/bindings/js/JSAbstractRangeCustom.cpp:
* Source/WebCore/bindings/js/JSCSSStyleValueCustom.cpp:
* Source/WebCore/bindings/js/JSDOMConstructorWithDocument.cpp:
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
* Source/WebCore/bindings/js/JSMutationRecordCustom.cpp:
* Source/WebCore/bindings/js/JSRangeCustom.cpp:
* Source/WebCore/bindings/js/JSStaticRangeCustom.cpp:
* Source/WebCore/bridge/runtime_root.cpp:
* Source/WebCore/css/MediaQueryList.cpp:
* Source/WebCore/dom/AbortController.cpp:
* Source/WebCore/dom/AbortSignal.cpp:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/ErrorEvent.cpp:
* Source/WebCore/dom/EventListenerMap.cpp:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
* Source/WebCore/dom/MessagePort.cpp:
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
* Source/WebCore/dom/make_names.pl:
(printFactoryCppFile):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/html/FormListedElement.cpp:
* Source/WebCore/html/GenericCachedHTMLCollection.cpp:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
* Source/WebCore/html/HTMLCollection.cpp:
* Source/WebCore/html/HTMLEmbedElement.cpp:
* Source/WebCore/html/HTMLFieldSetElement.cpp:
* Source/WebCore/html/HTMLFormElement.cpp:
* Source/WebCore/html/HTMLFrameSetElement.cpp:
* Source/WebCore/html/HTMLLinkElement.cpp:
* Source/WebCore/html/HTMLNameCollection.cpp:
* Source/WebCore/html/HTMLObjectElement.cpp:
* Source/WebCore/html/HTMLScriptElement.cpp:
* Source/WebCore/html/ImageDocument.cpp:
* Source/WebCore/html/PluginDocument.cpp:
* Source/WebCore/html/RadioNodeList.cpp:
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
* Source/WebCore/inspector/CommandLineAPIModule.cpp:
* Source/WebCore/inspector/agents/worker/WorkerDebuggerAgent.cpp:
* Source/WebCore/inspector/agents/worker/WorkerRuntimeAgent.cpp:
* Source/WebCore/loader/CrossOriginEmbedderPolicy.cpp:
* Source/WebCore/loader/DocumentLoader.cpp:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/HistoryController.cpp:
* Source/WebCore/loader/LinkLoader.cpp:
* Source/WebCore/loader/PolicyChecker.cpp:
* Source/WebCore/page/DOMTimer.cpp:
* Source/WebCore/page/DOMWindowExtension.cpp:
* Source/WebCore/page/DragController.cpp:
* Source/WebCore/page/EventSource.cpp:
* Source/WebCore/page/FocusController.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/PageSerializer.cpp:
* Source/WebCore/page/PerformanceMark.cpp:
* Source/WebCore/page/UserMessageHandlerDescriptor.cpp:
* Source/WebCore/page/UserMessageHandlersNamespace.cpp:
* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp:
* Source/WebCore/platform/ReferrerPolicy.cpp:
* Source/WebCore/platform/mediacapabilities/MediaCapabilitiesLogging.cpp:
* Source/WebCore/rendering/HitTestResult.cpp:
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/style/UserAgentStyle.cpp:
* Source/WebCore/svg/SVGElement.cpp:
* Source/WebCore/svg/SVGSVGElement.cpp:
* Source/WebCore/svg/SVGTRefElement.cpp:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
* Source/WebCore/workers/WorkerRunLoop.cpp:
* Source/WebCore/workers/WorkerThread.cpp:
* Source/WebCore/workers/service/ExtendableEvent.cpp:
* Source/WebCore/workers/service/NavigationPreloadManager.cpp:
* Source/WebCore/workers/service/ServiceWorker.cpp:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp:
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b364f323f70b816fa5f50da3ce75f3eb7e5dc47b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14666 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14644 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18389 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10606 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14651 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11804 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9868 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12536 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11179 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3284 "Found 1 jsc stress test failure: microbenchmarks/sorting-benchmark.js.mini-mode") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15509 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12891 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11795 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3072 "Passed tests") | 
<!--EWS-Status-Bubble-End-->