### PR TITLE
Remove unused 'containsScrollableArea' and add assert to 'addScrollableArea' in LocalFrameView.cpp|h

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5624,6 +5624,7 @@ void LocalFrameView::removeScrollableAreaForAnimatedScroll(ScrollableArea* scrol
 
 bool LocalFrameView::addScrollableArea(ScrollableArea* scrollableArea)
 {
+    ASSERT(scrollableArea);
     if (!m_scrollableAreas)
         m_scrollableAreas = makeUnique<ScrollableAreaSet>();
     
@@ -5642,11 +5643,6 @@ bool LocalFrameView::removeScrollableArea(ScrollableArea* scrollableArea)
         return true;
     }
     return false;
-}
-
-bool LocalFrameView::containsScrollableArea(ScrollableArea* scrollableArea) const
-{
-    return m_scrollableAreas && m_scrollableAreas->contains(*scrollableArea);
 }
 
 void LocalFrameView::scrollableAreaSetChanged()

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -596,7 +596,6 @@ public:
     WEBCORE_EXPORT bool addScrollableArea(ScrollableArea*);
     // Returns whether the scrollable area has just been removed.
     WEBCORE_EXPORT bool removeScrollableArea(ScrollableArea*);
-    bool containsScrollableArea(ScrollableArea*) const;
     const ScrollableAreaSet* scrollableAreas() const { return m_scrollableAreas.get(); }
     
     void addScrollableAreaForAnimatedScroll(ScrollableArea*);


### PR DESCRIPTION
<pre>
Remove unused 'containsScrollableArea' and add assert to 'addScrollableArea' in LocalFrameView.cpp|h
<a href="https://bugs.webkit.org/show_bug.cgi?id=259029">https://bugs.webkit.org/show_bug.cgi?id=259029</a>

Reviewed by NOBODY (OOPS!).

This patch just remove unused 'containsScrollableArea' function and also add 
ASSERT in 'addScrollableArea' to ensure that it has 'scrollableArea'.

* Source/WebCore/page/LocalFrameView.cpp:
(LocalFrameView::addScrollableArea): Add assert
(LocalFrameView::containsScrollableArea): Deleted
* Source/WebCore/page/LocalFrameView.h: Deleted 'containsScrollableArea'
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87c28625e88976cc13563f9f17ff07127e877099

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14955 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10861 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15020 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14981 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10144 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->