### PR TITLE
Media: media player overlapping with text on daringfireball.net

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -249,7 +249,7 @@
     --inline-controls-bar-height: 32px;
 }
 
-.media-controls.vision > .bottom.controls-bar {
+.media-controls.vision:not(.audio) > .bottom.controls-bar {
     bottom: var(--inline-controls-inside-margin);
 }
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8123,7 +8123,9 @@ bool HTMLMediaElement::ensureMediaControls()
 
         mediaControlsHostJSWrapperObject->putDirect(vm, controller, controllerValue, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
 
-        updatePageScaleFactorJSProperty();
+        if (m_mediaControlsDependOnPageScaleFactor)
+            updatePageScaleFactorJSProperty();
+
         RETURN_IF_EXCEPTION(scope, reportExceptionAndReturnFalse());
 
         updateUsesLTRUserInterfaceLayoutDirectionJSProperty();


### PR DESCRIPTION
#### df1f3e35c7630153e106ad48a287f9b7ee9b96ea
<pre>
Media: media player overlapping with text on daringfireball.net
<a href="https://bugs.webkit.org/show_bug.cgi?id=259222">https://bugs.webkit.org/show_bug.cgi?id=259222</a>
rdar://110986563

Reviewed by Mike Wyrzykowski.

There are two issues causing the overlapping and weird position:

1. When the page scale is &lt; 1, our media controls counter-scaling increases the size of the media
controls outside their layout size; they should be restricted to their layout size. 262952@main
tried to fix it, however it was not a complete fix because `updatePageScaleFactorJSProperty()` is
called in two places and the check for `m_mediaControlsDependOnPageScaleFactor` was only added in
one of these call sites.

2. All media controls have a `bottom` CSS property applied to them, which causes an offset to be
applied to the element. However, this was only ever intended to be applied in non-audio controls.

Fix (1) by simply adding the check in the other call site, and fix (2) by removing this property
from the audio controls.

* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision.fullscreen &gt; .bottom.controls-bar):
(.media-controls.vision &gt; .bottom.controls-bar): Deleted.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::ensureMediaControls):

Canonical link: <a href="https://commits.webkit.org/266071@main">https://commits.webkit.org/266071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/362dbcddf9c73a18fee37acf6dc8953e7f7e1ec1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14940 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10946 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18621 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14907 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12173 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10085 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11430 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15745 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->