### PR TITLE
[JSC] optimize `Promise.withResolvers` to avoid unnecessary object construction

### DIFF
--- a/Source/JavaScriptCore/builtins/ModuleLoader.js
+++ b/Source/JavaScriptCore/builtins/ModuleLoader.js
@@ -140,7 +140,7 @@ function fulfillFetch(entry, source)
     "use strict";
 
     if (!entry.fetch)
-        entry.fetch = @newPromiseCapability(@InternalPromise).@promise;
+        entry.fetch = @newPromiseCapability(@InternalPromise).promise;
     @forceFulfillPromise(entry.fetch, source);
     @setStateToMax(entry, @ModuleInstantiate);
 }

--- a/Source/JavaScriptCore/builtins/PromiseConstructor.js
+++ b/Source/JavaScriptCore/builtins/PromiseConstructor.js
@@ -49,7 +49,7 @@ function promiseAllSlow(iterable)
 
             --remainingElementsCount;
             if (remainingElementsCount === 0)
-                return promiseCapability.@resolve.@call(@undefined, values);
+                return promiseCapability.resolve.@call(@undefined, values);
 
             return @undefined;
         };
@@ -65,18 +65,18 @@ function promiseAllSlow(iterable)
             var nextPromise = promiseResolve.@call(this, value);
             var resolveElement = newResolveElement(index);
             ++remainingElementsCount;
-            nextPromise.then(resolveElement, promiseCapability.@reject);
+            nextPromise.then(resolveElement, promiseCapability.reject);
             ++index;
         }
 
         --remainingElementsCount;
         if (remainingElementsCount === 0)
-            promiseCapability.@resolve.@call(@undefined, values);
+            promiseCapability.resolve.@call(@undefined, values);
     } catch (error) {
-        promiseCapability.@reject.@call(@undefined, error);
+        promiseCapability.reject.@call(@undefined, error);
     }
 
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 @linkTimeConstant
@@ -212,7 +212,7 @@ function allSettled(iterable)
 
                 --remainingElementsCount;
                 if (remainingElementsCount === 0)
-                    return promiseCapability.@resolve.@call(@undefined, values);
+                    return promiseCapability.resolve.@call(@undefined, values);
 
                 return @undefined;
             },
@@ -231,7 +231,7 @@ function allSettled(iterable)
 
                 --remainingElementsCount;
                 if (remainingElementsCount === 0)
-                    return promiseCapability.@resolve.@call(@undefined, values);
+                    return promiseCapability.resolve.@call(@undefined, values);
 
                 return @undefined;
             }
@@ -254,12 +254,12 @@ function allSettled(iterable)
 
         --remainingElementsCount;
         if (remainingElementsCount === 0)
-            promiseCapability.@resolve.@call(@undefined, values);
+            promiseCapability.resolve.@call(@undefined, values);
     } catch (error) {
-        promiseCapability.@reject.@call(@undefined, error);
+        promiseCapability.reject.@call(@undefined, error);
     }
 
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 function any(iterable)
@@ -287,7 +287,7 @@ function any(iterable)
 
             --remainingElementsCount;
             if (remainingElementsCount === 0)
-                return promiseCapability.@reject.@call(@undefined, new @AggregateError(errors));
+                return promiseCapability.reject.@call(@undefined, new @AggregateError(errors));
 
             return @undefined;
         };
@@ -303,7 +303,7 @@ function any(iterable)
             var nextPromise = promiseResolve.@call(this, value);
             var rejectElement = newRejectElement(index);
             ++remainingElementsCount;
-            nextPromise.then(promiseCapability.@resolve, rejectElement);
+            nextPromise.then(promiseCapability.resolve, rejectElement);
             ++index;
         }
 
@@ -311,10 +311,10 @@ function any(iterable)
         if (remainingElementsCount === 0)
             throw new @AggregateError(errors);
     } catch (error) {
-        promiseCapability.@reject.@call(@undefined, error);
+        promiseCapability.reject.@call(@undefined, error);
     }
 
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 function race(iterable)
@@ -333,13 +333,13 @@ function race(iterable)
 
         for (var value of iterable) {
             var nextPromise = promiseResolve.@call(this, value);
-            nextPromise.then(promiseCapability.@resolve, promiseCapability.@reject);
+            nextPromise.then(promiseCapability.resolve, promiseCapability.reject);
         }
     } catch (error) {
-        promiseCapability.@reject.@call(@undefined, error);
+        promiseCapability.reject.@call(@undefined, error);
     }
 
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 function reject(reason)
@@ -372,13 +372,7 @@ function withResolvers()
 {
     "use strict";
 
-    var promiseCapability = @newPromiseCapability(this);
-
-    return {
-        promise: promiseCapability.@promise,
-        resolve: promiseCapability.@resolve,
-        reject: promiseCapability.@reject,
-    };
+    return @newPromiseCapability(this);
 }
 
 @nakedConstructor

--- a/Source/JavaScriptCore/builtins/PromiseOperations.js
+++ b/Source/JavaScriptCore/builtins/PromiseOperations.js
@@ -57,28 +57,28 @@ function newPromiseCapabilitySlow(constructor)
     "use strict";
 
     var promiseCapability = {
-        @resolve: @undefined,
-        @reject: @undefined,
-        @promise: @undefined,
+        resolve: @undefined,
+        reject: @undefined,
+        promise: @undefined,
     };
 
     var promise = new constructor((resolve, reject) => {
-        if (promiseCapability.@resolve !== @undefined)
+        if (promiseCapability.resolve !== @undefined)
             @throwTypeError("resolve function is already set");
-        if (promiseCapability.@reject !== @undefined)
+        if (promiseCapability.reject !== @undefined)
             @throwTypeError("reject function is already set");
 
-        promiseCapability.@resolve = resolve;
-        promiseCapability.@reject = reject;
+        promiseCapability.resolve = resolve;
+        promiseCapability.reject = reject;
     });
 
-    if (!@isCallable(promiseCapability.@resolve))
+    if (!@isCallable(promiseCapability.resolve))
         @throwTypeError("executor did not take a resolve function");
 
