### PR TITLE
[JSC] JSRopeString::resolveToBuffer should have fast path for two rope+non-rope case

### DIFF
--- a/JSTests/stress/rope-resolve-recursive-non-ascii.js
+++ b/JSTests/stress/rope-resolve-recursive-non-ascii.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string = '';
+    for (let i = 0; i < 1e5; ++i)
+        string += String.fromCharCode(i);
+    shouldBe(string.length, 1e5);
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(string[i], String.fromCharCode(i));
+}

--- a/JSTests/stress/rope-resolve-recursive.js
+++ b/JSTests/stress/rope-resolve-recursive.js
@@ -1,0 +1,13 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string = '';
+    for (let i = 0; i < 1e5; ++i)
+        string += String.fromCharCode(i & 0x7f);
+    shouldBe(string.length, 1e5);
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(string[i], String.fromCharCode(i & 0x7f));
+}

--- a/JSTests/stress/three-rope-non-ascii.js
+++ b/JSTests/stress/three-rope-non-ascii.js
@@ -1,0 +1,20 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string0 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string0 += String.fromCharCode(i);
+    let string1 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string1 += String.fromCharCode(i + 1e5);
+    let string2 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string2 += String.fromCharCode(i + 1e5 * 2);
+    let result = string0 + string1 + string2;
+    shouldBe(result.length, 1e5 * 3);
+    for (let i = 0; i < 3e5; ++i)
+        shouldBe(result[i], String.fromCharCode(i));
+}

--- a/JSTests/stress/three-rope.js
+++ b/JSTests/stress/three-rope.js
@@ -1,0 +1,24 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string0 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string0 += String.fromCharCode(i & 0x7f);
+    let string1 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string1 += String.fromCharCode(i & 0x7f);
+    let string2 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string2 += String.fromCharCode(i & 0x7f);
+    let result = string0 + string1 + string2;
+    shouldBe(result.length, 1e5 * 3);
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(result[i], String.fromCharCode(i & 0x7f));
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(result[i + 1e5 * 1], String.fromCharCode(i & 0x7f));
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(result[i + 1e5 * 2], String.fromCharCode(i & 0x7f));
+}

--- a/JSTests/stress/two-rope-non-ascii.js
+++ b/JSTests/stress/two-rope-non-ascii.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string0 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string0 += String.fromCharCode(i);
+    let string1 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string1 += String.fromCharCode(i + 1e5);
+    let result = string0 + string1;
+    shouldBe(result.length, 1e5 * 2);
+    for (let i = 0; i < 2e5; ++i)
+        shouldBe(result[i], String.fromCharCode(i));
+}

--- a/JSTests/stress/two-rope.js
+++ b/JSTests/stress/two-rope.js
@@ -1,0 +1,19 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let string0 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string0 += String.fromCharCode(i & 0x7f);
+    let string1 = '';
+    for (let i = 0; i < 1e5; ++i)
+        string1 += String.fromCharCode(i & 0x7f);
+    let result = string0 + string1;
+    shouldBe(result.length, 1e5 * 2);
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(result[i], String.fromCharCode(i & 0x7f));
+    for (let i = 0; i < 1e5; ++i)
+        shouldBe(result[i + 1e5], String.fromCharCode(i & 0x7f));
+}

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -595,7 +595,7 @@ public:
     JS_EXPORT_PRIVATE const String& resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const;
 
     template<typename Fibers, typename CharacterType>
-    static void resolveToBuffer(Fibers*, CharacterType* buffer, unsigned length);
+    static void resolveToBuffer(Fibers*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
 
 private:
     template<typename Fibers, typename CharacterType>
@@ -632,7 +632,7 @@ private:
     template<typename Function> const String& resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&&) const;
     JS_EXPORT_PRIVATE AtomString resolveRopeToAtomString(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE RefPtr<AtomStringImpl> resolveRopeToExistingAtomString(JSGlobalObject*) const;
-    template<typename CharacterType> void resolveRopeInternalNoSubstring(CharacterType*) const;
+    template<typename CharacterType> void resolveRopeInternalNoSubstring(CharacterType*, uint8_t* stackLimit) const;
     Identifier toIdentifier(JSGlobalObject*) const;
     void outOfMemory(JSGlobalObject* nullOrGlobalObjectForOOM) const;
     StringView unsafeView(JSGlobalObject*) const;


### PR DESCRIPTION
#### 9c5c2c9fc89f8d977ead596d3066df729561df9c
<pre>
[JSC] JSRopeString::resolveToBuffer should have fast path for two rope+non-rope case
<a href="https://bugs.webkit.org/show_bug.cgi?id=259176">https://bugs.webkit.org/show_bug.cgi?id=259176</a>
rdar://112178098

Reviewed by Michael Saboff.

JSRopeString can have three fibers. But we observed two fibers case, where only one is a rope, very commonly.
This happens when you write code like this,

    var string = &apos;&apos;;
    for (var i = 0; i &lt; 1e6; ++i)
        string += char

Then, the resulted string becomes two fibers rope, only left hand side gets super deep.
We can handle this string, just recursively handle the left side (via tail-call), but just spreading the right side.

This patch changes JSRopeString::resolveToBuffer to handle this kind of patterns efficiently. We carefully crafted this
code so that the above pattern becomes repeated tail call to JSRopeString::resolveToBuffer. We also have sp checker so that
this code works perfectly well even if the compiler is not supporting tail-calls (at some level, we stop and use slow-but-works mode).

* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeInternalNoSubstring const):
(JSC::JSRopeString::resolveRopeToAtomString const):
(JSC::JSRopeString::resolveRopeToExistingAtomString const):
(JSC::JSRopeString::resolveRopeWithFunction const):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBuffer):
(JSC::jsAtomString):

Canonical link: <a href="https://commits.webkit.org/266028@main">https://commits.webkit.org/266028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd2bfa74fac497cac2503d951fac4157cd9ba44b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14369 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12976 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/14793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12794 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14809 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/11434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/10731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/14793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/11948 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/9992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12684 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/11324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13042 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1433 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->