### PR TITLE
Fix Windows port clang-cl warnings for WebKit and Tools

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -98,9 +98,9 @@ uint64_t RemoteWCLayerTreeHost::messageSenderDestinationID() const
 
 void RemoteWCLayerTreeHost::update(WCUpdateInfo&& update, CompletionHandler<void(std::optional<WebKit::UpdateInfo>)>&& completionHandler)
 {
-    remoteGraphicsStreamWorkQueue().dispatch([this, weakThis = WeakPtr(*this), scene = m_scene.get(), update = WTFMove(update), completionHandler = WTFMove(completionHandler)]() mutable {
+    remoteGraphicsStreamWorkQueue().dispatch([weakThis = WeakPtr(*this), scene = m_scene.get(), update = WTFMove(update), completionHandler = WTFMove(completionHandler)]() mutable {
         auto updateInfo = scene->update(WTFMove(update));
-        RunLoop::main().dispatch([this, weakThis = WTFMove(weakThis), updateInfo = WTFMove(updateInfo), completionHandler = WTFMove(completionHandler)]() mutable {
+        RunLoop::main().dispatch([weakThis = WTFMove(weakThis), updateInfo = WTFMove(updateInfo), completionHandler = WTFMove(completionHandler)]() mutable {
             if (!weakThis)
                 return;
             completionHandler(WTFMove(updateInfo));

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -435,6 +435,9 @@ void Cache::retrieve(const WebCore::ResourceRequest& request, const GlobalFrameI
 #else
             UNUSED_PARAM(frameID);
             UNUSED_PARAM(this);
+            UNUSED_PARAM(isNavigatingToAppBoundDomain);
+            UNUSED_PARAM(allowPrivacyProxy);
+            UNUSED_PARAM(advancedPrivacyProtections);
 #endif
             FALLTHROUGH;
         }

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -48,7 +48,7 @@ class WebSocketTask : public CanMakeWeakPtr<WebSocketTask>, public WebCore::Curl
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebSocketTask(NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol);
-    ~WebSocketTask();
+    virtual ~WebSocketTask();
 
     void sendString(const IPC::DataReference&, CompletionHandler<void()>&&);
     void sendData(const IPC::DataReference&, CompletionHandler<void()>&&);

--- a/Source/WebKit/Shared/win/WebEventFactory.h
+++ b/Source/WebKit/Shared/win/WebEventFactory.h
@@ -48,6 +48,6 @@ public:
 #endif
 };
 
-inline MSG createNativeEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) { return { hwnd, message, wParam, lParam }; }
+inline MSG createNativeEvent(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) { return { hwnd, message, wParam, lParam, 0, { } }; }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -86,7 +86,7 @@ public:
         m_inspectorClient.closeFromFrontend(m_connectionID, m_targetID);
     }
 
-    Ref<API::InspectorConfiguration> configurationForRemoteInspector(RemoteWebInspectorUIProxy&)
+    Ref<API::InspectorConfiguration> configurationForRemoteInspector(RemoteWebInspectorUIProxy&) override
     {
         return API::InspectorConfiguration::create();
     }

--- a/Tools/MiniBrowser/win/MainWindow.cpp
+++ b/Tools/MiniBrowser/win/MainWindow.cpp
@@ -125,7 +125,6 @@ void MainWindow::createToolbar(HINSTANCE hInstance)
         return;
 
     const int ImageListID = 0;
-    const int numButtons = 4;
 
     HIMAGELIST hImageList;
     hImageList = ImageList_LoadImage(hInstance, MAKEINTRESOURCE(IDB_TOOLBAR), kToolbarImageSize, 0, CLR_DEFAULT, IMAGE_BITMAP, 0);
@@ -159,7 +158,9 @@ void MainWindow::createToolbar(HINSTANCE hInstance)
 
 void MainWindow::resizeToolbar(int parentWidth)
 {
-    TBBUTTONINFO info { sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_SIZE };
+    TBBUTTONINFO info { };
+    info.cbSize = sizeof(TBBUTTONINFO);
+    info.dwMask = TBIF_BYINDEX | TBIF_SIZE;
     info.cx = parentWidth - m_toolbarItemsWidth;
     SendMessage(m_hToolbarWnd, TB_SETBUTTONINFO, kToolbarURLBarIndex, reinterpret_cast<LPARAM>(&info));
 
@@ -178,8 +179,9 @@ void MainWindow::rescaleToolbar()
     const float scaleFactor = WebCore::deviceScaleFactorForWindow(m_hMainWnd);
     const int scaledImageSize = kToolbarImageSize * scaleFactor;
 
-    TBBUTTONINFO info { sizeof(TBBUTTONINFO), TBIF_BYINDEX | TBIF_SIZE };
-
+    TBBUTTONINFO info { };
+    info.cbSize = sizeof(TBBUTTONINFO);
+    info.dwMask = TBIF_BYINDEX | TBIF_SIZE;
     info.cx = 0;
     SendMessage(m_hToolbarWnd, TB_SETBUTTONINFO, kToolbarURLBarIndex, reinterpret_cast<LPARAM>(&info));
     info.cx = scaledImageSize * 2;

--- a/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp
@@ -123,9 +123,11 @@ TEST(WTF_StdLibExtras, MakeUniqueFunctionLocalTypeCompiles)
     struct LocalStruct {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
     };
+    IGNORE_CLANG_WARNINGS_BEGIN("unused-local-typedef")
     class LocalClass {
         WTF_MAKE_FAST_ALLOCATED;
     };
+    IGNORE_CLANG_WARNINGS_END
     auto s = makeUnique<LocalStruct>();
     auto c = makeUnique<LocalClass>();
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp
@@ -568,7 +568,7 @@ TEST(FloatRect, Transpose)
     EXPECT_FLOAT_EQ(120.0f, transposed.maxY());
 }
 
-#if USE(CG) || PLATFORM(WIN)
+#if USE(CG)
 static void checkCastRect(const WebCore::FloatRect& rect)
 {
     EXPECT_FLOAT_EQ(10.0f, rect.x());

--- a/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp
@@ -45,7 +45,6 @@ namespace TestWebKitAPI {
 
 static bool loadBeforeCrash = false;
 static bool loadAfterCrash = false;
-static bool calledCrashHandler = false;
 
 static void didFinishLoad(WKPageRef page, WKNavigationRef, WKTypeRef userData, const void* clientInfo)
 {
@@ -99,6 +98,8 @@ TEST(WebKit, ReloadPageAfterCrash)
 }
 
 #if !PLATFORM(WIN)
+
+static bool calledCrashHandler = false;
 
 static void nullJavaScriptCallback(WKSerializedScriptValueRef, WKErrorRef, void*)
 {


### PR DESCRIPTION
#### e51b17e2f6135304d65a02193e1d5acd59a9ffc4
<pre>
Fix Windows port clang-cl warnings for WebKit and Tools
<a href="https://bugs.webkit.org/show_bug.cgi?id=259206">https://bugs.webkit.org/show_bug.cgi?id=259206</a>

Reviewed by Yusuke Suzuki.

clang-cl reported the following warnings for Windows port WebKit and Tools:

include\memory(3167,9): warning: delete called on non-final &apos;WebKit::WebSocketTask&apos; that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
include\memory(3167,9): warning: delete called on non-final &apos;WebKit::WebSocketTask&apos; that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
Source\WebKit\GPUProcess\graphics\wc\RemoteWCLayerTreeHost.cpp(103,35): warning: lambda capture &apos;this&apos; is not used [-Wunused-lambda-capture]
Source\WebKit\NetworkProcess/cache/NetworkCache.cpp(415,253): warning: lambda capture &apos;isNavigatingToAppBoundDomain&apos; is not used [-Wunused-lambda-capture]
Source\WebKit\NetworkProcess/cache/NetworkCache.cpp(415,283): warning: lambda capture &apos;allowPrivacyProxy&apos; is not used [-Wunused-lambda-capture]
Source\WebKit\NetworkProcess/cache/NetworkCache.cpp(415,302): warning: lambda capture &apos;advancedPrivacyProtections&apos; is not used [-Wunused-lambda-capture]
Source\WebKit\Shared\win/WebEventFactory.h(51,126): warning: missing field &apos;time&apos; initializer [-Wmissing-field-initializers]
Source\WebKit\UIProcess\Inspector\socket\RemoteInspectorClient.cpp(89,38): warning: &apos;configurationForRemoteInspector&apos; overrides a member function but is not marked &apos;override&apos; [-Winconsistent-missing-override]
Tools\MiniBrowser\win\MainWindow.cpp(128,15): warning: unused variable &apos;numButtons&apos; [-Wunused-variable]
Tools\MiniBrowser\win\MainWindow.cpp(162,72): warning: missing field &apos;idCommand&apos; initializer [-Wmissing-field-initializers]
Tools\MiniBrowser\win\MainWindow.cpp(181,72): warning: missing field &apos;idCommand&apos; initializer [-Wmissing-field-initializers]
Tools\TestWebKitAPI\Tests\WTF\StdLibExtrasTests.cpp(127,9): warning: unused type alias &apos;__thisIsHereToForceASemicolonAfterThisMacro&apos; [-Wunused-local-typedef]
Tools\TestWebKitAPI\Tests\WebCore\FloatRectTests.cpp(572,13): warning: unused function &apos;checkCastRect&apos; [-Wunused-function]
Tools\TestWebKitAPI\Tests\WebKit\ReloadPageAfterCrash.cpp(48,13): warning: unused variable &apos;calledCrashHandler&apos; [-Wunused-variable]

* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::RemoteWCLayerTreeHost::update):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::retrieve):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
* Source/WebKit/Shared/win/WebEventFactory.h:
(WebKit::createNativeEvent):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp:
* Tools/MiniBrowser/win/MainWindow.cpp:
(MainWindow::createToolbar):
(MainWindow::resizeToolbar):
(MainWindow::rescaleToolbar):
* Tools/TestWebKitAPI/Tests/WTF/StdLibExtrasTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/FloatRectTests.cpp:
* Tools/TestWebKitAPI/Tests/WebKit/ReloadPageAfterCrash.cpp:

Canonical link: <a href="https://commits.webkit.org/266057@main">https://commits.webkit.org/266057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5985937aa8eb83f6f8f76b8969c5dd83c4554207

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14458 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12883 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14902 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11513 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18588 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14873 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11397 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3117 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->