### PR TITLE
Align some internal URL concepts with the URL Standard

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -50,7 +50,7 @@ void URL::invalidate()
 {
     m_isValid = false;
     m_protocolIsInHTTPFamily = false;
-    m_cannotBeABaseURL = false;
+    m_hasOpaquePath = false;
     m_schemeEnd = 0;
     m_userStart = 0;
     m_userEnd = 0;
@@ -794,14 +794,6 @@ bool URL::isMatchingDomain(StringView domain) const
 String encodeWithURLEscapeSequences(const String& input)
 {
     return percentEncodeCharacters(input, URLParser::isInUserInfoEncodeSet);
-}
-
-bool URL::isHierarchical() const
-{
-    if (!m_isValid)
-        return false;
-    ASSERT(m_string[m_schemeEnd] == ':');
-    return m_string[m_schemeEnd + 1] == '/';
 }
 
 static bool protocolIsInternal(StringView string, ASCIILiteral protocolLiteral)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -96,13 +96,6 @@ public:
     // when placing a URL in an if statment.
     operator bool() const = delete;
 
-    // Returns true if you can set the host and port for the URL.
-    // Non-hierarchical URLs don't have a host and port.
-    bool canSetHostOrPort() const { return isHierarchical(); }
-
-    bool canSetPathname() const { return isHierarchical(); }
-    WTF_EXPORT_PRIVATE bool isHierarchical() const;
-
     const String& string() const { return m_string; }
     WTF_EXPORT_PRIVATE String stringCenterEllipsizedToLength(unsigned length = 1024) const;
 
@@ -149,7 +142,7 @@ public:
     WTF_EXPORT_PRIVATE bool protocolIsJavaScript() const;
     bool protocolIsInFTPFamily() const { return protocolIs("ftp"_s) || protocolIs("ftps"_s); }
     bool protocolIsInHTTPFamily() const { return m_protocolIsInHTTPFamily; }
-    bool cannotBeABaseURL() const { return m_cannotBeABaseURL; }
+    bool hasOpaquePath() const { return m_hasOpaquePath; }
 
     WTF_EXPORT_PRIVATE bool isAboutBlank() const;
     WTF_EXPORT_PRIVATE bool isAboutSrcDoc() const;
@@ -230,7 +223,7 @@ private:
 
     unsigned m_isValid : 1;
     unsigned m_protocolIsInHTTPFamily : 1;
-    unsigned m_cannotBeABaseURL : 1;
+    unsigned m_hasOpaquePath : 1;
 
     // This is out of order to align the bits better. The port is after the host.
     unsigned m_portLength : 3;

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1082,7 +1082,7 @@ URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* non
     : m_inputString(WTFMove(input))
 {
     if (m_inputString.isNull()) {
-        if (base.isValid() && !base.m_cannotBeABaseURL) {
+        if (base.isValid() && !base.m_hasOpaquePath) {
             m_url = base;
             m_url.removeFragmentIdentifier();
         }
@@ -1160,7 +1160,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
         FileHost,
         PathStart,
         Path,
-        CannotBeABaseURLPath,
+        OpaquePath,
         UTF8Query,
         NonUTF8Query,
         Fragment,
@@ -1258,8 +1258,8 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
                         m_url.m_hostEnd = m_url.m_userStart;
                         m_url.m_portLength = 0;
                         m_url.m_pathAfterLastSlash = m_url.m_userStart;
-                        m_url.m_cannotBeABaseURL = true;
-                        state = State::CannotBeABaseURLPath;
+                        m_url.m_hasOpaquePath = true;
+                        state = State::OpaquePath;
                     }
                     break;
                 }
@@ -1279,11 +1279,11 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
             break;
         case State::NoScheme:
             LOG_STATE("NoScheme");
-            if (!base.isValid() || (base.m_cannotBeABaseURL && *c != '#')) {
+            if (!base.isValid() || (base.m_hasOpaquePath && *c != '#')) {
                 failure();
                 return;
             }
-            if (base.m_cannotBeABaseURL && *c == '#') {
+            if (base.m_hasOpaquePath && *c == '#') {
                 copyURLPartsUntil(base, URLPart::QueryEnd, c, nonUTF8QueryEncoding);
                 state = State::Fragment;
                 appendToASCIIBuffer('#');
@@ -1747,8 +1747,8 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
             utf8PercentEncode<isInDefaultEncodeSet>(c);
             ++c;
             break;
-        case State::CannotBeABaseURLPath:
-            LOG_STATE("CannotBeABaseURLPath");
+        case State::OpaquePath:
+            LOG_STATE("OpaquePath");
             if (*c == '?') {
                 m_url.m_pathEnd = currentPosition(c);
                 appendToASCIIBuffer('?');
@@ -1808,7 +1808,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
     switch (state) {
     case State::SchemeStart:
         LOG_FINAL_STATE("SchemeStart");
-        if (!currentPosition(c) && base.isValid() && !base.m_cannotBeABaseURL) {
+        if (!currentPosition(c) && base.isValid() && !base.m_hasOpaquePath) {
             m_url = base;
             m_url.removeFragmentIdentifier();
             return;
@@ -1998,8 +1998,8 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
         m_url.m_pathEnd = currentPosition(c);
         m_url.m_queryEnd = m_url.m_pathEnd;
         break;
-    case State::CannotBeABaseURLPath:
-        LOG_FINAL_STATE("CannotBeABaseURLPath");
+    case State::OpaquePath:
+        LOG_FINAL_STATE("OpaquePath");
         m_url.m_pathEnd = currentPosition(c);
         m_url.m_queryEnd = m_url.m_pathEnd;
         break;
@@ -2977,7 +2977,7 @@ bool URLParser::allValuesEqual(const URL& a, const URL& b)
 {
     URL_PARSER_LOG("%d %d %d %d %d %d %d %d %d %d %d %d %s\n%d %d %d %d %d %d %d %d %d %d %d %d %s",
         a.m_isValid,
-        a.m_cannotBeABaseURL,
+        a.m_hasOpaquePath,
         a.m_protocolIsInHTTPFamily,
         a.m_schemeEnd,
         a.m_userStart,
@@ -2990,7 +2990,7 @@ bool URLParser::allValuesEqual(const URL& a, const URL& b)
         a.m_queryEnd,
         a.m_string.utf8().data(),
         b.m_isValid,
-        b.m_cannotBeABaseURL,
+        b.m_hasOpaquePath,
         b.m_protocolIsInHTTPFamily,
         b.m_schemeEnd,
         b.m_userStart,
@@ -3005,7 +3005,7 @@ bool URLParser::allValuesEqual(const URL& a, const URL& b)
 
     return a.m_string == b.m_string
         && a.m_isValid == b.m_isValid
-        && a.m_cannotBeABaseURL == b.m_cannotBeABaseURL
+        && a.m_hasOpaquePath == b.m_hasOpaquePath
         && a.m_protocolIsInHTTPFamily == b.m_protocolIsInHTTPFamily
         && a.m_schemeEnd == b.m_schemeEnd
         && a.m_userStart == b.m_userStart

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -59,7 +59,7 @@ String URLDecomposition::username() const
 void URLDecomposition::setUsername(StringView user)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile())
+    if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
         return;
     fullURL.setUser(user);
     setFullURL(fullURL);
@@ -73,7 +73,7 @@ String URLDecomposition::password() const
 void URLDecomposition::setPassword(StringView password)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile())
+    if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
         return;
     fullURL.setPassword(password);
     setFullURL(fullURL);
@@ -104,7 +104,7 @@ void URLDecomposition::setHost(StringView value)
     if (!separator)
         return;
 
-    if (fullURL.cannotBeABaseURL() || !fullURL.canSetHostOrPort())
+    if (fullURL.hasOpaquePath())
         return;
 
     // No port if no colon or rightmost colon is within the IPv6 section.
@@ -140,7 +140,7 @@ void URLDecomposition::setHostname(StringView host)
     auto fullURL = this->fullURL();
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
-    if (fullURL.cannotBeABaseURL() || !fullURL.canSetHostOrPort())
+    if (fullURL.hasOpaquePath())
         return;
     fullURL.setHost(host);
     if (fullURL.isValid())
@@ -185,7 +185,7 @@ static std::optional<std::optional<uint16_t>> parsePort(StringView string, Strin
 void URLDecomposition::setPort(StringView value)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile() || !fullURL.canSetHostOrPort())
+    if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
         return;
     auto port = parsePort(value, fullURL.protocol());
     if (!port)
@@ -202,7 +202,7 @@ String URLDecomposition::pathname() const
 void URLDecomposition::setPathname(StringView value)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.cannotBeABaseURL() || !fullURL.canSetPathname())
+    if (fullURL.hasOpaquePath())
         return;
     fullURL.setPath(value);
     setFullURL(fullURL);

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -753,7 +753,9 @@ bool ContentSecurityPolicy::allowBaseURI(const URL& url, bool overrideContentSec
 
 static bool shouldReportProtocolOnly(const URL& url)
 {
-    return !url.isHierarchical() || url.protocolIsFile();
+    // FIXME: https://w3c.github.io/webappsec-csp/#strip-url-for-use-in-reports suggests this should
+    // be url.protocolIsInHTTPFamily().
+    return url.hasOpaquePath() || url.protocolIsFile();
 }
 
 String ContentSecurityPolicy::createURLForReporting(const URL& url, const String& violatedDirective, bool usesReportingAPI) const


### PR DESCRIPTION
#### 638ac8184b3860aafc3d68fec13300730af06a6d
<pre>
Align some internal URL concepts with the URL Standard
<a href="https://bugs.webkit.org/show_bug.cgi?id=259245">https://bugs.webkit.org/show_bug.cgi?id=259245</a>
rdar://112326744

Reviewed by Alex Christensen.

This is a minor refactoring to align with URL Standard changes:

* Rename cannotBeABaseURL to hasOpaquePath.
* Remove isHierarchical and friends as they are the same as
  hasOpaquePath.
* As an opaque path implies a null host, a null host check suffices.

Also add a FIXME to CSP as it does not appear to follow the
specification for reporting URLs.

* Source/WTF/wtf/URL.cpp:
(WTF::URL::invalidate):
(WTF::URL::isHierarchical const): Deleted.
* Source/WTF/wtf/URL.h:
(WTF::URL::hasOpaquePath const):
(WTF::URL::canSetHostOrPort const): Deleted.
(WTF::URL::canSetPathname const): Deleted.
(WTF::URL::cannotBeABaseURL const): Deleted.
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::URLParser):
(WTF::URLParser::parse):
(WTF::URLParser::allValuesEqual):
* Source/WebCore/html/URLDecomposition.cpp:
(WebCore::URLDecomposition::setUsername):
(WebCore::URLDecomposition::setPassword):
(WebCore::URLDecomposition::setHost):
(WebCore::URLDecomposition::setHostname):
(WebCore::URLDecomposition::setPort):
(WebCore::URLDecomposition::setPathname):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::shouldReportProtocolOnly):

Canonical link: <a href="https://commits.webkit.org/266090@main">https://commits.webkit.org/266090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e83950a4340f3f95acc828a6fe3a799a897891c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15023 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18684 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/10911 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14985 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12145 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10147 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/12885 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11499 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3146 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15812 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13254 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12077 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3185 "Passed tests") | 
<!--EWS-Status-Bubble-End-->