### PR TITLE
Fix integer overflow (-INT_MIN) in BMPImageReader::readInfoHeader

### DIFF
--- a/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
+++ b/Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp
@@ -260,6 +260,11 @@ bool BMPImageReader::readInfoHeader()
 
     // Detect top-down BMPs.
     if (m_infoHeader.biHeight < 0) {
+        // We can't negate INT32_MIN below to get a positive int32_t.
+        // isInfoHeaderValid() will reject heights of 1 << 16 or larger anyway,
+        // so just reject this bitmap now.
+        if (m_infoHeader.biHeight == INT32_MIN)
+            return m_parent->setFailed();
         m_isTopDown = true;
         m_infoHeader.biHeight = -m_infoHeader.biHeight;
     }


### PR DESCRIPTION
#### 3a311fd2cd7e267ba71dca49060ad2c6be31f36d
<pre>
Fix integer overflow (-INT_MIN) in BMPImageReader::readInfoHeader

<a href="https://bugs.webkit.org/show_bug.cgi?id=259033">https://bugs.webkit.org/show_bug.cgi?id=259033</a>

Reviewed by Don Olmstead.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/cbe3909f4f64e0f00e2eea6898395ece4672c913">https://chromium.googlesource.com/chromium/src.git/+/cbe3909f4f64e0f00e2eea6898395ece4672c913</a>

For non-Apple platforms, this patch just rejects bitmap in &apos;redInfoHeader&apos; to
avoid integer overflow.

NOTE: We don&apos;t have C++ tests similar to Blink so I am just merging &apos;change&apos;.

* Source/WebCore/platform/image-decoders/bmp/BMPImageReader.cpp:
(BMPImageReader::processInfoHeader): As above

Canonical link: <a href="https://commits.webkit.org/266085@main">https://commits.webkit.org/266085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10452a94d9857c788f1d725bc33a957892220da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14951 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15017 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18677 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10141 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15806 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1457 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->