### PR TITLE
Unreviewed non-unified source builds fix 2023-07-14

### DIFF
--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -35,8 +35,11 @@
 #include "Document.h"
 #include "JSCookieListItem.h"
 #include "JSDOMPromiseDeferred.h"
+#include "Page.h"
 #include "ScriptExecutionContext.h"
+#include "SecurityOrigin.h"
 #include <optional>
+#include <wtf/CompletionHandler.h>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -39,6 +39,7 @@
 #include "CrossOriginOpenerPolicy.h"
 #include "PolicyContainer.h"
 #include "SecurityOrigin.h"
+#include "URLKeepingBlobAlive.h"
 #include <mutex>
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/CrossThreadTask.h>

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.h
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.h
@@ -37,6 +37,8 @@ namespace WebCore {
 
 class BlobPart;
 class SecurityOrigin;
+class SecurityOriginData;
+class URLKeepingBlobAlive;
 
 struct PolicyContainer;
 

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -28,6 +28,7 @@
 
 #include "HTMLImageElement.h"
 #include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
 #include "LocalFrame.h"
 #include <limits>
 

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "APIFrameTreeNode.h"
 
+#include "WebPageProxy.h"
+
 namespace API {
 
 FrameTreeNode::~FrameTreeNode() = default;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -26,6 +26,10 @@
 #include "config.h"
 #include "ProvisionalFrameProxy.h"
 
+#include "VisitedLinkStore.h"
+#include "WebFrameProxy.h"
+#include "WebPageProxy.h"
+
 namespace WebKit {
 
 ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProcessProxy>&& process)


### PR DESCRIPTION
#### 4e68a149e83d28ec2963a292147c15e412b7ce0b
<pre>
Unreviewed non-unified source builds fix 2023-07-14
<a href="https://bugs.webkit.org/show_bug.cgi?id=259204">https://bugs.webkit.org/show_bug.cgi?id=259204</a>

* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
* Source/WebCore/fileapi/ThreadableBlobRegistry.h:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
* Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:

Canonical link: <a href="https://commits.webkit.org/266055@main">https://commits.webkit.org/266055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/360ae8577dbd59578a7046d9cf2fd7d4f7c51466

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14856 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14893 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/10908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11502 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14866 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11391 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3116 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->