### PR TITLE
[GTK][WPE] `TestJSC` `/jsc/basic` API test is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp
@@ -165,22 +165,25 @@ static void testJSCBasic()
         ExceptionHandler exceptionHandler(context.get());
 
         GRefPtr<JSCValue> result = adoptGRef(jsc_context_evaluate(context.get(), "2 + 2", -1));
+        g_object_set_data(G_OBJECT(result.get()), "is-original-jscvalue", GINT_TO_POINTER(TRUE));
         checker.watch(result.get());
         g_assert_true(jsc_value_get_context(result.get()) == context.get());
         g_assert_true(jsc_value_is_number(result.get()));
         g_assert_cmpint(jsc_value_to_int32(result.get()), ==, 4);
+        g_assert_cmpint(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(result.get()), "is-original-jscvalue")), ==, TRUE);
 
         GRefPtr<JSCValue> result2 = adoptGRef(jsc_context_evaluate(context.get(), "2 + 2", -1));
         checker.watch(result2.get());
         g_assert_true(jsc_value_get_context(result2.get()) == context.get());
         g_assert_true(result.get() == result2.get());
+        g_assert_cmpint(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(result2.get()), "is-original-jscvalue")), ==, TRUE);
 
         GRefPtr<JSCValue> result3 = adoptGRef(jsc_context_evaluate(context.get(), "3 + 1", -1));
         checker.watch(result3.get());
         g_assert_true(jsc_value_get_context(result3.get()) == context.get());
         g_assert_true(result.get() == result3.get());
+        g_assert_cmpint(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(result3.get()), "is-original-jscvalue")), ==, TRUE);
 
-        auto* resultPtr = result.get();
         result = nullptr;
         result2 = nullptr;
         result3 = nullptr;
@@ -189,7 +192,7 @@ static void testJSCBasic()
         g_assert_true(jsc_value_get_context(result4.get()) == context.get());
         g_assert_true(jsc_value_is_number(result4.get()));
         g_assert_cmpint(jsc_value_to_int32(result4.get()), ==, 4);
-        g_assert_false(result4.get() == resultPtr);
+        g_assert_cmpint(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(result4.get()), "is-original-jscvalue")), ==, FALSE);
     }
 
     {


### PR DESCRIPTION
#### 41d744be940c32814bcfc1740dcca8dfd3c38837
<pre>
[GTK][WPE] `TestJSC` `/jsc/basic` API test is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=259178">https://bugs.webkit.org/show_bug.cgi?id=259178</a>

Reviewed by Michael Catanzaro.

On WPE and GTK, when we evaluate a JS expression, we wrap the resulting
`JSValueRef` in `JSCValue`.

Internally, we cache and reuse a `JSValue` for expressions that evaluate
to the same `JSValueRef` result.

When `JSCValue` object is destroyed it is also removed from the cache.

There is a test in `testJSCBasic()` which checks that after we destroy
a `JSCValue` and then evaluate the same JS expression, a new `JSCValue`
wrapper is created:

```
GRefPtr&lt;JSCValue&gt; result = adoptGRef(jsc_context_evaluate(context.get(), &quot;2 + 2&quot;, -1));
auto* resultPtr = result.get();
result = nullptr;
GRefPtr&lt;JSCValue&gt; result4 = adoptGRef(jsc_context_evaluate(context.get(), &quot;2 + 2&quot;, -1));
g_assert_false(result4.get() == resultPtr);
```

To verify that we got a new object we simply compare memory addresses.
But it might happen (and actually happens on bots) that the new wrapper
is allocated at the same address as the original one, making this test fail.

What we can do instead, is to tag the original `JSCValue` and then
ensure that the new `JSCValue` is not tagged.

* Tools/TestWebKitAPI/Tests/JavaScriptCore/glib/TestJSC.cpp:
(testJSCBasic):

Canonical link: <a href="https://commits.webkit.org/266035@main">https://commits.webkit.org/266035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f83e4a41fe7508ea4eceee0dd18bc20cab8d822d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12100 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14821 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18532 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10740 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14812 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10001 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12693 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11333 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3329 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15665 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13052 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11941 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3117 "Passed tests") | 
<!--EWS-Status-Bubble-End-->