### PR TITLE
Google Photos will not allow preview of editing in Safari.

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-toggle-display-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-toggle-display-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<canvas id="onscreen" width="200" height="200"></canvas>
+<script>
+const canvas = document.getElementById('onscreen');
+
+const context = canvas.getContext('2d');
+
+const square = new Path2D();
+square.rect(50, 50, 100, 100);
+context.fillStyle = 'green';
+context.fill(square);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/offscreen-toggle-display.html
+++ b/LayoutTests/fast/canvas/offscreen-toggle-display.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=63; totalPixels=400" />
+</head>
+<body>
+<canvas id="offscreen" width="200" height="200"></canvas>
+<script>
+const canvas = document.getElementById('offscreen');
+
+const offscreenCanvas = canvas.transferControlToOffscreen();
+const offscreenContext = offscreenCanvas.getContext('2d');
+
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+requestAnimationFrame(function() {
+    const square = new Path2D();
+    square.rect(50, 50, 100, 100);
+    offscreenContext.fillStyle = 'green';
+    offscreenContext.fill(square);
+    offscreenContext.commit();
+
+    requestAnimationFrame(function() {
+        canvas.style.display = "none";
+
+        requestAnimationFrame(function() {
+            canvas.style.display = "inline";
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -654,7 +654,7 @@ void GraphicsLayer::setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDispl
 {
 }
 
-RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayer::createAsyncContentsDisplayDelegate()
+RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayer::createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate*)
 {
     return nullptr;
 }

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -550,7 +550,7 @@ public:
     virtual void setContentsToPlatformLayerHost(LayerHostingContextIdentifier) { }
     virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
-    WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate();
+    WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing);
 #if ENABLE(MODEL_ELEMENT)
     enum class ModelInteraction : uint8_t { Enabled, Disabled };
     virtual void setContentsToModel(RefPtr<Model>&&, ModelInteraction) { }

--- a/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h
@@ -54,11 +54,14 @@ public:
 #endif
 };
 
-class WEBCORE_EXPORT GraphicsLayerAsyncContentsDisplayDelegate : public GraphicsLayerContentsDisplayDelegate {
+class GraphicsLayerAsyncContentsDisplayDelegate : public GraphicsLayerContentsDisplayDelegate {
 public:
     virtual ~GraphicsLayerAsyncContentsDisplayDelegate() = default;
 
-    virtual bool tryCopyToLayer(ImageBuffer&) = 0;
+    virtual bool WEBCORE_EXPORT tryCopyToLayer(ImageBuffer&) = 0;
+
+    virtual bool isGraphicsLayerAsyncContentsDisplayDelegateCocoa() const { return false; }
+    virtual bool isGraphicsLayerCARemoteAsyncContentsDisplayDelegate() const { return false; }
 };
 
 }

--- a/Source/WebCore/platform/graphics/ImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferPipe.cpp
@@ -61,8 +61,7 @@ public:
     void setContentsToLayer(GraphicsLayer& layer) final
     {
         Locker locker { m_source->m_lock };
-        if (!m_source->m_delegate)
-            m_source->m_delegate = layer.createAsyncContentsDisplayDelegate();
+        m_source->m_delegate = layer.createAsyncContentsDisplayDelegate(m_source->m_delegate.get());
     }
 
     RefPtr<ImageBufferPipe::Source> source() const final

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1291,6 +1291,7 @@ void GraphicsLayerCA::setContentsToPlatformLayer(PlatformLayer* platformLayer, C
             m_contentsLayer = WTFMove(platformCALayer);
         else
             m_contentsLayer = createPlatformCALayer(platformLayer, this);
+        m_contentsLayer->setBackingStoreAttached(false);
     } else
         m_contentsLayer = nullptr;
 
@@ -5001,8 +5002,12 @@ Vector<std::pair<String, double>> GraphicsLayerCA::acceleratedAnimationsForTesti
     return animations;
 }
 
-RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCA::createAsyncContentsDisplayDelegate()
+RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> GraphicsLayerCA::createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing)
 {
+    if (existing && existing->isGraphicsLayerAsyncContentsDisplayDelegateCocoa()) {
+        static_cast<GraphicsLayerAsyncContentsDisplayDelegateCocoa*>(existing)->updateGraphicsLayerCA(*this);
+        return existing;
+    }
     return adoptRef(new GraphicsLayerAsyncContentsDisplayDelegateCocoa(*this));
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -203,7 +203,7 @@ public:
 
     constexpr static CompositingCoordinatesOrientation defaultContentsOrientation = CompositingCoordinatesOrientation::TopDown;
 
-    WEBCORE_EXPORT RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate() override;
+    WEBCORE_EXPORT RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate*) override;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     WEBCORE_EXPORT void setAcceleratedEffectsAndBaseValues(AcceleratedEffects&&, AcceleratedEffectValues&&) override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h
@@ -37,8 +37,13 @@ public:
     bool tryCopyToLayer(ImageBuffer&) final;
     void display(PlatformCALayer&) final { }
 
+    bool isGraphicsLayerAsyncContentsDisplayDelegateCocoa() const final { return true; }
+
+    void updateGraphicsLayerCA(GraphicsLayerCA&);
+
 private:
     RetainPtr<CALayer> m_layer;
+    RefPtr<NativeImage> m_image;
 };
 
 }

