### PR TITLE
@font-face src tech() should parse valid unsupported keywords

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
@@ -4,9 +4,9 @@ PASS Check that src: url("foo.ttf") tech() is invalid
 PASS Check that src: url("foo.ttf") tech(features-opentype) is valid
 PASS Check that src: url("foo.ttf") tech(features-aat) is valid
 PASS Check that src: url("foo.ttf") tech(color-COLRv0) is valid
-FAIL Check that src: url("foo.ttf") tech(color-COLRv1) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(color-COLRv1) is valid
 PASS Check that src: url("foo.ttf") tech(color-sbix) is valid
-FAIL Check that src: url("foo.ttf") tech(color-CBDT) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(color-CBDT) is valid
 PASS Check that src: url("foo.ttf") tech(variations) is valid
 PASS Check that src: url("foo.ttf") tech(palettes) is valid
 PASS Check that src: url("foo.ttf") tech("features-opentype") is invalid

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -104,6 +104,13 @@ std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(Sc
             return nullptr;
     }
 
+    if (!m_technologies.isEmpty()) {
+        for (auto technology : m_technologies) {
+            if (!FontCustomPlatformData::supportsTechnology(technology))
+                return nullptr;
+        }
+    }
+
     auto request = context.fontLoadRequest(m_location.resolvedURL.string(), isFormatSVG, isInitiatingElementInUserAgentShadowTree, m_loadedFromOpaqueSource);
     if (auto* cachedRequest = dynamicDowncast<CachedFontLoadRequest>(request.get()))
         m_cachedFont = &cachedRequest->cachedFont();

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8239,7 +8239,7 @@ Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleVa
         if (arg.type() != IdentToken)
             return { };
         auto technology = fromCSSValueID<FontTechnology>(arg.id());
-        if (technology != FontTechnology::Invalid && FontCustomPlatformData::supportsTechnology(technology))
+        if (technology != FontTechnology::Invalid)
             technologies.append(technology);
     } while (consumeCommaIncludingWhitespace(args) && !singleValue);
     if (!args.atEnd())

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -234,21 +234,21 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
         return nullptr;
 
     String format;
-    Vector<FontTechnology> supportedTechnologies;
+    Vector<FontTechnology> technologies;
     if (range.peek().functionId() == CSSValueFormat) {
         format = CSSPropertyParserHelpers::consumeFontFormat(range);
         if (format.isNull())
             return nullptr;
     }
     if (range.peek().functionId() == CSSValueTech) {
-        supportedTechnologies = CSSPropertyParserHelpers::consumeFontTech(range);
-        if (supportedTechnologies.isEmpty())
+        technologies = CSSPropertyParserHelpers::consumeFontTech(range);
+        if (technologies.isEmpty())
             return nullptr;
     }
     if (!range.atEnd())
         return nullptr;
 
-    return CSSFontFaceSrcResourceValue::create(WTFMove(location), WTFMove(format), WTFMove(supportedTechnologies), context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
+    return CSSFontFaceSrcResourceValue::create(WTFMove(location), WTFMove(format), WTFMove(technologies), context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
 }
 
 static RefPtr<CSSValue> consumeFontFaceSrcLocal(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -33,6 +33,7 @@
 #include "CSSParserImpl.h"
 #include "CSSPropertyParserHelpers.h"
 #include "CSSSelectorParser.h"
+#include "FontCustomPlatformData.h"
 #include "StyleRule.h"
 
 namespace WebCore {
@@ -177,8 +178,11 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontFormatFu
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontTechFunction(CSSParserTokenRange& range)
 {
     ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueFontTech);
-    auto supportedTechnologies = CSSPropertyParserHelpers::consumeFontTech(range, true);
-    return supportedTechnologies.isEmpty() ? Unsupported : Supported;
+    auto technologies = CSSPropertyParserHelpers::consumeFontTech(range, true);
+    if (technologies.isEmpty())
+        return Unsupported;
+    ASSERT(technologies.size() == 1);
+    return FontCustomPlatformData::supportsTechnology(technologies[0]) ? Supported : Unsupported;
 }
 
 // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>


### PR DESCRIPTION
#### 8a43470a0beb1a5aaaf7f6f0b94f8fe0ebf40dfb
<pre>
@font-face src tech() should parse valid unsupported keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=259145">https://bugs.webkit.org/show_bug.cgi?id=259145</a>
rdar://112135896

Reviewed by Myles C. Maxfield.

A valid tech() keyword argument should be parsed even if the represented
techonology is not supported by the engine. The engine should reject loading
the font for unsupported techonologies but this should happen only at
loading time and not at parsing time.

The reason why we were rejecting it before at parsing time it is for some
inconsistency in different parts of the spec which suggested that. That
will be fixed soon by the CWWG, see: <a href="https://github.com/w3c/csswg-drafts/issues/8793">https://github.com/w3c/csswg-drafts/issues/8793</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontTech):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFontTechFunction):

Canonical link: <a href="https://commits.webkit.org/265999@main">https://commits.webkit.org/265999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93afe2e6ae94c7c50edad6de28c3d3b7f4522de9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14266 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12018 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14691 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11339 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18427 "1 flakes 115 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14690 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9910 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11224 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->