### PR TITLE
[JSC] add support for `Promise.withResolvers`

### DIFF
--- a/JSTests/stress/promise-withResolvers.js
+++ b/JSTests/stress/promise-withResolvers.js
@@ -1,0 +1,90 @@
+//@ requireOptions("--usePromiseWithResolversMethod=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function notReached() {
+    throw new Error("should not reach here");
+}
+
+async function delay() {
+    return new Promise((resolve, reject) => {
+        setTimeout(resolve);
+    });
+}
+
+shouldBe(Promise.withResolvers.name, "withResolvers");
+shouldBe(Promise.withResolvers.length, 0);
+
+{
+    let {promise, resolve, reject} = Promise.withResolvers();
+
+    shouldBe(promise instanceof Promise, true);
+
+    shouldBe(resolve instanceof Function, true);
+    shouldBe(resolve.name, "resolve");
+    shouldBe(resolve.length, 1);
+
+    shouldBe(reject instanceof Function, true);
+    shouldBe(reject.name, "reject");
+    shouldBe(reject.length, 1);
+}
+
+async function test() {
+    // sync resolve
+    {
+        let {promise, resolve, reject} = Promise.withResolvers();
+        resolve(42);
+        reject("should not reject if already resolved");
+        shouldBe(await promise, 42);
+    }
+
+    // async resolve
+    {
+        let {promise, resolve, reject} = Promise.withResolvers();
+        await delay();
+        resolve(42);
+        await delay();
+        reject("should not reject if already resolved");
+        await delay();
+        shouldBe(await promise, 42);
+    }
+
+    // sync reject
+    {
+        let {promise, resolve, reject} = Promise.withResolvers();
+        reject(42);
+        resolve("should not resolve if already rejected");
+        try {
+            await promise;
+            notReached();
+        } catch (e) {
+            shouldBe(e, 42);
+        }
+    }
+
+    // async reject
+    {
+        let {promise, resolve, reject} = Promise.withResolvers();
+        await delay();
+        reject(42);
+        await delay();
+        resolve("should not resolve if already rejected");
+        await delay();
+        try {
+            await promise;
+            notReached();
+        } catch (e) {
+            shouldBe(e, 42);
+        }
+    }
+}
+
+test().catch(function(error) {
+    print(`FAIL: ${error}`);
+    print(String(error.stack));
+    $vm.abort();
+});
+drainMicrotasks();

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -368,6 +368,19 @@ function resolve(value)
     return @promiseResolve(this, value);
 }
 
+function withResolvers()
+{
+    "use strict";
+
+    var promiseCapability = @newPromiseCapability(this);
+
+    return {
+        promise: promiseCapability.@promise,
+        resolve: promiseCapability.@resolve,
+        reject: promiseCapability.@reject,
+    };
+}
+
 @nakedConstructor
 function Promise(executor)
 {

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -80,6 +80,11 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, promisePrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectWithoutTransition(vm, vm.propertyNames->length, jsNumber(1), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, speciesSymbol, PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
+
+    JSGlobalObject* globalObject = this->globalObject();
+
+    if (Options::usePromiseWithResolversMethod())
+        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withResolversPublicName(), promiseConstructorWithResolversCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 void JSPromiseConstructor::addOwnInternalSlots(VM& vm, JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -571,6 +571,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, useSetMethods, true, Normal, "Expose the various Set.prototype methods for handling combinations of sets") \
     v(Bool, useImportAssertion, false, Normal, "Enable import assertion.") \
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
+    v(Bool, usePromiseWithResolversMethod, false, Normal, "Expose the Promise.withResolvers() method.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \


### PR DESCRIPTION
#### 0e3ae70dd28cc89fc67a92312808f26ec35c60ff
<pre>
[JSC] add support for `Promise.withResolvers`
<a href="https://bugs.webkit.org/show_bug.cgi?id=259153">https://bugs.webkit.org/show_bug.cgi?id=259153</a>

Reviewed by Yusuke Suzuki.

This allows for developers to `resolve`/`reject` a `Promise` after it&apos;s been created instead of having to provide a function to `new Promise`.

For example, the following
```
function foo(target) {
    return new Promise((resolve, reject) =&gt; {
        target.addEventListener(&quot;good&quot;, resolve);
        target.addEventListener(&quot;bad&quot;, reject);
    });
}
```
can now be rewritten as
```
function foo(target, event) {
    let {promise, resolve, reject} = Promise.withResolvers();

    target.addEventListener(&quot;good&quot;, resolve);
    target.addEventListener(&quot;bad&quot;, reject);

    return promise;
}
```

Spec: <a href="https://tc39.es/proposal-promise-with-resolvers/">https://tc39.es/proposal-promise-with-resolvers/</a>
Proposal: <a href="https://github.com/tc39/proposal-promise-with-resolvers">https://github.com/tc39/proposal-promise-with-resolvers</a>

* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(withResolvers): Added.
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):

* Source/JavaScriptCore/runtime/OptionsList.h:
Add an off-by-default feature flag for this.

* JSTests/stress/promise-withResolvers.js: Added.

Canonical link: <a href="https://commits.webkit.org/266015@main">https://commits.webkit.org/266015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3e944b3b882b4d507c82bcb20347b30d71a4003

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12038 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14716 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18451 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10672 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14721 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9926 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12607 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11247 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3083 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15580 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/12963 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11863 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3090 "Passed tests") | 
<!--EWS-Status-Bubble-End-->