-    if (!@isCallable(promiseCapability.@reject))
+    if (!@isCallable(promiseCapability.reject))
         @throwTypeError("executor did not take a reject function");
 
-    promiseCapability.@promise = promise;
+    promiseCapability.promise = promise;
 
     return promiseCapability;
 }
@@ -97,7 +97,7 @@ function newPromiseCapability(constructor)
         function @reject(reason) {
             return @rejectPromiseWithFirstResolvingFunctionCallCheck(capturedPromise, reason);
         }
-        return { @resolve, @reject, @promise: promise };
+        return { resolve: @resolve, reject: @reject, promise };
     }
 
     return @newPromiseCapabilitySlow(constructor);
@@ -127,8 +127,8 @@ function promiseResolveSlow(constructor, value)
 
     @assert(constructor !== @Promise);
     var promiseCapability = @newPromiseCapabilitySlow(constructor);
-    promiseCapability.@resolve.@call(@undefined, value);
-    return promiseCapability.@promise;
+    promiseCapability.resolve.@call(@undefined, value);
+    return promiseCapability.promise;
 }
 
 @linkTimeConstant
@@ -138,8 +138,8 @@ function promiseRejectSlow(constructor, reason)
 
     @assert(constructor !== @Promise);
     var promiseCapability = @newPromiseCapabilitySlow(constructor);
-    promiseCapability.@reject.@call(@undefined, reason);
-    return promiseCapability.@promise;
+    promiseCapability.reject.@call(@undefined, reason);
+    return promiseCapability.promise;
 }
 
 @linkTimeConstant
@@ -304,7 +304,7 @@ function createResolvingFunctions(promise)
         return @rejectPromise(promise, reason);
     });
 
-    return { @resolve: resolve, @reject: reject };
+    return { resolve, reject };
 }
 
 @linkTimeConstant
@@ -413,7 +413,7 @@ function createResolvingFunctionsWithoutPromise(onFulfilled, onRejected, context
         @rejectWithoutPromise(reason, onFulfilled, onRejected, context);
     });
 
-    return { @resolve: resolve, @reject: reject };
+    return { resolve, reject };
 }
 
 @linkTimeConstant
@@ -458,7 +458,7 @@ function promiseReactionJob(promiseOrCapability, handler, argument, contextOrSta
             @rejectPromise(promiseOrCapability, error);
             return;
         }
-        promiseOrCapability.@reject.@call(@undefined, error);
+        promiseOrCapability.reject.@call(@undefined, error);
         return;
     }
 
@@ -466,7 +466,7 @@ function promiseReactionJob(promiseOrCapability, handler, argument, contextOrSta
         @resolvePromise(promiseOrCapability, result);
         return;
     }
-    promiseOrCapability.@resolve.@call(@undefined, result);
+    promiseOrCapability.resolve.@call(@undefined, result);
 }
 
 @linkTimeConstant
@@ -535,9 +535,9 @@ function promiseResolveThenableJob(thenable, then, resolvingFunctions)
     "use strict";
 
     try {
-        return then.@call(thenable, resolvingFunctions.@resolve, resolvingFunctions.@reject);
+        return then.@call(thenable, resolvingFunctions.resolve, resolvingFunctions.reject);
     } catch (error) {
-        return resolvingFunctions.@reject.@call(@undefined, error);
+        return resolvingFunctions.reject.@call(@undefined, error);
     }
 }
 
@@ -548,10 +548,10 @@ function promiseResolveThenableJobWithDerivedPromise(thenable, constructor, reso
 
     try {
         var promiseOrCapability = @newPromiseCapabilitySlow(constructor);
-        @performPromiseThen(thenable, resolvingFunctions.@resolve, resolvingFunctions.@reject, promiseOrCapability, @undefined);
-        return promiseOrCapability.@promise;
+        @performPromiseThen(thenable, resolvingFunctions.resolve, resolvingFunctions.reject, promiseOrCapability, @undefined);
+        return promiseOrCapability.promise;
     } catch (error) {
-        return resolvingFunctions.@reject.@call(@undefined, error);
+        return resolvingFunctions.reject.@call(@undefined, error);
     }
 }
 

--- a/Source/JavaScriptCore/builtins/PromisePrototype.js
+++ b/Source/JavaScriptCore/builtins/PromisePrototype.js
@@ -46,7 +46,7 @@ function then(onFulfilled, onRejected)
         promise = promiseOrCapability;
     } else {
         promiseOrCapability = @newPromiseCapabilitySlow(constructor);
-        promise = promiseOrCapability.@promise;
+        promise = promiseOrCapability.promise;
     }
 
     @performPromiseThen(this, onFulfilled, onRejected, promiseOrCapability, @undefined);

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -125,11 +125,11 @@ JSPromise::DeferredData JSPromise::convertCapabilityToDeferredData(JSGlobalObjec
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    result.promise = promiseCapability.getAs<JSPromise*>(globalObject, vm.propertyNames->builtinNames().promisePrivateName());
+    result.promise = promiseCapability.getAs<JSPromise*>(globalObject, vm.propertyNames->builtinNames().promisePublicName());
     RETURN_IF_EXCEPTION(scope, { });
-    result.resolve = promiseCapability.getAs<JSFunction*>(globalObject, vm.propertyNames->builtinNames().resolvePrivateName());
+    result.resolve = promiseCapability.getAs<JSFunction*>(globalObject, vm.propertyNames->builtinNames().resolvePublicName());
     RETURN_IF_EXCEPTION(scope, { });
-    result.reject = promiseCapability.getAs<JSFunction*>(globalObject, vm.propertyNames->builtinNames().rejectPrivateName());
+    result.reject = promiseCapability.getAs<JSFunction*>(globalObject, vm.propertyNames->builtinNames().rejectPublicName());
     RETURN_IF_EXCEPTION(scope, { });
 
     return result;

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.js
@@ -104,5 +104,5 @@ function closed()
     if (!@isReadableStreamBYOBReader(this))
         return @Promise.@reject(@makeGetterTypeError("ReadableStreamBYOBReader", "closed"));
 
-    return @getByIdDirectPrivate(this, "closedPromiseCapability").@promise;
+    return @getByIdDirectPrivate(this, "closedPromiseCapability").promise;
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js
@@ -91,5 +91,5 @@ function closed()
     if (!@isReadableStreamDefaultReader(this))
         return @Promise.@reject(@makeGetterTypeError("ReadableStreamDefaultReader", "closed"));
 
-    return @getByIdDirectPrivate(this, "closedPromiseCapability").@promise;
+    return @getByIdDirectPrivate(this, "closedPromiseCapability").promise;
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/ReadableStreamInternals.js
@@ -233,10 +233,10 @@ function readableStreamReaderGenericInitialize(reader, stream)
     if (@getByIdDirectPrivate(stream, "state") === @streamReadable)
         @putByIdDirectPrivate(reader, "closedPromiseCapability", @newPromiseCapability(@Promise));
     else if (@getByIdDirectPrivate(stream, "state") === @streamClosed)
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { @promise: @Promise.@resolve() });
+        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @Promise.@resolve() });
     else {
         @assert(@getByIdDirectPrivate(stream, "state") === @streamErrored);
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { @promise: @newHandledRejectedPromise(@getByIdDirectPrivate(stream, "storedError")) });
+        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @newHandledRejectedPromise(@getByIdDirectPrivate(stream, "storedError")) });
     }
 }
 
