### PR TITLE
REGRESSION: source code viewer on Github renders two overlapping carets

### DIFF
--- a/LayoutTests/fast/css/caret-color-auto-expected.html
+++ b/LayoutTests/fast/css/caret-color-auto-expected.html
@@ -23,7 +23,7 @@
 </style>
 </head>
 <body>
-<p>Tests that "caret-color: auto" behaves identical to omitting property caret-color.</p>
+<p>Tests that "caret-color: auto" causes the caret to take the "color" property of itself, if applicable.</p>
 <div id="test-container">
     <div id="test" contenteditable="true">
         <span>&nbsp;<!-- Needed for the caret to render in Firefox. --></span>

--- a/LayoutTests/fast/css/caret-color-auto.html
+++ b/LayoutTests/fast/css/caret-color-auto.html
@@ -24,7 +24,7 @@
 </style>
 </head>
 <body>
-<p>Tests that "caret-color: auto" behaves identical to omitting property caret-color.</p>
+<p>Tests that "caret-color: auto" causes the caret to take the "color" property of itself, if applicable.</p>
 <div id="test-container">
     <div id="test" contenteditable="true">
         <span>&nbsp;<!-- Needed for the caret to render in Firefox. --></span>

--- a/LayoutTests/fast/css/caret-color-with-inherited-color-property-expected.html
+++ b/LayoutTests/fast/css/caret-color-with-inherited-color-property-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+        #test-container {
+            height: 50px;
+            width: 50px;
+        }
+
+        #mock-caret {
+            width: 50px;
+            height: 100px;
+            position: absolute;
+            top: 100px;
+            left: 8px;
+            background-color: green;
+        }
+        </style>
+    </head>
+    <body>
+        <p>The caret should show as a green flashing square below.</p>
+        <div id="test-container">
+            <div id="mock-caret"></div>
+        </div>
+    </body>
+</html>

--- a/LayoutTests/fast/css/caret-color-with-inherited-color-property.html
+++ b/LayoutTests/fast/css/caret-color-with-inherited-color-property.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+        #test-container {
+            height: 150px;
+            width: 100px;
+            overflow: hidden;
+            color: green;
+        }
+
+        #test {
+            transform-origin: left top;
+            transform: scale(50, 50);
+            clip-path: inset(1px 99px 0px 0px);
+            font-size: 10px; /* Needed for the caret to render in Firefox. */
+            color: inherit;
+        }
+
+        </style>
+    </head>
+    <body>
+        <p>The caret should show as a green flashing square below.</p>
+        <div id="test-container">
+            <div id="test" contenteditable="true">
+                <span>&nbsp;<!-- Needed for the caret to render in Firefox. --></span>
+            </div>
+        </div>
+        <script>
+            document.getElementById("test").focus();
+            window.getSelection().modify("move", "left", "character"); // Place the caret at the start of the <span>.
+        </script>
+    </body>
+</html>

--- a/LayoutTests/fast/css/caret-color-with-initial-color-property-expected.html
+++ b/LayoutTests/fast/css/caret-color-with-initial-color-property-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+        #test-container {
+            height: 50px;
+            width: 50px;
+        }
+
+        #mock-caret {
+            width: 50px;
+            height: 100px;
+            position: absolute;
+            top: 100px;
+            left: 8px;
+            background-color: black;
+        }
+        </style>
+    </head>
+    <body>
+        <p>The caret should show as a black flashing square below.</p>
+        <div id="test-container">
+            <div id="mock-caret"></div>
+        </div>
+    </body>
+</html>

--- a/LayoutTests/fast/css/caret-color-with-initial-color-property.html
+++ b/LayoutTests/fast/css/caret-color-with-initial-color-property.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+        #test-container {
+            height: 150px;
+            width: 100px;
+            overflow: hidden;
+        }
+
+        #test {
+            transform-origin: left top;
+            transform: scale(50, 50);
+            clip-path: inset(1px 99px 0px 0px);
+            font-size: 10px; /* Needed for the caret to render in Firefox. */
+            color: initial;
+        }
+
+        </style>
+    </head>
+    <body>
+        <p>The caret should show as a black flashing square below.</p>
+        <div id="test-container">
+            <div id="test" contenteditable="true">
+                <span>&nbsp;<!-- Needed for the caret to render in Firefox. --></span>
+            </div>
+        </div>
+        <script>
+            document.getElementById("test").focus();
+            window.getSelection().modify("move", "left", "character"); // Place the caret at the start of the <span>.
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1170,6 +1170,8 @@ fast/css/caret-color-fallback-to-color.html [ Skip ]
 fast/css/caret-color-inherit.html [ Skip ]
 fast/css/caret-color-span-inside-editable-parent.html [ Skip ]
 fast/css/caret-color.html [ Skip ]
