### PR TITLE
Stop using Number.prototype.toLocaleString() for numeric console format specifiers

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js
@@ -809,14 +809,12 @@ WI.ConsoleMessageView = class ConsoleMessageView extends WI.Object
 
         function floatFormatter(obj, token)
         {
-            let value = typeof obj.value === "number" ? obj.value : obj.description;
-            return String.standardFormatters.f(value, token);
+            return parseFloat(typeof obj.value === "number" ? obj.value : obj.description).maxDecimals(token.precision);
         }
 
         function integerFormatter(obj)
         {
-            let value = typeof obj.value === "number" ? obj.value : obj.description;
-            return String.standardFormatters.d(value);
+            return parseInt(typeof obj.value === "number" ? obj.value : obj.description);
         }
 
         var currentStyle = null;


### PR DESCRIPTION
#### ae256c9a88dbbca6c460fa52db025f531b7a4cf5
<pre>
Stop using Number.prototype.toLocaleString() for numeric console format specifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259146">https://bugs.webkit.org/show_bug.cgi?id=259146</a>

Reviewed by Patrick Angle.

`console.log(&quot;%i&quot;, 1000)` should have the same output as `console.log(&quot;1000&quot;)`.

* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.js:
(WI.ConsoleMessageView.prototype._formatWithSubstitutionString.floatFormatter):
(WI.ConsoleMessageView.prototype._formatWithSubstitutionString.integerFormatter):
Remove calling `Number.prototype.toLocaleString` as that can insert unwanted text (e.g. commas).

Canonical link: <a href="https://commits.webkit.org/266020@main">https://commits.webkit.org/266020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fea96b46a0bea4e4ae567fcf976d0bac47b86ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12528 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12022 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14711 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10602 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14695 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18433 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14696 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9913 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11228 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->