### PR TITLE
Implement the set function in the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
@@ -1,26 +1,18 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.delete with name in options' specified 1 'cleanup' function, and 1 failed.
+
 FAIL cookieStore.delete with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.delete with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete domain starts with "." promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain that is not equal current host promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain set to the current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with domain set to a subdomain of the current hostname promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with path set to the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with path set to subdirectory of the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with missing / at the end of path promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with path that does not start with / promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.delete with get result promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+NOTRUN cookieStore.delete domain starts with "."
+NOTRUN cookieStore.delete with domain that is not equal current host
+NOTRUN cookieStore.delete with domain set to the current hostname
+NOTRUN cookieStore.delete with domain set to a subdomain of the current hostname
+NOTRUN cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
+NOTRUN cookieStore.delete with path set to the current directory
+NOTRUN cookieStore.delete with path set to subdirectory of the current directory
+NOTRUN cookieStore.delete with missing / at the end of path
+NOTRUN cookieStore.delete with path that does not start with /
+NOTRUN cookieStore.delete with get result
+NOTRUN cookieStore.delete with positional empty name
+NOTRUN cookieStore.delete with empty name in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookieStore fires change event for cookie set by cookieStore.set() promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookieStore fires change event for cookie set by cookieStore.set() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
@@ -1,3 +1,5 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore fires change event for cookie deleted by cookieStore.delete()' specified 1 'cleanup' function, and 1 failed.
+
 FAIL cookieStore fires change event for cookie deleted by cookieStore.delete() promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookieStore fires change event for cookie overwritten by cookieStore.set() promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT cookieStore fires change event for cookie overwritten by cookieStore.set() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
@@ -1,11 +1,13 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.getAll with no arguments' specified 2 'cleanup' functions, and 2 failed.
+
 FAIL cookieStore.getAll with no arguments promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with empty options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with name in both positional arguments and options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with absolute url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with relative url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with invalid url path in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with invalid url host in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+NOTRUN cookieStore.getAll with empty options
+NOTRUN cookieStore.getAll with positional name
+NOTRUN cookieStore.getAll with name in options
+NOTRUN cookieStore.getAll with name in both positional arguments and options
+NOTRUN cookieStore.getAll with absolute url in options
+NOTRUN cookieStore.getAll with relative url in options
+NOTRUN cookieStore.getAll with invalid url path in options
+NOTRUN cookieStore.getAll with invalid url host in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
@@ -1,3 +1,5 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.getAll returns multiple cookies written by cookieStore.set' specified 3 'cleanup' functions, and 3 failed.
+
 FAIL cookieStore.getAll returns multiple cookies written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
@@ -1,3 +1,5 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.getAll returns the cookie written by cookieStore.set' specified 1 'cleanup' function, and 1 failed.
+
 FAIL cookieStore.getAll returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
@@ -1,11 +1,13 @@
 
-FAIL cookieStore.get with no arguments returns TypeError promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with empty options returns TypeError promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with name in both positional arguments and options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with absolute url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with relative url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.get with invalid url host in options assert_unreached: Should have rejected: undefined Reached unreachable code
+Harness Error (FAIL), message = Test named 'cookieStore.get with no arguments returns TypeError' specified 1 'cleanup' function, and 1 failed.
+
+FAIL cookieStore.get with no arguments returns TypeError assert_unreached: Should have rejected: undefined Reached unreachable code
+NOTRUN cookieStore.get with empty options returns TypeError
+NOTRUN cookieStore.get with positional name
+NOTRUN cookieStore.get with name in options
+NOTRUN cookieStore.get with name in both positional arguments and options
+NOTRUN cookieStore.get with absolute url in options
+NOTRUN cookieStore.get with relative url in options
+NOTRUN cookieStore.get with invalid url path in options
+NOTRUN cookieStore.get with invalid url host in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt
@@ -1,3 +1,5 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.get returns null for a cookie deleted by cookieStore.delete' specified 1 'cleanup' function, and 1 failed.
+
 FAIL cookieStore.get returns null for a cookie deleted by cookieStore.delete promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,4 +1,6 @@
 
-FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (FAIL), message = Test named 'cookieStore.get() sees cookieStore.set() in frame' specified 1 'cleanup' function, and 1 failed.
+
+FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
+NOTRUN cookieStore.get() in frame sees cookieStore.set()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt
@@ -1,3 +1,5 @@
 
-FAIL cookieStore.get returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (FAIL), message = Test named 'cookieStore.get returns the cookie written by cookieStore.set' specified 1 'cleanup' function, and 1 failed.
+
+PASS cookieStore.get returns the cookie written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Set three simple origin session cookies sequentially and ensure they all end up in the cookie jar in order. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Set three simple origin session cookies in undefined order using Promise.all and ensure they all end up in the cookie jar in any order.  promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Set three simple origin session cookies sequentially and ensure they all end up in the cookie jar in order.
+PASS Set three simple origin session cookies in undefined order using Promise.all and ensure they all end up in the cookie jar in any order.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -1,34 +1,24 @@
 
+Harness Error (FAIL), message = Test named 'cookieStore.set with get result' specified 1 'cleanup' function, and 1 failed.
+
 FAIL cookieStore.set with positional name and value promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with name and value in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with empty name and an '=' in value promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS cookieStore.set with empty name and an '=' in value
 FAIL cookieStore.set with normal name and an '=' in value promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with expires set to a future Date promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with expires set to a past Date promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with expires set to a future timestamp promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with expires set to a past timestamp promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set domain starts with "." promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with domain that is not equal current host promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL cookieStore.set domain starts with "." assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with domain that is not equal current host assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with domain set to the current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with domain set to a subdomain of the current hostname promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+FAIL cookieStore.set with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set default domain is null and differs from current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with path set to the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set with path set to a subdirectory of the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set default path is / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 FAIL cookieStore.set adds / to path that does not end with / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with path that does not start with / promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with get result promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -1,13 +1,11 @@
 
-FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set of expired __Secure- cookie name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set of expired __Secure- cookie name on secure origin
 FAIL cookieStore.delete with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set of expired __Host- cookie name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
+PASS cookieStore.set of expired __Host- cookie name on secure origin
 FAIL cookieStore.delete with __Host- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with __Host- prefix and a domain option promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with malformed name. assert_equals: cookieStore thrown an incorrect exception - expected "TypeError" but got "NotSupportedError"
+FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`__Host-cookie-name`)).value')"
+PASS cookieStore.set with malformed name.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
@@ -1,5 +1,9 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: The operation is not supported.
 
-Harness Error (FAIL), message = Unhandled rejection: The operation is not supported.
-
+FAIL Partitioned cookies accessible on the top-level site they are created in via HTTP assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
+FAIL Partitioned cookies accessible on the top-level site they are created in via DOM assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
+FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS Cross-site window opened correctly
+FAIL Partitioned cookies are not accessible on a different top-level site via HTTP assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
+FAIL Partitioned cookies are not accessible on a different top-level site via DOM assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
+FAIL Partitioned cookies are not accessible on a different top-level site via CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2505,6 +2505,7 @@ platform/glib/media/media-can-play-dash.html [ Skip ]
 
 # The CookieStore API is not fully implemented on GTK/WPE yet.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
+imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of UNSUPPORTED tests.

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -993,6 +993,7 @@ webkit.org/b/251113 inspector/timeline/timeline-event-screenshots.html [ Skip ]
 
 # The CookieStore API is not fully implemented on macOS WK1 yet.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
+imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End features not supported in WebKit1

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -611,6 +611,7 @@ fast/dom/Window/window-special-properties.html [ Pass Failure ]
 
 # The CookieStore API is not fully implemented on WinCario yet.
 imported/w3c/web-platform-tests/cookie-store [ Skip ]
+imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Following tests are labeled "Skip" because not working well and causes crash or timeout

--- a/Source/WebCore/Modules/cookie-store/CookieInit.h
+++ b/Source/WebCore/Modules/cookie-store/CookieInit.h
@@ -35,8 +35,8 @@ namespace WebCore {
 struct CookieInit {
     String name;
     String value;
-    std::optional<DOMHighResTimeStamp> expires;
-    String domain;
+    std::optional<DOMHighResTimeStamp> expires { };
+    String domain { };
     String path { "/"_s };
     CookieSameSite sameSite { CookieSameSite::Strict };
 };

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -27,7 +27,6 @@
 
 #include "ActiveDOMObject.h"
 #include "EventTarget.h"
-#include <optional>
 #include <wtf/Forward.h>
 #include <wtf/IsoMalloc.h>
 
@@ -51,7 +50,7 @@ public:
     void getAll(const String& name, Ref<DeferredPromise>&&);
     void getAll(CookieStoreGetOptions&&, Ref<DeferredPromise>&&);
 
-    void set(const String& name, const String& value, Ref<DeferredPromise>&&);
+    void set(String&& name, String&& value, Ref<DeferredPromise>&&);
     void set(CookieInit&&, Ref<DeferredPromise>&&);
 
     void remove(const String& name, Ref<DeferredPromise>&&);

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -195,4 +195,9 @@ void CookieJar::getCookiesAsync(Document&, const URL&, const CookieStoreGetOptio
     completionHandler(std::nullopt);
 }
 
+void CookieJar::setCookieAsync(Document&, const URL&, const Cookie&, CompletionHandler<void(bool)>&& completionHandler) const
+{
+    completionHandler(false);
+}
+
 }

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -65,6 +65,7 @@ public:
     virtual void deleteCookie(const Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&);
 
     virtual void getCookiesAsync(Document&, const URL&, const CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<Cookie>>&&)>&&) const;
+    virtual void setCookieAsync(Document&, const URL&, const Cookie&, CompletionHandler<void(bool)>&&) const;
 
     // Cookie Cache.
     virtual void clearCache() { }

--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -162,6 +162,7 @@ public:
     WEBCORE_EXPORT void setCookie(const Cookie&);
     WEBCORE_EXPORT void setCookies(const Vector<Cookie>&, const URL&, const URL& mainDocumentURL);
     WEBCORE_EXPORT void setCookiesFromDOM(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, const String&, ShouldRelaxThirdPartyCookieBlocking) const;
+    WEBCORE_EXPORT bool setCookieFromDOM(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, Cookie&&) const;
     WEBCORE_EXPORT void deleteCookie(const Cookie&, CompletionHandler<void()>&&);
     WEBCORE_EXPORT void deleteCookie(const URL&, const String&, CompletionHandler<void()>&&) const;
     WEBCORE_EXPORT void deleteAllCookies(CompletionHandler<void()>&&);
