### PR TITLE
[JSC] TypedArray construction should scan JSArray in faster way

### DIFF
--- a/JSTests/microbenchmarks/typed-array-new-from-double-array-to-float64-typed-array.js
+++ b/JSTests/microbenchmarks/typed-array-new-from-double-array-to-float64-typed-array.js
@@ -1,0 +1,11 @@
+var array = [];
+for (var i = 0; i < 1024; ++i)
+    array.push(i + 0.5);
+
+function test(array) {
+    return new Float64Array(array);
+}
+noInline(test);
+
+for (var i = 0; i < 1e4; ++i)
+    test(array);

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayView.h
@@ -153,6 +153,9 @@ public:
 
     // [AllowShared] annotation allows accepting TypedArray originated from SharedArrayBuffer.
     static inline RefPtr<typename Adaptor::ViewType> toWrappedAllowShared(VM&, JSValue);
+
+    inline void copyFromInt32ShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);
+    inline void copyFromDoubleShapeArray(size_t offset, JSArray*, size_t objectOffset, size_t length);
     
 protected:
     friend struct TypedArrayClassInfos;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h
@@ -343,6 +343,59 @@ bool JSGenericTypedArrayView<Adaptor>::setFromTypedArray(JSGlobalObject* globalO
 }
 
 template<typename Adaptor>
