### PR TITLE
Implement the delete function in the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL CookieListItem - cookieStore.set defaults with positional name and value promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set defaults with name and value in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with domain set to the current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with path set to the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with sameSite set to strict promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with sameSite set to lax promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieListItem - cookieStore.set with sameSite set to none promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (string) "localhost" but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
@@ -1,18 +1,16 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.delete with name in options' specified 1 'cleanup' function, and 1 failed.
-
-FAIL cookieStore.delete with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.delete with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-NOTRUN cookieStore.delete domain starts with "."
-NOTRUN cookieStore.delete with domain that is not equal current host
-NOTRUN cookieStore.delete with domain set to the current hostname
-NOTRUN cookieStore.delete with domain set to a subdomain of the current hostname
-NOTRUN cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
-NOTRUN cookieStore.delete with path set to the current directory
-NOTRUN cookieStore.delete with path set to subdirectory of the current directory
-NOTRUN cookieStore.delete with missing / at the end of path
-NOTRUN cookieStore.delete with path that does not start with /
-NOTRUN cookieStore.delete with get result
-NOTRUN cookieStore.delete with positional empty name
-NOTRUN cookieStore.delete with empty name in options
+PASS cookieStore.delete with positional name
+PASS cookieStore.delete with name in options
+FAIL cookieStore.delete domain starts with "." assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.delete with domain that is not equal current host assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.delete with domain set to the current hostname assert_equals: expected null but got object "[object Object]"
+FAIL cookieStore.delete with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.delete with path set to the current directory assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete with path set to subdirectory of the current directory
+FAIL cookieStore.delete with missing / at the end of path assert_equals: expected null but got object "[object Object]"
+FAIL cookieStore.delete with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.delete with get result assert_equals: expected null but got object "[object Object]"
+FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.delete return type is Promise<void> promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.delete return type is Promise<void>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt
@@ -1,5 +1,5 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore fires change event for cookie deleted by cookieStore.delete()' specified 1 'cleanup' function, and 1 failed.
+Harness Error (TIMEOUT), message = null
 
-FAIL cookieStore fires change event for cookie deleted by cookieStore.delete() promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+TIMEOUT cookieStore fires change event for cookie deleted by cookieStore.delete() Test timed out
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
@@ -1,13 +1,15 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.getAll with no arguments' specified 2 'cleanup' functions, and 2 failed.
-
 FAIL cookieStore.getAll with no arguments promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-NOTRUN cookieStore.getAll with empty options
-NOTRUN cookieStore.getAll with positional name
-NOTRUN cookieStore.getAll with name in options
-NOTRUN cookieStore.getAll with name in both positional arguments and options
-NOTRUN cookieStore.getAll with absolute url in options
-NOTRUN cookieStore.getAll with relative url in options
-NOTRUN cookieStore.getAll with invalid url path in options
-NOTRUN cookieStore.getAll with invalid url host in options
+FAIL cookieStore.getAll with empty options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with name in both positional arguments and options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with absolute url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with relative url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.getAll with invalid url path in options promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL cookieStore.getAll with invalid url host in options promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.getAll returns multiple cookies written by cookieStore.set' specified 3 'cleanup' functions, and 3 failed.
-
 FAIL cookieStore.getAll returns multiple cookies written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.getAll returns the cookie written by cookieStore.set' specified 1 'cleanup' function, and 1 failed.
-
 FAIL cookieStore.getAll returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt
@@ -1,13 +1,11 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.get with no arguments returns TypeError' specified 1 'cleanup' function, and 1 failed.
-
 FAIL cookieStore.get with no arguments returns TypeError assert_unreached: Should have rejected: undefined Reached unreachable code
-NOTRUN cookieStore.get with empty options returns TypeError
-NOTRUN cookieStore.get with positional name
-NOTRUN cookieStore.get with name in options
-NOTRUN cookieStore.get with name in both positional arguments and options
-NOTRUN cookieStore.get with absolute url in options
-NOTRUN cookieStore.get with relative url in options
-NOTRUN cookieStore.get with invalid url path in options
-NOTRUN cookieStore.get with invalid url host in options
+FAIL cookieStore.get with empty options returns TypeError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.get with positional name
+PASS cookieStore.get with name in options
+PASS cookieStore.get with name in both positional arguments and options
+PASS cookieStore.get with absolute url in options
+PASS cookieStore.get with relative url in options
+FAIL cookieStore.get with invalid url path in options assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL cookieStore.get with invalid url host in options assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.get returns null for a cookie deleted by cookieStore.delete' specified 1 'cleanup' function, and 1 failed.
-
-FAIL cookieStore.get returns null for a cookie deleted by cookieStore.delete promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.get returns null for a cookie deleted by cookieStore.delete
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.get() sees cookieStore.set() in frame' specified 1 'cleanup' function, and 1 failed.
-
 FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
