### PR TITLE
Add release assert against key already existing in memory cache

### DIFF
--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -128,7 +128,10 @@ bool MemoryCache::add(CachedResource& resource)
 
     auto key = std::make_pair(resource.url(), resource.cachePartition());
 
-    ensureSessionResourceMap(resource.sessionID()).set(key, &resource);
+    auto& resources = ensureSessionResourceMap(resource.sessionID());
+
+    RELEASE_ASSERT(!resources.get(key));
+    resources.set(key, &resource);
     resource.setInCache(true);
     
     resourceAccessed(resource);
@@ -156,7 +159,7 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
     auto& resources = ensureSessionResourceMap(resource.sessionID());
     auto key = std::make_pair(resource.url(), resource.cachePartition());
 
-    ASSERT(!resources.get(key));
+    RELEASE_ASSERT(!resources.get(key));
     resources.set(key, &resource);
     resource.setInCache(true);
     resource.updateResponseAfterRevalidation(response);


### PR DESCRIPTION
#### 4f993e39b079abaeb0d60a51d5a70cb4f662dc23
<pre>
Add release assert against key already existing in memory cache
<a href="https://bugs.webkit.org/show_bug.cgi?id=259211">https://bugs.webkit.org/show_bug.cgi?id=259211</a>
rdar://112266773

Reviewed by Chris Dumez.

* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::add):
(WebCore::MemoryCache::revalidationSucceeded):

If the resource was there already we might end up with a resource with inCache flag still incorrectly set.

Canonical link: <a href="https://commits.webkit.org/266065@main">https://commits.webkit.org/266065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb496870b7cd42f50462c847d7694d2f9545a74d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14880 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14921 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18607 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14893 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10068 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11411 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3124 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/15730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->