### PR TITLE
Allow EnumeratedArray to infer the size of its internal array

### DIFF
--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -91,14 +91,40 @@ constexpr bool isValidEnumForPersistence(bool t)
     return !t || t == 1;
 }
 
-
 template<typename E>
 constexpr auto enumToUnderlyingType(E e)
 {
     return static_cast<std::underlying_type_t<E>>(e);
 }
 
+template<typename T, typename E> struct ZeroBasedContiguousEnumChecker;
+
+template<typename T, typename E, E e, E... es>
+struct ZeroBasedContiguousEnumChecker<T, EnumValues<E, e, es...>> {
+    template<size_t INDEX = 0>
+    static constexpr bool isZeroBasedContiguousEnum()
+    {
+        return (enumToUnderlyingType(e) == INDEX) ? ZeroBasedContiguousEnumChecker<T, EnumValues<E, es...>>::template isZeroBasedContiguousEnum<INDEX + 1>() : false;
+    }
+};
+
+template<typename T, typename E>
+struct ZeroBasedContiguousEnumChecker<T, EnumValues<E>> {
+    template<size_t>
+    static constexpr bool isZeroBasedContiguousEnum()
+    {
+        return true;
+    }
+};
+
+template<typename E, typename = std::enable_if_t<!std::is_same_v<std::underlying_type_t<E>, bool>>>
+constexpr bool isZeroBasedContiguousEnum()
+{
+    return ZeroBasedContiguousEnumChecker<std::underlying_type_t<E>, typename EnumTraits<E>::values>::isZeroBasedContiguousEnum();
 }
+
+} // namespace WTF
 
 using WTF::enumToUnderlyingType;
 using WTF::isValidEnum;
+using WTF::isZeroBasedContiguousEnum;

