### PR TITLE
Allow deserialization of NSURLError through _WKRemoteObjectRegistry

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -43,6 +43,9 @@
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/CString.h>
 
+@interface NSURLError : NSError
+@end
+
 static constexpr auto classNameKey = "$class"_s;
 static constexpr auto objectStreamKey = "$objectStream"_s;
 static constexpr auto stringKey = "$string"_s;
@@ -794,6 +797,8 @@ static const HashSet<CFTypeRef> alwaysAllowedClasses()
         (__bridge CFTypeRef)NSHTTPURLResponse.class,
         (__bridge CFTypeRef)NSURLResponse.class,
         (__bridge CFTypeRef)NSUUID.class,
+        (__bridge CFTypeRef)NSError.class,
+        (__bridge CFTypeRef)NSURLError.class,
     } };
     return classes.get();
 }


### PR DESCRIPTION
#### e402ca04a9ae04cf15ef2dd315a4d38877d701b0
<pre>
Allow deserialization of NSURLError through _WKRemoteObjectRegistry
<a href="https://bugs.webkit.org/show_bug.cgi?id=259152">https://bugs.webkit.org/show_bug.cgi?id=259152</a>
rdar://111806659

Reviewed by Chris Dumez and David Kilzer.

CFNetwork has an internal NSError subclass.  Since we stopped automatically
allowing deserialization of ObjC subclasses, all subclasses must be explicitly
allowed.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(alwaysAllowedClasses):

Canonical link: <a href="https://commits.webkit.org/266002@main">https://commits.webkit.org/266002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13169af5f0be56c7c04f0bd15370e3f5c97c304f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12027 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14713 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10599 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14701 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10758 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18435 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11842 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14698 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9917 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11233 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15565 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->