+void JSGenericTypedArrayView<Adaptor>::copyFromInt32ShapeArray(size_t offset, JSArray* array, size_t objectOffset, size_t length)
+{
+    ASSERT(canAccessRangeQuickly(offset, length));
+    ASSERT((array->indexingType() & IndexingShapeMask) == Int32Shape);
+    ASSERT(Adaptor::typeValue != TypeBigInt64 || Adaptor::typeValue != TypeBigUint64);
+    ASSERT((length + objectOffset) <= array->length());
+    ASSERT(array->isIteratorProtocolFastAndNonObservable());
+
+    // If the destination is uint32_t or int32_t, we can use copyElements.
+    // 1. int32_t -> uint32_t conversion does not change any bit representation. So we can simply copy them.
+    // 2. Hole is represented as JSEmpty in Int32Shape, which lower 32bits is zero. And we expect 0 for undefined, thus this copying simply works.
+    if constexpr (Adaptor::typeValue == TypeUint8 || Adaptor::typeValue == TypeInt8) {
+        WTF::copyElements(bitwise_cast<uint8_t*>(typedVector() + offset), bitwise_cast<const uint64_t*>(array->butterfly()->contiguous().data() + objectOffset), length);
+        return;
+    }
+    if constexpr (Adaptor::typeValue == TypeUint16 || Adaptor::typeValue == TypeInt16) {
+        WTF::copyElements(bitwise_cast<uint16_t*>(typedVector() + offset), bitwise_cast<const uint64_t*>(array->butterfly()->contiguous().data() + objectOffset), length);
+        return;
+    }
+    if constexpr (Adaptor::typeValue == TypeUint32 || Adaptor::typeValue == TypeInt32) {
+        WTF::copyElements(bitwise_cast<uint32_t*>(typedVector() + offset), bitwise_cast<const uint64_t*>(array->butterfly()->contiguous().data() + objectOffset), length);
+        return;
+    }
+    for (size_t i = 0; i < length; ++i) {
+        JSValue value = array->butterfly()->contiguous().at(array, static_cast<unsigned>(i + objectOffset)).get();
+        if (LIKELY(!!value))
+            setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromInt32(value.asInt32()));
+        else
+            setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromUndefined());
+    }
+}
+
+template<typename Adaptor>
+void JSGenericTypedArrayView<Adaptor>::copyFromDoubleShapeArray(size_t offset, JSArray* array, size_t objectOffset, size_t length)
+{
+    ASSERT(canAccessRangeQuickly(offset, length));
+    ASSERT((array->indexingType() & IndexingShapeMask) == DoubleShape);
+    ASSERT(Adaptor::typeValue != TypeBigInt64 || Adaptor::typeValue != TypeBigUint64);
+    ASSERT((length + objectOffset) <= array->length());
+    ASSERT(array->isIteratorProtocolFastAndNonObservable());
+
+    if constexpr (Adaptor::typeValue == TypeFloat64) {
+        // Double to double copy. Thus we can use memcpy (since Array will never overlap with TypedArrays' backing store).
+        WTF::copyElements(typedVector() + offset, array->butterfly()->contiguousDouble().data() + objectOffset, length);
+        return;
+    }
+    for (size_t i = 0; i < length; ++i) {
+        double d = array->butterfly()->contiguousDouble().at(array, static_cast<unsigned>(i + objectOffset));
+        setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromDouble(d));
+    }
+}
+
+template<typename Adaptor>
 bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalObject, size_t offset, JSObject* object, size_t objectOffset, size_t length)
 {
     VM& vm = globalObject->vm();
@@ -363,21 +416,11 @@ bool JSGenericTypedArrayView<Adaptor>::setFromArrayLike(JSGlobalObject* globalOb
             if (safeLength == length && (safeLength + objectOffset) >= array->length() && array->isIteratorProtocolFastAndNonObservable()) {
                 IndexingType indexingType = array->indexingType() & IndexingShapeMask;
                 if (indexingType == Int32Shape) {
-                    for (size_t i = 0; i < safeLength; ++i) {
-                        JSValue value = array->butterfly()->contiguous().at(array, static_cast<unsigned>(i + objectOffset)).get();
-                        if (LIKELY(!!value))
-                            setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromInt32(value.asInt32()));
-                        else
-                            setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromUndefined());
-                    }
+                    copyFromInt32ShapeArray(offset, array, objectOffset, safeLength);
                     return true;
                 }
-
                 if (indexingType == DoubleShape) {
-                    for (size_t i = 0; i < safeLength; ++i) {
-                        double d = array->butterfly()->contiguousDouble().at(array, static_cast<unsigned>(i + objectOffset));
-                        setIndexQuicklyToNativeValue(offset + i, Adaptor::toNativeFromDouble(d));
-                    }
+                    copyFromDoubleShapeArray(offset, array, objectOffset, safeLength);
                     return true;
                 }
             }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -775,20 +775,12 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewPrivateFuncFromFast(VM& vm, JS
         RETURN_IF_EXCEPTION(scope, { });
 
         if (indexingType == Int32Shape) {
-            for (unsigned i = 0; i < length; i++) {
-                JSValue value = array->butterfly()->contiguous().at(array, i).get();
-                if (LIKELY(!!value))
-                    result->setIndexQuicklyToNativeValue(i, ViewClass::Adaptor::toNativeFromInt32(value.asInt32()));
-                else
-                    result->setIndexQuicklyToNativeValue(i, ViewClass::Adaptor::toNativeFromUndefined());
-            }
-        } else {
-            ASSERT(indexingType == DoubleShape);
-            for (unsigned i = 0; i < length; i++) {
-                double d = array->butterfly()->contiguousDouble().at(array, i);
-                result->setIndexQuicklyToNativeValue(i, ViewClass::Adaptor::toNativeFromDouble(d));
-            }
+            result->copyFromInt32ShapeArray(0, array, 0, length);
+            return JSValue::encode(result);
         }
+
+        ASSERT(indexingType == DoubleShape);
+        result->copyFromDoubleShapeArray(0, array, 0, length);
         return JSValue::encode(result);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -107,4 +107,100 @@ TEST(WTF_StringCommon, FindIgnoringASCIICaseWithoutLengthIdentical)
     EXPECT_EQ(WTF::findIgnoringASCIICaseWithoutLength("needley", "needle"), 0UL);
 }
 
