### PR TITLE
[JSC] Further optimize JSRopeString::resolveRope

### DIFF
--- a/JSTests/microbenchmarks/rope-resolve-recursive.js
+++ b/JSTests/microbenchmarks/rope-resolve-recursive.js
@@ -1,0 +1,12 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+for (var i = 0; i < 100; ++i) {
+    let string = '';
+    for (let i = 0; i < 3e4; ++i)
+        string += String.fromCharCode(i & 0x7f);
+    shouldBe(string.length, 3e4);
+    shouldBe(string[30], String.fromCharCode(30 & 0x7f));
+}

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -142,7 +142,7 @@ DEFINE_VISIT_CHILDREN(JSString);
 template<typename CharacterType>
 void JSRopeString::resolveRopeInternalNoSubstring(CharacterType* buffer, uint8_t* stackLimit) const
 {
-    resolveToBuffer(this, buffer, length(), stackLimit);
+    resolveToBuffer(fiber0(), fiber1(), fiber2(), buffer, length(), stackLimit);
 }
 
 AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -594,12 +594,12 @@ public:
     // The rope value will remain a null string in that case.
     JS_EXPORT_PRIVATE const String& resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const;
 
-    template<typename Fibers, typename CharacterType>
-    static void resolveToBuffer(Fibers*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
+    template<typename CharacterType>
+    static void resolveToBuffer(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
 
 private:
-    template<typename Fibers, typename CharacterType>
-    static void resolveToBufferSlow(Fibers*, CharacterType* buffer, unsigned length);
+    template<typename CharacterType>
+    static void resolveToBufferSlow(JSString*, JSString*, JSString*, CharacterType* buffer, unsigned length, uint8_t* stackLimit);
 
     static JSRopeString* create(VM& vm, JSString* s1, JSString* s2)
     {

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -112,22 +112,6 @@ inline void JSRopeString::convertToNonRope(String&& string) const
     ASSERT(!JSString::isRope());
 }
 
-class JSStringFibers {
-public:
-    JSStringFibers(JSString* s1, JSString* s2, JSString* s3)
-        : m_fibers { s1, s2, s3 }
-    {
-    }
-
-    JSString* fiber(unsigned index) const { return m_fibers[index]; }
-    JSString* fiber0() const { return m_fibers[0]; }
-    JSString* fiber1() const { return m_fibers[1]; }
-    JSString* fiber2() const { return m_fibers[2]; }
-
-private:
-    std::array<JSString*, JSRopeString::s_maxInternalRopeLength> m_fibers { };
-};
-
 // Overview: These functions convert a JSString from holding a string in rope form
 // down to a simple String representation. It does so by building up the string
 // backwards, since we want to avoid recursion, we expect that the tree structure
@@ -138,22 +122,24 @@ private:
 // Vector before performing any concatenation, but by working backwards we likely
 // only fill the queue with the number of substrings at any given level in a
 // rope-of-ropes.)
-template<typename Fibers, typename CharacterType>
-void JSRopeString::resolveToBufferSlow(Fibers* fibers, CharacterType* buffer, unsigned length)
+template<typename CharacterType>
+void JSRopeString::resolveToBufferSlow(JSString* fiber0, JSString* fiber1, JSString* fiber2, CharacterType* buffer, unsigned length, uint8_t*)
 {
+    // Keep in mind that resolveToBufferSlow signature must be the same to resolveToBuffer to encourage tail-calls by clang, that's the reason why
+    // it takes the last stackLimit parameter still while it is not used here.
+
     CharacterType* position = buffer + length; // We will be working backwards over the rope.
     Vector<JSString*, 32, UnsafeVectorOverflow> workQueue; // These strings are kept alive by the parent rope, so using a Vector is OK.
 
-    for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
-        JSString* fiber = fibers->fiber(i);
-        if (!fiber)
-            break;
-        workQueue.append(fiber);
+    workQueue.append(fiber0);
+    if (fiber1) {
+        workQueue.append(fiber1);
+        if (fiber2)
+            workQueue.append(fiber2);
     }
 
-    while (!workQueue.isEmpty()) {
-        JSString* currentFiber = workQueue.last();
-        workQueue.removeLast();
+    do {
+        JSString* currentFiber = workQueue.takeLast();
 
         if (currentFiber->isRope()) {
             JSRopeString* currentFiberAsRope = static_cast<JSRopeString*>(currentFiber);
@@ -174,35 +160,33 @@ void JSRopeString::resolveToBufferSlow(Fibers* fibers, CharacterType* buffer, un
         StringView view = *currentFiber->valueInternal().impl();
         position -= view.length();
         view.getCharacters(position);
-    }
+    } while (!workQueue.isEmpty());
 
     ASSERT(buffer == position);
 }
 
-template<typename Fibers, typename CharacterType>
-inline void JSRopeString::resolveToBuffer(Fibers* fibers, CharacterType* buffer, unsigned length, uint8_t* stackLimit)
+template<typename CharacterType>
+inline void JSRopeString::resolveToBuffer(JSString* fiber0, JSString* fiber1, JSString* fiber2, CharacterType* buffer, unsigned length, uint8_t* stackLimit)
 {
-    if (UNLIKELY(bitwise_cast<uint8_t*>(currentStackPointer()) < stackLimit))
-        return JSRopeString::resolveToBufferSlow(fibers, buffer, length);
-
+    // We must ensure that all JSRopeString::resolveToBufferSlow and JSRopeString::resolveToBuffer calls must be done directly from this function, and it has
+    // exact same signature to JSRopeString::resolveToBuffer, which will be esured by clang via MUST_TAIL_CALL attribute.
+    // This allows clang to make these calls tail-calls, constructing significantly efficient rope resolution here.
     static_assert(3 == JSRopeString::s_maxInternalRopeLength);
-    CharacterType* position = buffer;
-    auto* fiber0 = fibers->fiber0();
-    auto* fiber1 = fibers->fiber1();
-    auto* fiber2 = fibers->fiber2();
+
+    if (UNLIKELY(bitwise_cast<uint8_t*>(currentStackPointer()) < stackLimit))
+        MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, stackLimit);
 
     // 3 fibers.
     if (fiber2) {
         if (fiber0->isRope() || fiber1->isRope() || fiber2->isRope())
-            return JSRopeString::resolveToBufferSlow(fibers, buffer, length);
+            MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, stackLimit);
 
-        for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
-            JSString* fiber = fibers->fiber(i);
-            ASSERT(!fiber->isRope());
-            StringView view = fiber->valueInternal().impl();
-            view.getCharacters(position);
-            position += view.length();
-        }
+        StringView view0 = fiber0->valueInternal().impl();
+        view0.getCharacters(buffer);
+        StringView view1 = fiber1->valueInternal().impl();
+        view1.getCharacters(buffer + view0.length());
+        StringView view2 = fiber2->valueInternal().impl();
+        view2.getCharacters(buffer + view0.length() + view1.length());
         return;
     }
 
@@ -210,46 +194,51 @@ inline void JSRopeString::resolveToBuffer(Fibers* fibers, CharacterType* buffer,
     if (LIKELY(fiber1)) {
         if (fiber0->isRope()) {
             if (fiber1->isRope())
-                return JSRopeString::resolveToBufferSlow(fibers, buffer, length);
+                MUST_TAIL_CALL return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, stackLimit);
 
             auto* rope0 = static_cast<const JSRopeString*>(fiber0);
-            StringView view1 = fiber1->valueInternal().impl();
-            view1.getCharacters(position + rope0->length());
+            {
+                StringView view1 = fiber1->valueInternal().impl();
+                view1.getCharacters(buffer + rope0->length());
+            }
             if (rope0->isSubstring()) {
                 StringView view0 = *rope0->substringBase()->valueInternal().impl();
                 unsigned offset = rope0->substringOffset();
                 unsigned length = rope0->length();
-                view0.substring(offset, length).getCharacters(position);
+                view0.substring(offset, length).getCharacters(buffer);
                 return;
             }
-            return resolveToBuffer(rope0, position, rope0->length(), stackLimit);
+            MUST_TAIL_CALL return resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer, rope0->length(), stackLimit);
         }
 
         if (fiber1->isRope()) {
-            StringView view0 = fiber0->valueInternal().impl();
-            view0.getCharacters(position);
             auto* rope1 = static_cast<const JSRopeString*>(fiber1);
+            {
+                StringView view0 = fiber0->valueInternal().impl();
+                view0.getCharacters(buffer);
+                buffer += view0.length();
+            }
             if (rope1->isSubstring()) {
                 StringView view1 = *rope1->substringBase()->valueInternal().impl();
                 unsigned offset = rope1->substringOffset();
                 unsigned length = rope1->length();
-                view1.substring(offset, length).getCharacters(position + view0.length());
+                view1.substring(offset, length).getCharacters(buffer);
                 return;
             }
-            return resolveToBuffer(rope1, position + view0.length(), rope1->length(), stackLimit);
+            MUST_TAIL_CALL return resolveToBuffer(rope1->fiber0(), rope1->fiber1(), rope1->fiber2(), buffer, rope1->length(), stackLimit);
         }
 
         StringView view0 = fiber0->valueInternal().impl();
-        view0.getCharacters(position);
+        view0.getCharacters(buffer);
         StringView view1 = fiber1->valueInternal().impl();
-        view1.getCharacters(position + view0.length());
+        view1.getCharacters(buffer + view0.length());
         return;
     }
 
     // 1 fiber.
     if (!fiber0->isRope()) {
         StringView view0 = fiber0->valueInternal().impl();
-        view0.getCharacters(position);
+        view0.getCharacters(buffer);
         return;
     }
 
@@ -258,10 +247,10 @@ inline void JSRopeString::resolveToBuffer(Fibers* fibers, CharacterType* buffer,
         StringView view0 = *rope0->substringBase()->valueInternal().impl();
         unsigned offset = rope0->substringOffset();
         unsigned length = rope0->length();
-        view0.substring(offset, length).getCharacters(position);
+        view0.substring(offset, length).getCharacters(buffer);
         return;
     }
-    return resolveToBuffer(rope0, position, rope0->length(), stackLimit);
+    MUST_TAIL_CALL return resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer, rope0->length(), stackLimit);
 }
 
 inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* string)
