### PR TITLE
[Curl] Replace CURLOPT_POSTFIELDSIZE with CURLOPT_POSTFIELDSIZE_LARGE

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -487,10 +487,10 @@ void CurlHandle::enableHttpPostRequest()
 {
     enableHttp();
     curl_easy_setopt(m_handle, CURLOPT_POST, 1L);
-    curl_easy_setopt(m_handle, CURLOPT_POSTFIELDSIZE, 0L);
+    curl_easy_setopt(m_handle, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(0));
 }
 
-void CurlHandle::setPostFieldLarge(curl_off_t size)
+void CurlHandle::setPostFieldSize(curl_off_t size)
 {
     if (expectedSizeOfCurlOffT() != sizeof(long long))
         size = static_cast<int>(size);
@@ -502,10 +502,10 @@ void CurlHandle::enableHttpPutRequest()
 {
     enableHttp();
     curl_easy_setopt(m_handle, CURLOPT_UPLOAD, 1L);
-    curl_easy_setopt(m_handle, CURLOPT_INFILESIZE, 0L);
+    curl_easy_setopt(m_handle, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(0));
 }
 
-void CurlHandle::setInFileSizeLarge(curl_off_t size)
+void CurlHandle::setInFileSize(curl_off_t size)
 {
     if (expectedSizeOfCurlOffT() != sizeof(long long))
         size = static_cast<int>(size);

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -260,9 +260,9 @@ public:
     void enableHttpGetRequest();
     void enableHttpHeadRequest();
     void enableHttpPostRequest();
-    void setPostFieldLarge(curl_off_t);
+    void setPostFieldSize(curl_off_t);
     void enableHttpPutRequest();
-    void setInFileSizeLarge(curl_off_t);
+    void setInFileSize(curl_off_t);
     void setHttpCustomRequest(const String&);
 
     void enableConnectionOnly();

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -545,9 +545,9 @@ void CurlRequest::setupSendData(bool forPutMethod)
         m_curlHandle->appendRequestHeader("Transfer-Encoding: chunked"_s);
     else {
         if (forPutMethod)
-            m_curlHandle->setInFileSizeLarge(static_cast<curl_off_t>(m_formDataStream.totalSize()));
+            m_curlHandle->setInFileSize(static_cast<curl_off_t>(m_formDataStream.totalSize()));
         else
-            m_curlHandle->setPostFieldLarge(static_cast<curl_off_t>(m_formDataStream.totalSize()));
+            m_curlHandle->setPostFieldSize(static_cast<curl_off_t>(m_formDataStream.totalSize()));
     }
 
     m_curlHandle->setReadCallbackFunction(willSendDataCallback, this);


### PR DESCRIPTION
#### 7a87c11590a3f0bcce3721c8e3373ade6da32cdf
<pre>
[Curl] Replace CURLOPT_POSTFIELDSIZE with CURLOPT_POSTFIELDSIZE_LARGE
<a href="https://bugs.webkit.org/show_bug.cgi?id=259137">https://bugs.webkit.org/show_bug.cgi?id=259137</a>

Reviewed by Fujii Hironori.

Two options are used to set post field size in CurlContext.cpp:
CURLOPT_POSTFIELDSIZE and CURLOPT_POSTFIELDSIZE_LARGE.
Unify these options to CURLOPT_POSTFIELDSIZE_LARGE for better readability.
Also, CURLOPT_INFILESIZE is unified to CURLOPT_INFILESIZE_LARGE.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::enableHttpPostRequest):
(WebCore::CurlHandle::setPostFieldSize):
(WebCore::CurlHandle::enableHttpPutRequest):
(WebCore::CurlHandle::setInFileSize):
(WebCore::CurlHandle::setPostFieldLarge): Deleted.
(WebCore::CurlHandle::setInFileSizeLarge): Deleted.
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::setupSendData):

Canonical link: <a href="https://commits.webkit.org/265987@main">https://commits.webkit.org/265987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3eb61ad10991ba65b3698a3dfb9cf0b29de3c05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14233 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/11987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14676 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14658 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18400 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14662 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9879 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15524 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1398 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->