@@ -307,7 +307,7 @@ function readableStreamPipeTo(stream, sink)
 
     const reader = @acquireReadableStreamDefaultReader(stream);
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise.@then(() => { }, (e) => { sink.error(e); });
+    @getByIdDirectPrivate(reader, "closedPromiseCapability").promise.@then(() => { }, (e) => { sink.error(e); });
 
     function doPipe() {
         @readableStreamDefaultReaderRead(reader).@then(function(result) {
@@ -359,7 +359,7 @@ function readableStreamPipeToWritableStream(source, destination, preventClose, p
     pipeState.shuttingDown = false;
     pipeState.promiseCapability = @newPromiseCapability(@Promise);
     pipeState.pendingReadPromiseCapability = @newPromiseCapability(@Promise);
-    pipeState.pendingReadPromiseCapability.@resolve.@call();
+    pipeState.pendingReadPromiseCapability.resolve.@call();
     pipeState.pendingWritePromise = @Promise.@resolve();
 
     if (signal !== @undefined) {
@@ -378,19 +378,19 @@ function readableStreamPipeToWritableStream(source, destination, preventClose, p
                         shouldWait = false;
                         return;
                     }
-                    promiseCapability.@resolve.@call();
+                    promiseCapability.resolve.@call();
                 }
                 let handleRejectedPromise = (e) => {
-                    promiseCapability.@reject.@call(@undefined, e);
+                    promiseCapability.reject.@call(@undefined, e);
                 }
                 promiseDestination.@then(handleResolvedPromise, handleRejectedPromise);
                 promiseSource.@then(handleResolvedPromise, handleRejectedPromise);
-                return promiseCapability.@promise;
+                return promiseCapability.promise;
             }, reason);
         };
         pipeState.abortAlgorithmIdentifier = @addAbortAlgorithmToSignal(signal, algorithm)
         if (!pipeState.abortAlgorithmIdentifier)
-            return pipeState.promiseCapability.@promise;
+            return pipeState.promiseCapability.promise;
         pipeState.signal = signal;
     }
 
@@ -401,7 +401,7 @@ function readableStreamPipeToWritableStream(source, destination, preventClose, p
 
     @pipeToLoop(pipeState);
 
-    return pipeState.promiseCapability.@promise;
+    return pipeState.promiseCapability.promise;
 }
 
 function pipeToLoop(pipeState)
@@ -420,32 +420,32 @@ function pipeToDoReadWrite(pipeState)
     @assert(!pipeState.shuttingDown);
 
     pipeState.pendingReadPromiseCapability = @newPromiseCapability(@Promise);
-    @getByIdDirectPrivate(pipeState.writer, "readyPromise").@promise.@then(() => {
+    @getByIdDirectPrivate(pipeState.writer, "readyPromise").promise.@then(() => {
         if (pipeState.shuttingDown) {
-            pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, false);
+            pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, false);
             return;
         }
 
         @readableStreamDefaultReaderRead(pipeState.reader).@then((result) => {
             const canWrite = !result.done && @getByIdDirectPrivate(pipeState.writer, "stream") !== @undefined;
-            pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, canWrite);
+            pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, canWrite);
             if (!canWrite)
                 return;
 
             pipeState.pendingWritePromise = @writableStreamDefaultWriterWrite(pipeState.writer, result.value).@then(@undefined, () => { });
         }, (e) => {
-            pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, false);
+            pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, false);
         });
     }, (e) => {
-        pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, false);
+        pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, false);
     });
-    return pipeState.pendingReadPromiseCapability.@promise;
+    return pipeState.pendingReadPromiseCapability.promise;
 }
 
 function pipeToErrorsMustBePropagatedForward(pipeState)
 {
     const action = () => {
-        pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, false);
+        pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, false);
         const error = @getByIdDirectPrivate(pipeState.source, "storedError");
         if (!pipeState.preventAbort) {
             @pipeToShutdownWithAction(pipeState, () => @writableStreamAbort(pipeState.destination, error), error);
@@ -459,7 +459,7 @@ function pipeToErrorsMustBePropagatedForward(pipeState)
         return;
     }
 
-    @getByIdDirectPrivate(pipeState.reader, "closedPromiseCapability").@promise.@then(@undefined, action);
+    @getByIdDirectPrivate(pipeState.reader, "closedPromiseCapability").promise.@then(@undefined, action);
 }
 
 function pipeToErrorsMustBePropagatedBackward(pipeState)
@@ -476,13 +476,13 @@ function pipeToErrorsMustBePropagatedBackward(pipeState)
         action();
         return;
     }
