### PR TITLE
REGRESSION(265827@main): Logical properties fail to override physical properties with variable references

### DIFF
--- a/LayoutTests/fast/css/variables/variable-reference-override-deferred-cached-expected.html
+++ b/LayoutTests/fast/css/variables/variable-reference-override-deferred-cached-expected.html
@@ -1,0 +1,9 @@
+<style>
+div {
+    margin-inline-start:200px;
+    width:100px;
+    height:100px;
+    background-color:green;
+}
+</style>
+<div><div></div></div>

--- a/LayoutTests/fast/css/variables/variable-reference-override-deferred-cached.html
+++ b/LayoutTests/fast/css/variables/variable-reference-override-deferred-cached.html
@@ -1,0 +1,13 @@
+<style>
+div {
+    --a: 50px;
+    margin-left:var(--a);
+    width:100px;
+    height:100px;
+    background-color:green;
+}
+div {
+    margin-inline-start:200px;
+}
+</style>
+<div><div></div></div>

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -233,6 +233,9 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
             if (m_includedProperties.contains(PropertyType::VariableReference)) {
                 if (current.value()->hasVariableReferences())
                     return true;
+                // Apply all deferred properties if we have applied any. They may override the ones we already applied.
+                if (propertyID >= firstDeferredProperty && m_lastIndexForDeferred)
+                    return true;
             }
             if (m_includedProperties.containsAny({ PropertyType::AfterAnimation, PropertyType::AfterTransition })) {
                 if (shouldApplyAfterAnimation(current)) {


### PR DESCRIPTION
#### 593a553fd1eb21d0d8c8da49abb46d175144c6e0
<pre>
REGRESSION(265827@main): Logical properties fail to override physical properties with variable references
<a href="https://bugs.webkit.org/show_bug.cgi?id=259186">https://bugs.webkit.org/show_bug.cgi?id=259186</a>
rdar://112194939

Reviewed by Simon Fraser.

The code assumes that only values set later on the same property can override a variable reference.
This is not true in case properties with separate physical and logical versions

* LayoutTests/fast/css/variables/variable-reference-override-deferred-cached-expected.html: Added.
* LayoutTests/fast/css/variables/variable-reference-override-deferred-cached.html: Added.
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):

If we have seen any variable references overriding deferred properties start applying all subsequent
deferred properties.

Canonical link: <a href="https://commits.webkit.org/266033@main">https://commits.webkit.org/266033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb206541929faae1762f24b26b50f4a198616c25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14381 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14802 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14823 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10005 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->