### PR TITLE
Add null check in NetworkStateNotifier::updateStateWithoutNotifying

### DIFF
--- a/Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp
+++ b/Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp
@@ -35,6 +35,9 @@ namespace WebCore {
 
 void NetworkStateNotifier::updateStateWithoutNotifying()
 {
+    if (!m_store)
+        return;
+
     auto key = adoptCF(SCDynamicStoreKeyCreateNetworkInterface(0, kSCDynamicStoreDomainState));
     auto propertyList = dynamic_cf_cast<CFDictionaryRef>(adoptCF(SCDynamicStoreCopyValue(m_store.get(), key.get())));
     if (!propertyList)


### PR DESCRIPTION
#### 302c4c541393a12749c9791968f8fbe6aa1f797e
<pre>
Add null check in NetworkStateNotifier::updateStateWithoutNotifying
<a href="https://bugs.webkit.org/show_bug.cgi?id=259163">https://bugs.webkit.org/show_bug.cgi?id=259163</a>
rdar://111926368

Reviewed by Brent Fulgham.

Crash logs indicate m_store can be null and it crashes when it is.
In NetworkStateNotifier::startObserving we early return if it&apos;s null.
This adds another early return.

* Source/WebCore/platform/network/mac/NetworkStateNotifierMac.cpp:
(WebCore::NetworkStateNotifier::updateStateWithoutNotifying):

Canonical link: <a href="https://commits.webkit.org/266011@main">https://commits.webkit.org/266011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d88dfe4a63f229fd6a8134efcaf02d4a30ed1104

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14307 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14735 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11375 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11873 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14730 "Passed tests") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12023 "Failed to checkout and rebase branch from PR 15797") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15597 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1421 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->