-    @getByIdDirectPrivate(pipeState.writer, "closedPromise").@promise.@then(@undefined, action);
+    @getByIdDirectPrivate(pipeState.writer, "closedPromise").promise.@then(@undefined, action);
 }
 
 function pipeToClosingMustBePropagatedForward(pipeState)
 {
     const action = () => {
-        pipeState.pendingReadPromiseCapability.@resolve.@call(@undefined, false);
+        pipeState.pendingReadPromiseCapability.resolve.@call(@undefined, false);
         const error = @getByIdDirectPrivate(pipeState.source, "storedError");
         if (!pipeState.preventClose) {
             @pipeToShutdownWithAction(pipeState, () => @writableStreamDefaultWriterCloseWithErrorPropagation(pipeState.writer));
@@ -494,7 +494,7 @@ function pipeToClosingMustBePropagatedForward(pipeState)
         action();
         return;
     }
-    @getByIdDirectPrivate(pipeState.reader, "closedPromiseCapability").@promise.@then(action, () => { });
+    @getByIdDirectPrivate(pipeState.reader, "closedPromiseCapability").promise.@then(action, () => { });
 }
 
 function pipeToClosingMustBePropagatedBackward(pipeState)
@@ -534,7 +534,7 @@ function pipeToShutdownWithAction(pipeState, action)
     };
 
     if (@getByIdDirectPrivate(pipeState.destination, "state") === "writable" && !@writableStreamCloseQueuedOrInFlight(pipeState.destination)) {
-        pipeState.pendingReadPromiseCapability.@promise.@then(() => {
+        pipeState.pendingReadPromiseCapability.promise.@then(() => {
             pipeState.pendingWritePromise.@then(finalize, finalize);
         }, (e) => @pipeToFinalize(pipeState, e));
         return;
@@ -560,7 +560,7 @@ function pipeToShutdown(pipeState)
     };
 
     if (@getByIdDirectPrivate(pipeState.destination, "state") === "writable" && !@writableStreamCloseQueuedOrInFlight(pipeState.destination)) {
-        pipeState.pendingReadPromiseCapability.@promise.@then(() => {
+        pipeState.pendingReadPromiseCapability.promise.@then(() => {
             pipeState.pendingWritePromise.@then(finalize, finalize);
         }, (e) => @pipeToFinalize(pipeState, e));
         return;
@@ -577,9 +577,9 @@ function pipeToFinalize(pipeState)
         @removeAbortAlgorithmFromSignal(pipeState.signal, pipeState.abortAlgorithmIdentifier)
 
     if (arguments.length > 1)
-        pipeState.promiseCapability.@reject.@call(@undefined, arguments[1]);
+        pipeState.promiseCapability.reject.@call(@undefined, arguments[1]);
     else
-        pipeState.promiseCapability.@resolve.@call();
+        pipeState.promiseCapability.resolve.@call();
 }
 
 function readableStreamTee(stream, shouldClone)
@@ -616,11 +616,11 @@ function readableStreamTee(stream, shouldClone)
     const branch1 = @createInternalReadableStreamFromUnderlyingSource(branch1Source);
     const branch2 = @createInternalReadableStreamFromUnderlyingSource(branch2Source);
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise.@then(@undefined, function(e) {
+    @getByIdDirectPrivate(reader, "closedPromiseCapability").promise.@then(@undefined, function(e) {
         @readableStreamDefaultControllerError(branch1.@readableStreamController, e);
         @readableStreamDefaultControllerError(branch2.@readableStreamController, e);
         if (!teeState.canceled1 || !teeState.canceled2)
-            teeState.cancelPromiseCapability.@resolve.@call();
+            teeState.cancelPromiseCapability.resolve.@call();
     });
 
     // Additional fields compared to the spec, as they are needed within pull/cancel functions.
@@ -651,7 +651,7 @@ function readableStreamTeePullFunction(teeState, reader, shouldClone)
                 if (!teeState.canceled2)
                     @readableStreamDefaultControllerClose(teeState.branch2.@readableStreamController);
                 if (!teeState.canceled1 || !teeState.canceled2)
-                    teeState.cancelPromiseCapability.@resolve.@call();
+                    teeState.cancelPromiseCapability.resolve.@call();
                 return;
             }
             // chunk steps.
@@ -664,7 +664,7 @@ function readableStreamTeePullFunction(teeState, reader, shouldClone)
                 } catch (e) {
                     @readableStreamDefaultControllerError(teeState.branch1.@readableStreamController, e);
                     @readableStreamDefaultControllerError(teeState.branch2.@readableStreamController, e);
-                    @readableStreamCancel(teeState.stream, e).@then(teeState.cancelPromiseCapability.@resolve, teeState.cancelPromiseCapability.@reject);
+                    @readableStreamCancel(teeState.stream, e).@then(teeState.cancelPromiseCapability.resolve, teeState.cancelPromiseCapability.reject);
                     return;
                 }
             }
@@ -696,10 +696,10 @@ function readableStreamTeeBranch1CancelFunction(teeState, stream)
         teeState.reason1 = r;
         if (teeState.canceled2) {
             @readableStreamCancel(stream, [teeState.reason1, teeState.reason2]).@then(
-                teeState.cancelPromiseCapability.@resolve,
-                teeState.cancelPromiseCapability.@reject);
+                teeState.cancelPromiseCapability.resolve,
+                teeState.cancelPromiseCapability.reject);
         }
-        return teeState.cancelPromiseCapability.@promise;
+        return teeState.cancelPromiseCapability.promise;
     }
 }
 
@@ -712,10 +712,10 @@ function readableStreamTeeBranch2CancelFunction(teeState, stream)
         teeState.reason2 = r;
         if (teeState.canceled1) {
             @readableStreamCancel(stream, [teeState.reason1, teeState.reason2]).@then(
-                teeState.cancelPromiseCapability.@resolve,
-                teeState.cancelPromiseCapability.@reject);
+                teeState.cancelPromiseCapability.resolve,
+                teeState.cancelPromiseCapability.reject);
         }
