### PR TITLE
[JSC] Fix satisfy cache in module loader

### DIFF
--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -90,6 +90,7 @@ void JSModuleLoader::finishCreation(JSGlobalObject* globalObject, VM& vm)
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().requestFetchPublicName(), moduleLoaderRequestFetchCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().requestInstantiatePublicName(), moduleLoaderRequestInstantiateCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().requestSatisfyPublicName(), moduleLoaderRequestSatisfyCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().requestSatisfyUtilPublicName(), moduleLoaderRequestSatisfyUtilCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().linkPublicName(), moduleLoaderLinkCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().moduleEvaluationPublicName(), moduleLoaderModuleEvaluationCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().asyncModuleEvaluationPublicName(), moduleLoaderAsyncModuleEvaluationCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));


### PR DESCRIPTION
#### 29e1ceddc500bd7379bc86081b8b0ab76cbee4c2
<pre>
[JSC] Fix satisfy cache in module loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=258540">https://bugs.webkit.org/show_bug.cgi?id=258540</a>
rdar://110339520

Reviewed by Yusuke Suzuki.

Current satisfy cache in ModuleLoader.js is problematic when
module entries who encounter some visited children in requestSatisfy.
This is because the way we use to break infinitely looping is to
return a promise of instantiation for the visited children.
In that case, when all children&apos;s promises are fulfilled, we should
not mark the entry as satisfied since we don&apos;t know whether the visited
module entry is satisfied or not.

Current spec doesn&apos;t have concept satisfy before link phase see:
1. <a href="https://tc39.es/ecma262/#sec-import-calls">https://tc39.es/ecma262/#sec-import-calls</a>
2. <a href="https://tc39.es/ecma262/#sec-ContinueDynamicImport">https://tc39.es/ecma262/#sec-ContinueDynamicImport</a>
3. <a href="https://tc39.es/ecma262/#sec-LoadRequestedModules">https://tc39.es/ecma262/#sec-LoadRequestedModules</a>
4. <a href="https://tc39.es/ecma262/#sec-InnerModuleLoading">https://tc39.es/ecma262/#sec-InnerModuleLoading</a>

Ideally we should use DFS (<a href="https://tc39.es/ecma262/#sec-moduledeclarationlinking)">https://tc39.es/ecma262/#sec-moduledeclarationlinking)</a>
to track strongly connected component (SCC). If the requestSatisfyUtil
promise for the start entry of the SCC is fulfilled, then we can mark all entries
of the SCC satisfied. However, current requestSatisfyUtil cannot guarantee DFS due
to various requestInstantiate time for children. And we don&apos;t prefer to force DFS.
This is because if one child requests a lot of time in requestInstantiate, then the
other children have to wait for it. And this is expensive. This patch fixes this
issue by updating those &quot;satisfying entries&quot; after the root entry is resolved
in satisfy phase.

* Source/JavaScriptCore/builtins/ModuleLoader.js:
(linkTimeConstant.newRegistryEntry):
(visibility.PrivateRecursive.requestSatisfy):
(async visibility.PrivateRecursive.requestSatisfyUtil):
(visibility.PrivateRecursive.link):
(visibility.PrivateRecursive.linkAndEvaluateModule):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::finishCreation):

Canonical link: <a href="https://commits.webkit.org/266063@main">https://commits.webkit.org/266063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ecca5bb09971232d51cd12f87ccf4ab8ff1c1c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12697 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12145 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14848 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14880 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18573 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10797 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14858 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10043 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12752 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11381 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3340 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13111 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1445 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3129 "Passed tests") | 
<!--EWS-Status-Bubble-End-->