### PR TITLE
Guard MatchedDeclarationsCache against destruction while modifying m_entries map

### DIFF
--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -34,17 +34,29 @@
 #include "Document.h"
 #include "FontCascade.h"
 #include "RenderStyleInlines.h"
+#include "StyleResolver.h"
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
 namespace Style {
 
-MatchedDeclarationsCache::MatchedDeclarationsCache()
-    : m_sweepTimer(*this, &MatchedDeclarationsCache::sweep)
+MatchedDeclarationsCache::MatchedDeclarationsCache(const Resolver& owner)
+    : m_owner(owner)
+    , m_sweepTimer(*this, &MatchedDeclarationsCache::sweep)
 {
 }
 
 MatchedDeclarationsCache::~MatchedDeclarationsCache() = default;
+
+void MatchedDeclarationsCache::ref() const
+{
+    m_owner->ref();
+}
+
+void MatchedDeclarationsCache::deref() const
+{
+    m_owner->deref();
+}
 
 bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderStyle& style, const RenderStyle& parentStyle)
 {
@@ -147,6 +159,8 @@ void MatchedDeclarationsCache::invalidate()
 
 void MatchedDeclarationsCache::clearEntriesAffectedByViewportUnits()
 {
+    Ref protectedThis { *this };
+
     m_entries.removeIf([](auto& keyValue) {
         return keyValue.value.renderStyle->usesViewportUnits();
     });
@@ -154,6 +168,8 @@ void MatchedDeclarationsCache::clearEntriesAffectedByViewportUnits()
 
 void MatchedDeclarationsCache::sweep()
 {
+    Ref protectedThis { *this };
+
     // Look for cache entries containing a style declaration with a single ref and remove them.
     // This may happen when an element attribute mutation causes it to generate a new inlineStyle()
     // or presentationalHintStyle(), potentially leaving this cache with the last ref on the old one.

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -28,15 +28,18 @@
 #include "MatchResult.h"
 #include "RenderStyle.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
 namespace Style {
 
+class Resolver;
+
 class MatchedDeclarationsCache {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    MatchedDeclarationsCache();
+    explicit MatchedDeclarationsCache(const Resolver&);
     ~MatchedDeclarationsCache();
 
     static bool isCacheable(const Element&, const RenderStyle&, const RenderStyle& parentStyle);
@@ -60,9 +63,13 @@ public:
     void invalidate();
     void clearEntriesAffectedByViewportUnits();
 
+    void ref() const;
+    void deref() const;
+
 private:
     void sweep();
 
+    CheckedRef<const Resolver> m_owner;
     HashMap<unsigned, Entry, AlreadyHashed> m_entries;
     Timer m_sweepTimer;
     unsigned m_additionsSinceLastSweep { 0 };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -147,6 +147,7 @@ Resolver::Resolver(Document& document, ScopeType scopeType)
     : m_document(document)
     , m_scopeType(scopeType)
     , m_ruleSets(*this)
+    , m_matchedDeclarationsCache(*this)
     , m_matchAuthorAndUserStyles(settings().authorAndUserStylesEnabled())
 {
     initialize();

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -29,6 +29,7 @@
 #include "RuleSet.h"
 #include "StyleScopeRuleSets.h"
 #include <memory>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -80,7 +81,7 @@ struct ResolutionContext {
     bool isSVGUseTreeRoot { false };
 };
 
-class Resolver : public RefCounted<Resolver> {
+class Resolver : public RefCounted<Resolver>, public CanMakeCheckedPtr {
     WTF_MAKE_ISO_ALLOCATED(Resolver);
 public:
     // Style resolvers are shared between shadow trees with identical styles. That's why we don't simply provide a Style::Scope.


### PR DESCRIPTION
#### a64778e92200eb9030afd753c803f5623eead6f5
<pre>
Guard MatchedDeclarationsCache against destruction while modifying m_entries map
<a href="https://bugs.webkit.org/show_bug.cgi?id=259147">https://bugs.webkit.org/show_bug.cgi?id=259147</a>
rdar://107338197

Reviewed by Antti Koivisto.

Guard MatchedDeclarationsCache against destruction while modifying m_entries map.
We suspect that MatchedDeclarationsCache is getting destroyed while modifying
m_entries inside sweep().

* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::MatchedDeclarationsCache):
(WebCore::Style::MatchedDeclarationsCache::ref):
(WebCore::Style::MatchedDeclarationsCache::deref):
(WebCore::Style::MatchedDeclarationsCache::clearEntriesAffectedByViewportUnits):
(WebCore::Style::MatchedDeclarationsCache::sweep):
* Source/WebCore/style/MatchedDeclarationsCache.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::Resolver):
* Source/WebCore/style/StyleResolver.h:

Canonical link: <a href="https://commits.webkit.org/265998@main">https://commits.webkit.org/265998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8305e811d2509f2c768e333740ac09c75f08dbd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14277 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14717 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14702 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10761 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11349 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14701 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9918 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11234 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15566 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->