-NOTRUN cookieStore.get() in frame sees cookieStore.set()
+FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.value')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.get returns the cookie written by cookieStore.set' specified 1 'cleanup' function, and 1 failed.
-
 PASS cookieStore.get returns the cookie written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -1,24 +1,22 @@
 
-Harness Error (FAIL), message = Test named 'cookieStore.set with get result' specified 1 'cleanup' function, and 1 failed.
-
-FAIL cookieStore.set with positional name and value promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with name and value in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.set with positional name and value
+PASS cookieStore.set with name and value in options
 PASS cookieStore.set with empty name and an '=' in value
-FAIL cookieStore.set with normal name and an '=' in value promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with expires set to a future Date promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with expires set to a past Date promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with expires set to a future timestamp promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with expires set to a past timestamp promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.set with normal name and an '=' in value
+PASS cookieStore.set with expires set to a future Date
+PASS cookieStore.set with expires set to a past Date
+PASS cookieStore.set with expires set to a future timestamp
+PASS cookieStore.set with expires set to a past timestamp
 FAIL cookieStore.set domain starts with "." assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with domain that is not equal current host assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with domain set to the current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.set with domain set to the current hostname
 FAIL cookieStore.set with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set default domain is null and differs from current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with path set to the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set with path set to a subdirectory of the current directory promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.set with path set to the current directory
+FAIL cookieStore.set with path set to a subdirectory of the current directory assert_equals: expected null but got object "[object Object]"
 FAIL cookieStore.set default path is / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.set adds / to path that does not end with / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected (string) "/cookie-store/" but got (undefined) undefined
 FAIL cookieStore.set with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt
@@ -1,10 +1,10 @@
 
 FAIL cookieStore.set with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
 PASS cookieStore.set of expired __Secure- cookie name on secure origin
-FAIL cookieStore.delete with __Secure- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.delete with __Secure- name on secure origin
 FAIL cookieStore.set with __Host- name on secure origin promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`${prefix}cookie-name`)).value')"
 PASS cookieStore.set of expired __Host- cookie name on secure origin
-FAIL cookieStore.delete with __Host- name on secure origin promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.delete with __Host- name on secure origin
 FAIL cookieStore.set with __Host- prefix and a domain option assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with __Host- prefix a path option promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating '(await cookieStore.get(`__Host-cookie-name`)).value')"
 PASS cookieStore.set with malformed name.

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -53,7 +53,7 @@ public:
     void set(String&& name, String&& value, Ref<DeferredPromise>&&);
     void set(CookieInit&&, Ref<DeferredPromise>&&);
 
-    void remove(const String& name, Ref<DeferredPromise>&&);
+    void remove(String&& name, Ref<DeferredPromise>&&);
     void remove(CookieStoreDeleteOptions&&, Ref<DeferredPromise>&&);
 
     using RefCounted::ref;


### PR DESCRIPTION
#### 525b38fe412e28097b9c30af5d549d13bd19899c
<pre>
Implement the delete function in the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259220">https://bugs.webkit.org/show_bug.cgi?id=259220</a>

Reviewed by Chris Dumez.

The delete function creates a cookie with the options given and
sets the expires field to a time in the past (we set it to the
epoch). Then it uses the Cookie Store API set function to set
this cookie so that the CFNetwork will update the existing cookies
with these options and delete them since they are expired.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_delete_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_special_names.https.any-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::remove):
* Source/WebCore/Modules/cookie-store/CookieStore.h:

Canonical link: <a href="https://commits.webkit.org/266078@main">https://commits.webkit.org/266078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a29931f3b3bf5676116d32cf511449d121b8e2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14969 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18641 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14935 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10102 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11450 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3138 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->