### PR TITLE
heap-use-after-free | JSC::RegExpObject::execInline; JSC::regExpProtoFuncExec

### DIFF
--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -197,3 +197,4 @@ testRegExp(/(?<A>)|(?<A>)*\k<A>/, "", ["", "", undefined], { A: "" });
 
 // Test 31
 testRegExp(/(?:(?<A>a)|(?<A>b)*)\k<A>/, "bb", ["bb",undefined,"b"], { A: "b" });
+testRegExp(/((?<A>A+)(?<B>B+)(?<C>C+)(?<D>D+))+|((?<B>B+)(?<C>C+)(?<D>D+))+|((?<A>A+)(?<C>C+)(?<D>D+))+|((?<C>C+)(?<D>D+))+|((?<B>B+)(?<D>D+))+|((?<A>A+)(?<D>D+))+|((?<D>D+))/, "AAD", ["AAD", undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, "AAD", "AA", "D", undefined, undefined], { A: "AA", B: undefined, C: undefined, D: "D" });

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -149,9 +149,11 @@ public:
                 output[(firstSubpatternId << 1) + i] = offsetNoMatch;
             }
 
+            unsigned nameGroupIdx = 0;
             for (unsigned duplicateNamedGroupId : m_duplicateNamedGroups) {
-                subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(duplicateNamedGroupId)] = output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)];
+                subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(nameGroupIdx)] = output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)];
                 output[pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)] = 0;
+                ++nameGroupIdx;
             }
 
             new (getDisjunctionContext()) DisjunctionContext();
@@ -167,8 +169,11 @@ public:
             for (unsigned i = 0; i < (m_numNestedSubpatterns << 1); ++i)
                 output[(firstSubpatternId << 1) + i] = subpatternAndGroupIdBackup[i];
 
-            for (unsigned duplicateNamedGroupId : m_duplicateNamedGroups)
-                output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)] = subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(duplicateNamedGroupId)];
+            unsigned nameGroupIdx = 0;
+            for (unsigned duplicateNamedGroupId : m_duplicateNamedGroups) {
+                output[m_pattern->offsetForDuplicateNamedGroupId(duplicateNamedGroupId)] = subpatternAndGroupIdBackup[backupOffsetForDuplicateNamedGroup(nameGroupIdx)];
+                ++nameGroupIdx;
+            }
         }
 
         DisjunctionContext* getDisjunctionContext()
@@ -178,8 +183,9 @@ public:
 
         unsigned backupOffsetForDuplicateNamedGroup(unsigned duplicateNamedGroup)
         {
-            ASSERT(duplicateNamedGroup);
-            return (m_numNestedSubpatterns << 1) + duplicateNamedGroup - 1;
+            unsigned offset = (m_numNestedSubpatterns << 1) + duplicateNamedGroup;
+            ASSERT(offset < m_numBackupIds);
+            return offset;
         }
 
         static size_t allocationSize(unsigned numberOfSubpatterns, unsigned numDuplicateNamedGroups)


### PR DESCRIPTION
#### 9257a50c70baaa8dee34f5934b4f105017bf92ab
<pre>
heap-use-after-free | JSC::RegExpObject::execInline; JSC::regExpProtoFuncExec
<a href="https://bugs.webkit.org/show_bug.cgi?id=259143">https://bugs.webkit.org/show_bug.cgi?id=259143</a>
rdar://111502448

Reviewed by Yusuke Suzuki.

Fixed the saving and restoring of duplicate groups IDs for nested / counted Parens in the YARR
interpreter.  We only save the number of duplicate groups needed for the current parenthesis.
We were using the duplicate groups ID, which may exceed the number of duplicate IDs we need to
save.  Changed the code to save these ID using a counted index instead of their actual value.
Added an ASSERT in backupOffsetForDuplicateNamedGroup() where we calculate the offset in the
saved context buffer.

Added a new regression test case.

* JSTests/stress/regexp-duplicate-named-captures.js:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::ParenthesesDisjunctionContext):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::restoreOutput):
(JSC::Yarr::Interpreter::ParenthesesDisjunctionContext::backupOffsetForDuplicateNamedGroup):

Canonical link: <a href="https://commits.webkit.org/266009@main">https://commits.webkit.org/266009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8365a34eff8401f4cec05bb8583e186a8fed4492

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12012 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14700 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14685 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18429 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10647 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11828 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14692 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11845 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9904 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12577 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11218 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3292 "Found 2 jsc stress test failures: microbenchmarks/sorting-benchmark.js.default, microbenchmarks/sorting-benchmark.js.no-cjit-collect-continuously") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3082 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15550 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12932 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11835 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3079 "Passed tests") | 
<!--EWS-Status-Bubble-End-->