@@ -305,14 +294,17 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
     AtomString atomString;
     if (!ropeString->isSubstring()) {
         uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
+        JSString* fiber0 = ropeString->fiber0();
+        JSString* fiber1 = ropeString->fiber1();
+        JSString* fiber2 = ropeString->fiber2();
         if (ropeString->is8Bit()) {
             LChar characters[KeyAtomStringCache::maxStringLengthForCache];
-            JSRopeString::resolveToBuffer(ropeString, characters, length, stackLimit);
+            JSRopeString::resolveToBuffer(fiber0, fiber1, fiber2, characters, length, stackLimit);
             WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
             return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
         }
         UChar characters[KeyAtomStringCache::maxStringLengthForCache];
-        JSRopeString::resolveToBuffer(ropeString, characters, length, stackLimit);
+        JSRopeString::resolveToBuffer(fiber0, fiber1, fiber2, characters, length, stackLimit);
         WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
         return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
     }
@@ -355,16 +347,55 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1
         return jsString(vm, String { AtomStringImpl::add(buffer) });
     };
 
-    uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
-    JSStringFibers fibers(s1, s2, nullptr);
+    // This is quite unfortunate, but duplicating this part here is the key of performance improvement in JetStream2/WSL,
+    // which stress this jsAtomString significantly.
+    auto resolveWith2Fibers = [&](JSString* fiber0, JSString* fiber1, auto* buffer, unsigned length) {
+        uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
+        if (fiber0->isRope()) {
+            if (fiber1->isRope())
+                return JSRopeString::resolveToBufferSlow(fiber0, fiber1, nullptr, buffer, length, stackLimit);
+
+            auto* rope0 = static_cast<const JSRopeString*>(fiber0);
+            StringView view1 = fiber1->valueInternal().impl();
+            view1.getCharacters(buffer + rope0->length());
+            if (rope0->isSubstring()) {
+                StringView view0 = *rope0->substringBase()->valueInternal().impl();
+                unsigned offset = rope0->substringOffset();
+                unsigned length = rope0->length();
+                view0.substring(offset, length).getCharacters(buffer);
+                return;
+            }
+            return JSRopeString::resolveToBuffer(rope0->fiber0(), rope0->fiber1(), rope0->fiber2(), buffer, rope0->length(), stackLimit);
+        }
+
+        if (fiber1->isRope()) {
+            StringView view0 = fiber0->valueInternal().impl();
+            view0.getCharacters(buffer);
+            auto* rope1 = static_cast<const JSRopeString*>(fiber1);
+            if (rope1->isSubstring()) {
+                StringView view1 = *rope1->substringBase()->valueInternal().impl();
+                unsigned offset = rope1->substringOffset();
+                unsigned length = rope1->length();
+                view1.substring(offset, length).getCharacters(buffer + view0.length());
+                return;
+            }
+            return JSRopeString::resolveToBuffer(rope1->fiber0(), rope1->fiber1(), rope1->fiber2(), buffer + view0.length(), rope1->length(), stackLimit);
+        }
+
+        StringView view0 = fiber0->valueInternal().impl();
+        view0.getCharacters(buffer);
+        StringView view1 = fiber1->valueInternal().impl();
+        view1.getCharacters(buffer + view0.length());
+    };
+
     if (s1->is8Bit() && s2->is8Bit()) {
         LChar characters[KeyAtomStringCache::maxStringLengthForCache];
-        JSRopeString::resolveToBuffer(&fibers, characters, length, stackLimit);
+        resolveWith2Fibers(s1, s2, characters, length);
         WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
         return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
     }
     UChar characters[KeyAtomStringCache::maxStringLengthForCache];
