### PR TITLE
[GLIB] Initialize FILE* attributes to nullptr in CGroupMemoryController

### DIFF
--- a/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
+++ b/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h
@@ -67,15 +67,15 @@ public:
 private:
     CString m_cgroupMemoryControllerPath;
 
-    FILE* m_cgroupMemoryMemswLimitInBytesFile;
-    FILE* m_cgroupMemoryMemswUsageInBytesFile;
-    FILE* m_cgroupMemoryLimitInBytesFile;
-    FILE* m_cgroupMemoryUsageInBytesFile;
+    FILE* m_cgroupMemoryMemswLimitInBytesFile { nullptr };
+    FILE* m_cgroupMemoryMemswUsageInBytesFile { nullptr };
+    FILE* m_cgroupMemoryLimitInBytesFile { nullptr };
+    FILE* m_cgroupMemoryUsageInBytesFile { nullptr };
 
-    FILE* m_cgroupV2MemoryMemswMaxFile;
-    FILE* m_cgroupV2MemoryMaxFile;
-    FILE* m_cgroupV2MemoryHighFile;
-    FILE* m_cgroupV2MemoryCurrentFile;
+    FILE* m_cgroupV2MemoryMemswMaxFile { nullptr };
+    FILE* m_cgroupV2MemoryMaxFile { nullptr };
+    FILE* m_cgroupV2MemoryHighFile { nullptr };
+    FILE* m_cgroupV2MemoryCurrentFile { nullptr };
 
     void disposeMemoryController();
     size_t getCgroupFileValue(FILE*);


### PR DESCRIPTION
#### 0cda93700071903a7c63eb0768810d254771223c
<pre>
[GLIB] Initialize FILE* attributes to nullptr in CGroupMemoryController
<a href="https://bugs.webkit.org/show_bug.cgi?id=259185">https://bugs.webkit.org/show_bug.cgi?id=259185</a>

Reviewed by Carlos Alberto Lopez Perez.

... since the CGroupMemoryController FILE* attributes are not inmediatelly
initialized during the construction but after the creation when
setMemoryControllerPath() is called.

* Source/WebKit/UIProcess/linux/MemoryPressureMonitor.h:

Canonical link: <a href="https://commits.webkit.org/266031@main">https://commits.webkit.org/266031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1970e2caaacb063eb48f4939d166cc5305a6b9fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12097 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14797 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14817 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10852 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11330 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3097 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15662 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->