### PR TITLE
Out-of-view InteractionRegion layers should be culled

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -1,0 +1,147 @@
+
+(CALayer tree root
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (sublayers
+    (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (sublayers
+        (
+          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+          (layer anchorPoint [x: 0 y: 0])
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+              (layer anchorPoint [x: 0 y: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                  (layer position [x: 400 y: 400])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                      (layer position [x: 400 y: 400])
+                      (sublayers
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (sublayers
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                      (layer anchorPoint [x: 0 y: 0]))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                      (layer position [x: 0 y: 0])
+                                      (layer anchorPoint [x: 0 y: 0]))))
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0]))))))
+                        (
+                          (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                          (layer position [x: 400 y: 400])
+                          (sublayers
+                            (
+                              (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (sublayers
+                                (
+                                  (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (sublayers
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (type 0)
+                                      (layer bounds [x: 0 y: 0 width: 700 height: 36])
+                                      (layer position [x: 400 y: 400])
+                                      (layer cornerRadius 8))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (sublayers
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                          (layer anchorPoint [x: 0 y: 0]))
+                                        (
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 512])
+                                          (layer position [x: 0 y: 0])
+                                          (layer anchorPoint [x: 0 y: 0]))))
+                                    (
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer anchorPoint [x: 0 y: 0]))))))))))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (
+          (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
+          (layer position [x: 400 y: 400])
+          (layer opacity 0)
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
+              (layer position [x: 397 y: 397])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
+                  (layer position [x: 397 y: 397])
+                  (layer cornerRadius 4.760000000000001))))
+            (
+              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
+              (layer position [x: 397 y: 397])
+              (layer opacity 0.005))))
+        (
+          (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+          (layer position [x: 792.9200000000001 y: 792.9200000000001])
+          (layer opacity 0)
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer position [x: 4.08 y: 4.08])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+                  (layer position [x: 4.08 y: 4.08])
+                  (layer cornerRadius 4.760000000000001))))
+            (
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer position [x: 4.08 y: 4.08])
+              (layer opacity 0.005))))))))

--- a/LayoutTests/interaction-region/interaction-layers-culling.html
+++ b/LayoutTests/interaction-region/interaction-layers-culling.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    #test a {
+        display: block;
+        margin: 50px;
+        font-size: 30px;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+</div>
+
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+let testEl = document.getElementById("test");
+for (let i = 0; i < 1000; i++) {
+    let link = document.createElement("a");
+    link.textContent = `Link ${i}`;
+    link.href = "#";
+    testEl.appendChild(link);
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getCALayerTree();
+    testEl.remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2723,6 +2723,10 @@ void GraphicsLayerCA::updateCoverage(const CommitState& commitState)
         backing->setCoverageRect(m_coverageRect);
     }
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    m_layer->setCoverageRect(m_coverageRect);
+#endif
+
     bool requiresBacking = m_intersectsCoverageRect
         || !allowsBackingStoreDetaching()
         || commitState.ancestorWithTransformAnimationIntersectsCoverageRect // FIXME: Compute backing exactly for descendants of animating layers.

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -213,6 +213,10 @@ public:
     virtual void setBackingStoreAttached(bool) = 0;
     virtual bool backingStoreAttached() const = 0;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    virtual void setCoverageRect(const FloatRect&) = 0;
+#endif
+
     virtual void setMinificationFilter(FilterType) = 0;
     virtual void setMagnificationFilter(FilterType) = 0;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -99,6 +99,10 @@ public:
     void setBackingStoreAttached(bool) override;
     bool backingStoreAttached() const override;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    void setCoverageRect(const FloatRect&) override;
+#endif
+
     bool geometryFlipped() const override;
     WEBCORE_EXPORT void setGeometryFlipped(bool) override;
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -695,6 +695,12 @@ bool PlatformCALayerCocoa::backingStoreAttached() const
     return m_backingStoreAttached;
 }
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+void PlatformCALayerCocoa::setCoverageRect(const FloatRect&)
+{
+}
+#endif
+
 bool PlatformCALayerCocoa::geometryFlipped() const
 {
     return [m_layer isGeometryFlipped];

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -70,6 +70,9 @@ header: "RemoteLayerTreeTransaction.h"
 #endif
     ScrollingNodeIDChanged
     VideoGravityChanged
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    CoverageRectChanged
+#endif
 };
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -313,18 +313,20 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     applyPropertiesToLayer(node.layer(), &node, layerTreeHost, properties, layerContentsType);
+    if (properties.changedProperties & LayerChange::EventRegionChanged)
+        node.setEventRegion(properties.eventRegion);
+    updateMask(node, properties, relatedLayers);
+
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if (properties.changedProperties & LayerChange::CoverageRectChanged)
+        node.setCoverageRect(properties.coverageRect);
     applyCommonPropertiesToLayer(node.interactionRegionsLayer(), properties);
     // Replicate animations on the InteractionRegion layers, the LayerTreeHost only keeps track of the original animations.
     if (properties.changedProperties & LayerChange::AnimationsChanged)
         PlatformCAAnimationRemote::updateLayerAnimations(node.interactionRegionsLayer(), nullptr, properties.addedAnimations, properties.keysOfAnimationsToRemove);