-    JSRopeString::resolveToBuffer(&fibers, characters, length, stackLimit);
+    resolveWith2Fibers(s1, s2, characters, length);
     WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
     return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }
@@ -404,16 +435,26 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1
         return jsString(vm, String { AtomStringImpl::add(buffer) });
     };
 
-    uint8_t* stackLimit = bitwise_cast<uint8_t*>(vm.softStackLimit());
-    JSStringFibers fibers(s1, s2, s3);
+    auto resolveWith3Fibers = [&](JSString* fiber0, JSString* fiber1, JSString* fiber2, auto* buffer, unsigned length) {
+        if (fiber0->isRope() || fiber1->isRope() || fiber2->isRope())
+            return JSRopeString::resolveToBufferSlow(fiber0, fiber1, fiber2, buffer, length, bitwise_cast<uint8_t*>(vm.softStackLimit()));
+
+        StringView view0 = fiber0->valueInternal().impl();
+        view0.getCharacters(buffer);
+        StringView view1 = fiber1->valueInternal().impl();
+        view1.getCharacters(buffer + view0.length());
+        StringView view2 = fiber2->valueInternal().impl();
+        view2.getCharacters(buffer + view0.length() + view1.length());
+    };
+
     if (s1->is8Bit() && s2->is8Bit() && s3->is8Bit()) {
         LChar characters[KeyAtomStringCache::maxStringLengthForCache];
-        JSRopeString::resolveToBuffer(&fibers, characters, length, stackLimit);
+        resolveWith3Fibers(s1, s2, s3, characters, length);
         WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
         return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
     }
     UChar characters[KeyAtomStringCache::maxStringLengthForCache];