-        return teeState.cancelPromiseCapability.@promise;
+        return teeState.cancelPromiseCapability.promise;
     }
 }
 
@@ -764,8 +764,8 @@ function readableStreamError(stream, error)
 
     const reader = @getByIdDirectPrivate(stream, "reader");
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").@reject.@call(@undefined, error);
-    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise;
+    @getByIdDirectPrivate(reader, "closedPromiseCapability").reject.@call(@undefined, error);
+    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
     @markPromiseAsHandled(promise);
 
     if (@isReadableStreamDefaultReader(reader))
@@ -929,7 +929,7 @@ function readableStreamClose(stream)
             @fulfillPromise(requests[index], { value: @undefined, done: true });
     }
 
-    @getByIdDirectPrivate(reader, "closedPromiseCapability").@resolve.@call();
+    @getByIdDirectPrivate(reader, "closedPromiseCapability").resolve.@call();
 }
 
 function readableStreamFulfillReadRequest(stream, chunk, done)
@@ -1018,11 +1018,11 @@ function readableStreamReaderGenericRelease(reader)
     @assert(@getByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "reader") === reader);
 
     if (@getByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "state") === @streamReadable)
-        @getByIdDirectPrivate(reader, "closedPromiseCapability").@reject.@call(@undefined, @makeTypeError("releasing lock of reader whose stream is still in readable state"));
+        @getByIdDirectPrivate(reader, "closedPromiseCapability").reject.@call(@undefined, @makeTypeError("releasing lock of reader whose stream is still in readable state"));
     else
-        @putByIdDirectPrivate(reader, "closedPromiseCapability", { @promise: @newHandledRejectedPromise(@makeTypeError("reader released lock")) });
+        @putByIdDirectPrivate(reader, "closedPromiseCapability", { promise: @newHandledRejectedPromise(@makeTypeError("reader released lock")) });
 
-    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").@promise;
+    const promise = @getByIdDirectPrivate(reader, "closedPromiseCapability").promise;
     @markPromiseAsHandled(promise);
     @putByIdDirectPrivate(@getByIdDirectPrivate(reader, "ownerReadableStream"), "reader", @undefined);
     @putByIdDirectPrivate(reader, "ownerReadableStream", @undefined);

--- a/Source/WebCore/Modules/streams/TransformStreamInternals.js
+++ b/Source/WebCore/Modules/streams/TransformStreamInternals.js
@@ -82,7 +82,7 @@ function createInternalTransformStreamFromTransformer(transformer, writableStrat
 
     const internalTransformStream = {};
     const startPromiseCapability = @newPromiseCapability(@Promise);
-    const [readable, writable] = @initializeTransformStream(internalTransformStream, startPromiseCapability.@promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
+    const [readable, writable] = @initializeTransformStream(internalTransformStream, startPromiseCapability.promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
     @setUpTransformStreamDefaultControllerFromTransformer(internalTransformStream, transformer, transformerDict);
 
     if ("start" in transformerDict) {
@@ -90,12 +90,12 @@ function createInternalTransformStreamFromTransformer(transformer, writableStrat
         const startAlgorithm = () => @promiseInvokeOrNoopMethodNoCatch(transformer, transformerDict["start"], [controller]);
         startAlgorithm().@then(() => {
             // FIXME: We probably need to resolve start promise with the result of the start algorithm.
-            startPromiseCapability.@resolve.@call();
+            startPromiseCapability.resolve.@call();
         }, (error) => {
-            startPromiseCapability.@reject.@call(@undefined, error);
+            startPromiseCapability.reject.@call(@undefined, error);
         });
     } else
-        startPromiseCapability.@resolve.@call();
+        startPromiseCapability.resolve.@call();
 
     return [internalTransformStream, readable, writable];
 }
@@ -115,15 +115,15 @@ function createTransformStream(startAlgorithm, transformAlgorithm, flushAlgorith
 
     const stream = {};
     const startPromiseCapability = @newPromiseCapability(@Promise);
-    const [readable, writable] = @initializeTransformStream(stream, startPromiseCapability.@promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
+    const [readable, writable] = @initializeTransformStream(stream, startPromiseCapability.promise, writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark, readableSizeAlgorithm);
 
     const controller = new @TransformStreamDefaultController(@isTransformStream);
     @setUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm);
 
     startAlgorithm().@then(() => {
-        startPromiseCapability.@resolve.@call();
+        startPromiseCapability.resolve.@call();
     }, (error) => {
-        startPromiseCapability.@reject.@call(@undefined, error);
+        startPromiseCapability.reject.@call(@undefined, error);
     });
 
     return [stream, readable, writable];
@@ -201,7 +201,7 @@ function transformStreamSetBackpressure(stream, backpressure)
 
     const backpressureChangePromise = @getByIdDirectPrivate(stream, "backpressureChangePromise");
     if (backpressureChangePromise !== @undefined)
-        backpressureChangePromise.@resolve.@call();
+        backpressureChangePromise.resolve.@call();
 
     @putByIdDirectPrivate(stream, "backpressureChangePromise", @newPromiseCapability(@Promise));
     @putByIdDirectPrivate(stream, "backpressure", backpressure);
@@ -300,12 +300,12 @@ function transformStreamDefaultControllerPerformTransform(controller, chunk)
 
     const transformPromise = @getByIdDirectPrivate(controller, "transformAlgorithm").@call(@undefined, chunk);
     transformPromise.@then(() => {
-        promiseCapability.@resolve();
+        promiseCapability.resolve();
     }, (r) => {
         @transformStreamError(@getByIdDirectPrivate(controller, "stream"), r);
-        promiseCapability.@reject.@call(@undefined, r);
+        promiseCapability.reject.@call(@undefined, r);
     });
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 function transformStreamDefaultControllerTerminate(controller)
@@ -339,24 +339,24 @@ function transformStreamDefaultSinkWriteAlgorithm(stream, chunk)
 
         const backpressureChangePromise = @getByIdDirectPrivate(stream, "backpressureChangePromise");
         @assert(backpressureChangePromise !== @undefined);
-        backpressureChangePromise.@promise.@then(() => {
+        backpressureChangePromise.promise.@then(() => {
             const state = @getByIdDirectPrivate(writable, "state");
             if (state === "erroring") {
-                promiseCapability.@reject.@call(@undefined, @getByIdDirectPrivate(writable, "storedError"));
+                promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(writable, "storedError"));
                 return;
             }
 
             @assert(state === "writable");
             @transformStreamDefaultControllerPerformTransform(controller, chunk).@then(() => {
-                promiseCapability.@resolve();
+                promiseCapability.resolve();
             }, (e) => {
-                promiseCapability.@reject.@call(@undefined, e);
+                promiseCapability.reject.@call(@undefined, e);
             });
         }, (e) => {
-            promiseCapability.@reject.@call(@undefined, e);
+            promiseCapability.reject.@call(@undefined, e);
         });
 
-        return promiseCapability.@promise;
+        return promiseCapability.promise;
     }
     return @transformStreamDefaultControllerPerformTransform(controller, chunk);
 }
@@ -385,19 +385,19 @@ function transformStreamDefaultSinkCloseAlgorithm(stream)
     const promiseCapability = @newPromiseCapability(@Promise);
     flushPromise.@then(() => {
         if (@getByIdDirectPrivate(readable, "state") === @streamErrored) {
-            promiseCapability.@reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
+            promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
             return;
         }
 
         // FIXME: Update readableStreamDefaultControllerClose to make this check.
         if (@readableStreamDefaultControllerCanCloseOrEnqueue(readableController))
             @readableStreamDefaultControllerClose(readableController);
-        promiseCapability.@resolve();
+        promiseCapability.resolve();
     }, (r) => {
         @transformStreamError(@getByIdDirectPrivate(controller, "stream"), r);
-        promiseCapability.@reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
+        promiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(readable, "storedError"));
     });
-    return promiseCapability.@promise;
+    return promiseCapability.promise;
 }
 
 function transformStreamDefaultSourcePullAlgorithm(stream)
@@ -409,5 +409,5 @@ function transformStreamDefaultSourcePullAlgorithm(stream)
 
     @transformStreamSetBackpressure(stream, false);
 
-    return @getByIdDirectPrivate(stream, "backpressureChangePromise").@promise;
+    return @getByIdDirectPrivate(stream, "backpressureChangePromise").promise;
 }

