### PR TITLE
[UI-side compositing] Cannot grab the scrubber to scroll to the end of a long page (build log)

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -180,7 +180,7 @@ public:
     WEBCORE_EXPORT TiledBacking* tiledBacking() const;
 
     WEBCORE_EXPORT ScrollingNodeID scrollingNodeID() const override;
-    ScrollableArea* scrollableAreaForScrollingNodeID(ScrollingNodeID) const;
+    WEBCORE_EXPORT ScrollableArea* scrollableAreaForScrollingNodeID(ScrollingNodeID) const;
     bool usesAsyncScrolling() const final;
 
     WEBCORE_EXPORT void enterCompositingMode();

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -1173,16 +1173,6 @@ bool AsyncScrollingCoordinator::scrollAnimatorEnabled() const
     return settings.scrollAnimatorEnabled();
 }
 
-void AsyncScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
-{
-    auto* frameView = frameViewForScrollingNode(nodeID);
-    if (!frameView)
-        return;
-    
-    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
-        scrollableArea->scrollbarsController().setScrollbarVisibilityState(orientation, isVisible);
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -75,7 +75,6 @@ public:
     
     WEBCORE_EXPORT void setMouseIsOverContentArea(ScrollableArea&, bool) override;
     WEBCORE_EXPORT void setMouseMovedInContentArea(ScrollableArea&) override;
-    WEBCORE_EXPORT void scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID, ScrollbarOrientation, bool);
 
 protected:
     WEBCORE_EXPORT AsyncScrollingCoordinator(Page*);
@@ -95,6 +94,7 @@ protected:
     void scheduleRenderingUpdate();
 
     bool eventTrackingRegionsDirty() const { return m_eventTrackingRegionsDirty; }
+    WEBCORE_EXPORT LocalFrameView* frameViewForScrollingNode(ScrollingNodeID) const;
 
 private:
     bool isAsyncScrollingCoordinator() const override { return true; }
@@ -172,8 +172,6 @@ private:
     void wheelEventScrollDidEndForNode(ScrollingNodeID);
     
     WEBCORE_EXPORT void setMouseIsOverScrollbar(Scrollbar*, bool isOverScrollbar) override;
-
-    LocalFrameView* frameViewForScrollingNode(ScrollingNodeID) const;
 
     void hysterisisTimerFired(PAL::HysteresisState);
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -248,7 +248,8 @@ public:
     WEBCORE_EXPORT Seconds frameDuration();
     WEBCORE_EXPORT Seconds maxAllowableRenderingUpdateDurationForSynchronization();
     WEBCORE_EXPORT virtual void scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID, ScrollbarOrientation, bool) { };
-    
+    WEBCORE_EXPORT virtual void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, ScrollbarOrientation, int) { };
+
 protected:
     WEBCORE_EXPORT WheelEventHandlingResult handleWheelEventWithNode(const PlatformWheelEvent&, OptionSet<WheelEventProcessingSteps>, ScrollingTreeNode*, EventTargeting = EventTargeting::Propagate);
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -497,6 +497,11 @@ void ScrollingTreeScrollingNode::scrollbarVisibilityDidChange(ScrollbarOrientati
     scrollingTree().scrollingTreeNodeScrollbarVisibilityDidChange(scrollingNodeID(), orientation, isVisible);
 }
 
+void ScrollingTreeScrollingNode::scrollbarMinimumThumbLengthDidChange(ScrollbarOrientation orientation, int minimumThumbLength)
+{
+    scrollingTree().scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(scrollingNodeID(), orientation, minimumThumbLength);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -136,6 +136,7 @@ public:
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
     
     void scrollbarVisibilityDidChange(ScrollbarOrientation, bool);
+    void scrollbarMinimumThumbLengthDidChange(ScrollbarOrientation, int);
 
 protected:
     ScrollingTreeScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.h
@@ -57,7 +57,7 @@ public:
 
     RetainPtr<NSScrollerImp> takeScrollerImp() { return std::exchange(m_scrollerImp, { }); }
     NSScrollerImp *scrollerImp() { return m_scrollerImp.get(); }
-    void setScrollerImp(NSScrollerImp *imp) { m_scrollerImp = imp; }
+    void setScrollerImp(NSScrollerImp *imp);
     void updateScrollbarStyle();
     void updatePairScrollerImps();
 
@@ -70,8 +70,10 @@ public:
     void setLastKnownMousePositionInScrollbar(IntPoint position) { m_lastKnownMousePositionInScrollbar = position; }
     IntPoint lastKnownMousePositionInScrollbar() const;
     void visibilityChanged(bool);
+    void updateMinimumKnobLength(int);
     void detach();
 private:
+    int m_minimumKnobLength { 0 };
     bool m_isVisible { false };
     ScrollerPairMac& m_pair;
     const ScrollbarOrientation m_orientation;

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -330,7 +330,7 @@ ScrollerMac::~ScrollerMac()
 void ScrollerMac::attach()
 {
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
+    setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil]);
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 }
 
