### PR TITLE
[iOS] Stop using -[UIScrollView _isInterruptingDeceleration] in WebKit

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -554,7 +554,6 @@ typedef enum {
 @property (nonatomic, readonly, getter=_isAnimatingScroll) BOOL isAnimatingScroll;
 @property (nonatomic) CGFloat horizontalScrollDecelerationFactor;
 @property (nonatomic) CGFloat verticalScrollDecelerationFactor;
-@property (nonatomic, readonly) BOOL _isInterruptingDeceleration;
 @property (nonatomic, getter=_contentScrollInset, setter=_setContentScrollInset:) UIEdgeInsets contentScrollInset;
 @property (nonatomic, readonly) UIEdgeInsets _systemContentInset;
 @property (nonatomic, getter=_allowsAsyncScrollEvent, setter=_setAllowsAsyncScrollEvent:) BOOL _allowsAsyncScrollEvent;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2349,7 +2349,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 {
     OptionSet<WebKit::ViewStabilityFlag> stabilityFlags;
 
-    if (scrollView.isDragging || scrollView.isZooming || scrollView._isInterruptingDeceleration)
+    if (scrollView.isDragging || scrollView.isZooming)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewInteracting);
 
     if (scrollView.isDecelerating || scrollView._isAnimatingZoom || scrollView._isScrollingToTop || scrollView.isZoomBouncing)

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.h
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.h
@@ -27,11 +27,12 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import <UIKit/UIKit.h>
 #import <wtf/RetainPtr.h>
 
-OBJC_CLASS UIAlertController;
-OBJC_CLASS UIScrollView;
-OBJC_CLASS UITouch;
+@interface UIScrollView (WebKitInternal)
+@property (readonly, nonatomic) BOOL _wk_isInterruptingDeceleration;
+@end
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -30,6 +30,15 @@
 
 #import "UIKitSPI.h"
 
+@implementation UIScrollView (WebKitInternal)
+
+- (BOOL)_wk_isInterruptingDeceleration
+{
+    return self.decelerating && self.tracking;
+}
+
+@end
+
 namespace WebKit {
 
 RetainPtr<UIAlertController> createUIAlertController(NSString *title, NSString *message)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -47,6 +47,7 @@
 #import "TextInputSPI.h"
 #import "TextRecognitionUpdateResult.h"
 #import "UIKitSPI.h"
+#import "UIKitUtilities.h"
 #import "UserInterfaceIdiom.h"
 #import "WKActionSheetAssistant.h"
 #import "WKContextMenuElementInfoInternal.h"
@@ -2902,7 +2903,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (BOOL)_isInterruptingDecelerationForScrollViewOrAncestor:(UIScrollView *)scrollView
 {
     return [self _hasEnclosingScrollView:scrollView matchingCriteria:[](UIScrollView *scrollView) {
-        return scrollView._isInterruptingDeceleration;
+        return scrollView._wk_isInterruptingDeceleration;
     }];
 }
 
@@ -8368,10 +8369,10 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 {
     NSSet<UITouch *> *touches = [event touchesForGestureRecognizer:gestureRecognizer];
     for (UITouch *touch in touches) {
-        if ([touch.view isKindOfClass:[UIScrollView class]] && [(UIScrollView *)touch.view _isInterruptingDeceleration])
+        if (dynamic_objc_cast<UIScrollView>(touch.view)._wk_isInterruptingDeceleration)
             return YES;
     }
-    return self._scroller._isInterruptingDeceleration;
+    return self._scroller._wk_isInterruptingDeceleration;
 }
 
 - (BOOL)isAnyTouchOverActiveArea:(NSSet *)touches


### PR DESCRIPTION
#### 41a2db639391c73e7eba6df8c136705c213b1276
<pre>
[iOS] Stop using -[UIScrollView _isInterruptingDeceleration] in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=259252">https://bugs.webkit.org/show_bug.cgi?id=259252</a>
rdar://112334670

Reviewed by Megan Gardner.

Replace uses of `-[UIScrollView _isInterruptingDeceleration]` with a combination of `-isTracking`
and `-isDecelerating` instead. We currently use this SPI for two purposes: determining view
stability and preventing some gestures from firing when tapping to interrupt momentum scrolling.

Note that the only case I found where `decelerating &amp;&amp; tracking` yields different results than
`_isInterruptingDeceleration` is the case where, after interrupting scroll view decleration with a
tap, `tracking` will be `NO` while `_isInterruptingDeceleration` is still `YES`. However, this
shouldn&apos;t matter to WebKit because `-gestureRecognizerShouldBegin:` has already been invoked on the
gesture recognizers that care about scroll view deceleration (i.e. touch events, synthetic click),
and `decelerating` is still set to `YES` so the view stability heuristic would still report unstable
state.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewWillBeginDecelerating:]):
(-[WKWebView _viewStabilityState:]):

When determining view stability, we currently return YES if `-_isInterruptingDeceleration` is set.
This is actually redundant since:

1.  The resulting view stability `OptionSet` is only checked to see whether or not it&apos;s empty, so
    the actual values of the flags returned don&apos;t influence any behavior (i.e. it&apos;s just for
    debugging and readability).

2.  We already consult `-isDecelerating` right below, which is set to `YES` over the course of
    `-_isInterruptingDeceleration`, so in all cases where we would&apos;ve considered the view to be in
    unstable state due to `-_isInterruptingDeceleration`, we would also consider it to be in
    unstable state regardless, due to the fact that the scroll view is decelerating.

* Source/WebKit/UIProcess/ios/UIKitUtilities.h:
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIScrollView _wk_isInterruptingDeceleration]):

Add a new category method that implements a helper method `-_wk_isInterruptingDeceleration`; this
acts as a drop-in replacement for `-_isInterruptingDeceleration`, that&apos;s suitable for current uses
within WebKit.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _isInterruptingDecelerationForScrollViewOrAncestor:]):
(-[WKContentView gestureRecognizer:isInterruptingMomentumScrollingWithEvent:]):

Take care of the second use of this SPI property, which prevents certain gestures (touch events and
synthetic click) from firing if the user is interrupting a momentum scroll; see comment above for
an explanation about why this should not change behavior.

Canonical link: <a href="https://commits.webkit.org/266111@main">https://commits.webkit.org/266111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31fe40a854f78376e5af611f9809a5bb06283940

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14966 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15038 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11025 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18693 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12100 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14995 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11514 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->