### PR TITLE
REBASELINE: [ macOS ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function.html

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2728,9 +2728,9 @@ webkit.org/b/237415 webgl/1.0.x/conformance/rendering/clipping-wide-points.html 
 [ Monterey ] imported/w3c/web-platform-tests/css/css-fonts/variations/variable-opsz-size-adjust.html [ Skip ]
 
 # webkit.org/b/255178 [ Ventura iOS arm64 ] 3X imported/w3c/web-platform-tests/css/css-color/parsing (layout-tests) are constant text failures
-[ Ventura ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function.html [ Failure ]
-[ Ventura ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html [ Failure ]
-[ Ventura ] imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html [ Failure ]
+[ Ventura x86_64 ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function.html [ Failure ]
+[ Ventura x86_64 ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html [ Failure ]
+[ Ventura x86_64 ] imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html [ Failure ]
 
 # webkit.org/b/255427 [ Ventura ] 4/13 batch mark expectations and branch bugs
 [ Ventura ] http/tests/media/hls/track-in-band-hls-metadata-cue-duration.html [ Pass Failure ]

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt
@@ -1,0 +1,478 @@
+
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.33 0.36 0.24)" but got "rgb(84, 92, 61)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.4375 0.415625 0.2625)" but got "rgb(112, 106, 67)"
+FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20%), hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.4375 0.415625 0.2625)" but got "rgb(112, 106, 67)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), 25% hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.240625 0.2875 0.2125)" but got "rgb(61, 73, 54)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%), hsl(30deg 30% 40%) 25%)' assert_equals: expected "color(srgb 0.240625 0.2875 0.2125)" but got "rgb(61, 73, 54)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40%) 75%)' assert_equals: expected "color(srgb 0.4375 0.415625 0.2625)" but got "rgb(112, 106, 67)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 30%, hsl(30deg 30% 40%) 90%)' assert_equals: expected "color(srgb 0.4375 0.415625 0.2625)" but got "rgb(112, 106, 67)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 12.5%, hsl(30deg 30% 40%) 37.5%)' assert_equals: expected "color(srgb 0.4375 0.415625 0.2625 / 0.5)" but got "rgba(112, 106, 67, 0.5)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 0%, hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.52 0.4 0.28)" but got "rgb(133, 102, 71)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.372222 0.411111 0.255556 / 0.6)" but got "rgba(95, 105, 65, 0.6)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20%) 25%, hsl(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.42346 0.402889 0.258893 / 0.85)" but got "rgba(108, 103, 66, 0.85)"
+FAIL Property color value 'color-mix(in hsl, 25% hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.472245 0.447041 0.270612 / 0.7)" but got "rgba(121, 114, 69, 0.7)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), 25% hsl(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.2674 0.3304 0.2296 / 0.5)" but got "rgba(68, 84, 59, 0.5)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4), hsl(30deg 30% 40% / .8) 25%)' assert_equals: expected "color(srgb 0.2674 0.3304 0.2296 / 0.5)" but got "rgba(68, 84, 59, 0.5)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 25%, hsl(30deg 30% 40% / .8) 75%)' assert_equals: expected "color(srgb 0.472245 0.447041 0.270612 / 0.7)" but got "rgba(121, 114, 69, 0.7)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 30%, hsl(30deg 30% 40% / .8) 90%)' assert_equals: expected "color(srgb 0.472245 0.447041 0.270612 / 0.7)" but got "rgba(121, 114, 69, 0.7)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 12.5%, hsl(30deg 30% 40% / .8) 37.5%)' assert_equals: expected "color(srgb 0.472245 0.447041 0.270612 / 0.35)" but got "rgba(121, 114, 69, 0.35)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / .4) 0%, hsl(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.52 0.4 0.28 / 0.8)" but got "rgba(133, 102, 71, 0.8)"
+FAIL Property color value 'color-mix(in hsl, transparent, hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.52 0.4 0.28 / 0.5)" but got "rgba(133, 87, 71, 0.5)"
+FAIL Property color value 'color-mix(in hsl, transparent 10%, hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.52 0.4 0.28 / 0.9)" but got "rgba(133, 99, 71, 0.9)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0), hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.46 0.52 0.28 / 0.5)" but got "rgba(118, 133, 71, 0.5)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 10% 20% / 0) 10%, hsl(30deg 30% 40%))' assert_equals: expected "color(srgb 0.52 0.436 0.28 / 0.9)" but got "rgba(133, 111, 71, 0.9)"
+FAIL Property color value 'color-mix(in hsl, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl shorter hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.333333 0.75)" but got "rgb(64, 85, 191)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.333333 0.75)" but got "rgb(64, 85, 191)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.666667 0.75)" but got "rgb(64, 170, 191)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.666667 0.75)" but got "rgb(64, 170, 191)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.75 0.666667)" but got "rgb(64, 191, 170)"
+FAIL Property color value 'color-mix(in hsl longer hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.75 0.666667)" but got "rgb(64, 191, 170)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.333333 0.75)" but got "rgb(64, 85, 191)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.666667 0.75)" but got "rgb(64, 170, 191)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.75 0.666667)" but got "rgb(64, 191, 170)"
+FAIL Property color value 'color-mix(in hsl increasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(40deg 50% 50%), hsl(60deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.333333 0.75)" but got "rgb(64, 85, 191)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(60deg 50% 50%), hsl(40deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.666667 0.25)" but got "rgb(191, 170, 64)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(50deg 50% 50%), hsl(330deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.333333 0.25)" but got "rgb(191, 85, 64)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(330deg 50% 50%), hsl(50deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.666667 0.75)" but got "rgb(64, 170, 191)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(20deg 50% 50%), hsl(320deg 50% 50%))' assert_equals: expected "color(srgb 0.75 0.25 0.333333)" but got "rgb(191, 64, 85)"
+FAIL Property color value 'color-mix(in hsl decreasing hue, hsl(320deg 50% 50%), hsl(20deg 50% 50%))' assert_equals: expected "color(srgb 0.25 0.75 0.666667)" but got "rgb(64, 191, 170)"
+FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(none none none))' assert_equals: expected "color(srgb none none none)" but got "rgb(0, 0, 0)"
+FAIL Property color value 'color-mix(in hsl, hsl(none none none), hsl(30deg 40% 80%))' assert_equals: expected "color(srgb 0.88 0.8 0.72)" but got "rgb(224, 204, 184)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(none none none))' assert_equals: expected "color(srgb 0.32 0.48 0.32)" but got "rgb(82, 122, 82)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% none), hsl(30deg 40% 60%))' assert_equals: expected "color(srgb 0.66 0.72 0.48)" but got "rgb(168, 184, 122)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 20% 40%), hsl(30deg 20% none))' assert_equals: expected "color(srgb 0.44 0.48 0.32)" but got "rgb(112, 122, 82)"
+FAIL Property color value 'color-mix(in hsl, hsl(none 20% 40%), hsl(30deg none 80%))' assert_equals: expected "color(srgb 0.68 0.6 0.52)" but got "rgb(173, 153, 133)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40%))' assert_equals: expected "color(srgb 0.56 0.56 0.24)" but got "rgb(143, 143, 61)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / 0.5))' assert_equals: expected "color(srgb 0.56 0.56 0.24 / 0.5)" but got "rgba(143, 143, 61, 0.5)"
+FAIL Property color value 'color-mix(in hsl, hsl(120deg 40% 40% / none), hsl(0deg 40% 40% / none))' assert_equals: expected "color(srgb 0.56 0.56 0.24 / none)" but got "rgba(143, 143, 61, 0)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.575 0.7 0.2)" but got "rgb(147, 179, 52)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.65 0.6 0.25)" but got "rgb(166, 153, 64)"
+FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20%), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.65 0.6 0.25)" but got "rgb(166, 153, 64)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.375 0.75 0.15)" but got "rgb(96, 191, 39)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% 40%) 25%)' assert_equals: expected "color(srgb 0.375 0.75 0.15)" but got "rgb(96, 191, 39)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 25%, hwb(30deg 30% 40%) 75%)' assert_equals: expected "color(srgb 0.65 0.6 0.25)" but got "rgb(166, 153, 64)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 30%, hwb(30deg 30% 40%) 90%)' assert_equals: expected "color(srgb 0.65 0.6 0.25)" but got "rgb(166, 153, 64)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 12.5%, hwb(30deg 30% 40%) 37.5%)' assert_equals: expected "color(srgb 0.65 0.6 0.25 / 0.5)" but got "rgba(166, 153, 64, 0.5)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%) 0%, hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.45 0.3)" but got "rgb(153, 115, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.558333 0.666667 0.233333 / 0.6)" but got "rgba(143, 170, 60, 0.6)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.628571 0.583929 0.271429 / 0.7)" but got "rgba(160, 149, 70, 0.7)"
+FAIL Property color value 'color-mix(in hwb, 25% hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.628571 0.583929 0.271429 / 0.7)" but got "rgba(160, 149, 70, 0.7)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), 25% hwb(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.373026 0.757895 0.142105 / 0.95)" but got "rgba(95, 193, 37, 0.95)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4), hwb(30deg 30% 40% / .8) 25%)' assert_equals: expected "color(srgb 0.3825 0.72 0.18 / 0.5)" but got "rgba(98, 184, 46, 0.5)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 25%, hwb(30deg 30% 40% / .8) 75%)' assert_equals: expected "color(srgb 0.628571 0.583929 0.271429 / 0.7)" but got "rgba(160, 149, 70, 0.7)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 30%, hwb(30deg 30% 40% / .8) 90%)' assert_equals: expected "color(srgb 0.628571 0.583929 0.271429 / 0.7)" but got "rgba(160, 149, 70, 0.7)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 12.5%, hwb(30deg 30% 40% / .8) 37.5%)' assert_equals: expected "color(srgb 0.628571 0.583929 0.271429 / 0.35)" but got "rgba(160, 149, 70, 0.35)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / .4) 0%, hwb(30deg 30% 40% / .8))' assert_equals: expected "color(srgb 0.6 0.45 0.3 / 0.8)" but got "rgba(153, 115, 77, 0.8)"
+FAIL Property color value 'color-mix(in hwb, transparent, hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.45 0.3 / 0.5)" but got "rgba(153, 96, 77, 0.5)"
+FAIL Property color value 'color-mix(in hwb, transparent 10%, hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.45 0.3 / 0.9)" but got "rgba(153, 111, 77, 0.9)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.525 0.6 0.3 / 0.5)" but got "rgba(134, 153, 77, 0.5)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / 0) 10%, hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.495 0.3 / 0.9)" but got "rgba(153, 126, 77, 0.9)"
+FAIL Property color value 'color-mix(in hwb, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb shorter hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.35 0.6)" but got "rgb(77, 89, 153)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.35 0.6)" but got "rgb(77, 89, 153)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.55 0.6)" but got "rgb(77, 141, 153)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.55 0.6)" but got "rgb(77, 141, 153)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.6 0.55)" but got "rgb(77, 153, 141)"
+FAIL Property color value 'color-mix(in hwb longer hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.6 0.55)" but got "rgb(77, 153, 141)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.35 0.6)" but got "rgb(77, 89, 153)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.55 0.6)" but got "rgb(77, 141, 153)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.6 0.55)" but got "rgb(77, 153, 141)"
+FAIL Property color value 'color-mix(in hwb increasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(40deg 30% 40%), hwb(60deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.35 0.6)" but got "rgb(77, 89, 153)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(60deg 30% 40%), hwb(40deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.55 0.3)" but got "rgb(153, 141, 77)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(50deg 30% 40%), hwb(330deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.35 0.3)" but got "rgb(153, 89, 77)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(330deg 30% 40%), hwb(50deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.55 0.6)" but got "rgb(77, 141, 153)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(20deg 30% 40%), hwb(320deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.3 0.35)" but got "rgb(153, 77, 89)"
+FAIL Property color value 'color-mix(in hwb decreasing hue, hwb(320deg 30% 40%), hwb(20deg 30% 40%))' assert_equals: expected "color(srgb 0.3 0.6 0.55)" but got "rgb(77, 153, 141)"
+FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(none none none))' assert_equals: expected "color(srgb none none none)" but got "rgb(255, 0, 0)"
+FAIL Property color value 'color-mix(in hwb, hwb(none none none), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.6 0.45 0.3)" but got "rgb(153, 115, 77)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(none none none))' assert_equals: expected "color(srgb 0.1 0.8 0.1)" but got "rgb(26, 204, 26)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% none), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.5 0.6 0.2)" but got "rgb(128, 153, 51)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20%), hwb(30deg 30% none))' assert_equals: expected "color(srgb 0.65 0.8 0.2)" but got "rgb(166, 204, 51)"
+FAIL Property color value 'color-mix(in hwb, hwb(none 10% 20%), hwb(30deg none 40%))' assert_equals: expected "color(srgb 0.7 0.4 0.1)" but got "rgb(179, 102, 26)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40%))' assert_equals: expected "color(srgb 0.575 0.7 0.2)" but got "rgb(147, 179, 51)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / 0.5))' assert_equals: expected "color(srgb 0.575 0.7 0.2 / 0.5)" but got "rgba(147, 179, 51, 0.5)"
+FAIL Property color value 'color-mix(in hwb, hwb(120deg 10% 20% / none), hwb(30deg 30% 40% / none))' assert_equals: expected "color(srgb 0.575 0.7 0.2 / none)" but got "rgba(147, 179, 51, 0)"
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, 25% lch(10 20 30deg), lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg), 25% lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg), lch(50 60 70deg) 25%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg) 25%, lch(50 60 70deg) 75%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg) 30%, lch(50 60 70deg) 90%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg) 12.5%, lch(50 60 70deg) 37.5%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg) 0%, lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8))'
+PASS Property color value 'color-mix(in lch, 25% lch(10 20 30deg / .4), lch(50 60 70deg / .8))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4), 25% lch(50 60 70deg / .8))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4), lch(50 60 70deg / .8) 25%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 25%, lch(50 60 70deg / .8) 75%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 30%, lch(50 60 70deg / .8) 90%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 12.5%, lch(50 60 70deg / .8) 37.5%)'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / .4) 0%, lch(50 60 70deg / .8))'
+FAIL Property color value 'color-mix(in lch, transparent, lch(0.3 0.4 30deg))' assert_equals: expected "lch(0.3 0.4 30 / 0.5)" but got "lch(0.3 0.4 15 / 0.5)"
+FAIL Property color value 'color-mix(in lch, transparent 10%, lch(0.3 0.4 30deg))' assert_equals: expected "lch(0.3 0.4 30 / 0.9)" but got "lch(0.3 0.40000004 27 / 0.9)"
+PASS Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0), lch(0.3 0.4 30deg))'
+FAIL Property color value 'color-mix(in lch, lch(0.1 0.2 120deg / 0) 10%, lch(0.3 0.4 30deg))' assert_equals: expected "lch(0.3 0.4 39 / 0.9)" but got "lch(0.3 0.40000004 39 / 0.9)"
+PASS Property color value 'color-mix(in lch, lch(100 0 40deg), lch(100 0 60deg))'
+PASS Property color value 'color-mix(in lch, lch(100 0 60deg), lch(100 0 40deg))'
+PASS Property color value 'color-mix(in lch, lch(100 0 50deg), lch(100 0 330deg))'
+PASS Property color value 'color-mix(in lch, lch(100 0 330deg), lch(100 0 50deg))'
+PASS Property color value 'color-mix(in lch, lch(100 0 20deg), lch(100 0 320deg))'
+PASS Property color value 'color-mix(in lch, lch(100 0 320deg), lch(100 0 20deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 40deg), lch(100 0 60deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 60deg), lch(100 0 40deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 50deg), lch(100 0 330deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 330deg), lch(100 0 50deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 20deg), lch(100 0 320deg))'
+PASS Property color value 'color-mix(in lch shorter hue, lch(100 0 320deg), lch(100 0 20deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 40deg), lch(100 0 60deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 60deg), lch(100 0 40deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 50deg), lch(100 0 330deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 330deg), lch(100 0 50deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 20deg), lch(100 0 320deg))'
+PASS Property color value 'color-mix(in lch longer hue, lch(100 0 320deg), lch(100 0 20deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 40deg), lch(100 0 60deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 60deg), lch(100 0 40deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 50deg), lch(100 0 330deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 330deg), lch(100 0 50deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 20deg), lch(100 0 320deg))'
+PASS Property color value 'color-mix(in lch increasing hue, lch(100 0 320deg), lch(100 0 20deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 40deg), lch(100 0 60deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 60deg), lch(100 0 40deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 50deg), lch(100 0 330deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 330deg), lch(100 0 50deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 20deg), lch(100 0 320deg))'
+PASS Property color value 'color-mix(in lch decreasing hue, lch(100 0 320deg), lch(100 0 20deg))'
+PASS Property color value 'color-mix(in lch, lch(none none none), lch(none none none))'
+PASS Property color value 'color-mix(in lch, lch(none none none), lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg), lch(none none none))'
+PASS Property color value 'color-mix(in lch, lch(10 20 none), lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg), lch(50 60 none))'
+PASS Property color value 'color-mix(in lch, lch(none 20 30deg), lch(50 none 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / 0.5))'
+PASS Property color value 'color-mix(in lch, lch(10 20 30deg / none), lch(50 60 70deg / none))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg), oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg) 25%, oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, 25% oklch(0.1 0.2 30deg), oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg), 25% oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg), oklch(0.5 0.6 70deg) 25%)'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg) 25%, oklch(0.5 0.6 70deg) 75%)'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg) 30%, oklch(0.5 0.6 70deg) 90%)'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg) 12.5%, oklch(0.5 0.6 70deg) 37.5%)'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg) 0%, oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4), oklch(0.5 0.6 70deg / .8))'
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 25%, oklch(0.5 0.6 70deg / .8))' assert_equals: expected "oklch(0.44285713 0.54285717 60 / 0.7)" but got "oklch(0.44285715 0.54285717 60 / 0.7)"
+FAIL Property color value 'color-mix(in oklch, 25% oklch(0.1 0.2 30deg / .4), oklch(0.5 0.6 70deg / .8))' assert_equals: expected "oklch(0.44285713 0.54285717 60 / 0.7)" but got "oklch(0.44285715 0.54285717 60 / 0.7)"
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4), 25% oklch(0.5 0.6 70deg / .8))' assert_equals: expected "oklch(0.26 0.36 40 / 0.5)" but got "oklch(0.26000002 0.36 40 / 0.5)"
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4), oklch(0.5 0.6 70deg / .8) 25%)' assert_equals: expected "oklch(0.26 0.36 40 / 0.5)" but got "oklch(0.26000002 0.36 40 / 0.5)"
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 25%, oklch(0.5 0.6 70deg / .8) 75%)' assert_equals: expected "oklch(0.44285713 0.54285717 60 / 0.7)" but got "oklch(0.44285715 0.54285717 60 / 0.7)"
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 30%, oklch(0.5 0.6 70deg / .8) 90%)' assert_equals: expected "oklch(0.44285713 0.54285717 60 / 0.7)" but got "oklch(0.44285715 0.54285717 60 / 0.7)"
+FAIL Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 12.5%, oklch(0.5 0.6 70deg / .8) 37.5%)' assert_equals: expected "oklch(0.44285713 0.54285717 60 / 0.35)" but got "oklch(0.44285715 0.54285717 60 / 0.35)"
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / .4) 0%, oklch(0.5 0.6 70deg / .8))'
+FAIL Property color value 'color-mix(in oklch, transparent, oklch(30 40 30deg))' assert_equals: expected "oklch(30 40 30 / 0.5)" but got "oklch(30 40 15 / 0.5)"
+FAIL Property color value 'color-mix(in oklch, transparent 10%, oklch(30 40 30deg))' assert_equals: expected "oklch(30 40 30 / 0.9)" but got "oklch(30 40 27 / 0.9)"
+PASS Property color value 'color-mix(in oklch, oklch(10 20 120deg / 0), oklch(30 40 30deg))'
+PASS Property color value 'color-mix(in oklch, oklch(10 20 120deg / 0) 10%, oklch(30 40 30deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 40deg), oklch(1 0 60deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 60deg), oklch(1 0 40deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 50deg), oklch(1 0 330deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 330deg), oklch(1 0 50deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 20deg), oklch(1 0 320deg))'
+PASS Property color value 'color-mix(in oklch, oklch(1 0 320deg), oklch(1 0 20deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 40deg), oklch(1 0 60deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 60deg), oklch(1 0 40deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 50deg), oklch(1 0 330deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 330deg), oklch(1 0 50deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 20deg), oklch(1 0 320deg))'
+PASS Property color value 'color-mix(in oklch shorter hue, oklch(1 0 320deg), oklch(1 0 20deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 40deg), oklch(1 0 60deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 60deg), oklch(1 0 40deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 50deg), oklch(1 0 330deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 330deg), oklch(1 0 50deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 20deg), oklch(1 0 320deg))'
+PASS Property color value 'color-mix(in oklch longer hue, oklch(1 0 320deg), oklch(1 0 20deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 40deg), oklch(1 0 60deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 60deg), oklch(1 0 40deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 50deg), oklch(1 0 330deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 330deg), oklch(1 0 50deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 20deg), oklch(1 0 320deg))'
+PASS Property color value 'color-mix(in oklch increasing hue, oklch(1 0 320deg), oklch(1 0 20deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 40deg), oklch(1 0 60deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 60deg), oklch(1 0 40deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 50deg), oklch(1 0 330deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 330deg), oklch(1 0 50deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 20deg), oklch(1 0 320deg))'
+PASS Property color value 'color-mix(in oklch decreasing hue, oklch(1 0 320deg), oklch(1 0 20deg))'
+PASS Property color value 'color-mix(in oklch, oklch(none none none), oklch(none none none))'
+PASS Property color value 'color-mix(in oklch, oklch(none none none), oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg), oklch(none none none))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 none), oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg), oklch(0.5 0.6 none))'
+PASS Property color value 'color-mix(in oklch, oklch(none 0.2 30deg), oklch(0.5 none 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / none), oklch(0.5 0.6 70deg))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / none), oklch(0.5 0.6 70deg / 0.5))'
+PASS Property color value 'color-mix(in oklch, oklch(0.1 0.2 30deg / none), oklch(0.5 0.6 70deg / none))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30), lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, 25% lab(10 20 30), lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30), 25% lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30), lab(50 60 70) 25%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30) 25%, lab(50 60 70) 75%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30) 30%, lab(50 60 70) 90%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30) 12.5%, lab(50 60 70) 37.5%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30) 0%, lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8))'
+PASS Property color value 'color-mix(in lab, 25% lab(10 20 30 / .4), lab(50 60 70 / .8))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4), 25% lab(50 60 70 / .8))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4), lab(50 60 70 / .8) 25%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4) 25%, lab(50 60 70 / .8) 75%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4) 30%, lab(50 60 70 / .8) 90%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4) 12.5%, lab(50 60 70 / .8) 37.5%)'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / .4) 0%, lab(50 60 70 / .8))'
+PASS Property color value 'color-mix(in lab, transparent, lab(30 40 50))'
+PASS Property color value 'color-mix(in lab, transparent 10%, lab(30 40 50))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / 0), lab(30 40 50))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / 0) 10%, lab(30 40 50))'
+PASS Property color value 'color-mix(in lab, lab(none none none), lab(none none none))'
+PASS Property color value 'color-mix(in lab, lab(none none none), lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30), lab(none none none))'
+PASS Property color value 'color-mix(in lab, lab(10 20 none), lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30), lab(50 60 none))'
+PASS Property color value 'color-mix(in lab, lab(none 20 30), lab(50 none 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / none), lab(50 60 70))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / 0.5))'
+PASS Property color value 'color-mix(in lab, lab(10 20 30 / none), lab(50 60 70 / none))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3), oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3) 25%, oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, 25% oklab(0.1 0.2 0.3), oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3), 25% oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3), oklab(0.5 0.6 0.7) 25%)'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3) 25%, oklab(0.5 0.6 0.7) 75%)'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3) 30%, oklab(0.5 0.6 0.7) 90%)'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3) 12.5%, oklab(0.5 0.6 0.7) 37.5%)'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3) 0%, oklab(0.5 0.6 0.7))'
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4), oklab(0.5 0.6 0.7 / .8))' assert_equals: expected "oklab(0.36666664 0.46666664 0.56666664 / 0.6)" but got "oklab(0.36666664 0.46666664 0.56666666 / 0.6)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4) 25%, oklab(0.5 0.6 0.7 / .8))' assert_equals: expected "oklab(0.44285713 0.54285717 0.6428571 / 0.7)" but got "oklab(0.44285715 0.54285717 0.64285713 / 0.7)"
+FAIL Property color value 'color-mix(in oklab, 25% oklab(0.1 0.2 0.3 / .4), oklab(0.5 0.6 0.7 / .8))' assert_equals: expected "oklab(0.44285713 0.54285717 0.6428571 / 0.7)" but got "oklab(0.44285715 0.54285717 0.64285713 / 0.7)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4), 25% oklab(0.5 0.6 0.7 / .8))' assert_equals: expected "oklab(0.26 0.36 0.46 / 0.5)" but got "oklab(0.26000002 0.36 0.46 / 0.5)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4), oklab(0.5 0.6 0.7 / .8) 25%)' assert_equals: expected "oklab(0.26 0.36 0.46 / 0.5)" but got "oklab(0.26000002 0.36 0.46 / 0.5)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4) 25%, oklab(0.5 0.6 0.7 / .8) 75%)' assert_equals: expected "oklab(0.44285713 0.54285717 0.6428571 / 0.7)" but got "oklab(0.44285715 0.54285717 0.64285713 / 0.7)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4) 30%, oklab(0.5 0.6 0.7 / .8) 90%)' assert_equals: expected "oklab(0.44285713 0.54285717 0.6428571 / 0.7)" but got "oklab(0.44285715 0.54285717 0.64285713 / 0.7)"
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4) 12.5%, oklab(0.5 0.6 0.7 / .8) 37.5%)' assert_equals: expected "oklab(0.44285713 0.54285717 0.6428571 / 0.35)" but got "oklab(0.44285715 0.54285717 0.64285713 / 0.35)"
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / .4) 0%, oklab(0.5 0.6 0.7 / .8))'
+PASS Property color value 'color-mix(in oklab, transparent, oklab(0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in oklab, transparent 10%, oklab(0.3 0.4 0.5))' assert_equals: expected "oklab(0.3 0.4 0.5 / 0.9)" but got "oklab(0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / 0), oklab(0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / 0) 10%, oklab(0.3 0.4 0.5))' assert_equals: expected "oklab(0.3 0.4 0.5 / 0.9)" but got "oklab(0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in oklab, oklab(none none none), oklab(none none none))'
+PASS Property color value 'color-mix(in oklab, oklab(none none none), oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3), oklab(none none none))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 none), oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3), oklab(0.5 0.6 none))'
+PASS Property color value 'color-mix(in oklab, oklab(none 0.2 0.3), oklab(0.5 none 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / 0.5))'
+PASS Property color value 'color-mix(in oklab, oklab(0.1 0.2 0.3 / none), oklab(0.5 0.6 0.7 / none))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3), color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3) 25%, color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, 25% color(srgb .1 .2 .3), color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3), color(srgb .5 .6 .7) 25%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3), 25% color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3) 25%, color(srgb .5 .6 .7) 75%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3) 30%, color(srgb .5 .6 .7) 90%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3) 12.5%, color(srgb .5 .6 .7) 37.5%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3) 0%, color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .5), color(srgb .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4) 25%, color(srgb .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb, 25% color(srgb .1 .2 .3 / .4), color(srgb .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4), color(srgb .5 .6 .7 / .8) 25%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4), 25% color(srgb .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4) 25%, color(srgb .5 .6 .7 / .8) 75%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4) 30%, color(srgb .5 .6 .7 / .8) 90%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4) 12.5%, color(srgb .5 .6 .7 / .8) 37.5%)'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / .4) 0%, color(srgb .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb, transparent, color(srgb 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in srgb, transparent 10%, color(srgb 0.3 0.4 0.5))' assert_equals: expected "color(srgb 0.3 0.4 0.5 / 0.9)" but got "color(srgb 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in srgb, color(srgb 0.1 0.2 0.3 / 0), color(srgb 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in srgb, color(srgb 0.1 0.2 0.3 / 0) 10%, color(srgb 0.3 0.4 0.5))' assert_equals: expected "color(srgb 0.3 0.4 0.5 / 0.9)" but got "color(srgb 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in srgb, color(srgb 2 3 4 / 5), color(srgb 4 6 8 / 10))'
+PASS Property color value 'color-mix(in srgb, color(srgb -2 -3 -4), color(srgb -4 -6 -8))'
+PASS Property color value 'color-mix(in srgb, color(srgb -2 -3 -4 / -5), color(srgb -4 -6 -8 / -10))'
+PASS Property color value 'color-mix(in srgb, color(srgb none none none), color(srgb none none none))'
+PASS Property color value 'color-mix(in srgb, color(srgb none none none), color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3), color(srgb none none none))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 none), color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3), color(srgb .5 .6 none))'
+PASS Property color value 'color-mix(in srgb, color(srgb none .2 .3), color(srgb .5 none .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / none), color(srgb .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / none), color(srgb .5 .6 .7 / 0.5))'
+PASS Property color value 'color-mix(in srgb, color(srgb .1 .2 .3 / none), color(srgb .5 .6 .7 / none))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3), color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3) 25%, color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, 25% color(srgb-linear .1 .2 .3), color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3), color(srgb-linear .5 .6 .7) 25%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3), 25% color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3) 25%, color(srgb-linear .5 .6 .7) 75%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3) 30%, color(srgb-linear .5 .6 .7) 90%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3) 12.5%, color(srgb-linear .5 .6 .7) 37.5%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3) 0%, color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .5), color(srgb-linear .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4) 25%, color(srgb-linear .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb-linear, 25% color(srgb-linear .1 .2 .3 / .4), color(srgb-linear .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4), color(srgb-linear .5 .6 .7 / .8) 25%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4), 25% color(srgb-linear .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4) 25%, color(srgb-linear .5 .6 .7 / .8) 75%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4) 30%, color(srgb-linear .5 .6 .7 / .8) 90%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4) 12.5%, color(srgb-linear .5 .6 .7 / .8) 37.5%)'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / .4) 0%, color(srgb-linear .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in srgb-linear, transparent, color(srgb-linear 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in srgb-linear, transparent 10%, color(srgb-linear 0.3 0.4 0.5))' assert_equals: expected "color(srgb-linear 0.3 0.4 0.5 / 0.9)" but got "color(srgb-linear 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear 0.1 0.2 0.3 / 0), color(srgb-linear 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in srgb-linear, color(srgb-linear 0.1 0.2 0.3 / 0) 10%, color(srgb-linear 0.3 0.4 0.5))' assert_equals: expected "color(srgb-linear 0.3 0.4 0.5 / 0.9)" but got "color(srgb-linear 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear 2 3 4 / 5), color(srgb-linear 4 6 8 / 10))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear -2 -3 -4), color(srgb-linear -4 -6 -8))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear -2 -3 -4 / -5), color(srgb-linear -4 -6 -8 / -10))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear none none none), color(srgb-linear none none none))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear none none none), color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3), color(srgb-linear none none none))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 none), color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3), color(srgb-linear .5 .6 none))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear none .2 .3), color(srgb-linear .5 none .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / none), color(srgb-linear .5 .6 .7))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / none), color(srgb-linear .5 .6 .7 / 0.5))'
+PASS Property color value 'color-mix(in srgb-linear, color(srgb-linear .1 .2 .3 / none), color(srgb-linear .5 .6 .7 / none))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, 25% color(xyz .1 .2 .3), color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 .7) 25%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3), 25% color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3) 25%, color(xyz .5 .6 .7) 75%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3) 30%, color(xyz .5 .6 .7) 90%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3) 12.5%, color(xyz .5 .6 .7) 37.5%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3) 0%, color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .5), color(xyz .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz, 25% color(xyz .1 .2 .3 / .4), color(xyz .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4), color(xyz .5 .6 .7 / .8) 25%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4), 25% color(xyz .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4) 25%, color(xyz .5 .6 .7 / .8) 75%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4) 30%, color(xyz .5 .6 .7 / .8) 90%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4) 12.5%, color(xyz .5 .6 .7 / .8) 37.5%)'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / .4) 0%, color(xyz .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz, transparent, color(xyz 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz, transparent 10%, color(xyz 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d65 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d65 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz, color(xyz 0.1 0.2 0.3 / 0), color(xyz 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz, color(xyz 0.1 0.2 0.3 / 0) 10%, color(xyz 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d65 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d65 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz, color(xyz 2 3 4 / 5), color(xyz 4 6 8 / 10))'
+PASS Property color value 'color-mix(in xyz, color(xyz -2 -3 -4), color(xyz -4 -6 -8))'
+PASS Property color value 'color-mix(in xyz, color(xyz -2 -3 -4 / -5), color(xyz -4 -6 -8 / -10))'
+PASS Property color value 'color-mix(in xyz, color(xyz none none none), color(xyz none none none))'
+PASS Property color value 'color-mix(in xyz, color(xyz none none none), color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3), color(xyz none none none))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 none), color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3), color(xyz .5 .6 none))'
+PASS Property color value 'color-mix(in xyz, color(xyz none .2 .3), color(xyz .5 none .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / 0.5))'
+PASS Property color value 'color-mix(in xyz, color(xyz .1 .2 .3 / none), color(xyz .5 .6 .7 / none))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3) 25%, color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, 25% color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 .7) 25%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), 25% color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3) 25%, color(xyz-d50 .5 .6 .7) 75%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3) 30%, color(xyz-d50 .5 .6 .7) 90%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3) 12.5%, color(xyz-d50 .5 .6 .7) 37.5%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3) 0%, color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .5), color(xyz-d50 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4) 25%, color(xyz-d50 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d50, 25% color(xyz-d50 .1 .2 .3 / .4), color(xyz-d50 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4), color(xyz-d50 .5 .6 .7 / .8) 25%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4), 25% color(xyz-d50 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4) 25%, color(xyz-d50 .5 .6 .7 / .8) 75%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4) 30%, color(xyz-d50 .5 .6 .7 / .8) 90%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4) 12.5%, color(xyz-d50 .5 .6 .7 / .8) 37.5%)'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / .4) 0%, color(xyz-d50 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d50, transparent, color(xyz-d50 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz-d50, transparent 10%, color(xyz-d50 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d50 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d50 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 0.1 0.2 0.3 / 0), color(xyz-d50 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz-d50, color(xyz-d50 0.1 0.2 0.3 / 0) 10%, color(xyz-d50 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d50 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d50 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 2 3 4 / 5), color(xyz-d50 4 6 8 / 10))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 -2 -3 -4), color(xyz-d50 -4 -6 -8))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 -2 -3 -4 / -5), color(xyz-d50 -4 -6 -8 / -10))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 none none none), color(xyz-d50 none none none))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 none none none), color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 none none none))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 none), color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3), color(xyz-d50 .5 .6 none))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 none .2 .3), color(xyz-d50 .5 none .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / none), color(xyz-d50 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / none), color(xyz-d50 .5 .6 .7 / 0.5))'
+PASS Property color value 'color-mix(in xyz-d50, color(xyz-d50 .1 .2 .3 / none), color(xyz-d50 .5 .6 .7 / none))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3), color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3) 25%, color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, 25% color(xyz-d65 .1 .2 .3), color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3), color(xyz-d65 .5 .6 .7) 25%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3), 25% color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3) 25%, color(xyz-d65 .5 .6 .7) 75%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3) 30%, color(xyz-d65 .5 .6 .7) 90%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3) 12.5%, color(xyz-d65 .5 .6 .7) 37.5%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3) 0%, color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .5), color(xyz-d65 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4) 25%, color(xyz-d65 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d65, 25% color(xyz-d65 .1 .2 .3 / .4), color(xyz-d65 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4), color(xyz-d65 .5 .6 .7 / .8) 25%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4), 25% color(xyz-d65 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4) 25%, color(xyz-d65 .5 .6 .7 / .8) 75%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4) 30%, color(xyz-d65 .5 .6 .7 / .8) 90%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4) 12.5%, color(xyz-d65 .5 .6 .7 / .8) 37.5%)'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / .4) 0%, color(xyz-d65 .5 .6 .7 / .8))'
+PASS Property color value 'color-mix(in xyz-d65, transparent, color(xyz-d65 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz-d65, transparent 10%, color(xyz-d65 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d65 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d65 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 0.1 0.2 0.3 / 0), color(xyz-d65 0.3 0.4 0.5))'
+FAIL Property color value 'color-mix(in xyz-d65, color(xyz-d65 0.1 0.2 0.3 / 0) 10%, color(xyz-d65 0.3 0.4 0.5))' assert_equals: expected "color(xyz-d65 0.3 0.4 0.5 / 0.9)" but got "color(xyz-d65 0.3 0.40000004 0.5 / 0.9)"
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 2 3 4 / 5), color(xyz-d65 4 6 8 / 10))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 -2 -3 -4), color(xyz-d65 -4 -6 -8))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 -2 -3 -4 / -5), color(xyz-d65 -4 -6 -8 / -10))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 none none none), color(xyz-d65 none none none))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 none none none), color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3), color(xyz-d65 none none none))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 none), color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3), color(xyz-d65 .5 .6 none))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 none .2 .3), color(xyz-d65 .5 none .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / none), color(xyz-d65 .5 .6 .7))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / none), color(xyz-d65 .5 .6 .7 / 0.5))'
+PASS Property color value 'color-mix(in xyz-d65, color(xyz-d65 .1 .2 .3 / none), color(xyz-d65 .5 .6 .7 / none))'
+


### PR DESCRIPTION
#### da18a41f078978a2d49677f117bea08c2930ff42
<pre>
REBASELINE: [ macOS ] imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=255178">https://bugs.webkit.org/show_bug.cgi?id=255178</a>
rdar://107773785

Unreviewed rebaseline.

Setting a Monterey specific rebaseline.

* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-color-mix-function-expected.txt: Added.
</pre>