--- a/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js
+++ b/Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js
@@ -48,7 +48,7 @@ function closed()
     if (!@isWritableStreamDefaultWriter(this))
         return @Promise.@reject(@makeGetterTypeError("WritableStreamDefaultWriter", "closed"));
 
-    return @getByIdDirectPrivate(this, "closedPromise").@promise;
+    return @getByIdDirectPrivate(this, "closedPromise").promise;
 }
 
 @getter
@@ -73,7 +73,7 @@ function ready()
     if (!@isWritableStreamDefaultWriter(this))
         return @Promise.@reject(@makeThisTypeError("WritableStreamDefaultWriter", "ready"));
 
-    return @getByIdDirectPrivate(this, "readyPromise").@promise;
+    return @getByIdDirectPrivate(this, "readyPromise").promise;
 }
 
 function abort()

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -163,20 +163,20 @@ function setUpWritableStreamDefaultWriter(writer, stream)
     const state = @getByIdDirectPrivate(stream, "state");
     if (state === "writable") {
         if (@writableStreamCloseQueuedOrInFlight(stream) || !@getByIdDirectPrivate(stream, "backpressure"))
-            readyPromiseCapability.@resolve.@call();
+            readyPromiseCapability.resolve.@call();
     } else if (state === "erroring") {
-        readyPromiseCapability.@reject.@call(@undefined, @getByIdDirectPrivate(stream, "storedError"));
-        @markPromiseAsHandled(readyPromiseCapability.@promise);
+        readyPromiseCapability.reject.@call(@undefined, @getByIdDirectPrivate(stream, "storedError"));
+        @markPromiseAsHandled(readyPromiseCapability.promise);
     } else if (state === "closed") {
-        readyPromiseCapability.@resolve.@call();
-        closedPromiseCapability.@resolve.@call();
+        readyPromiseCapability.resolve.@call();
+        closedPromiseCapability.resolve.@call();
     } else {
         @assert(state === "errored");
         const storedError = @getByIdDirectPrivate(stream, "storedError");
-        readyPromiseCapability.@reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(readyPromiseCapability.@promise);
-        closedPromiseCapability.@reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(closedPromiseCapability.@promise);
+        readyPromiseCapability.reject.@call(@undefined, storedError);
+        @markPromiseAsHandled(readyPromiseCapability.promise);
+        closedPromiseCapability.reject.@call(@undefined, storedError);
+        @markPromiseAsHandled(closedPromiseCapability.promise);
     }
 }
 
@@ -191,7 +191,7 @@ function writableStreamAbort(stream, reason)
 
     const pendingAbortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (pendingAbortRequest !== @undefined)
-        return pendingAbortRequest.promise.@promise;
+        return pendingAbortRequest.promise.promise;
 
     @assert(state === "writable" || state === "erroring");
     let wasAlreadyErroring = false;
@@ -205,7 +205,7 @@ function writableStreamAbort(stream, reason)
 
     if (!wasAlreadyErroring)
         @writableStreamStartErroring(stream, reason);
-    return abortPromiseCapability.@promise;
+    return abortPromiseCapability.promise;
 }
 
 function writableStreamClose(stream)
@@ -222,11 +222,11 @@ function writableStreamClose(stream)
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined && @getByIdDirectPrivate(stream, "backpressure") && state === "writable")
-        @getByIdDirectPrivate(writer, "readyPromise").@resolve.@call();
+        @getByIdDirectPrivate(writer, "readyPromise").resolve.@call();
         
     @writableStreamDefaultControllerClose(@getByIdDirectPrivate(stream, "controller"));
 
