### PR TITLE
@font-face src format() should parse valid unsupported keywords

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
@@ -11,7 +11,7 @@ PASS Check that src: url("foo.ttf") format("truetype") is valid
 PASS Check that src: url("foo.ttf") format("woff") is valid
 PASS Check that src: url("foo.ttf") format("woff2") is valid
 PASS Check that src: url("foo.ttf") format("opentype", "truetype") is invalid
-FAIL Check that src: url("foo.ttf") format(collection) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") format(collection) is valid
 PASS Check that src: url("foo.ttf") format(opentype) is valid
 PASS Check that src: url("foo.ttf") format(truetype) is valid
 PASS Check that src: url("foo.ttf") format(woff) is valid

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8248,6 +8248,22 @@ Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleVa
     return technologies;
 }
 
+static bool isFontFormatKeywordValid(CSSValueID id)
+{
+    switch (id) {
+    case CSSValueCollection:
+    case CSSValueEmbeddedOpentype:
+    case CSSValueOpentype:
+    case CSSValueSvg:
+    case CSSValueTruetype:
+    case CSSValueWoff:
+    case CSSValueWoff2:
+        return true;
+    default:
+        return false;
+    }
+}
+
 String consumeFontFormat(CSSParserTokenRange& range, bool rejectStringValues)
 {
     // https://drafts.csswg.org/css-fonts/#descdef-font-face-src
@@ -8256,12 +8272,11 @@ String consumeFontFormat(CSSParserTokenRange& range, bool rejectStringValues)
     auto& arg = args.consumeIncludingWhitespace();
     if (!args.atEnd())
         return nullString();
-    if (arg.type() != IdentToken && (rejectStringValues || arg.type() != StringToken))
-        return nullString();
-    auto format = arg.value().toString();
-    if (arg.type() == IdentToken && !FontCustomPlatformData::supportsFormat(format))
-        return nullString();
-    return format;
+    if (arg.type() == IdentToken && isFontFormatKeywordValid(arg.id()))
+        return arg.value().toString();
+    if (arg.type() == StringToken && !rejectStringValues)
+        return arg.value().toString();
+    return nullString();
 }
 
 // MARK: @font-palette-values

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -171,7 +171,9 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontFormatFu
 {
     ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueFontFormat);
     auto format = CSSPropertyParserHelpers::consumeFontFormat(range, true);
-    return format.isNull() ? Unsupported : Supported;
+    if (format.isNull())
+        return Unsupported;
+    return FontCustomPlatformData::supportsFormat(format) ? Supported : Unsupported;
 }
 
 // <supports-font-tech-fn>


### PR DESCRIPTION
#### b2a00a22e3c413618df230613ed43dfbf9d2e39f
<pre>
@font-face src format() should parse valid unsupported keywords
<a href="https://bugs.webkit.org/show_bug.cgi?id=259144">https://bugs.webkit.org/show_bug.cgi?id=259144</a>
rdar://112135869

Reviewed by Tim Nguyen.

A valid format() keyword (ident) argument should be parsed even if the represented
format is not supported by the engine. The engine should reject loading
the font for unsupported formats but this should happen only at
loading time and not at parsing time.

The reason why we were rejecting it before, at parsing time, is for some
inconsistency in different parts of the spec. That
will be fixed soon by the CSSWG, see: <a href="https://github.com/w3c/csswg-drafts/issues/8793">https://github.com/w3c/csswg-drafts/issues/8793</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::isFontFormatKeywordValid):
(WebCore::CSSPropertyParserHelpers::consumeFontFormat):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFontFormatFunction):

Canonical link: <a href="https://commits.webkit.org/266043@main">https://commits.webkit.org/266043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a9aa35b979ae93ecdfdedf7a6b5b1af37dcc815

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14843 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11456 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14828 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10012 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11345 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3106 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15678 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->