### PR TITLE
[Curl] Remove chunked transfer processing for PUT/POST methods

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -259,10 +259,8 @@ public:
     void enableHttp();
     void enableHttpGetRequest();
     void enableHttpHeadRequest();
-    void enableHttpPostRequest();
-    void setPostFieldSize(curl_off_t);
-    void enableHttpPutRequest();
-    void setInFileSize(curl_off_t);
+    void enableHttpPostRequest(curl_off_t size);
+    void enableHttpPutRequest(curl_off_t size);
     void setHttpCustomRequest(const String&);
 
     void enableConnectionOnly();
@@ -326,7 +324,6 @@ private:
     };
 
     void enableRequestHeaders();
-    static int expectedSizeOfCurlOffT();
 
     static CURLcode willSetupSslCtxCallback(CURL*, void* sslCtx, void* userData);
     CURLcode willSetupSslCtx(void* sslCtx);

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -35,7 +35,6 @@
 #if USE(CURL)
 
 #include "BlobRegistry.h"
-#include "CurlContext.h"
 #include "Logging.h"
 #include <wtf/MainThread.h>
 
@@ -81,29 +80,20 @@ const Vector<uint8_t>* CurlFormDataStream::getPostData()
     return m_postData.get();
 }
 
-bool CurlFormDataStream::shouldUseChunkTransfer()
-{
-    computeContentLength();
-
-    return m_shouldUseChunkTransfer;
-}
-
 unsigned long long CurlFormDataStream::totalSize()
 {
-    computeContentLength();
+    if (!m_formData)
+        return 0;
 
-    return m_totalSize;
-}
-
-void CurlFormDataStream::computeContentLength()
-{
-    if (!m_formData || m_isContentLengthUpdated)
-        return;
+    if (m_isContentLengthUpdated)
+        return m_totalSize;
 
     m_isContentLengthUpdated = true;
 
     for (const auto& element : m_formData->elements())
         m_totalSize += element.lengthInBytes();
+
+    return m_totalSize;
 }
 
 std::optional<size_t> CurlFormDataStream::read(char* buffer, size_t size)

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.h
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.h
@@ -39,18 +39,13 @@ public:
 
     void clean();
 
-    size_t elementSize() { return m_formData ? m_formData->elements().size() : 0; }
-
     const Vector<uint8_t>* getPostData();
-    bool shouldUseChunkTransfer();
     unsigned long long totalSize();
 
     std::optional<size_t> read(char*, size_t);
     unsigned long long totalReadSize() { return m_totalReadSize; }
 
 private:
-    void computeContentLength();
-
     std::optional<size_t> readFromFile(const FormDataElement::EncodedFileData&, char*, size_t);
     std::optional<size_t> readFromData(const Vector<uint8_t>&, char*, size_t);
 
@@ -58,7 +53,6 @@ private:
 
     std::unique_ptr<Vector<uint8_t>> m_postData;
     bool m_isContentLengthUpdated { false };
-    bool m_shouldUseChunkTransfer { false };
     unsigned long long m_totalSize { 0 };
     unsigned long long m_totalReadSize { 0 };
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -114,7 +114,6 @@ private:
     void appendAcceptLanguageHeader(HTTPHeaderMap&);
     void setupPOST();
     void setupPUT();
-    void setupSendData(bool forPutMethod);
 
     // Processing for DidReceiveResponse
     bool needToInvokeDidReceiveResponse() const { return m_didReceiveResponse && !m_didNotifyResponse; }


### PR DESCRIPTION
#### 04637e99dc2ac4864a2b21553f377ce9ec553977
<pre>
[Curl] Remove chunked transfer processing for PUT/POST methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=259209">https://bugs.webkit.org/show_bug.cgi?id=259209</a>

Reviewed by Fujii Hironori.

CurlFormDataStream::shouldUseChunkTransfer() always returns false since 204820@main.
Since chunked transfer processing has not been used for a long time, we will
remove chunked transfer processing for PUT/POST methods.

It also requires libcurl built with large file support as a required feature.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlContext::CurlContext):
(WebCore::CurlHandle::enableHttpPostRequest):
(WebCore::CurlHandle::enableHttpPutRequest):
(WebCore::CurlHandle::setPostFieldSize): Deleted.
(WebCore::CurlHandle::setInFileSize): Deleted.
(WebCore::CurlHandle::expectedSizeOfCurlOffT): Deleted.
* Source/WebCore/platform/network/curl/CurlContext.h:
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::totalSize):
(WebCore::CurlFormDataStream::shouldUseChunkTransfer): Deleted.
(WebCore::CurlFormDataStream::computeContentLength): Deleted.
* Source/WebCore/platform/network/curl/CurlFormDataStream.h:
(WebCore::CurlFormDataStream::elementSize): Deleted.
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::setupPUT):
(WebCore::CurlRequest::setupPOST):
(WebCore::CurlRequest::setupSendData): Deleted.
* Source/WebCore/platform/network/curl/CurlRequest.h:

Canonical link: <a href="https://commits.webkit.org/266059@main">https://commits.webkit.org/266059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d14e16ddd7299d4d0dbc0f59b79cfba54c86fff6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12167 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12887 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/13630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/10768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14907 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11516 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/11992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/11684 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14879 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11400 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3118 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/11994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->