-    JSRopeString::resolveToBuffer(&fibers, characters, length, stackLimit);
+    resolveWith3Fibers(s1, s2, s3, characters, length);
     WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
     return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -281,6 +281,18 @@
 #define NOT_TAIL_CALLED
 #endif
 
+/* MUST_TAIL_CALL */
+
+#if !defined(MUST_TAIL_CALL) && defined(__cplusplus) && defined(__has_cpp_attribute)
+#if __has_cpp_attribute(clang::musttail)
+#define MUST_TAIL_CALL [[clang::musttail]]
+#endif
+#endif
+
+#if !defined(MUST_TAIL_CALL)
+#define MUST_TAIL_CALL
+#endif
+
 /* RETURNS_NONNULL */
 #if !defined(RETURNS_NONNULL) && COMPILER(GCC_COMPATIBLE)
 #define RETURNS_NONNULL __attribute__((returns_nonnull))


### PR DESCRIPTION
#### 4d816460b765acd8aef90ab474615850b91ecc35
<pre>
[JSC] Further optimize JSRopeString::resolveRope
<a href="https://bugs.webkit.org/show_bug.cgi?id=259203">https://bugs.webkit.org/show_bug.cgi?id=259203</a>
rdar://112241674

Reviewed by Mark Lam.

This patch furhter improves JSRopeString::resolveRope and jsAtomString.

1. We crafted JSRopeString::resolveToBuffer very carefully so that it becomes tail calls well.
   This allows clang to make it loop instead of calls for recursive resolveToBuffer calls, which
   is significantly efficient. We ensure this condition is met by using MUST_TAIL_CALL C++ attribute,
   which is available in clang.
2. We tweak jsAtomString to make it better in terms of performance. It turned out these duplicate part
   is mandatory to make it super efficient, which is observed by JetStream2/WSL.

Simple rope resolution gets 3-4% improvement.

                                   ToT                     Patched

rope-resolve-recursive       21.3292+-0.6975     ^     20.5524+-0.0687        ^ definitely 1.0378x faster

* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeInternalNoSubstring const):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::resolveToBufferSlow):
(JSC::JSRopeString::resolveToBuffer):
(JSC::jsAtomString):
(JSC::JSStringFibers::JSStringFibers): Deleted.
(JSC::JSStringFibers::fiber const): Deleted.
(JSC::JSStringFibers::fiber0 const): Deleted.
(JSC::JSStringFibers::fiber1 const): Deleted.
(JSC::JSStringFibers::fiber2 const): Deleted.
(): Deleted.
* Source/WTF/wtf/Compiler.h:

Canonical link: <a href="https://commits.webkit.org/266060@main">https://commits.webkit.org/266060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39683a0a0264ae19f5e0c66fc798d2289cac6c16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12724 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12168 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14871 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12888 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14908 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11517 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18595 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10819 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14881 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12046 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12779 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11401 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3355 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13138 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1444 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3143 "Passed tests") | 
<!--EWS-Status-Bubble-End-->