### PR TITLE
Don't call deferNonVisibleProcessEarlyMemoryCleanupTimer from worker threads

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -160,7 +160,8 @@ void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
 
 void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
 {
-    WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();
+    if (isMainRunLoop())
+        WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();
 
     if (cachedNativeImage(image.renderingResourceIdentifier()))
         return;


### PR DESCRIPTION
#### 1ace3d3f33b26d072a9c04c962986b2912232557
<pre>
Don&apos;t call deferNonVisibleProcessEarlyMemoryCleanupTimer from worker threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=259170">https://bugs.webkit.org/show_bug.cgi?id=259170</a>
rdar://110910174

Reviewed by Simon Fraser.

We call deferNonVisibleProcessEarlyMemoryCleanupTimer in
RemoteResourceCacheProxy::recordNativeImageUse. The idea there is to
avoid discarding decoded image data in background tabs if the background
tab is drawing images, which might be some canvas work, or it could be
other things like Safari taking a tab snapshot. If we didn&apos;t avoid this,
we could thrash between discarding decoded data and redecoding.

OffscreenCanvas can also draw images on worker threads, but
deferNonVisibleProcessEarlyMemoryCleanupTimer is not safe to call from
non-main threads. We can safely skip this call if we&apos;re not on the main
thread: workers do not have access to images which are stored in the
MemoryCache, so we are not at risk of discarding decoded image data that
the worker will want to re-decode to draw.

* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):

Canonical link: <a href="https://commits.webkit.org/266024@main">https://commits.webkit.org/266024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67445a393392a44916d6dd5b17d16907c8de4b0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14770 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10814 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11567 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14758 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11290 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3091 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->