### PR TITLE
[WPE][GTK] API test `TestDownloads` `/webkit/Downloads/local-file-error` is flaky

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp
@@ -428,14 +428,6 @@ void webkitDownloadCancelled(WebKitDownload* download)
 
 void webkitDownloadFinished(WebKitDownload* download)
 {
-    if (download->priv->isCancelled) {
-        // Since cancellation is asynchronous, didFinish might be called even
-        // if the download was cancelled. User cancelled the download,
-        // so we should fail with cancelled error even if the download
-        // actually finished successfully.
-        webkitDownloadCancelled(download);
-        return;
-    }
     if (download->priv->timer)
         g_timer_stop(download->priv->timer.get());
     g_signal_emit(download, signals[FINISHED], 0, nullptr);
@@ -602,7 +594,7 @@ void webkit_download_cancel(WebKitDownload* download)
 
     download->priv->isCancelled = true;
     download->priv->download->cancel([download = Ref { *download->priv->download }] (auto*) {
-        download->client().didFinish(download.get());
+        download->client().legacyDidCancel(download.get());
     });
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp
@@ -93,19 +93,28 @@ private:
 
     void didFail(DownloadProxy& downloadProxy, const ResourceError& error, API::Data*) override
     {
+        if (webkitDownloadIsCancelled(m_download.get()))
+            return;
+
         ASSERT(m_download);
-        if (webkitDownloadIsCancelled(m_download.get())) {
-            // Cancellation takes precedence over other errors.
-            webkitDownloadCancelled(m_download.get());
-        } else
-            webkitDownloadFailed(m_download.get(), error);
+        webkitDownloadFailed(m_download.get(), error);
         m_download = nullptr;
     }
 
     void didFinish(DownloadProxy& downloadProxy) override
     {
+        if (webkitDownloadIsCancelled(m_download.get()))
+            return;
+
         ASSERT(m_download);
         webkitDownloadFinished(m_download.get());
+        m_download = nullptr;
+    }
+
+    void legacyDidCancel(WebKit::DownloadProxy&)
+    {
+        ASSERT(m_download);
+        webkitDownloadCancelled(m_download.get());
         m_download = nullptr;
     }
 


### PR DESCRIPTION
#### b73ca668112d75dd0975cd8568740eb65f3ff103
<pre>
[WPE][GTK] API test `TestDownloads` `/webkit/Downloads/local-file-error` is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=259210">https://bugs.webkit.org/show_bug.cgi?id=259210</a>

Reviewed by Carlos Garcia Campos.

In one of the subtests, we start downloading a local file and then
immediately cancel it.

When the download completes fast, `WebKitDownloadClient::didFinish()`
method can be called twice. Firstly, because the download is actually
completed, and secondly, from `Download::cancel()`&apos;s completion handler,
which we set in `webkit_download_cancel()&apos;.

Since we set `m_download` to `nullptr`
in `WebKitDownloadClient::didFinish()`, the second call will crash.

The solution is to call `WebKitDownloadClient::legacyDidCancel()`
instead of `WebKitDownloadClient::didFinish()` from the download&apos;s
cancel completion handler.

* Source/WebKit/UIProcess/API/glib/WebKitDownload.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitDownloadClient.cpp:

Canonical link: <a href="https://commits.webkit.org/266725@main">https://commits.webkit.org/266725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6db690775f8d9002feb071619e71e1efcdce13e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14459 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16200 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13674 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16924 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12458 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20044 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13535 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16424 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11595 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13046 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3521 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->