--- a/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm
@@ -42,16 +42,23 @@ GraphicsLayerAsyncContentsDisplayDelegateCocoa::GraphicsLayerAsyncContentsDispla
 
 bool GraphicsLayerAsyncContentsDisplayDelegateCocoa::tryCopyToLayer(ImageBuffer& image)
 {
-    auto native = image.clone()->sinkIntoNativeImage();
+    m_image = image.clone()->sinkIntoNativeImage();
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
 
-    [m_layer setContents:(__bridge id)native->platformImage().get()];
+    [m_layer setContents:(__bridge id)m_image->platformImage().get()];
 
     [CATransaction commit];
 
     return true;
+}
+
+void GraphicsLayerAsyncContentsDisplayDelegateCocoa::updateGraphicsLayerCA(GraphicsLayerCA& layer)
+{
+    layer.setContentsToPlatformLayer(m_layer.get(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+    if (m_image)
+        [m_layer setContents:(__bridge id)m_image->platformImage().get()];
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -63,7 +63,7 @@ private:
 
     WebCore::Color pageTiledBackingBorderColor() const override;
 
-    RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate() final;
+    RefPtr<WebCore::GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(WebCore::GraphicsLayerAsyncContentsDisplayDelegate*) final;
 
     RemoteLayerTreeContext* m_context;
 };


### PR DESCRIPTION
#### cbd73ab873ddc90f1857c70d2214dedd586ae661
<pre>
Google Photos will not allow preview of editing in Safari.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259263">https://bugs.webkit.org/show_bug.cgi?id=259263</a>
&lt;rdar://107687640&gt;

Reviewed by Dean Jackson.

OffscreenCanvas can asynchronously push frames to the layer associated with the HTMLCanvasElement that is being controlled.
This happens using a GraphicsLayerAsyncContentsDisplayDelegate, created by the GraphicsLayer for the HTMLCanvasElement.

If style changes that result in the recreation of the GraphicsLayer, the OffscreenCanvas continues to push frames to the original
delegate, and they get dropped.

This makes ImageBufferPipe always ask the current GraphicsLayer to make sure we have a valid delegate, providing the delegate
that was used last time. If the GraphicsLayer has changed, it can reconfigure the delegate to make sure it&apos;s targetting the right layer.

We need to reconfigure the delegate, rather than recreating one, since the delegate owns the &apos;current&apos; frame and we need to ensure this
is retained. Otherwise compositing wouldn&apos;t have a frame until the next time the OffscreenCanvas draws (which could be never).

* LayoutTests/fast/canvas/offscreen-toggle-display-expected.html: Added.
* LayoutTests/fast/canvas/offscreen-toggle-display.html: Added.
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::createAsyncContentsDisplayDelegate):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/GraphicsLayerContentsDisplayDelegate.h:
* Source/WebCore/platform/graphics/ImageBufferPipe.cpp:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::contentsLayerIDForModel const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/GraphicsLayerAsyncContentsDisplayDelegateCocoa.mm:
(WebCore::GraphicsLayerAsyncContentsDisplayDelegateCocoa::updateGraphicsLayerCA):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createAsyncContentsDisplayDelegate):

Canonical link: <a href="https://commits.webkit.org/266120@main">https://commits.webkit.org/266120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af779c333cd4ae781c8a9a49e10341515ce08922

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12926 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13250 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15033 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15115 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11692 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12165 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15067 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10218 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11559 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3170 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->