### PR TITLE
MotionMark's multiply suite reaches max complexity on faster devices

### DIFF
--- a/PerformanceTests/MotionMark/resources/strings.js
+++ b/PerformanceTests/MotionMark/resources/strings.js
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 var Strings = {
-    version: "1.2",
+    version: "1.2.1",
     text: {
         testName: "Test Name",
         score: "Score",

--- a/PerformanceTests/MotionMark/tests/master/resources/multiply.js
+++ b/PerformanceTests/MotionMark/tests/master/resources/multiply.js
@@ -37,7 +37,7 @@ var MultiplyStage = Utilities.createSubclass(Stage,
         ["opacity", 0, 1],
         ["display", "none", "block"]
     ],
-    totalRows: 55,
+    totalRows: 68,
 
     initialize: function(benchmark, options)
     {


### PR DESCRIPTION
#### 1b4bc5cdb6a591f6abff5582b477c6a54037de43
<pre>
MotionMark&apos;s multiply suite reaches max complexity on faster devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=259216">https://bugs.webkit.org/show_bug.cgi?id=259216</a>
rdar://112664646

Reviewed by NOBODY (OOPS!).

The Multiply subtest was maxing out on faster macOS hardware, which prevents it from computing
an accurate score.

Increase the numebr of rows from 55 to 68 to temporarily resolve this issue.

This subsumes <a href="https://github.com/WebKit/WebKit/pull/15849.">https://github.com/WebKit/WebKit/pull/15849.</a>

* PerformanceTests/MotionMark/resources/strings.js:
* PerformanceTests/MotionMark/tests/master/resources/multiply.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b4bc5cdb6a591f6abff5582b477c6a54037de43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14237 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16860 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17635 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13060 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20627 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17078 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12198 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->