@@ -369,7 +369,7 @@ void ScrollerMac::updateValues()
 
 void ScrollerMac::updateScrollbarStyle()
 {
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
+    setScrollerImp([NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()]);
     updatePairScrollerImps();
 }
 
@@ -425,6 +425,20 @@ void ScrollerMac::visibilityChanged(bool isVisible)
         return;
     m_isVisible = isVisible;
     m_pair.node().scrollbarVisibilityDidChange(m_orientation, isVisible);
+}
+
+void ScrollerMac::updateMinimumKnobLength(int minimumKnobLength)
+{
+    if (m_minimumKnobLength == minimumKnobLength)
+        return;
+    m_minimumKnobLength = minimumKnobLength;
+    m_pair.node().scrollbarMinimumThumbLengthDidChange(m_orientation, m_minimumKnobLength);
+}
+
+void ScrollerMac::setScrollerImp(NSScrollerImp *imp)
+{
+    m_scrollerImp = imp;
+    updateMinimumKnobLength([m_scrollerImp knobMinLength]);
 }
 
 String ScrollerMac::scrollbarState() const

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -533,4 +533,9 @@ bool Scrollbar::shouldRegisterScrollbar() const
     return m_scrollableArea.scrollbarsController().shouldRegisterScrollbars();
 }
 
+int Scrollbar::minimumThumbLength() const
+{
+    return m_scrollableArea.scrollbarsController().minimumThumbLength(m_orientation);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -142,6 +142,7 @@ public:
     float deviceScaleFactor() const;
 
     bool shouldRegisterScrollbar() const;
+    int minimumThumbLength() const;
 
 protected:
     Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -96,6 +96,9 @@ public:
     WEBCORE_EXPORT virtual bool shouldDrawIntoScrollbarLayer(Scrollbar&) const { return true; }
     WEBCORE_EXPORT virtual bool shouldRegisterScrollbars() const { return true; }
 
+    WEBCORE_EXPORT virtual void setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation, int) { }
+    WEBCORE_EXPORT virtual int minimumThumbLength(WebCore::ScrollbarOrientation) { return 0; }
+
 private:
     ScrollableArea& m_scrollableArea;
     bool m_scrollbarAnimationsUnsuspendedByUserInteraction { true };

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -438,9 +438,12 @@ IntRect ScrollbarThemeMac::trackRect(Scrollbar& scrollbar, bool painting)
 
 int ScrollbarThemeMac::minimumThumbLength(Scrollbar& scrollbar)
 {
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
-    return [scrollbarMap().get(&scrollbar) knobMinLength];
-    END_BLOCK_OBJC_EXCEPTIONS
+    if (scrollbar.shouldRegisterScrollbar()) {
+        BEGIN_BLOCK_OBJC_EXCEPTIONS
+        return [scrollbarMap().get(&scrollbar) knobMinLength];
+        END_BLOCK_OBJC_EXCEPTIONS
+    } else
+        return scrollbar.minimumThumbLength();
 }
 
 static bool shouldCenterOnThumb(const PlatformMouseEvent& evt)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -434,6 +434,11 @@ void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidCha
     m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
 }
 
+void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
+{
+    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength));
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -165,6 +165,7 @@ public:
     void sendScrollingTreeNodeDidScroll();
     
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
+    void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, int);
 
 protected:
     RemoteScrollingTree* scrollingTree() const { return m_scrollingTree.get(); }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -47,6 +47,7 @@ public:
     virtual ~RemoteScrollingTreeMac();
 
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, ScrollbarOrientation, bool) override;
+    void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, ScrollbarOrientation, int) override;
 
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -518,6 +518,14 @@ void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarVisibilityDidChange(Scrol
     });
 }
 
+void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
+{
+    RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, orientation, minimumThumbLength] {
+        if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
+            scrollingCoordinatorProxy->scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength);
+    });
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -49,13 +49,18 @@ public:
     void mouseExitedScrollbar(WebCore::Scrollbar*) const final;
     bool shouldScrollbarParticipateInHitTesting(WebCore::Scrollbar*) final;
 
+    void setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation, int) final;
     void setScrollbarVisibilityState(WebCore::ScrollbarOrientation, bool) final;
     bool shouldDrawIntoScrollbarLayer(WebCore::Scrollbar&) const final;
     bool shouldRegisterScrollbars() const final { return scrollableArea().isListBox(); }
+    int minimumThumbLength(WebCore::ScrollbarOrientation) final;
 
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };
     bool m_verticalOverlayScrollbarIsVisible { false };