-    if (properties.changedProperties & LayerChange::EventRegionChanged)
-        updateLayersForInteractionRegions(node, properties);
+    if (properties.changedProperties & LayerChange::EventRegionChanged || properties.changedProperties & LayerChange::CoverageRectChanged)
+        updateLayersForInteractionRegions(node);
 #endif
-    updateMask(node, properties, relatedLayers);
-
-    if (properties.changedProperties & LayerChange::EventRegionChanged)
-        node.setEventRegion(properties.eventRegion);
 
 #if ENABLE(SCROLLING_THREAD)
     if (properties.changedProperties & LayerChange::ScrollingNodeIDChanged)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -112,6 +112,9 @@ enum class LayerChange : uint64_t {
 #endif
 #endif
     VideoGravityChanged                 = 1LLU << 44,
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    CoverageRectChanged                 = 1LLU << 45,
+#endif
 };
 
 class RemoteLayerTreeTransaction {
@@ -218,6 +221,9 @@ public:
         bool userInteractionEnabled { true };
         WebCore::EventRegion eventRegion;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        WebCore::FloatRect coverageRect;
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         bool isSeparated { false };
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -169,6 +169,9 @@ RemoteLayerTreeTransaction::LayerProperties::LayerProperties(const LayerProperti
     , contentsHidden(other.contentsHidden)
     , userInteractionEnabled(other.userInteractionEnabled)
     , eventRegion(other.eventRegion)
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    , coverageRect(other.coverageRect)
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     , isSeparated(other.isSeparated)
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
@@ -323,6 +326,10 @@ void RemoteLayerTreeTransaction::LayerProperties::encode(IPC::Encoder& encoder) 
     if (changedProperties & LayerChange::EventRegionChanged)
         encoder << eventRegion;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if (changedProperties & LayerChange::CoverageRectChanged)
+        encoder << coverageRect;
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     if (changedProperties & LayerChange::SeparatedChanged)
         encoder << isSeparated;
@@ -583,6 +590,12 @@ bool RemoteLayerTreeTransaction::LayerProperties::decode(IPC::Decoder& decoder, 
         result.eventRegion = WTFMove(*eventRegion);
     }
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if (result.changedProperties & LayerChange::CoverageRectChanged) {
+        if (!decoder.decode(result.coverageRect))
+            return false;
+    }
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     if (result.changedProperties & LayerChange::SeparatedChanged) {
         if (!decoder.decode(result.isSeparated))
@@ -1002,6 +1015,10 @@ static void dumpChangedLayers(TextStream& ts, const RemoteLayerTreeTransaction::
         if (layerProperties.changedProperties & LayerChange::EventRegionChanged)
             ts.dumpProperty("eventRegion", layerProperties.eventRegion);
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+        if (layerProperties.changedProperties & LayerChange::CoverageRectChanged)
+            ts.dumpProperty("coverageRect", layerProperties.coverageRect);
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         if (layerProperties.changedProperties & LayerChange::SeparatedChanged)
             ts.dumpProperty("isSeparated", layerProperties.isSeparated);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h
@@ -35,7 +35,7 @@ OBJC_CLASS NSMutableArray;
 
 namespace WebKit {
 
-void updateLayersForInteractionRegions(const RemoteLayerTreeNode&, const RemoteLayerTreeTransaction::LayerProperties&);
+void updateLayersForInteractionRegions(const RemoteLayerTreeNode&);
 void insertInteractionRegionLayersForLayer(NSMutableArray *, CALayer *);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -176,10 +176,8 @@ void insertInteractionRegionLayersForLayer(NSMutableArray *sublayers, CALayer *l
     }
 }
 
-void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node, const RemoteLayerTreeTransaction::LayerProperties& properties)
+void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node)
 {
-    ASSERT(properties.changedProperties & LayerChange::EventRegionChanged);
-
     CALayer *layer = node.interactionRegionsLayer();
 
     HashMap<std::pair<IntRect, InteractionRegion::Type>, CALayer *>existingLayers;
@@ -193,10 +191,14 @@ void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node, const Re
     bool applyBackgroundColorForDebugging = [[NSUserDefaults standardUserDefaults] boolForKey:@"WKInteractionRegionDebugFill"];
 
     NSUInteger insertionPoint = 0;
-    for (const WebCore::InteractionRegion& region : properties.eventRegion.interactionRegions()) {
+    for (const WebCore::InteractionRegion& region : node.eventRegion().interactionRegions()) {
+        IntRect rect = region.rectInLayerCoordinates;
+
+        if (node.coverageRect() && !node.coverageRect()->intersects(rect))
+            continue;
+
         bool foundInPosition = false;
         RetainPtr<CALayer> regionLayer;
-        IntRect rect = region.rectInLayerCoordinates;
         auto key = std::make_pair(rect, region.type);
         auto interactionRegionGroupName = interactionRegionGroupNameForRegion(node.layerID(), region);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -58,6 +58,21 @@ public:
     CALayer *layer() const { return m_layer.get(); }
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     CALayer *interactionRegionsLayer() const { return m_interactionRegionsLayer.get(); }
+
+    struct CoverageRectMarkableTraits {
+        static bool isEmptyValue(const WebCore::FloatRect& value)
+        {
+            return value.isEmpty();
+        }
+
+        static WebCore::FloatRect emptyValue()
+        {
+            return { };
+        }
+    };
+
+    const Markable<WebCore::FloatRect, CoverageRectMarkableTraits> coverageRect() const { return m_coverageRect; }
+    void setCoverageRect(const WebCore::FloatRect& value) { m_coverageRect = value; }
 #endif
 #if PLATFORM(IOS_FAMILY)
     UIView *uiView() const { return m_uiView.get(); }
@@ -124,6 +139,7 @@ private:
     RetainPtr<CALayer> m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     RetainPtr<CALayer> m_interactionRegionsLayer;
+    Markable<WebCore::FloatRect, CoverageRectMarkableTraits> m_coverageRect;
 #endif
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UIView> m_uiView;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -119,6 +119,10 @@ public:
     void setBackingStoreAttached(bool) override;
     bool backingStoreAttached() const override;
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    void setCoverageRect(const WebCore::FloatRect&) override;
+#endif
+
     bool geometryFlipped() const override;
     void setGeometryFlipped(bool) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -649,6 +649,14 @@ bool PlatformCALayerRemote::backingStoreAttached() const
     return m_properties.backingStoreAttached;
 }
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+void PlatformCALayerRemote::setCoverageRect(const FloatRect& value)
+{
+    m_properties.coverageRect = value;
+    m_properties.notePropertiesChanged(LayerChange::CoverageRectChanged);
+}
+#endif
+
 void PlatformCALayerRemote::setGeometryFlipped(bool value)
 {
     m_properties.geometryFlipped = value;


### PR DESCRIPTION
#### 47a5853ddf044928125a26ae03723bb675780aa1
<pre>
Out-of-view InteractionRegion layers should be culled
<a href="https://bugs.webkit.org/show_bug.cgi?id=259142">https://bugs.webkit.org/show_bug.cgi?id=259142</a>
rdar://111595133

Reviewed by Simon Fraser.

Set the computed coverage rect on UI-side layers and use it to cull
InteractionRegion layers.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateCoverage):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setCoverageRect):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode):
(WebKit::dumpChangedLayers):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setCoverageRect):
Propagate the coverage rect to the UI-side layer.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
Call `updateLayersForInteractionRegions` when either the EventRegion or
the CoverageRect changes.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::coverageRect const):
(WebKit::RemoteLayerTreeNode::setCoverageRect):
Store the coverage rect on the RemoteLayerTreeNode alongside the
event region.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
If the node has a known coverage rect, only add InteractionRegion layers
that intersect with it.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt: Added.
* LayoutTests/interaction-region/interaction-layers-culling.html: Added.
Add new test to cover culling.

Canonical link: <a href="https://commits.webkit.org/266105@main">https://commits.webkit.org/266105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d5eb78ad0a8bc42bed684ab4aaa37ff81a262cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12815 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14939 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18620 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14906 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10083 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11412 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3155 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15744 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->