### PR TITLE
CSS "size" should be a descriptor for @page, not a CSS property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['size'] = "initial" should not set the property value
+PASS e.style['size'] = "inherit" should not set the property value
+PASS e.style['size'] = "revert" should not set the property value
+PASS e.style['size'] = "revert-layer" should not set the property value
+PASS e.style['size'] = "unset" should not set the property value
+PASS e.style['size'] = "640px 480px" should not set the property value
+PASS e.style['size'] = "8.5in 11in" should not set the property value
+PASS e.style['size'] = "a4" should not set the property value
+PASS e.style['size'] = "3in 10in" should not set the property value
+PASS e.style['size'] = "jis-b5" should not set the property value
+PASS e.style['size'] = "auto" should not set the property value
+PASS e.style['size'] = "landscape" should not set the property value
+PASS e.style['size'] = "letter" should not set the property value
+PASS e.style['size'] = "legal landscape" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-page-3/#page-orientation-prop">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+  // size is not a property, but a descriptor. test_invalid_value() tries to specify
+  // it on an element, and this should fail, even when using a valid
+  // value. size is only valid as a descriptor inside an @page rule.
+  test_invalid_value("size", "initial");
+  test_invalid_value("size", "inherit");
+  test_invalid_value("size", "revert");
+  test_invalid_value("size", "revert-layer");
+  test_invalid_value("size", "unset");
+  test_invalid_value("size", "640px 480px");
+  test_invalid_value("size", "8.5in 11in");
+  test_invalid_value("size", "a4");
+  test_invalid_value("size", "3in 10in");
+  test_invalid_value("size", "jis-b5");
+  test_invalid_value("size", "auto");
+  test_invalid_value("size", "landscape");
+  test_invalid_value("size", "letter");
+  test_invalid_value("size", "legal landscape");
+</script>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5410,20 +5410,6 @@
                 "url": "https://www.w3.org/TR/SVG11/painting.html#ShapeRenderingProperty"
             }
         },
-        "size": {
-            "codegen-properties": {
-                "computable": false,
-                "custom": "All",
-                "parser-function": "consumeSize",
-                "parser-function-requires-context-mode": true,
-                "parser-grammar-unused": "<length>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
-                "parser-grammar-unused-reason": "Needs support for '||' groups and the '{A,B}' multiplier."
-            },
-            "specification": {
-                "category": "css-page",
-                "url": "https://www.w3.org/TR/css3-page/#page-size-prop"
-            }
-        },
         "stop-color": {
             "codegen-properties": {
                 "svg": true,
@@ -9696,6 +9682,21 @@
                 }
             }
         },
+        "@page": {
+            "size": {
+                "codegen-properties": {
+                    "custom": "All",
+                    "parser-function": "consumeSize",
+                    "parser-function-requires-context-mode": true,
+                    "parser-grammar-unused": "<length>{1,2} | auto | [ <page-size> || [ portrait | landscape ] ]",
+                    "parser-grammar-unused-reason": "Needs support for '||' groups and the '{A,B}' multiplier."
+                },
+                "specification": {
+                    "category": "css-page",
+                    "url": "https://drafts.csswg.org/css-page/#page-size-prop"
+                }
+            }
+        },
         "@property": {
             "syntax": {
                 "codegen-properties": {
@@ -9883,7 +9884,7 @@
         "css-page": {
             "shortname": "CSS Paged Media",
             "longname": "CSS Paged Media Module",
-            "url": "https://www.w3.org/TR/css3-page/"
+            "url": "https://drafts.csswg.org/css-page/"
         },
         "css-properties-and-values": {
             "shortname": "CSS Properties and Values API",


### PR DESCRIPTION
#### 43570d67d749e1649c2e79779682362b8becab5f
<pre>
CSS &quot;size&quot; should be a descriptor for @page, not a CSS property
<a href="https://bugs.webkit.org/show_bug.cgi?id=239965">https://bugs.webkit.org/show_bug.cgi?id=239965</a>

Reviewed by NOBODY (OOPS!).

Move &quot;size&quot; out of the properties section to the decriptors section.
Also add a WPT exported at: <a href="https://github.com/web-platform-tests/wpt/pull/41056">https://github.com/web-platform-tests/wpt/pull/41056</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-invalid.html: Added.
* Source/WebCore/css/CSSProperties.json:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43570d67d749e1649c2e79779682362b8becab5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12845 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13171 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13498 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14584 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12264 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12907 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15673 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13191 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/14584 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13010 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/15673 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/13498 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15035 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/15673 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/13498 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/15035 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/15673 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/13498 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/15035 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12248 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/13191 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11511 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/13498 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15825 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12089 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->