+
+    int m_horizontalMinimumThumbLength { 0 };
+    int m_verticalMinimumThumbLength { 0 };
     ThreadSafeWeakPtr<WebCore::ScrollingCoordinator> m_coordinator;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -94,5 +94,18 @@ bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar
     return scrollbar.isCustomScrollbar() || scrollbar.isMockScrollbar();
 }
 
+void RemoteScrollbarsController::setScrollbarMinimumThumbLength(WebCore::ScrollbarOrientation orientation, int minimumThumbLength)
+{
+    if (orientation == WebCore::ScrollbarOrientation::Horizontal)
+        m_horizontalMinimumThumbLength = minimumThumbLength;
+    else
+        m_verticalMinimumThumbLength = minimumThumbLength;
+}
+
+int RemoteScrollbarsController::minimumThumbLength(WebCore::ScrollbarOrientation orientation)
+{
+    return orientation == WebCore::ScrollbarOrientation::Horizontal ? m_horizontalMinimumThumbLength : m_verticalMinimumThumbLength;
+}
+
 }
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -97,6 +97,7 @@ private:
     void startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason);
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool);
+    void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID nodeID, WebCore::ScrollbarOrientation orientation, int minimumThumbLength);
 
     WebCore::WheelEventHandlingResult handleWheelEventForScrolling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in
@@ -32,6 +32,7 @@ messages -> RemoteScrollingCoordinator {
     StartDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
     StopDeferringScrollingTestCompletionForNode(uint64_t nodeID, WebCore::WheelEventTestMonitor::DeferReason reason);
     ScrollingTreeNodeScrollbarVisibilityDidChange(uint64_t nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, bool isVisible);
+    ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(uint64_t nodeID, enum:uint8_t WebCore::ScrollbarOrientation orientation, int minimumThumbLength);
 }
 
 #endif // ENABLE(ASYNC_SCROLLING)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -44,6 +44,7 @@
 #import <WebCore/Page.h>
 #import <WebCore/RenderLayerCompositor.h>
 #import <WebCore/RenderView.h>
+#import <WebCore/ScrollbarsController.h>
 #import <WebCore/ScrollingStateFrameScrollingNode.h>
 #import <WebCore/ScrollingTreeFixedNodeCocoa.h>
 #import <WebCore/ScrollingTreeStickyNodeCocoa.h>
@@ -186,9 +187,24 @@ WheelEventHandlingResult RemoteScrollingCoordinator::handleWheelEventForScrollin
     return WheelEventHandlingResult::handled();
 }
 
-void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, WebCore::ScrollbarOrientation orientation, bool isVisible)
+void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
 {
-    AsyncScrollingCoordinator::scrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible);
+    auto* frameView = frameViewForScrollingNode(nodeID);
+    if (!frameView)
+        return;
+
+    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
+        scrollableArea->scrollbarsController().setScrollbarVisibilityState(orientation, isVisible);
+}
+
+void RemoteScrollingCoordinator::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
+{
+    auto* frameView = frameViewForScrollingNode(nodeID);
+    if (!frameView)
+        return;
+
+    if (auto* scrollableArea = frameView->scrollableAreaForScrollingNodeID(nodeID))
+        scrollableArea->scrollbarsController().setScrollbarMinimumThumbLength(orientation, minimumThumbLength);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 0f2ddd2e32274c34d687b6263b7664cc4c9aa5b2
<pre>
[UI-side compositing] Cannot grab the scrubber to scroll to the end of a long page (build log)
<a href="https://bugs.webkit.org/show_bug.cgi?id=259167">https://bugs.webkit.org/show_bug.cgi?id=259167</a>
rdar://112154989

Reviewed by Simon Fraser.

After <a href="https://commits.webkit.org/265731@main">https://commits.webkit.org/265731@main</a> removed NSScrollerImps in the web process, when
ScrollbarThemeMac::minimumThumbLength would query the scrollbar map, it wouldn&apos;t be able to
find the NSScrollerImp, so it would return 0. This resulted in users not being able to drag
the scrollbar. To resolve this, plumb the knobMinLength property to the web process, where it
is tracked by RemoteScrollbarsController.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
(WebCore::AsyncScrollingCoordinator::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::scrollbarMinimumThumbLengthDidChange):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::updateScrollbarStyle):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::minimumThumbLength const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::setScrollbarMinimumThumbLength):
(WebCore::ScrollbarsController::minimumThumbLength):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::hasThumb):
(WebCore::ScrollbarThemeMac::minimumThumbLength):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::setScrollbarMinimumThumbLength):
(WebKit::RemoteScrollbarsController::minimumThumbLength):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):

Canonical link: <a href="https://commits.webkit.org/266124@main">https://commits.webkit.org/266124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/479d1fae3a6b70717141033c57e1a1d1ae770704

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12695 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14846 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14878 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11493 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18570 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14855 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15703 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1470 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->