--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <array>
+#include <wtf/EnumTraits.h>
 
 namespace WTF {
 
@@ -33,7 +34,7 @@ namespace WTF {
 // This assumes the values of the enum start at 0 and monotonically increase by 1
 // (so the conversion function between size_t and the enum is just a simple static_cast).
 // LastValue is the maximum value of the enum, which determines the size of the array.
-template <typename Key, typename T, Key LastValue>
+template <typename Key, typename T, Key LastValue = EnumTraits<Key>::values::max>
 class EnumeratedArray {
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -53,7 +53,21 @@ struct ComponentTransferFunction {
 
 enum class ComponentTransferChannel : uint8_t { Red, Green, Blue, Alpha };
 
-using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction, ComponentTransferChannel::Alpha>;
+} // namespace WebCore
+
+namespace WTF {
+template<> struct EnumTraits<WebCore::ComponentTransferChannel> {
+    using values = EnumValues<WebCore::ComponentTransferChannel,
+        WebCore::ComponentTransferChannel::Red,
+        WebCore::ComponentTransferChannel::Green,
+        WebCore::ComponentTransferChannel::Blue,
+        WebCore::ComponentTransferChannel::Alpha>;
+};
+}
+
+namespace WebCore {
+
+using ComponentTransferFunctions = EnumeratedArray<ComponentTransferChannel, ComponentTransferFunction>;
 
 class FEComponentTransfer : public FilterEffect {
 public:

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#import <wtf/EnumeratedArray.h>
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
 #import <wtf/HashTraits.h>

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2009, 2010, 2012 Google Inc. All rights reserved.
 # Copyright (C) 2009 Torch Mobile Inc.
-# Copyright (C) 2009-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2009-2023 Apple Inc. All rights reserved.
 # Copyright (C) 2010 Chris Jerdonek (cjerdonek@webkit.org)
 #
 # Redistribution and use in source and binary forms, with or without
@@ -1364,6 +1364,8 @@ class _EnumState(object):
                 if self.is_webidl_enum:
                     return False
                 if enum_name in _ALLOW_ALL_UPPERCASE_ENUM:
+                    return False
+                if len(all_uppercase.group('value')) < 2:
                     return False
                 return not all_uppercase.group('value') in _ALLOW_ABBREVIATION_ENUM_VALUES
             return match(expr_starts_lowercase, value_declaration)

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,9 +34,27 @@ enum class TestEnum {
     C,
 };
 
+enum class TestNonContiguousEnum {
+    A = 0,
+    B = 1,
+    C = 3,
+};
+
+enum class TestNonZeroBasedEnum {
+    A = 1,
+    B = 2,
+    C = 3,
+};
+
 namespace WTF {
 template<> struct EnumTraits<TestEnum> {
     using values = EnumValues<TestEnum, TestEnum::A, TestEnum::B, TestEnum::C>;
+};
+template<> struct EnumTraits<TestNonContiguousEnum> {
+    using values = EnumValues<TestNonContiguousEnum, TestNonContiguousEnum::A, TestNonContiguousEnum::B, TestNonContiguousEnum::C>;
+};
+template<> struct EnumTraits<TestNonZeroBasedEnum> {
+    using values = EnumValues<TestNonZeroBasedEnum, TestNonZeroBasedEnum::A, TestNonZeroBasedEnum::B, TestNonZeroBasedEnum::C>;
 };
 }
 
@@ -65,4 +83,14 @@ TEST(WTF_EnumTraits, ValuesTraits)
     EXPECT_EQ(expectedValues.size(), 0UL);
 }
 
+TEST(WTF_EnumTraits, ZeroBasedContiguousEnum)
+{
+    static_assert(isZeroBasedContiguousEnum<TestEnum>());
+    EXPECT_TRUE(isZeroBasedContiguousEnum<TestEnum>());
+    static_assert(!isZeroBasedContiguousEnum<TestNonContiguousEnum>());
+    EXPECT_FALSE(isZeroBasedContiguousEnum<TestNonContiguousEnum>());
+    static_assert(!isZeroBasedContiguousEnum<TestNonZeroBasedEnum>());
+    EXPECT_FALSE(isZeroBasedContiguousEnum<TestNonZeroBasedEnum>());
 }
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,8 @@
 #include "config.h"
 #include <wtf/EnumeratedArray.h>
 
+#include <wtf/EnumTraits.h>
+
 namespace TestWebKitAPI {
 
 enum class Foo {
@@ -33,6 +35,23 @@ enum class Foo {
     Two,
     Three,
 };
+
+} // namespace TestWebKitAPI
+
+namespace WTF {
+
+template<> struct EnumTraits<TestWebKitAPI::Foo> {
+    using values = EnumValues<
+        TestWebKitAPI::Foo,
+        TestWebKitAPI::Foo::One,
+        TestWebKitAPI::Foo::Two,
+        TestWebKitAPI::Foo::Three
+    >;
+};
+
+} // namespace WTF
+
+namespace TestWebKitAPI {
 
 TEST(WTF_EnumeratedArray, Basic)
 {
@@ -144,6 +163,13 @@ TEST(WTF_EnumeratedArray, Iteration)
         }
         ++index;
     }
+}
+
+TEST(WTF_EnumeratedArray, InferMax)
+{
+    EnumeratedArray<Foo, int> array1 { { 3, 10, 17 } };
+    EXPECT_EQ(array1.front(), 3);
+    EXPECT_EQ(array1.back(), 17);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 376d4439778b24d4d73abf7e291f27912aa3017f
<pre>
Allow EnumeratedArray to infer the size of its internal array
<a href="https://bugs.webkit.org/show_bug.cgi?id=259174">https://bugs.webkit.org/show_bug.cgi?id=259174</a>
rdar://112177459

Reviewed by Yusuke Suzuki.

We can use our existing pattern of EnumTraits to automatically calculate
what the maximum value of the enum is at compile time.

This patch also adds isZeroBasedContiguousEnum() which indicates whether the
enum is a good candidate for EnumeratedArray, but doesn&apos;t require it because
we have a few places in WebKit which use EnumeratedArray but aren&apos;t suitable
for using the EnumTraits pattern. Once these places are migrated, we can require
all enums used in EnumeratedArray to be isZeroBasedContiguousEnum().

* Source/WTF/wtf/EnumTraits.h:
(WTF::isZeroBasedContiguousEnum):
* Source/WTF/wtf/EnumeratedArray.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/EnumeratedArray.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/266026@main">https://commits.webkit.org/266026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16feced900eb450fd6ad4b08aea70832f53fb279

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14355 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14782 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14794 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/12706 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11423 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10724 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14786 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9980 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12672 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11310 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3094 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15642 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13028 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11920 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3107 "Passed tests") | 
<!--EWS-Status-Bubble-End-->