### PR TITLE
[iOS] Remove a few unused method and class declarations in UIKitSPI.h

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -87,14 +87,11 @@
 #import <UIKit/UIWebBrowserView.h>
 #import <UIKit/UIWebDocumentView.h>
 #import <UIKit/UIWebFormAccessory.h>
-#import <UIKit/UIWebGeolocationPolicyDecider.h>
 #import <UIKit/UIWebScrollView.h>
 #import <UIKit/UIWebTiledView.h>
 #import <UIKit/UIWindowScene_Private.h>
 #import <UIKit/UIWindow_Private.h>
 #import <UIKit/_UIApplicationRotationFollowing.h>
-#import <UIKit/_UIBackdropViewSettings.h>
-#import <UIKit/_UIBackdropView_Private.h>
 #import <UIKit/_UIHighlightView.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 #import <UIKit/_UINavigationParallaxTransition.h>
@@ -598,7 +595,6 @@ typedef NS_ENUM(NSUInteger, UIScrollPhase) {
 @property (nonatomic, getter=_allowableSeparation, setter=_setAllowableSeparation:) CGFloat allowableSeparation;
 @property (nonatomic, readonly) CGPoint location;
 @property (nonatomic) CGFloat allowableMovement;
-@property (nonatomic, readonly) CGPoint centroid;
 @property (nonatomic) CFTimeInterval maximumIntervalBetweenSuccessiveTaps;
 @end
 
@@ -767,10 +763,6 @@ typedef NS_ENUM (NSInteger, _UIBackdropMaskViewFlags) {
 - (NSString *)recursiveDescription;
 @end
 
-@protocol UISelectionInteractionAssistant
-- (void)showSelectionCommands;
-@end
-
 typedef NS_ENUM(NSInteger, UIWKSelectionTouch) {
     UIWKSelectionTouchStarted = 0,
     UIWKSelectionTouchMoved = 1,
@@ -932,37 +924,7 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)accessoryTab:(BOOL)isNext;
 @end
 
-@interface UIWebGeolocationPolicyDecider : NSObject
-@end
-
-@interface UIWebGeolocationPolicyDecider ()
-+ (instancetype)sharedPolicyDecider;
-- (void)decidePolicyForGeolocationRequestFromOrigin:(id)securityOrigin requestingURL:(NSURL *)requestingURL window:(UIWindow *)window listener:(id)listener;
-- (void)decidePolicyForGeolocationRequestFromOrigin:(id)securityOrigin requestingURL:(NSURL *)requestingURL view:(UIView *)view listener:(id)listener;
-@end
-
 @interface _UILookupGestureRecognizer : UIGestureRecognizer
-@end
-
-typedef NS_ENUM(NSInteger, _UIBackdropViewStylePrivate) {
-    _UIBackdropViewStyle_Light = 2020,
-};
-
-@interface _UIBackdropViewSettings : NSObject
-@end
-
-@interface _UIBackdropViewSettings ()
-+ (_UIBackdropViewSettings *)settingsForPrivateStyle:(_UIBackdropViewStylePrivate)style;
-@property (nonatomic, assign) CGFloat scale;
-@end
-
-@interface _UIBackdropView : UIView
-@end
-
-@interface _UIBackdropView ()
-- (instancetype)initWithPrivateStyle:(_UIBackdropViewStylePrivate)style;
-- (instancetype)initWithSettings:(_UIBackdropViewSettings *)settings;
-@property (nonatomic, strong, readonly) UIView *contentView;
 @end
 
 @interface _UIHighlightView : UIView
@@ -980,7 +942,7 @@ typedef NS_ENUM(NSInteger, _UIBackdropViewStylePrivate) {
 @end
 
 @interface _UINavigationParallaxTransition ()
-- (instancetype) initWithCurrentOperation:(UINavigationControllerOperation)operation;
+- (instancetype)initWithCurrentOperation:(UINavigationControllerOperation)operation;
 @end
 
 @protocol _UINavigationInteractiveTransitionBaseDelegate;
@@ -1143,7 +1105,6 @@ typedef enum {
 WTF_EXTERN_C_BEGIN
 
 NSTimeInterval _UIDragInteractionDefaultLiftDelay(void);
-CGFloat UIRoundToScreenScale(CGFloat value, UIScreen *);
 
 WTF_EXTERN_C_END
 
@@ -1224,20 +1185,8 @@ typedef NSInteger UICompositingMode;
 + (UIColorEffect *)colorEffectSaturate:(CGFloat)saturationAmount;
 @end
 
-@interface UIBlurEffect ()
-+ (UIBlurEffect *)effectWithBlurRadius:(CGFloat)blurRadius;
-@end
-
-typedef NS_ENUM(NSInteger, _UIPopoverPresentationHorizontalAlignment) {
-    _UIPopoverPresentationHorizontalAlignmentCenter,
-    _UIPopoverPresentationHorizontalAlignmentLeading,
-    _UIPopoverPresentationHorizontalAlignmentTrailing,
-};
-
 @interface UIPopoverPresentationController ()
 @property (assign, nonatomic, setter=_setCentersPopoverIfSourceViewNotSet:, getter=_centersPopoverIfSourceViewNotSet) BOOL _centersPopoverIfSourceViewNotSet;
-@property (assign, nonatomic, setter=_setShouldHideArrow:, getter=_shouldHideArrow) BOOL _shouldHideArrow;
-@property (assign, nonatomic, setter=_setPreferredHorizontalAlignment:) _UIPopoverPresentationHorizontalAlignment _preferredHorizontalAlignment;
 @end
 
 @interface UIWKDocumentContext : NSObject
@@ -1302,7 +1251,6 @@ typedef NS_ENUM(NSUInteger, UIMenuOptionsPrivate) {
 @interface UIContextMenuInteraction ()
 @property (nonatomic, readonly) UIGestureRecognizer *gestureRecognizerForFailureRelationships;
 - (void)_presentMenuAtLocation:(CGPoint)location;
-- (void)dismissMenu;
 @end
 
 #endif // USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -466,8 +466,6 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
 + (BOOL)_addCompletion:(void(^)(BOOL))completion;
 @end
 
-@protocol UISelectionInteractionAssistant;
-
 @interface WKFocusedElementInfo : NSObject <_WKFocusedElementInfo>
 - (instancetype)initWithFocusedElementInformation:(const WebKit::FocusedElementInformation&)information isUserInitiated:(BOOL)isUserInitiated userObject:(NSObject <NSSecureCoding> *)userObject;
 @end

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -356,13 +356,6 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 @property (nonatomic, readonly) BOOL _requiresKeyboardWhenFirstResponder;
 @end
 
-@interface UIWebGeolocationPolicyDecider : NSObject
-@end
-
-@interface UIWebGeolocationPolicyDecider ()
-+ (instancetype)sharedPolicyDecider;
-@end
-
 @protocol UIWKInteractionViewProtocol_Staging_91919121 <UIWKInteractionViewProtocol>
 @optional
 - (void)willInsertFinalDictationResult;


### PR DESCRIPTION
#### 0b48930c5498f6d0b0ecde016113956ff02331c4
<pre>
[iOS] Remove a few unused method and class declarations in UIKitSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=259262">https://bugs.webkit.org/show_bug.cgi?id=259262</a>

Reviewed by Aditya Keerthi.

Remove several unused SPI methods; no change in behavior.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

`_UIBackdropView` and related methods were only used in `WKPDFPageNumberIndicator` to fix
rdar://23760981; it&apos;s no longer necessary, now that we use PDFKit&apos;s remote view controller, and
removed this class entirely.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/266093@main">https://commits.webkit.org/266093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50c974184fec091b38656372d99ba33e86abbf07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12934 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14982 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15057 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18706 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15008 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11532 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15847 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->