-    return closePromiseCapability.@promise;
+    return closePromiseCapability.promise;
 }
 
 function writableStreamAddWriteRequest(stream)
@@ -237,7 +237,7 @@ function writableStreamAddWriteRequest(stream)
     const writePromiseCapability = @newPromiseCapability(@Promise);
     const writeRequests = @getByIdDirectPrivate(stream, "writeRequests");
     @arrayPush(writeRequests, writePromiseCapability);
-    return writePromiseCapability.@promise;
+    return writePromiseCapability.promise;
 }
 
 function writableStreamCloseQueuedOrInFlight(stream)
@@ -270,7 +270,7 @@ function writableStreamFinishErroring(stream)
     const storedError = @getByIdDirectPrivate(stream, "storedError");
     const requests = @getByIdDirectPrivate(stream, "writeRequests");
     for (let index = 0, length = requests.length; index < length; ++index)
-        requests[index].@reject.@call(@undefined, storedError);
+        requests[index].reject.@call(@undefined, storedError);
 
     @putByIdDirectPrivate(stream, "writeRequests", []);
 
@@ -282,16 +282,16 @@ function writableStreamFinishErroring(stream)
 
     @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
     if (abortRequest.wasAlreadyErroring) {
-        abortRequest.promise.@reject.@call(@undefined, storedError);
+        abortRequest.promise.reject.@call(@undefined, storedError);
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
         return;
     }
 
     @getByIdDirectPrivate(controller, "abortSteps").@call(@undefined, abortRequest.reason).@then(() => {
-        abortRequest.promise.@resolve.@call();
+        abortRequest.promise.resolve.@call();
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     }, (reason) => {
-        abortRequest.promise.@reject.@call(@undefined, reason);
+        abortRequest.promise.reject.@call(@undefined, reason);
         @writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     });
 }
@@ -299,7 +299,7 @@ function writableStreamFinishErroring(stream)
 function writableStreamFinishInFlightClose(stream)
 {
     const inFlightCloseRequest = @getByIdDirectPrivate(stream, "inFlightCloseRequest");
-    inFlightCloseRequest.@resolve.@call();
+    inFlightCloseRequest.resolve.@call();
 
     @putByIdDirectPrivate(stream, "inFlightCloseRequest", @undefined);
 
@@ -310,7 +310,7 @@ function writableStreamFinishInFlightClose(stream)
         @putByIdDirectPrivate(stream, "storedError", @undefined);
         const abortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
         if (abortRequest !== @undefined) {
-            abortRequest.promise.@resolve.@call();
+            abortRequest.promise.resolve.@call();
             @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
         }
     }
@@ -319,7 +319,7 @@ function writableStreamFinishInFlightClose(stream)
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined)
-        @getByIdDirectPrivate(writer, "closedPromise").@resolve.@call();
+        @getByIdDirectPrivate(writer, "closedPromise").resolve.@call();
 
     @assert(@getByIdDirectPrivate(stream, "pendingAbortRequest") === @undefined);
     @assert(@getByIdDirectPrivate(stream, "storedError") === @undefined);
@@ -329,7 +329,7 @@ function writableStreamFinishInFlightCloseWithError(stream, error)
 {
     const inFlightCloseRequest = @getByIdDirectPrivate(stream, "inFlightCloseRequest");
     @assert(inFlightCloseRequest !== @undefined);
-    inFlightCloseRequest.@reject.@call(@undefined, error);
+    inFlightCloseRequest.reject.@call(@undefined, error);
 
     @putByIdDirectPrivate(stream, "inFlightCloseRequest", @undefined);
 
@@ -338,7 +338,7 @@ function writableStreamFinishInFlightCloseWithError(stream, error)
 
     const abortRequest = @getByIdDirectPrivate(stream, "pendingAbortRequest");
     if (abortRequest !== @undefined) {
-        abortRequest.promise.@reject.@call(@undefined, error);
+        abortRequest.promise.reject.@call(@undefined, error);
         @putByIdDirectPrivate(stream, "pendingAbortRequest", @undefined);
     }
 
@@ -349,7 +349,7 @@ function writableStreamFinishInFlightWrite(stream)
 {
     const inFlightWriteRequest = @getByIdDirectPrivate(stream, "inFlightWriteRequest");
     @assert(inFlightWriteRequest !== @undefined);
-    inFlightWriteRequest.@resolve.@call();
+    inFlightWriteRequest.resolve.@call();
 
     @putByIdDirectPrivate(stream, "inFlightWriteRequest", @undefined);
 }
@@ -358,7 +358,7 @@ function writableStreamFinishInFlightWriteWithError(stream, error)
 {
     const inFlightWriteRequest = @getByIdDirectPrivate(stream, "inFlightWriteRequest");
     @assert(inFlightWriteRequest !== @undefined);
-    inFlightWriteRequest.@reject.@call(@undefined, error);
+    inFlightWriteRequest.reject.@call(@undefined, error);
 
     @putByIdDirectPrivate(stream, "inFlightWriteRequest", @undefined);
 
@@ -402,15 +402,15 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream)
     const closeRequest = @getByIdDirectPrivate(stream, "closeRequest");
     if (closeRequest !== @undefined) {
         @assert(@getByIdDirectPrivate(stream, "inFlightCloseRequest") === @undefined);
-        closeRequest.@reject.@call(@undefined, storedError);
+        closeRequest.reject.@call(@undefined, storedError);
         @putByIdDirectPrivate(stream, "closeRequest", @undefined);
     }
 
     const writer = @getByIdDirectPrivate(stream, "writer");
     if (writer !== @undefined) {
         const closedPromise = @getByIdDirectPrivate(writer, "closedPromise");
-        closedPromise.@reject.@call(@undefined, storedError);
-        @markPromiseAsHandled(closedPromise.@promise);
+        closedPromise.reject.@call(@undefined, storedError);
+        @markPromiseAsHandled(closedPromise.promise);
     }
 }
 
