### PR TITLE
Resync libwebrtc to M115.0.5790.95

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/video_codec.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/video_codec.h
@@ -148,6 +148,15 @@ class RTC_EXPORT VideoCodec {
   bool active;
 
   unsigned int qpMax;
+  // The actual number of simulcast streams. This is <= 1 in singlecast (it can
+  // be 0 in old code paths), but it is also 1 in the {active,inactive,inactive}
+  // "single RTP simulcast" use case and the legacy kSVC use case. In all other
+  // cases this is the same as the number of encodings (which may include
+  // inactive encodings). In other words:
+  // - `numberOfSimulcastStreams <= 1` in singlecast and singlecast-like setups
+  //   including legacy kSVC (encodings interpreted as spatial layers) or
+  //   standard kSVC (1 active encoding).
+  // - `numberOfSimulcastStreams > 1` in simulcast of 2+ active encodings.
   unsigned char numberOfSimulcastStreams;
   SimulcastStream simulcastStream[kMaxSimulcastStreams];
   SpatialLayer spatialLayers[kMaxSpatialLayers];

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/BUILD.gn
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/BUILD.gn
@@ -2430,6 +2430,7 @@ if (rtc_include_tests && !build_with_chromium) {
       "../api/transport:field_trial_based_config",
       "../api/transport:sctp_transport_factory_interface",
       "../api/transport/rtp:rtp_source",
+      "../api/units:data_rate",
       "../api/units:time_delta",
       "../api/units:timestamp",
       "../api/video:builtin_video_bitrate_allocator_factory",

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection.h
@@ -567,7 +567,8 @@ class PeerConnection : public PeerConnectionInternal,
 
   // Invoked when TransportController connection completion is signaled.
   // Reports stats for all transports in use.
-  void ReportTransportStats() RTC_RUN_ON(network_thread());
+  void ReportTransportStats(std::vector<RtpTransceiverProxyRefPtr> transceivers)
+      RTC_RUN_ON(network_thread());
 
   // Gather the usage of IPv4/IPv6 as best connection.
   static void ReportBestConnectionState(const cricket::TransportStats& stats);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_integrationtest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_integrationtest.cc
@@ -1831,6 +1831,10 @@ TEST_P(PeerConnectionIntegrationTest,
   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
                  callee()->ice_connection_state(), kDefaultTimeout);
 
+  // Part of reporting the stats will occur on the network thread, so flush it
+  // before checking NumEvents.
+  SendTask(network_thread(), [] {});
+
   EXPECT_METRIC_EQ(1, webrtc::metrics::NumEvents(
                           "WebRTC.PeerConnection.CandidatePairType_UDP",
                           webrtc::kIceCandidatePairHostNameHostName));
@@ -1958,6 +1962,10 @@ TEST_P(PeerConnectionIntegrationIceStatesTest, MAYBE_VerifyBestConnection) {
                  caller()->ice_connection_state(), kDefaultTimeout);
   EXPECT_EQ_WAIT(webrtc::PeerConnectionInterface::kIceConnectionConnected,
                  callee()->ice_connection_state(), kDefaultTimeout);
+
+  // Part of reporting the stats will occur on the network thread, so flush it
+  // before checking NumEvents.
+  SendTask(network_thread(), [] {});
 
   // TODO(bugs.webrtc.org/9456): Fix it.
   const int num_best_ipv4 = webrtc::metrics::NumEvents(

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc
@@ -3542,6 +3542,11 @@ bool ParseSsrcGroupAttribute(absl::string_view line,
     if (!GetValueFromString(line, fields[i], &ssrc, error)) {
       return false;
     }
+    // Reject duplicates. While not forbidden by RFC 5576,
+    // they don't make sense.
+    if (absl::c_linear_search(ssrcs, ssrc)) {
+      return ParseFailed(line, "Duplicate SSRC in ssrc-group", error);
+    }
     ssrcs.push_back(ssrc);
   }
   ssrc_groups->push_back(SsrcGroup(semantics, ssrcs));

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp_unittest.cc
@@ -5056,3 +5056,29 @@ TEST_F(WebRtcSdpTest, RejectSessionLevelMediaLevelExtmapMixedUsage) {
   JsepSessionDescription jdesc(kDummyType);
   EXPECT_FALSE(SdpDeserialize(sdp, &jdesc));
 }
+
+TEST_F(WebRtcSdpTest, RejectDuplicateSsrcInSsrcGroup) {
+  std::string sdp =
+      "v=0\r\n"
+      "o=- 0 3 IN IP4 127.0.0.1\r\n"
+      "s=-\r\n"
+      "t=0 0\r\n"
+      "a=group:BUNDLE 0\r\n"
+      "a=fingerprint:sha-1 "
+      "4A:AD:B9:B1:3F:82:18:3B:54:02:12:DF:3E:5D:49:6B:19:E5:7C:AB\r\n"
+      "a=setup:actpass\r\n"
+      "a=ice-ufrag:ETEn\r\n"
+      "a=ice-pwd:OtSK0WpNtpUjkY4+86js7Z/l\r\n"
+      "m=video 9 UDP/TLS/RTP/SAVPF 96 97\r\n"
+      "c=IN IP4 0.0.0.0\r\n"
+      "a=rtcp-mux\r\n"
+      "a=sendonly\r\n"
+      "a=mid:0\r\n"
+      "a=rtpmap:96 VP8/90000\r\n"
+      "a=rtpmap:97 rtx/90000\r\n"
+      "a=fmtp:97 apt=96\r\n"
+      "a=ssrc-group:FID 1234 1234\r\n"
+      "a=ssrc:1234 cname:test\r\n";
+  JsepSessionDescription jdesc(kDummyType);
+  EXPECT_FALSE(SdpDeserialize(sdp, &jdesc));
+}

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint.cc
@@ -58,7 +58,8 @@ bool BitrateConstraint::IsAdaptationUpAllowed(
     }
 
     if (VideoStreamEncoderResourceManager::IsSimulcastOrMultipleSpatialLayers(
-            encoder_settings_->encoder_config())) {
+            encoder_settings_->encoder_config(),
+            encoder_settings_->video_codec())) {
       // Resolution bitrate limits usage is restricted to singlecast.
       return true;
     }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint_unittest.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint_unittest.cc
@@ -47,7 +47,7 @@ void FillCodecConfig(VideoCodec* video_codec,
                      bool svc) {
   size_t num_layers = params.size();
   video_codec->codecType = kVideoCodecVP8;
-  video_codec->numberOfSimulcastStreams = num_layers;
+  video_codec->numberOfSimulcastStreams = svc ? 1 : num_layers;
 
   encoder_config->number_of_streams = svc ? 1 : num_layers;
   encoder_config->simulcast_layers.resize(num_layers);

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.cc
@@ -815,7 +815,8 @@ void VideoStreamEncoderResourceManager::OnQualityRampUp() {
 }
 
 bool VideoStreamEncoderResourceManager::IsSimulcastOrMultipleSpatialLayers(
-    const VideoEncoderConfig& encoder_config) {
+    const VideoEncoderConfig& encoder_config,
+    const VideoCodec& video_codec) {
   const std::vector<VideoStream>& simulcast_layers =
       encoder_config.simulcast_layers;
   if (simulcast_layers.empty()) {
@@ -824,7 +825,7 @@ bool VideoStreamEncoderResourceManager::IsSimulcastOrMultipleSpatialLayers(
 
   absl::optional<int> num_spatial_layers;
   if (simulcast_layers[0].scalability_mode.has_value() &&
-      encoder_config.number_of_streams == 1) {
+      video_codec.numberOfSimulcastStreams == 1) {
     num_spatial_layers = ScalabilityModeToNumSpatialLayers(
         *simulcast_layers[0].scalability_mode);
   }

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.h
@@ -153,7 +153,8 @@ class VideoStreamEncoderResourceManager
   void OnQualityRampUp() override;
 
   static bool IsSimulcastOrMultipleSpatialLayers(
-      const VideoEncoderConfig& encoder_config);
+      const VideoEncoderConfig& encoder_config,
+      const VideoCodec& video_codec);
 
  private:
   class InitialFrameDropper;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/config/video_encoder_config.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/config/video_encoder_config.h
@@ -181,9 +181,15 @@ class VideoEncoderConfig {
   // down to lower layers for the video encoding.
   // `simulcast_layers` is also used for configuring non-simulcast (when there
   // is a single VideoStream).
+  // We have the same number of `simulcast_layers` as we have negotiated
+  // encodings, for example 3 are used in both simulcast and legacy kSVC.
   std::vector<VideoStream> simulcast_layers;
 
   // Max number of encoded VideoStreams to produce.
+  // This is the same as the number of encodings negotiated (i.e. SSRCs),
+  // whether or not those encodings are `active`, except for when legacy kSVC
+  // is used. In this case we have three SSRCs but `number_of_streams` is
+  // changed to 1 to tell lower layers to limit the number of streams.
   size_t number_of_streams;
 
   // Legacy Google conference mode flag for simulcast screenshare

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.cc
@@ -405,7 +405,7 @@ void ApplySpatialLayerBitrateLimits(
     return;
   }
   if (VideoStreamEncoderResourceManager::IsSimulcastOrMultipleSpatialLayers(
-          encoder_config) ||
+          encoder_config, *codec) ||
       encoder_config.simulcast_layers.size() <= 1) {
     // Resolution bitrate limits usage is restricted to singlecast.
     return;


### PR DESCRIPTION
#### 3b3a755c53e569ab807b7ef86483902f259e1c8d
<pre>
Resync libwebrtc to M115.0.5790.95
<a href="https://bugs.webkit.org/show_bug.cgi?id=259183">https://bugs.webkit.org/show_bug.cgi?id=259183</a>
rdar://problem/112187110

Reviewed by Eric Carlson.

Cherry-pick webrtc patches that got merged in M115 branch: ad3838a9b5 ba943f71e6 f0d954f659 f5ffd45855 6603550a42 43670de877

* Source/ThirdParty/libwebrtc/Source/webrtc/api/video_codecs/video_codec.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/call/rtp_payload_params.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/call/rtp_payload_params_unittest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/BUILD.gn:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/data_channel_controller.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_encodings_integrationtest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/peer_connection_integrationtest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/webrtc_sdp_unittest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/bitrate_constraint_unittest.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/adaptation/video_stream_encoder_resource_manager.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/config/video_encoder_config.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/video_stream_encoder.cc:

Canonical link: <a href="https://commits.webkit.org/266045@main">https://commits.webkit.org/266045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50adefeaae11d0e0b8595b35a07ce1aa3620df94

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12095 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14794 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14818 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18525 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14802 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9996 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11328 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3107 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->