### PR TITLE
[iOS] Remove all instances of UICalloutBar in WebKit

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -34,7 +34,6 @@
 #import <UIKit/UIApplication_Private.h>
 #import <UIKit/UIBarButtonItem_Private.h>
 #import <UIKit/UIBlurEffect_Private.h>
-#import <UIKit/UICalloutBar.h>
 #import <UIKit/UIClickInteraction_Private.h>
 #import <UIKit/UIClickPresentationInteraction_Private.h>
 #import <UIKit/UIColorEffect.h>
@@ -1197,11 +1196,6 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 @property (nonatomic) BOOL dontDismiss;
 @end
 ALLOW_DEPRECATED_DECLARATIONS_END
-
-@interface UICalloutBar : UIView
-+ (UICalloutBar *)activeCalloutBar;
-+ (void)fadeSharedCalloutBar;
-@end
 
 @interface UIAutoRotatingWindow : UIApplicationRotationFollowingWindow
 @end

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -509,7 +509,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<UIDragInteraction> _dragInteraction;
     RetainPtr<UIDropInteraction> _dropInteraction;
     BOOL _isAnimatingDragCancel;
-    BOOL _shouldRestoreCalloutBarAfterDrop;
+    BOOL _shouldRestoreEditMenuAfterDrop;
     RetainPtr<UIView> _visibleContentViewSnapshot;
     RetainPtr<UIView> _unselectedContentSnapshot;
     RetainPtr<_UITextDragCaretView> _editDropCaretView;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm
@@ -334,7 +334,7 @@ static RetainPtr<CGImageRef> iconImage()
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS) && PLATFORM(IOS_FAMILY)
 
-static void simulateCalloutBarAppearance(TestWKWebView *webView)
+static void simulateEditMenuAppearance(TestWKWebView *webView)
 {
     __block bool done = false;
     [webView.textInputContentView requestPreferredArrowDirectionForEditMenuWithCompletionHandler:^(UIEditMenuArrowDirection) {
@@ -357,7 +357,7 @@ static BOOL simulateEditContextMenuAppearance(TestWKWebView *webView, CGPoint lo
 
 static void invokeRemoveBackgroundAction(TestWKWebView *webView)
 {
-    simulateCalloutBarAppearance(webView);
+    simulateEditMenuAppearance(webView);
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
@@ -397,7 +397,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
     [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; nodeIndex = [...image.parentNode.childNodes].indexOf(image);"
         "getSelection().setBaseAndExtent(image.parentNode, nodeIndex, image.parentNode, nodeIndex + 1);"];
     [webView waitForNextPresentationUpdate];
-    simulateCalloutBarAppearance(webView.get());
+    simulateEditMenuAppearance(webView.get());
 
     auto menuBuilder = adoptNS([[TestUIMenuBuilder alloc] init]);
     [webView buildMenuWithBuilder:menuBuilder.get()];
@@ -405,7 +405,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
 
     [webView selectAll:nil];
     [webView waitForNextPresentationUpdate];
-    simulateCalloutBarAppearance(webView.get());
+    simulateEditMenuAppearance(webView.get());
 
     [menuBuilder reset];
     [webView buildMenuWithBuilder:menuBuilder.get()];
@@ -413,7 +413,7 @@ TEST(ImageAnalysisTests, MenuControllerItems)
 
     [webView objectByEvaluatingJavaScript:@"getSelection().setBaseAndExtent(document.body, 0, image.parentNode, nodeIndex + 1);"];
     [webView waitForNextPresentationUpdate];
-    simulateCalloutBarAppearance(webView.get());
+    simulateEditMenuAppearance(webView.get());
 
     [menuBuilder reset];
     [webView buildMenuWithBuilder:menuBuilder.get()];
@@ -477,7 +477,7 @@ TEST(ImageAnalysisTests, AllowRemoveBackgroundOnce)
     [webView objectByEvaluatingJavaScript:@"let image = document.images[0]; nodeIndex = [...image.parentNode.childNodes].indexOf(image);"
         "getSelection().setBaseAndExtent(image.parentNode, nodeIndex, image.parentNode, nodeIndex + 1)"];
     [webView waitForNextPresentationUpdate];
-    simulateCalloutBarAppearance(webView.get());
+    simulateEditMenuAppearance(webView.get());
 
     auto menuBuilder = adoptNS([TestUIMenuBuilder new]);
     [webView buildMenuWithBuilder:menuBuilder.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAppHighlights.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAppHighlights.mm
@@ -215,21 +215,6 @@ TEST(AppHighlights, AppHighlightRestoreFromStorageV1)
     }, 2, @"Expected Highlights to be populated.");
 }
 
-#if PLATFORM(IOS_FAMILY)
-
-TEST(AppHighlights, AvoidForcingCalloutBarInitialization)
-{
-    auto defaultConfiguration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:defaultConfiguration.get() addToWindow:NO]);
-    [webView synchronouslyLoadTestPageNamed:@"simple"];
-    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
-    [webView waitForNextPresentationUpdate];
-
-    EXPECT_NULL(UICalloutBar.activeCalloutBar);
-}
-
-#endif // PLATFORM(IOS_FAMILY)
-
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(APP_HIGHLIGHTS)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -474,7 +474,6 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     RetainPtr<TestMessageHandler> _testHandler;
     RetainPtr<WKUserScript> _onloadScript;
 #if PLATFORM(IOS_FAMILY)
-    std::unique_ptr<ClassMethodSwizzler> _sharedCalloutBarSwizzler;
     InputSessionChangeCount _inputSessionChangeCount;
     UIEdgeInsets _overrideSafeAreaInset;
 #endif
@@ -495,15 +494,6 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     return [self initWithFrame:frame configuration:configuration addToWindow:YES];
 }
 