+fast/css/caret-color-with-initial-color-property.html [ Skip ]
+fast/css/caret-color-with-inherited-color-property.html [ Skip ]
 fast/history/visited-link-caret-color.html [ Skip ]
 css3/color-filters/color-filter-caret-color.html [ Skip ]
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -369,7 +369,7 @@
             "codegen-properties": {
                 "visited-link-color-support": true,
                 "color-property": true,
-                "custom": "Value",
+                "custom": "All",
                 "high-priority": true,
                 "fast-path-inherited": true,
                 "parser-grammar": "<color accept-quirky-colors-in-quirks-mode>"

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -58,7 +58,7 @@ class CaretBase {
     WTF_MAKE_NONCOPYABLE(CaretBase);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*, const std::optional<VisibleSelection>&);
+    WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*);
 protected:
     enum class CaretVisibility : bool { Visible, Hidden };
     explicit CaretBase(CaretVisibility = CaretVisibility::Hidden);
@@ -67,7 +67,7 @@ protected:
     void clearCaretRect();
     bool updateCaretRect(Document&, const VisiblePosition& caretPosition);
     bool shouldRepaintCaret(const RenderView*, bool isContentEditable) const;
-    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, CaretAnimator*, const std::optional<VisibleSelection>&) const;
+    void paintCaret(const Node&, GraphicsContext&, const LayoutPoint&, CaretAnimator*) const;
 
     const LayoutRect& localCaretRectWithoutUpdate() const { return m_caretLocalRect; }
 

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1373,7 +1373,7 @@ Color RenderThemeIOS::insertionPointColor()
 
 Color RenderThemeIOS::autocorrectionReplacementMarkerColor(const RenderText& renderer) const
 {
-    auto caretColor = CaretBase::computeCaretColor(renderer.style(), renderer.textNode(), std::nullopt);
+    auto caretColor = CaretBase::computeCaretColor(renderer.style(), renderer.textNode());
     if (!caretColor.isValid())
         caretColor = insertionPointColor();
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1590,6 +1590,8 @@ public:
     inline SVGPaintType fillPaintType() const;
     inline StyleColor fillPaintColor() const;
     inline void setFillPaintColor(const StyleColor&);
+    inline void setHasExplicitlySetColor(bool);
+    inline bool hasExplicitlySetColor() const;
     inline float fillOpacity() const;
     inline void setFillOpacity(float);
 
@@ -2197,6 +2199,8 @@ private:
         unsigned autosizeStatus : 5;
 #endif
         // 51 bits
+        unsigned hasExplicitlySetColor : 1;
+        // 52 bits
     };
 
     // This constructor is used to implement the replace operation.

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -464,6 +464,7 @@ constexpr TextEmphasisFill RenderStyle::initialTextEmphasisFill() { return TextE
 constexpr TextEmphasisMark RenderStyle::initialTextEmphasisMark() { return TextEmphasisMark::None; }
 constexpr OptionSet<TextEmphasisPosition> RenderStyle::initialTextEmphasisPosition() { return { TextEmphasisPosition::Over, TextEmphasisPosition::Right }; }
 inline StyleColor RenderStyle::initialTextFillColor() { return StyleColor::currentColor(); }
+inline bool RenderStyle::hasExplicitlySetColor() const { return m_inheritedFlags.hasExplicitlySetColor; }
 constexpr TextGroupAlign RenderStyle::initialTextGroupAlign() { return TextGroupAlign::None; }
 inline Length RenderStyle::initialTextIndent() { return zeroLength(); }
 constexpr TextIndentLine RenderStyle::initialTextIndentLine() { return TextIndentLine::FirstLine; }
@@ -803,7 +804,8 @@ inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other)
         && pointerEvents == other.pointerEvents
         && insideLink == other.insideLink
         && insideDefaultButton == other.insideDefaultButton
-        && writingMode == other.writingMode;
+        && writingMode == other.writingMode
+        && hasExplicitlySetColor == other.hasExplicitlySetColor;
 }
 
 inline bool RenderStyle::NonInheritedFlags::operator==(const NonInheritedFlags& other) const

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -299,6 +299,7 @@ inline void RenderStyle::setTextEmphasisFill(TextEmphasisFill fill) { SET(m_rare
 inline void RenderStyle::setTextEmphasisMark(TextEmphasisMark mark) { SET(m_rareInheritedData, textEmphasisMark, static_cast<unsigned>(mark)); }
 inline void RenderStyle::setTextEmphasisPosition(OptionSet<TextEmphasisPosition> position) { SET(m_rareInheritedData, textEmphasisPosition, static_cast<unsigned>(position.toRaw())); }
 inline void RenderStyle::setTextFillColor(const StyleColor& color) { SET(m_rareInheritedData, textFillColor, color); }
+inline void RenderStyle::setHasExplicitlySetColor(bool value) { m_inheritedFlags.hasExplicitlySetColor = value; }
 inline void RenderStyle::setTextGroupAlign(TextGroupAlign value) { SET_NESTED(m_nonInheritedData, rareData, textGroupAlign, static_cast<unsigned>(value)); }
 inline void RenderStyle::setTextIndent(Length&& length) { SET(m_rareInheritedData, indent, WTFMove(length)); }
 inline void RenderStyle::setTextIndentLine(TextIndentLine value) { SET(m_rareInheritedData, textIndentLine, static_cast<unsigned>(value)); }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -89,6 +89,7 @@ public:
     DECLARE_PROPERTY_CUSTOM_HANDLERS(BoxShadow);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(CaretColor);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Clip);
+    DECLARE_PROPERTY_CUSTOM_HANDLERS(Color);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(Contain);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(ContainIntrinsicWidth);
     DECLARE_PROPERTY_CUSTOM_HANDLERS(ContainIntrinsicHeight);
@@ -163,8 +164,6 @@ public:
     static void applyInitialCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
     static void applyInheritCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const AtomString& name);
     static void applyValueCustomProperty(BuilderState&, const CSSRegisteredCustomProperty*, const CSSCustomPropertyValue&);