@@ -443,7 +443,7 @@ function writableStreamUpdateBackpressure(stream, backpressure)
         if (backpressure)
            @putByIdDirectPrivate(writer, "readyPromise", @newPromiseCapability(@Promise));
         else
-            @getByIdDirectPrivate(writer, "readyPromise").@resolve.@call();
+            @getByIdDirectPrivate(writer, "readyPromise").resolve.@call();
     }
     @putByIdDirectPrivate(stream, "backpressure", backpressure);
 }
@@ -482,30 +482,30 @@ function writableStreamDefaultWriterCloseWithErrorPropagation(writer)
 function writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error)
 {
     let closedPromiseCapability = @getByIdDirectPrivate(writer, "closedPromise");
-    let closedPromise = closedPromiseCapability.@promise;
+    let closedPromise = closedPromiseCapability.promise;
 
     if ((@getPromiseInternalField(closedPromise, @promiseFieldFlags) & @promiseStateMask) !== @promiseStatePending) {
         closedPromiseCapability = @newPromiseCapability(@Promise);
-        closedPromise = closedPromiseCapability.@promise;
+        closedPromise = closedPromiseCapability.promise;
         @putByIdDirectPrivate(writer, "closedPromise", closedPromiseCapability);
     }
 
-    closedPromiseCapability.@reject.@call(@undefined, error);
+    closedPromiseCapability.reject.@call(@undefined, error);
     @markPromiseAsHandled(closedPromise);
 }
 
 function writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error)
 {
     let readyPromiseCapability = @getByIdDirectPrivate(writer, "readyPromise");
-    let readyPromise = readyPromiseCapability.@promise;
+    let readyPromise = readyPromiseCapability.promise;
 
     if ((@getPromiseInternalField(readyPromise, @promiseFieldFlags) & @promiseStateMask) !== @promiseStatePending) {
         readyPromiseCapability = @newPromiseCapability(@Promise);
-        readyPromise = readyPromiseCapability.@promise;
+        readyPromise = readyPromiseCapability.promise;
         @putByIdDirectPrivate(writer, "readyPromise", readyPromiseCapability);
     }
 
-    readyPromiseCapability.@reject.@call(@undefined, error);
+    readyPromiseCapability.reject.@call(@undefined, error);
     @markPromiseAsHandled(readyPromise);
 }
 


### PR DESCRIPTION
#### 0aebf750430c0f2bf1ad6b96a6d38c9640c63056
<pre>
[JSC] optimize `Promise.withResolvers` to avoid unnecessary object construction
<a href="https://bugs.webkit.org/show_bug.cgi?id=259175">https://bugs.webkit.org/show_bug.cgi?id=259175</a>

Reviewed by Yusuke Suzuki.

Rework `newPromiseCapability` (and `newPromiseCapabilitySlow`) to return an object containing `promise`/`resolve`/`reject` instead of `@promise`/`@resolve`/`@reject` so that `Promise.withResolvers` can directly use it instead of transforming it into another object.

As a result, update all the other callsites that use `@promise`/`@resolve`/`@reject` to use `promise`/`resolve`/`reject` as well.

* Source/JavaScriptCore/builtins/ModuleLoader.js:
(fulfillFetch):
* Source/JavaScriptCore/builtins/PromiseConstructor.js:
(promiseAllSlow):
(promiseNewOnRejected):
(allSettled):
(any):
(race):
(withResolvers):
* Source/JavaScriptCore/builtins/PromiseOperations.js:
(newPromiseCapabilitySlow):
(newPromiseCapability):
(promiseResolveSlow):
(promiseRejectSlow):
(createResolvingFunctions):
(createResolvingFunctionsWithoutPromise):
(promiseReactionJob):
(promiseResolveThenableJob):
(promiseResolveThenableJobWithDerivedPromise):
* Source/JavaScriptCore/builtins/PromisePrototype.js:
(then):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::convertCapabilityToDeferredData):
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.js:
(closed):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.js:
(closed):
* Source/WebCore/Modules/streams/ReadableStreamInternals.js:
(readableStreamReaderGenericInitialize):
(readableStreamPipeTo):
(readableStreamPipeToWritableStream):
(pipeToErrorsMustBePropagatedForward):
(pipeToErrorsMustBePropagatedBackward):
(pipeToClosingMustBePropagatedForward):
(pipeToShutdownWithAction):
(pipeToShutdown):
(pipeToFinalize):
(readableStreamTee):
(pullAlgorithm):
(readableStreamTeePullFunction):
(readableStreamTeeBranch1CancelFunction):
(readableStreamTeeBranch2CancelFunction):
(readableStreamError):
(readableStreamClose):
(readableStreamReaderGenericRelease):
* Source/WebCore/Modules/streams/TransformStreamInternals.js:
(createInternalTransformStreamFromTransformer):
(createTransformStream):
(transformStreamSetBackpressure):
(transformStreamDefaultControllerPerformTransform):
(transformStreamDefaultSinkWriteAlgorithm):
(transformStreamDefaultSinkCloseAlgorithm):
(transformStreamDefaultSourcePullAlgorithm):
* Source/WebCore/Modules/streams/WritableStreamDefaultWriter.js:
(closed):
(ready):
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(setUpWritableStreamDefaultWriter):
(writableStreamAbort):
(writableStreamClose):
(writableStreamAddWriteRequest):
(writableStreamFinishErroring):
(writableStreamFinishInFlightWrite):
(writableStreamFinishInFlightWriteWithError):
(writableStreamRejectCloseAndClosedPromiseIfNeeded):
(writableStreamUpdateBackpressure):
(writableStreamDefaultWriterEnsureClosedPromiseRejected):
(writableStreamDefaultWriterEnsureReadyPromiseRejected):

Canonical link: <a href="https://commits.webkit.org/266036@main">https://commits.webkit.org/266036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54d119def17a339cd1f6f0461a4468534f84a0aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14779 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14793 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18509 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10723 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14782 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11937 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9979 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12671 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11309 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3103 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15641 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13027 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11919 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3105 "Passed tests") | 
<!--EWS-Status-Bubble-End-->