### PR TITLE
[JSC] Use 32byte stride for ARM64 gcSafe ops

### DIFF
--- a/Source/JavaScriptCore/heap/GCMemoryOperations.h
+++ b/Source/JavaScriptCore/heap/GCMemoryOperations.h
@@ -92,32 +92,31 @@ ALWAYS_INLINE void gcSafeMemcpy(T* dst, T* src, size_t bytes)
             : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
         );
 #elif CPU(ARM64)
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 16) * 16;
-        size_t offset = 0;
+        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 32) * 32;
 
         uint64_t dstPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(dst));
         uint64_t srcPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(src));
+        uint64_t end = dstPtr + bytes;
+        uint64_t alignedEnd = dstPtr + alignedBytes;
 
         asm volatile(
             "1:\t\n"
-            "cmp %x[offset], %x[alignedBytes]\t\n"
+            "cmp %x[dstPtr], %x[alignedEnd]\t\n"
             "b.eq 2f\t\n"
-            "ldr q0, [%x[srcPtr], %x[offset]]\t\n"
-            "str q0, [%x[dstPtr], %x[offset]]\t\n"
-            "add %x[offset], %x[offset], #0x10\t\n"
+            "ldp q0, q1, [%x[srcPtr]], #0x20\t\n"
+            "stp q0, q1, [%x[dstPtr]], #0x20\t\n"
             "b 1b\t\n"
 
             "2:\t\n"
-            "cmp %x[offset], %x[bytes]\t\n"
+            "cmp %x[dstPtr], %x[end]\t\n"
             "b.eq 3f\t\n"
-            "ldr d0, [%x[srcPtr], %x[offset]]\t\n"
-            "str d0, [%x[dstPtr], %x[offset]]\t\n"
-            "add %x[offset], %x[offset], #0x8\t\n"
+            "ldr d0, [%x[srcPtr]], #0x8\t\n"
+            "str d0, [%x[dstPtr]], #0x8\t\n"
             "b 2b\t\n"
 
             "3:\t\n"
 
-            : [alignedBytes] "+r" (alignedBytes), [bytes] "+r" (bytes), [offset] "+r" (offset), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
+            : [end] "+r" (end), [alignedEnd] "+r" (alignedEnd), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
             :
             : "d0", "d1", "memory"
         );
@@ -209,29 +208,30 @@ ALWAYS_INLINE void gcSafeMemmove(T* dst, T* src, size_t bytes)
             : "xmm0", "xmm1", "xmm2", "xmm3", "memory", "cc"
         );
 #elif CPU(ARM64)
-        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 16) * 16;
-        uint64_t dstPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(dst));
-        uint64_t srcPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(src));
+        uint64_t alignedBytes = (static_cast<uint64_t>(bytes) / 32) * 32;
+        uint64_t dstPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(dst) + static_cast<uint64_t>(bytes));
+        uint64_t srcPtr = static_cast<uint64_t>(bitwise_cast<uintptr_t>(src) + static_cast<uint64_t>(bytes));
+        uint64_t alignedEnd = bitwise_cast<uintptr_t>(dst) + alignedBytes;
+        uint64_t end = bitwise_cast<uintptr_t>(dst);
 
         asm volatile(
             "1:\t\n"
-            "cmp %x[alignedBytes], %x[bytes]\t\n"
+            "cmp %x[dstPtr], %x[alignedEnd]\t\n"
             "b.eq 2f\t\n"
-            "sub %x[bytes], %x[bytes], #0x8\t\n"
-            "ldr d0, [%x[srcPtr], %x[bytes]]\t\n"
-            "str d0, [%x[dstPtr], %x[bytes]]\t\n"
+            "ldr d0, [%x[srcPtr], #-0x8]!\t\n"
+            "str d0, [%x[dstPtr], #-0x8]!\t\n"
             "b 1b\t\n"
 
             "2:\t\n"
-            "cbz %x[alignedBytes], 3f\t\n"
-            "sub %x[alignedBytes], %x[alignedBytes], #0x10\t\n"
-            "ldr q0, [%x[srcPtr], %x[alignedBytes]]\t\n"
-            "str q0, [%x[dstPtr], %x[alignedBytes]]\t\n"
+            "cmp %x[dstPtr], %x[end]\t\n"
+            "b.eq 3f\t\n"
+            "ldp q0, q1, [%x[srcPtr], #-0x20]!\t\n"
+            "stp q0, q1, [%x[dstPtr], #-0x20]!\t\n"
             "b 2b\t\n"
 
             "3:\t\n"
 
-            : [alignedBytes] "+r" (alignedBytes), [bytes] "+r" (bytes), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
+            : [alignedEnd] "+r" (alignedEnd), [end] "+r" (end), [dstPtr] "+r" (dstPtr), [srcPtr] "+r" (srcPtr)
             :
             : "d0", "d1", "memory"
         );


### PR DESCRIPTION
#### 8e00fd0e6445fc2ac9820723a5f9b354d629dff4
<pre>
[JSC] Use 32byte stride for ARM64 gcSafe ops
<a href="https://bugs.webkit.org/show_bug.cgi?id=259226">https://bugs.webkit.org/show_bug.cgi?id=259226</a>
rdar://112284761

Reviewed by Mark Lam.

This patch extends gcSafe mem ops stride from 16 to 32 bytes.
We do not use SIMD v128 etc. here for now, which could be beneficial
for more larger sized ones. We clean up these ops with prefix / postfix
increment addressing in ARM64.

* Source/JavaScriptCore/heap/GCMemoryOperations.h:
(JSC::gcSafeMemcpy):
(JSC::gcSafeMemmove):

Canonical link: <a href="https://commits.webkit.org/266079@main">https://commits.webkit.org/266079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7916b95ec4aeb07b6c84a1b18baf87804e563fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18636 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10864 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14928 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12094 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10099 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12829 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11446 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3368 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15760 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13197 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1454 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12027 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3157 "Passed tests") | 
<!--EWS-Status-Bubble-End-->