-
-    static void applyValueColor(BuilderState&, CSSValue&);
 
 private:
     static void resetEffectiveZoom(BuilderState&);
@@ -2034,7 +2033,31 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
         auto color = builderState.colorFromPrimitiveValue(primitiveValue, ForVisitedLink::Yes);
         builderState.style().setVisitedLinkColor(resolveColor(color));
     }
+
     builderState.style().setDisallowsFastPathInheritance();
+    builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInitialColor(BuilderState& builderState)
+{
+    if (builderState.applyPropertyToRegularStyle())
+        builderState.style().setColor(RenderStyle::initialColor());
+    if (builderState.applyPropertyToVisitedLinkStyle())
+        builderState.style().setVisitedLinkColor(RenderStyle::initialColor());
+
+    builderState.style().setDisallowsFastPathInheritance();
+    builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
+}
+
+inline void BuilderCustom::applyInheritColor(BuilderState& builderState)
+{
+    if (builderState.applyPropertyToRegularStyle())
+        builderState.style().setColor(builderState.parentStyle().color());
+    if (builderState.applyPropertyToVisitedLinkStyle())
+        builderState.style().setVisitedLinkColor(builderState.parentStyle().color());
+
+    builderState.style().setDisallowsFastPathInheritance();
+    builderState.style().setHasExplicitlySetColor(builderState.isAuthorOrigin());
 }
 
 inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -106,6 +106,11 @@ public:
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
 
+    bool isAuthorOrigin() const
+    {
+        return m_currentProperty && m_currentProperty->cascadeLevel == CascadeLevel::Author;
+    }
+
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.
     friend void maybeUpdateFontForLetterSpacing(BuilderState&, CSSValue&);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -387,7 +387,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
             // rather than the focused element. This causes caret colors in editable children to be
             // ignored in favor of the editing host's caret color. See: <https://webkit.org/b/229809>.
             if (RefPtr editableRoot = selection.rootEditableElement(); editableRoot && editableRoot->renderer()) {
-                postLayoutData.caretColor = CaretBase::computeCaretColor(editableRoot->renderer()->style(), editableRoot.get(), std::nullopt);
+                postLayoutData.caretColor = CaretBase::computeCaretColor(editableRoot->renderer()->style(), editableRoot.get());
                 postLayoutData.hasGrammarDocumentMarkers = editableRoot->document().markers().hasMarkers(makeRangeSelectingNodeContents(*editableRoot), DocumentMarker::Grammar);
             }
         }

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1388,7 +1388,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     auto* renderer = focusedElement->renderer();
     if (!renderer)
         return nil;
-    auto color = WebCore::CaretBase::computeCaretColor(renderer->style(), renderer->element(), std::nullopt);
+    auto color = WebCore::CaretBase::computeCaretColor(renderer->style(), renderer->element());
     return color.isValid() ? cachedCGColor(color).autorelease() : nil;
 }
 


### PR DESCRIPTION
#### 4cc63dfc70a9df30e97dfd5753f8cdad28f96301
<pre>
REGRESSION: source code viewer on Github renders two overlapping carets
<a href="https://bugs.webkit.org/show_bug.cgi?id=259166">https://bugs.webkit.org/show_bug.cgi?id=259166</a>
rdar://112056259

Reviewed by Aditya Keerthi.

The color of the caret should respect both the `caret-color` and the `color` properties.
Because every element implicitly has a `color`, the color of the caret should only reflect
this property if set by the author.

* LayoutTests/fast/css/caret-color-with-color-property-expected.html: Added.
* LayoutTests/fast/css/caret-color-with-color-property.html: Added.
* LayoutTests/fast/css/caret-color-with-inherited-color-property-expected.html: Added.
* LayoutTests/fast/css/caret-color-with-inherited-color-property.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasExplicitlySetColor const):
(WebCore::RenderStyle::InheritedFlags::operator== const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setHasExplicitlySetColor):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueColor):
(WebCore::Style::BuilderCustom::applyInitialColor):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::isAuthorOrigin const):

Canonical link: <a href="https://commits.webkit.org/266070@main">https://commits.webkit.org/266070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a99653b61ddb18c4f9472e612a0ca72cf91ee963

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14491 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12194 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14894 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14937 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11544 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14910 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11414 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15743 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->