+TEST(WTF_StringCommon, CopyElements64To8)
+{
+    Vector<uint8_t> destination;
+    destination.resize(4096);
+
+    Vector<uint64_t> source;
+    source.reserveInitialCapacity(4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+
+    WTF::copyElements(destination.data(), source.data(), 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[i], static_cast<uint8_t>(i));
+}
+
+TEST(WTF_StringCommon, CopyElements64To16)
+{
+    Vector<uint16_t> destination;
+    destination.resize(4096 + 4 + 4096);
+
+    Vector<uint64_t> source;
+    source.reserveInitialCapacity(4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+    source.append(0xffff);
+    source.append(0x10000);
+    source.append(UINT64_MAX);
+    source.append(0x7fff);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+
+    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[i], static_cast<uint16_t>(i));
+    EXPECT_EQ(destination[4096 + 0], 0xffffU);
+    EXPECT_EQ(destination[4096 + 1], 0x0000U);
+    EXPECT_EQ(destination[4096 + 2], 0xffffU);
+    EXPECT_EQ(destination[4096 + 3], 0x7fffU);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[4096 + 4 + i], static_cast<uint16_t>(i));
+}
+
+TEST(WTF_StringCommon, CopyElements64To32)
+{
+    Vector<uint32_t> destination;
+    destination.resize(4096 + 4 + 4096);
+
+    Vector<uint64_t> source;
+    source.reserveInitialCapacity(4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+    source.append(0xffffffffU);
+    source.append(0x100000000ULL);
+    source.append(UINT64_MAX);
+    source.append(0x7fffffffU);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+
+    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[i], static_cast<uint32_t>(i));
+    EXPECT_EQ(destination[4096 + 0], 0xffffffffU);
+    EXPECT_EQ(destination[4096 + 1], 0x00000000U);
+    EXPECT_EQ(destination[4096 + 2], 0xffffffffU);
+    EXPECT_EQ(destination[4096 + 3], 0x7fffffffU);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[4096 + 4 + i], static_cast<uint32_t>(i));
+}
+
+TEST(WTF_StringCommon, CopyElements32To16)
+{
+    Vector<uint16_t> destination;
+    destination.resize(4096 + 4 + 4096);
+
+    Vector<uint32_t> source;
+    source.reserveInitialCapacity(4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+    source.append(0xffff);
+    source.append(0x10000);
+    source.append(UINT32_MAX);
+    source.append(0x7fff);
+    for (unsigned i = 0; i < 4096; ++i)
+        source.append(i);
+
+    WTF::copyElements(destination.data(), source.data(), 4096 + 4 + 4096);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[i], static_cast<uint16_t>(i));
+    EXPECT_EQ(destination[4096 + 0], 0xffffU);
+    EXPECT_EQ(destination[4096 + 1], 0x0000U);
+    EXPECT_EQ(destination[4096 + 2], 0xffffU);
+    EXPECT_EQ(destination[4096 + 3], 0x7fffU);
+    for (unsigned i = 0; i < 4096; ++i)
+        EXPECT_EQ(destination[4096 + 4 + i], static_cast<uint16_t>(i));
+}
+
 } // namespace


### PR DESCRIPTION
#### 01b454ac1e6860442583d4b6157857047dc8a616
<pre>
[JSC] TypedArray construction should scan JSArray in faster way
<a href="https://bugs.webkit.org/show_bug.cgi?id=259241">https://bugs.webkit.org/show_bug.cgi?id=259241</a>
rdar://112315641

Reviewed by Michael Saboff.

Use SIMD function to convert JSValue to TypedArray destination types.
By leveraging ARM64 ld2, ld4, we can extract Int32 from JSValue efficiently, and we can store
them to destination.

1. Extract StringImpl::copyCharacters and define WTF::copyElements. It does super fast SIMD copies based on source and destination types.
   It can include widening or narrowing (so source and destination types may be different).
2. Use WTF::copyElements in TypedArray#from and TypedArray constructors.

                                                     ToT                     Patched

typed-array-from-array                        134.4441+-0.4424     ^     13.6653+-0.1270        ^ definitely 9.8383x faster
typed-array-new-from-int32-array               14.5654+-0.0179     ^      2.5779+-0.0212        ^ definitely 5.6501x faster
typed-array-new-from-double-array-to-float64-typed-array
                                                6.0447+-0.0299     ^      3.7598+-0.0156        ^ definitely 1.6077x faster

* JSTests/microbenchmarks/typed-array-new-from-double-array-to-float64-typed-array.js: Added.
(test):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewInlines.h:
(JSC::JSGenericTypedArrayView&lt;Adaptor&gt;::setFromArrayLike):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewPrivateFuncFromFast):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::copyElements):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::copyCharacters):

Canonical link: <a href="https://commits.webkit.org/266182@main">https://commits.webkit.org/266182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8198e3d7826fbbd1bf4596553c6aa69d809015b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12875 "14 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15066 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18716 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10952 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12121 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15018 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12186 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10180 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12926 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11540 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3401 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15856 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13297 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1490 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12119 "Built successfully") | | [⏳ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Tests-EWS "Waiting to run tests") | 
<!--EWS-Status-Bubble-End-->