@@ -175,7 +176,7 @@ public:
     WEBCORE_EXPORT bool getRawCookies(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, Vector<Cookie>&) const;
     WEBCORE_EXPORT void getHostnamesWithCookies(HashSet<String>& hostnames);
     WEBCORE_EXPORT std::pair<String, bool> cookiesForDOM(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;
-    WEBCORE_EXPORT std::optional<Vector<Cookie>> cookiesForDOMAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, const CookieStoreGetOptions&) const;
+    WEBCORE_EXPORT std::optional<Vector<Cookie>> cookiesForDOMAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const;
     WEBCORE_EXPORT std::pair<String, bool> cookieRequestHeaderFieldValue(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;
     WEBCORE_EXPORT std::pair<String, bool> cookieRequestHeaderFieldValue(const CookieRequestHeaderFieldProxy&) const;
 
@@ -241,7 +242,7 @@ private:
 #if PLATFORM(COCOA)
     enum IncludeHTTPOnlyOrNot { DoNotIncludeHTTPOnly, IncludeHTTPOnly };
     std::pair<String, bool> cookiesForSession(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeHTTPOnlyOrNot, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;
-    std::optional<Vector<Cookie>> cookiesForSessionAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeHTTPOnlyOrNot, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, const CookieStoreGetOptions&) const;
+    std::optional<Vector<Cookie>> cookiesForSessionAsVector(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeHTTPOnlyOrNot, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const;
     RetainPtr<NSArray> httpCookies(CFHTTPCookieStorageRef) const;
     RetainPtr<NSArray> httpCookiesForURL(CFHTTPCookieStorageRef, NSURL *firstParty, const std::optional<SameSiteInfo>&, NSURL *) const;
     RetainPtr<NSArray> cookiesForURL(const URL& firstParty, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking) const;

--- a/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
+++ b/Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp
@@ -125,6 +125,12 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     cookieDatabase().setCookie(firstParty, url, value, CookieJarDB::Source::Script, cappedLifetime);
 }
 
+bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, Cookie&& cookie) const
+{
+    // FIXME: Implement for the Cookie Store API.
+    return false;
+}
+
 void NetworkStorageSession::setCookiesFromHTTPResponse(const URL& firstParty, const URL& url, const String& value) const
 {
     cookieDatabase().setCookie(firstParty, url, value, CookieJarDB::Source::Network);
@@ -157,7 +163,7 @@ std::pair<String, bool> NetworkStorageSession::cookiesForDOM(const URL& firstPar
     return cookiesForSession(*this, firstParty, url, false, includeSecureCookies);
 }
 
-std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, const CookieStoreGetOptions& options) const
+std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, IncludeSecureCookies includeSecureCookies, ApplyTrackingPrevention applyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&& options) const
 {
     // FIXME: Implement for the Cookie Store API.
     return std::nullopt;

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -391,6 +391,12 @@ void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameS
     soup_cookies_free(existingCookies);
 }
 
+bool NetworkStorageSession::setCookieFromDOM(const URL&, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, Cookie&&) const
+{
+    // FIXME: Implement for the Cookie Store API.
+    return false;
+}
+
 void NetworkStorageSession::setCookies(const Vector<Cookie>& cookies, const URL& url, const URL& firstParty)
 {
     for (auto cookie : cookies) {
@@ -660,7 +666,7 @@ std::pair<String, bool> NetworkStorageSession::cookiesForDOM(const URL& firstPar
     return cookiesForSession(*this, firstParty, url, sameSiteInfo, frameID, pageID, false, includeSecureCookies, applyTrackingPrevention, relaxThirdPartyCookieBlocking);
 }
 
-std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL&, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, const CookieStoreGetOptions&) const
+std::optional<Vector<Cookie>> NetworkStorageSession::cookiesForDOMAsVector(const URL&, const SameSiteInfo&, const URL&, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, IncludeSecureCookies, ApplyTrackingPrevention, ShouldRelaxThirdPartyCookieBlocking, CookieStoreGetOptions&&) const
 {
     // FIXME: Implement for the Cookie Store API.
     return std::nullopt;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -250,11 +250,13 @@ private:
 
     void cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(String cookieString, bool secureCookiesAccessed)>&&);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ApplyTrackingPrevention, const String&, WebCore::ShouldRelaxThirdPartyCookieBlocking);
