### PR TITLE
[macOS] LocalSampleBufferDisplayLayer is rotating video frames on the wrong side

### DIFF
--- a/LayoutTests/fast/mediastream/video-rotation2-expected.txt
+++ b/LayoutTests/fast/mediastream/video-rotation2-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Ensure rotation is clockwise
+

--- a/LayoutTests/fast/mediastream/video-rotation2.html
+++ b/LayoutTests/fast/mediastream/video-rotation2.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="fuzzy" content="maxDifference=10;totalPixels=30" />
+        <title>Testing video rotation is clockwise</title>
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <div id="redRectangle" style="z-index: 0; position: absolute; top: 0px; left: 0px; background-color:red; width:200px; height:400px"></div>
+        <!-- we just leave a small rectangle hole where the video should be all green -->
+        <video style="z-index: 1; position: absolute; top: 0px; left: 0px;" id="video" autoplay playsInline style="filter:grayscale(100%)"></video>
+        <div id="greenRectangle1" style="z-index: 2; position: absolute; top: 0px; left: 0px; background-color:green; width:45px; height:400px"></div>
+        <div id="greenRectangle2" style="z-index: 2; position: absolute; top: 0px; left: 53px; background-color:green; width:147px; height:400px"></div>
+        <div id="greenRectangle3" style="z-index: 2; position: absolute; top: 0px; left: 0px; background-color:green; width:200px; height:60px"></div>
+        <div id="greenRectangle4" style="z-index: 2; position: absolute; top: 70px; left: 0px; background-color:green; width:200px; height:330px"></div>
+        <image id='image' style="z-index: 0; position: absolute; top: 0px; left: 0px; background-color:red; width:200px; height:400px"></image>
+        <canvas id='canvas' style="z-index: 0; position: absolute; top: 0px; left: 0px; background-color:red; width:200px; height:400px"></canvas>
+        <script>
+if (window.testRunner)
+    testRunner.setMockCameraOrientation(90);
+
+async function getSnapshotData()
+{
+    const dataURL = await new Promise(resolve => testRunner.takeViewPortSnapshot(resolve));
+    const loadPromise = new Promise((resolve, reject) => {
+        image.onload = resolve;
+        image.onerror = reject;
+        setTimeout(() => reject("image load timed out"), 2000);
+    });
+    image.src = dataURL;
+    await loadPromise;
+
+    canvas.width = image.width;
+    canvas.height = image.height;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+
+    return canvas.getContext('2d').getImageData(0, 0, 200, 400).data;
+}
+
+function isWhitePixel(data, i)
+{
+    return data[i] > 250 && data[i + 1] > 250 && data[i + 2] > 250;
+}
+
+function isGreenPixel(data, i)
+{
+    return data[i] < 50 && data[i + 1] > 100 && data[i + 1] < 150 && data[i + 2] < 50;
+}
+
+promise_test(async () => {
+    video.srcObject = await navigator.mediaDevices.getUserMedia({video: {width: 400, height: 200} });
+    await video.play();
+
+    if (!window.testRunner)
+        return;
+
+    let data;
+    let isOK = false;
+    let counter = 0;
+    while (++counter < 100 && !isOK) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        // All data should be almost green
+        data = await getSnapshotData();
+        isOK = true;
+        for (let i = 0; i < data.length; i = i + 4) {
+            if (isOK && counter == 99 && !isGreenPixel(data, i))
+                console.log(i + " : " + data[i] + ", " + data[i + 1] + ", " + data[i + 2]);
+            isOK &= isGreenPixel(data, i);
+        }
+    }
+    assert_less_than(counter, 100);
+    assert_true(!!isOK);
+}, "Ensure rotation is clockwise");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1692,6 +1692,8 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 # This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
 fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
 
+fast/mediastream/video-rotation2.html [ Failure Pass ]
+
 # Missing/broken pageIsFocused notification.
 fast/mediastream/device-change-event-2.html [ Timeout Failure ]
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -373,7 +373,12 @@ static inline CGAffineTransform videoTransformationMatrix(VideoFrame& videoFrame
     if (!width || !height)
         return CGAffineTransformIdentity;
 
-    auto videoTransform = CGAffineTransformMakeRotation(static_cast<int>(videoFrame.rotation()) * M_PI / 180);
+#if PLATFORM(MAC)
+    int rotationAngle = -static_cast<int>(videoFrame.rotation());
+#else
+    int rotationAngle = static_cast<int>(videoFrame.rotation());
+#endif
+    auto videoTransform = CGAffineTransformMakeRotation(rotationAngle * M_PI / 180);
     if (videoFrame.isMirrored())
         videoTransform = CGAffineTransformScale(videoTransform, -1, 1);
 


### PR DESCRIPTION
#### 2a4d7141520c91bc674ed6c860b533b756205d17
<pre>
[macOS] LocalSampleBufferDisplayLayer is rotating video frames on the wrong side
<a href="https://bugs.webkit.org/show_bug.cgi?id=259187">https://bugs.webkit.org/show_bug.cgi?id=259187</a>
rdar://112127520

Reviewed by Eric Carlson.

transform is applied counter-clockwise in macOS and clockwise in iOS.
Update rotation matrix accordingly.

* LayoutTests/fast/mediastream/video-rotation2-expected.txt: Added.
* LayoutTests/fast/mediastream/video-rotation2.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::videoTransformationMatrix):

Canonical link: <a href="https://commits.webkit.org/266061@main">https://commits.webkit.org/266061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8019bc2cc5d7dd2499e01072db41c88643c0dc59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12170 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14869 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12891 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10771 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/14914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11519 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18597 "layout-tests (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14883 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3120 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->