-#if PLATFORM(IOS_FAMILY)
-
-static UICalloutBar *suppressUICalloutBar()
-{
-    return nil;
-}
-
-#endif
-
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration addToWindow:(BOOL)addToWindow
 {
     self = [super initWithFrame:frame configuration:configuration];
@@ -514,8 +504,6 @@ static UICalloutBar *suppressUICalloutBar()
         [self _setUpTestWindow:frame];
 
 #if PLATFORM(IOS_FAMILY)
-    // FIXME: Remove this workaround once <https://webkit.org/b/175204> is fixed.
-    _sharedCalloutBarSwizzler = makeUnique<ClassMethodSwizzler>([UICalloutBar class], @selector(sharedCalloutBar), reinterpret_cast<IMP>(suppressUICalloutBar));
     _inputSessionChangeCount = 0;
     // We suppress safe area insets by default in order to ensure consistent results when running against device models
     // that may or may not have safe area insets, have insets with different values (e.g. iOS devices with a notch).

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -35,7 +35,6 @@
 #import <UIKit/UIAction_Private.h>
 #import <UIKit/UIApplication_Private.h>
 #import <UIKit/UIBarButtonItemGroup_Private.h>
-#import <UIKit/UICalloutBar.h>
 #import <UIKit/UIKeyboardImpl.h>
 #import <UIKit/UIKeyboard_Private.h>
 #import <UIKit/UIResponder_Private.h>
@@ -141,11 +140,6 @@ WTF_EXTERN_C_END
 @end
 
 @interface UIKeyboard : UIView
-@end
-
-@interface UICalloutBar : UIView
-+ (UICalloutBar *)sharedCalloutBar;
-+ (UICalloutBar *)activeCalloutBar;
 @end
 
 @interface _UINavigationInteractiveTransitionBase : UIPercentDrivenInteractiveTransition

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1170,20 +1170,6 @@ WebCore::FloatRect UIScriptControllerIOS::rectForMenuAction(CFStringRef action) 
 {
     UIView *viewForAction = nil;
 
-    if (UIView *calloutBar = UICalloutBar.activeCalloutBar; calloutBar.window) {
-        for (UIButton *button in findAllViewsInHierarchyOfType(calloutBar, UIButton.class)) {
-            NSString *buttonTitle = [button titleForState:UIControlStateNormal];
-            if (!buttonTitle.length)
-                continue;
-
-            if (![buttonTitle isEqualToString:(__bridge NSString *)action])
-                continue;
-
-            viewForAction = button;
-            break;
-        }
-    }
-
     auto searchForLabel = [&](UIWindow *window) -> UILabel * {
         for (UILabel *label in findAllViewsInHierarchyOfType(window, UILabel.class)) {
             if ([label.text isEqualToString:(__bridge NSString *)action])
@@ -1204,11 +1190,7 @@ WebCore::FloatRect UIScriptControllerIOS::rectForMenuAction(CFStringRef action) 
 
 JSObjectRef UIScriptControllerIOS::menuRect() const
 {
-    UIView *containerView = nil;
-    if (auto *calloutBar = UICalloutBar.activeCalloutBar; calloutBar.window)
-        containerView = calloutBar;
-    else
-        containerView = findAllViewsInHierarchyOfType(webView().textEffectsWindow, internalClassNamed(@"_UIEditMenuListView")).firstObject;
+    auto containerView = findAllViewsInHierarchyOfType(webView().textEffectsWindow, internalClassNamed(@"_UIEditMenuListView")).firstObject;
     return containerView ? toObject([containerView convertRect:containerView.bounds toView:platformContentView()]) : nullptr;
 }
 


### PR DESCRIPTION
#### 127b86b20b91c47794e615285dde394a221ae6c3
<pre>
[iOS] Remove all instances of UICalloutBar in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=259197">https://bugs.webkit.org/show_bug.cgi?id=259197</a>
rdar://112114237

Reviewed by Megan Gardner and Aditya Keerthi.

`UICalloutBar` has been long replaced by the edit menu (and its associated interaction) since iOS
16. This patch removes several codepaths that only existed to support layout and API tests against
iOS 15 — this is no longer necessary, now that our oldest supported iOS test runners are on 16.4.

No change in behavior.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _requestEvasionRectsAboveSelectionIfNeeded:]):

Additionally rename several references to &quot;callout bar&quot; to &quot;edit menu&quot; instead.

(-[WKContentView cleanUpDragSourceSessionState]):
(-[WKContentView _restoreEditMenuIfNeeded]):
(-[WKContentView dragInteraction:willAnimateLiftWithAnimator:session:]):
(-[WKContentView dragInteraction:session:didEndWithOperation:]):
(-[WKContentView _restoreCalloutBarIfNeeded]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ImageAnalysisTests.mm:
(TestWebKitAPI::simulateEditMenuAppearance):
(TestWebKitAPI::invokeRemoveBackgroundAction):
(TestWebKitAPI::TEST):

Remove an obsolete test that was only checking that we avoid eagerly instantiating `UICalloutBar`
when changing the text selection. This test is no longer relevant with edit menus because the bug
was triggered by callout-bar-specific code that was invoked by WebKit code; in comparison, edit
menus ask the first responder (the content view) to build the edit menu upon presentation.

(TestWebKitAPI::simulateCalloutBarAppearance): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKAppHighlights.mm:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView initWithFrame:configuration:addToWindow:]):
(suppressUICalloutBar): Deleted.
* Tools/TestWebKitAPI/ios/UIKitSPI.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::rectForMenuAction const):
(WTR::UIScriptControllerIOS::menuRect const):

Canonical link: <a href="https://commits.webkit.org/266047@main">https://commits.webkit.org/266047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09497ddd4531e05ac5a30c6224b6a887fb035524

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14402 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14820 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14845 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18546 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14829 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10021 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11355 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3110 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->