### PR TITLE
[iOS] Various editing layout tests occasionally crash under TextChecker::closeSpellDocumentWithTag

### DIFF
--- a/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
+++ b/Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm
@@ -171,6 +171,15 @@ static NSTextCheckingType nsTextCheckingType(NSString *typeString)
 
 @synthesize spellCheckerLoggingEnabled = _spellCheckerLoggingEnabled;
 
+#if PLATFORM(IOS_FAMILY)
+
+static LayoutTestSpellChecker *swizzledInitializeTextChecker()
+{
+    return [ensureGlobalLayoutTestSpellChecker() retain];
+}
+
+#endif
+
 + (instancetype)checker
 {
     auto *spellChecker = ensureGlobalLayoutTestSpellChecker();
@@ -182,7 +191,7 @@ static NSTextCheckingType nsTextCheckingType(NSString *typeString)
     globallySwizzledSharedSpellCheckerImplementation = method_setImplementation(originalSharedSpellCheckerMethod, reinterpret_cast<IMP>(ensureGlobalLayoutTestSpellChecker));
 #else
     originalInitializeTextCheckerMethod = class_getInstanceMethod(UITextChecker.class, @selector(_initWithAsynchronousLoading:));
-    globallySwizzledInitializeTextCheckerImplementation = method_setImplementation(originalInitializeTextCheckerMethod, reinterpret_cast<IMP>(ensureGlobalLayoutTestSpellChecker));
+    globallySwizzledInitializeTextCheckerImplementation = method_setImplementation(originalInitializeTextCheckerMethod, reinterpret_cast<IMP>(swizzledInitializeTextChecker));
 #endif
 
     hasSwizzledLayoutTestSpellChecker = YES;


### PR DESCRIPTION
#### 0c2e3d5a3e16e1883524cf902e2398d23de8197b
<pre>
[iOS] Various editing layout tests occasionally crash under TextChecker::closeSpellDocumentWithTag
<a href="https://bugs.webkit.org/show_bug.cgi?id=259253">https://bugs.webkit.org/show_bug.cgi?id=259253</a>

Reviewed by Aditya Keerthi.

After my prior change in 265869@main to enable swizzling out grammar checking results on iOS, some
layout tests crash due to an invalid `LayoutTestSpellChecker` instance. This is because
`ensureGlobalLayoutTestSpellChecker()` lazily initializes the fake spell checker for layout tests
with a retain count of 1, and continues holding on to it as a singleton; however, the logic to
swizzle out the text checker returned by `-_initWithAsynchronousLoading:` only returns the result of
`ensureGlobalLayoutTestSpellChecker()`.

WebKit code that&apos;s calling into `-_initWithAsynchronousLoading:` expects a +1 object and proceeds to
store the pointer in a `RetainPtr`, releasing (and destroying it) after the spell document is closed
(i.e. if the web view is destroyed). This means that the next time anything attempts to reset the
global spell checker, we end up accessing invalid memory.

Fix this by simply retaining the global `LayoutTestSpellChecker` before returning it in the swizzled
initializer, to make the retain counting work as intended.

* Tools/TestRunnerShared/cocoa/LayoutTestSpellChecker.mm:
(swizzledInitializeTextChecker):
(+[LayoutTestSpellChecker checker]):

Canonical link: <a href="https://commits.webkit.org/266103@main">https://commits.webkit.org/266103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d58a46daa0788d9e92b7cff1cc61c67a954033f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15039 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11626 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18694 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10158 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11515 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3154 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->