-    void cookiesForDOMAsync(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, const WebCore::CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&);
     void cookieRequestHeaderFieldValue(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(String cookieString, bool secureCookiesAccessed)>&&);
     void getRawCookies(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
     void setRawCookie(const WebCore::Cookie&);
     void deleteCookie(const URL&, const String& cookieName, CompletionHandler<void()>&&);
+
+    void cookiesForDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::CookieStoreGetOptions&&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&);
+    void setCookieFromDOMAsync(const URL&, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::ApplyTrackingPrevention, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::Cookie&&, CompletionHandler<void(bool)>&&);
 
     void registerInternalFileBlobURL(const URL&, const String& path, const String& replacementPath, SandboxExtension::Handle&&, const String& contentType);
     void registerInternalBlobURL(const URL&, Vector<WebCore::BlobPart>&&, const String& contentType);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -38,15 +38,17 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     ConvertMainResourceLoadToDownload(std::optional<WebCore::ResourceLoaderIdentifier> mainResourceLoadIdentifier, WebKit::DownloadID downloadID, WebCore::ResourceRequest request, WebCore::ResourceResponse response, std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain)
 
     CookiesForDOM(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (String cookieString, bool didAccessSecureCookies) Synchronous
-
-    CookiesForDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::CookieStoreGetOptions options) -> (std::optional<Vector<WebCore::Cookie>> cookies)
-
     SetCookiesFromDOM(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, String cookieString, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking)
     CookieRequestHeaderFieldValue(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (String cookieString, bool didAccessSecureCookies) Synchronous
     GetRawCookies(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (Vector<WebCore::Cookie> cookies) Synchronous
     SetRawCookie(struct WebCore::Cookie cookie)
     DeleteCookie(URL url, String cookieName) -> ()
     DomCookiesForHost(URL host, bool subscribeToCookieChangeNotifications) -> (Vector<WebCore::Cookie> cookies) Synchronous
+
+    CookiesForDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::CookieStoreGetOptions options) -> (std::optional<Vector<WebCore::Cookie>> cookies)
+
+    SetCookieFromDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::Cookie cookie) -> (bool setSuccessfully)
+
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     UnsubscribeFromCookieChangeNotifications(HashSet<String> hosts)
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.h
@@ -52,6 +52,7 @@ public:
     void deleteCookie(const WebCore::Document&, const URL&, const String& cookieName, CompletionHandler<void()>&&) final;
 
     void getCookiesAsync(WebCore::Document&, const URL&, const WebCore::CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<WebCore::Cookie>>&&)>&&) const final;
+    void setCookieAsync(WebCore::Document&, const URL&, const WebCore::Cookie&, CompletionHandler<void(bool)>&&) const final;
 
     void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&);
     void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&);


### PR DESCRIPTION
#### 7d9eadacc38058d8875e9b9fd7f093d617a8e409
<pre>
Implement the set function in the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259196">https://bugs.webkit.org/show_bug.cgi?id=259196</a>

Reviewed by Chris Dumez.

CookieStore (on the WebProcess side), will make an IPC to the
Network Process (via WebCookieJar) and will pass the constructed
cookie through the IPC. The Network process will store the cookie
and if this process is successful, the promise will be resolved
with undefined. Otherwise, the promise will be rejected with a
TypeError.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_basic.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_overwrite.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_ordering.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/Modules/cookie-store/CookieInit.h:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):
* Source/WebCore/Modules/cookie-store/CookieStore.h:
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::setCookieAsync const):
* Source/WebCore/loader/CookieJar.h:
* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::cookiesForSessionAsVector const):
(WebCore::NetworkStorageSession::cookiesForDOMAsVector const):
(WebCore::NetworkStorageSession::setCookieFromDOM const):
* Source/WebCore/platform/network/curl/NetworkStorageSessionCurl.cpp:
(WebCore::NetworkStorageSession::setCookieFromDOM const):
(WebCore::NetworkStorageSession::cookiesForDOMAsVector const):
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookieFromDOM const):
(WebCore::NetworkStorageSession::cookiesForDOMAsVector const):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::cookiesForDOMAsync):
(WebKit::NetworkConnectionToWebProcess::setCookieFromDOMAsync):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::setCookieAsync const):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/266064@main">https://commits.webkit.org/266064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e3e75b3722af4437f60e46637d9960fab04f588

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12169 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14872 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14910 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10920 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18599 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14885 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11402 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3123 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->