### PR TITLE
REGRESSION (iOS 17 beta): "Origin" field is missing in the request when using "Link modulepreload"

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/preload/modulepreload-expected.txt
@@ -1,13 +1,10 @@
-CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
-CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
-CONSOLE MESSAGE: Origin http://localhost:8800 is not allowed by Access-Control-Allow-Origin. Status code: 500
 
 PASS link rel=modulepreload
 PASS same-origin link rel=modulepreload crossorigin=anonymous
 PASS same-origin link rel=modulepreload crossorigin=use-credentials
-FAIL cross-origin link rel=modulepreload promise_test: Unhandled rejection with value: object "[object Event]"
-FAIL cross-origin link rel=modulepreload crossorigin=anonymous promise_test: Unhandled rejection with value: object "[object Event]"
-FAIL cross-origin link rel=modulepreload crossorigin=use-credentials promise_test: Unhandled rejection with value: object "[object Event]"
+PASS cross-origin link rel=modulepreload
+PASS cross-origin link rel=modulepreload crossorigin=anonymous
+PASS cross-origin link rel=modulepreload crossorigin=use-credentials
 PASS link rel=modulepreload with submodules
 PASS link rel=modulepreload for a module with syntax error
 PASS link rel=modulepreload for a module with network error

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -343,6 +343,7 @@ std::unique_ptr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const Lin
             options.credentials = equalLettersIgnoringASCIICase(params.crossOrigin, "use-credentials"_s) ? FetchOptions::Credentials::Include : FetchOptions::Credentials::SameOrigin;
             CachedResourceRequest cachedRequest { ResourceRequest { url }, WTFMove(options) };
             cachedRequest.setOrigin(document.securityOrigin());
+            updateRequestForAccessControl(cachedRequest.resourceRequest(), document.securityOrigin(), options.storedCredentialsPolicy);
             return cachedRequest;
         }
         return createPotentialAccessControlRequest(url, WTFMove(options), document, params.crossOrigin);


### PR DESCRIPTION
#### ba2a851809a33013068ec8511883055cabd239be
<pre>
REGRESSION (iOS 17 beta): &quot;Origin&quot; field is missing in the request when using &quot;Link modulepreload&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258863">https://bugs.webkit.org/show_bug.cgi?id=258863</a>
rdar://111800089

Reviewed by Ryosuke Niwa.

260709@main forgot to add the updateRequestForAccessControl call from
createPotentialAccessControlRequest.  The Origin header is added in the network
process for network loads, but for loads through WKURLSchemeHandler we never
get an Origin header any more.  This adds it back.

* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preloadIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKURLSchemeHandler-1.mm:

Canonical link: <a href="https://commits.webkit.org/266054@main">https://commits.webkit.org/266054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f263bafcd8f0333b5232259f51018282de10fa6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14852 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12866 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14885 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18577 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14862 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11386 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1442 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->