### PR TITLE
[IPC] Refactor ConnectionSendSyncResult so it's impossible to represent an invalid reply.

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -86,7 +86,7 @@ template<typename Message> bool ServiceWorkerDownloadTask::sendToServiceWorker(M
     if (!m_serviceWorkerConnection)
         return false;
 
-    return m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) == IPC::Error::NoError;
+    return !m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0);
 }
 
 void ServiceWorkerDownloadTask::dispatch(Function<void()>&& function)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -130,12 +130,12 @@ template<typename Message> bool ServiceWorkerFetchTask::sendToServiceWorker(Mess
     if (!m_serviceWorkerConnection)
         return false;
 
-    return m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0) == IPC::Error::NoError;
+    return !m_serviceWorkerConnection->ipcConnection().send(std::forward<Message>(message), 0);
 }
 
 template<typename Message> bool ServiceWorkerFetchTask::sendToClient(Message&& message)
 {
-    return m_loader.connectionToWebProcess().connection().send(std::forward<Message>(message), m_loader.coreIdentifier()) == IPC::Error::NoError;
+    return !m_loader.connectionToWebProcess().connection().send(std::forward<Message>(message), m_loader.coreIdentifier());
 }
 
 void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorkerConnection)

--- a/Source/WebKit/Platform/IPC/MessageSender.cpp
+++ b/Source/WebKit/Platform/IPC/MessageSender.cpp
@@ -37,7 +37,7 @@ bool MessageSender::sendMessage(UniqueRef<Encoder>&& encoder, OptionSet<SendOpti
     auto* connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
-    return connection->sendMessage(WTFMove(encoder), sendOptions) == Error::NoError;
+    return !connection->sendMessage(WTFMove(encoder), sendOptions);
 }
 
 bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, AsyncReplyHandler replyHandler, OptionSet<SendOption> sendOptions)
@@ -45,7 +45,7 @@ bool MessageSender::sendMessageWithAsyncReply(UniqueRef<Encoder>&& encoder, Asyn
     auto* connection = messageSenderConnection();
     ASSERT(connection);
     // FIXME: Propagate errors out.
-    return connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions) == Error::NoError;
+    return !connection->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(replyHandler), sendOptions);
 }
 
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -43,7 +43,7 @@ template<typename MessageType> inline auto MessageSender::sendSync(MessageType&&
     static_assert(MessageType::isSync);
     if (auto* connection = messageSenderConnection())
         return connection->sendSync(std::forward<MessageType>(message), destinationID, timeout, options);
-    return { nullptr, std::nullopt, Error::NoMessageSenderConnection };
+    return makeUnexpected(ErrorType::NoMessageSenderConnection);
 }
 
 template<typename MessageType, typename C> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> options)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -231,10 +231,10 @@ bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Optio
 
     case State::Running:
         if (asyncReplyHandler) {
-            if (connection()->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(*asyncReplyHandler), sendOptions) == IPC::Error::NoError)
+            if (!connection()->sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(*asyncReplyHandler), sendOptions))
                 return true;
         } else {
-            if (connection()->sendMessage(WTFMove(encoder), sendOptions) == IPC::Error::NoError)
+            if (!connection()->sendMessage(WTFMove(encoder), sendOptions))
                 return true;
         }
         break;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -442,7 +442,7 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
 
     WeakPtr weakThis { *this };
     auto startTime = MonotonicTime::now();
-    while (process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError) {
+    while (!process.connection()->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(m_identifier, activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives)) {
         if (!weakThis || activityStateChangeID == ActivityStateChangeAsynchronous || activityStateChangeID <= m_activityStateChangeID)
             return;
     }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2766,7 +2766,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _isWaitingOnPositionInformation = YES;
     if (![self _hasValidOutstandingPositionInformationRequest:request])
         [self requestAsynchronousPositionInformationUpdate:request];
-    bool receivedResponse = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageID(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
+    bool receivedResponse = !connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageID(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
     _hasValidPositionInformation = receivedResponse && _positionInformation.canBeValid;
     return _hasValidPositionInformation;
 }
@@ -5247,7 +5247,7 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
     if (!useSyncRequest)
         return;
 
-    if (_page->process().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
+    if (_page->process().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting))
         RELEASE_LOG(TextInput, "Timed out while waiting for autocorrection context.");
 
     if (_autocorrectionContextNeedsUpdate)

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -190,7 +190,7 @@
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
         if (auto* connection = _page->process().connection()) {
-            bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(_page->webPageID(), 500_ms) == IPC::Error::NoError;
+            bool receivedReply = !connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(_page->webPageID(), 500_ms);
             if (!receivedReply)
                 _state = WebKit::ImmediateActionState::TimedOut;
         }

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -376,7 +376,7 @@ bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEven
         return false;
 
     send(Messages::WebPage::RequestAcceptsFirstMouse(eventNumber, event), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
-    bool receivedReply = m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
+    bool receivedReply = !m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
 
     if (!receivedReply)
         return false;

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -310,9 +310,9 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
 bool GPUProcessConnection::waitForDidInitialize()
 {
     if (!m_hasInitialized) {
-        auto result = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
-        if (result != IPC::Error::NoError) {
-            RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(result));
+        auto error = m_connection->waitForAndDispatchImmediately<Messages::GPUProcessConnection::DidInitialize>(0, defaultTimeout);
+        if (error) {
+            RELEASE_LOG_ERROR(Process, "%p - GPUProcessConnection::waitForDidInitialize - failed, error:%" PUBLIC_LOG_STRING, this, IPC::errorAsString(error));
             invalidate();
             return false;
         }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -74,15 +74,15 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::send(T&& message)
         return;
 
     m_imageBuffer->backingStoreWillChange();
-    auto result = m_renderingBackend->streamConnection().send(WTFMove(message), m_destinationBufferIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
+    auto error = m_renderingBackend->streamConnection().send(WTFMove(message), m_destinationBufferIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
 #if !RELEASE_LOG_DISABLED
-    if (UNLIKELY(result != IPC::Error::NoError)) {
+    if (UNLIKELY(error)) {
         auto& parameters = m_renderingBackend->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(error));
     }
 #else
-    UNUSED_VARIABLE(result);
+    UNUSED_VARIABLE(error);
 #endif
 }
 
@@ -98,7 +98,7 @@ ALWAYS_INLINE void RemoteDisplayListRecorderProxy::sendSync(T&& message)
     if (UNLIKELY(!result.succeeded())) {
         auto& parameters = m_renderingBackend->parameters();
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteDisplayListRecorderProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error));
+            parameters.pageProxyID.toUInt64(), parameters.pageID.toUInt64(), parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error()));
     }
 #else
     UNUSED_VARIABLE(result);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -139,8 +139,8 @@ void RemoteGraphicsContextGLProxy::markContextChanged()
         GraphicsContextGL::markContextChanged();
         if (isContextLost())
             return;
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MarkContextChanged());
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MarkContextChanged());
+        if (error)
             markContextLost();
     }
 }
@@ -158,8 +158,8 @@ void RemoteGraphicsContextGLProxy::ensureExtensionEnabled(const String& name)
         m_enabledExtensions.add(name);
         if (isContextLost())
             return;
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::EnsureExtensionEnabled(name));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::EnsureExtensionEnabled(name));
+        if (error)
             markContextLost();
     }
 }
@@ -206,8 +206,8 @@ void RemoteGraphicsContextGLProxy::reshape(int width, int height)
         return;
     m_currentWidth = width;
     m_currentHeight = height;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Reshape(width, height));
-    if (sendResult != IPC::Error::NoError)
+    auto error = send(Messages::RemoteGraphicsContextGL::Reshape(width, height));
+    if (error)
         markContextLost();
 }
 
@@ -280,12 +280,12 @@ bool RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame(WebCore::VideoFrame
         return false;
 
     auto sharedVideoFrame = m_sharedVideoFrameWriter.write(videoFrame, [this](auto& semaphore) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameSemaphore { semaphore });
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameSemaphore { semaphore });
+        if (error)
             markContextLost();
     }, [this](auto&& handle) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameMemory { WTFMove(handle) });
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::SetSharedVideoFrameMemory { WTFMove(handle) });
+        if (error)
             markContextLost();
     });
     if (!sharedVideoFrame || isContextLost())
@@ -334,8 +334,8 @@ GCGLErrorCodeSet RemoteGraphicsContextGLProxy::getErrors()
 void RemoteGraphicsContextGLProxy::simulateEventForTesting(SimulatedEventForTesting event)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::SimulateEventForTesting(event));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::SimulateEventForTesting(event));
+        if (error)
             markContextLost();
     }
 }
@@ -419,8 +419,8 @@ inlineCase:
 void RemoteGraphicsContextGLProxy::multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysANGLE(mode, toArrayReferenceTuple<int32_t, int32_t>(firstsAndCounts)));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysANGLE(mode, toArrayReferenceTuple<int32_t, int32_t>(firstsAndCounts)));
+        if (error)
             markContextLost();
     }
 }
@@ -428,8 +428,8 @@ void RemoteGraphicsContextGLProxy::multiDrawArraysANGLE(GCGLenum mode, GCGLSpanT
 void RemoteGraphicsContextGLProxy::multiDrawArraysInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei> firstsCountsAndInstanceCounts)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysInstancedANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t>(firstsCountsAndInstanceCounts)));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysInstancedANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t>(firstsCountsAndInstanceCounts)));
+        if (error)
             markContextLost();
     }
 }
@@ -437,8 +437,8 @@ void RemoteGraphicsContextGLProxy::multiDrawArraysInstancedANGLE(GCGLenum mode, 
 void RemoteGraphicsContextGLProxy::multiDrawElementsANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei> countsAndOffsets, GCGLenum type)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsANGLE(mode, toArrayReferenceTuple<int32_t, int32_t>(countsAndOffsets), type));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsANGLE(mode, toArrayReferenceTuple<int32_t, int32_t>(countsAndOffsets), type));
+        if (error)
             markContextLost();
     }
 }
@@ -446,8 +446,8 @@ void RemoteGraphicsContextGLProxy::multiDrawElementsANGLE(GCGLenum mode, GCGLSpa
 void RemoteGraphicsContextGLProxy::multiDrawElementsInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei> countsOffsetsAndInstanceCounts, GCGLenum type)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsInstancedANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t>(countsOffsetsAndInstanceCounts), type));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsInstancedANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t>(countsOffsetsAndInstanceCounts), type));
+        if (error)
             markContextLost();
     }
 }
@@ -455,8 +455,8 @@ void RemoteGraphicsContextGLProxy::multiDrawElementsInstancedANGLE(GCGLenum mode
 void RemoteGraphicsContextGLProxy::multiDrawArraysInstancedBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei, const GCGLuint> firstsCountsInstanceCountsAndBaseInstances)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysInstancedBaseInstanceANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t>(firstsCountsInstanceCountsAndBaseInstances)));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawArraysInstancedBaseInstanceANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t>(firstsCountsInstanceCountsAndBaseInstances)));
+        if (error)
             markContextLost();
     }
 }
@@ -464,8 +464,8 @@ void RemoteGraphicsContextGLProxy::multiDrawArraysInstancedBaseInstanceANGLE(GCG
 void RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei, const GCGLsizei, const GCGLint, const GCGLuint> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, GCGLenum type)
 {
     if (!isContextLost()) {
-        auto sendResult = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances), type));
-        if (sendResult != IPC::Error::NoError)
+        auto error = send(Messages::RemoteGraphicsContextGL::MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, toArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances), type));
+        if (error)
             markContextLost();
     }
 }
@@ -525,7 +525,7 @@ void RemoteGraphicsContextGLProxy::waitUntilInitialized()
         return;
     if (m_didInitialize)
         return;
-    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGraphicsContextGLProxy::WasCreated>(m_graphicsContextGLIdentifier, defaultSendTimeout) == IPC::Error::NoError)
+    if (!m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGraphicsContextGLProxy::WasCreated>(m_graphicsContextGLIdentifier, defaultSendTimeout))
         return;
     markContextLost();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -34,8 +34,8 @@ void RemoteGraphicsContextGLProxy::activeTexture(GCGLenum texture)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ActiveTexture(texture));
+    if (error) {
         markContextLost();
         return;
     }
@@ -45,8 +45,8 @@ void RemoteGraphicsContextGLProxy::attachShader(PlatformGLObject program, Platfo
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::AttachShader(program, shader));
+    if (error) {
         markContextLost();
         return;
     }
@@ -56,8 +56,8 @@ void RemoteGraphicsContextGLProxy::bindAttribLocation(PlatformGLObject arg0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindAttribLocation(arg0, index, name));
+    if (error) {
         markContextLost();
         return;
     }
@@ -67,8 +67,8 @@ void RemoteGraphicsContextGLProxy::bindBuffer(GCGLenum target, PlatformGLObject 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindBuffer(target, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -78,8 +78,8 @@ void RemoteGraphicsContextGLProxy::bindFramebuffer(GCGLenum target, PlatformGLOb
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindFramebuffer(target, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -89,8 +89,8 @@ void RemoteGraphicsContextGLProxy::bindRenderbuffer(GCGLenum target, PlatformGLO
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindRenderbuffer(target, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -100,8 +100,8 @@ void RemoteGraphicsContextGLProxy::bindTexture(GCGLenum target, PlatformGLObject
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindTexture(target, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -111,8 +111,8 @@ void RemoteGraphicsContextGLProxy::blendColor(GCGLclampf red, GCGLclampf green, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendColor(red, green, blue, alpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -122,8 +122,8 @@ void RemoteGraphicsContextGLProxy::blendEquation(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendEquation(mode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -133,8 +133,8 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparate(GCGLenum modeRGB, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparate(modeRGB, modeAlpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -144,8 +144,8 @@ void RemoteGraphicsContextGLProxy::blendFunc(GCGLenum sfactor, GCGLenum dfactor)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendFunc(sfactor, dfactor));
+    if (error) {
         markContextLost();
         return;
     }
@@ -155,8 +155,8 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparate(GCGLenum srcRGB, GCGLenum d
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -179,8 +179,8 @@ void RemoteGraphicsContextGLProxy::clear(GCGLbitfield mask)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Clear(mask));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Clear(mask));
+    if (error) {
         markContextLost();
         return;
     }
@@ -190,8 +190,8 @@ void RemoteGraphicsContextGLProxy::clearColor(GCGLclampf red, GCGLclampf green, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearColor(red, green, blue, alpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -201,8 +201,8 @@ void RemoteGraphicsContextGLProxy::clearDepth(GCGLclampf depth)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearDepth(depth));
+    if (error) {
         markContextLost();
         return;
     }
@@ -212,8 +212,8 @@ void RemoteGraphicsContextGLProxy::clearStencil(GCGLint s)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearStencil(s));
+    if (error) {
         markContextLost();
         return;
     }
@@ -223,8 +223,8 @@ void RemoteGraphicsContextGLProxy::colorMask(GCGLboolean red, GCGLboolean green,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ColorMask(static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -234,8 +234,8 @@ void RemoteGraphicsContextGLProxy::compileShader(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompileShader(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -245,8 +245,8 @@ void RemoteGraphicsContextGLProxy::copyTexImage2D(GCGLenum target, GCGLint level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CopyTexImage2D(target, level, internalformat, x, y, width, height, border));
+    if (error) {
         markContextLost();
         return;
     }
@@ -256,8 +256,8 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage2D(GCGLenum target, GCGLint le
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -345,8 +345,8 @@ void RemoteGraphicsContextGLProxy::cullFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CullFace(mode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -356,8 +356,8 @@ void RemoteGraphicsContextGLProxy::deleteBuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteBuffer(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -367,8 +367,8 @@ void RemoteGraphicsContextGLProxy::deleteFramebuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteFramebuffer(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -378,8 +378,8 @@ void RemoteGraphicsContextGLProxy::deleteProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteProgram(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -389,8 +389,8 @@ void RemoteGraphicsContextGLProxy::deleteRenderbuffer(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteRenderbuffer(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -400,8 +400,8 @@ void RemoteGraphicsContextGLProxy::deleteShader(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteShader(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -411,8 +411,8 @@ void RemoteGraphicsContextGLProxy::deleteTexture(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteTexture(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -422,8 +422,8 @@ void RemoteGraphicsContextGLProxy::depthFunc(GCGLenum func)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DepthFunc(func));
+    if (error) {
         markContextLost();
         return;
     }
@@ -433,8 +433,8 @@ void RemoteGraphicsContextGLProxy::depthMask(GCGLboolean flag)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DepthMask(static_cast<bool>(flag)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -444,8 +444,8 @@ void RemoteGraphicsContextGLProxy::depthRange(GCGLclampf zNear, GCGLclampf zFar)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DepthRange(zNear, zFar));
+    if (error) {
         markContextLost();
         return;
     }
@@ -455,8 +455,8 @@ void RemoteGraphicsContextGLProxy::destroyEGLImage(GCEGLImage handle)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DestroyEGLImage(static_cast<uint64_t>(reinterpret_cast<intptr_t>(handle))));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DestroyEGLImage(static_cast<uint64_t>(reinterpret_cast<intptr_t>(handle))));
+    if (error) {
         markContextLost();
         return;
     }
@@ -466,8 +466,8 @@ void RemoteGraphicsContextGLProxy::detachShader(PlatformGLObject arg0, PlatformG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DetachShader(arg0, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -477,8 +477,8 @@ void RemoteGraphicsContextGLProxy::disable(GCGLenum cap)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Disable(cap));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Disable(cap));
+    if (error) {
         markContextLost();
         return;
     }
@@ -488,8 +488,8 @@ void RemoteGraphicsContextGLProxy::disableVertexAttribArray(GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DisableVertexAttribArray(index));
+    if (error) {
         markContextLost();
         return;
     }
@@ -499,8 +499,8 @@ void RemoteGraphicsContextGLProxy::drawArrays(GCGLenum mode, GCGLint first, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawArrays(mode, first, count));
+    if (error) {
         markContextLost();
         return;
     }
@@ -510,8 +510,8 @@ void RemoteGraphicsContextGLProxy::drawElements(GCGLenum mode, GCGLsizei count, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawElements(mode, count, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -521,8 +521,8 @@ void RemoteGraphicsContextGLProxy::enable(GCGLenum cap)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Enable(cap));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Enable(cap));
+    if (error) {
         markContextLost();
         return;
     }
@@ -532,8 +532,8 @@ void RemoteGraphicsContextGLProxy::enableVertexAttribArray(GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::EnableVertexAttribArray(index));
+    if (error) {
         markContextLost();
         return;
     }
@@ -543,8 +543,8 @@ void RemoteGraphicsContextGLProxy::finish()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Finish());
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Finish());
+    if (error) {
         markContextLost();
         return;
     }
@@ -554,8 +554,8 @@ void RemoteGraphicsContextGLProxy::flush()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Flush());
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Flush());
+    if (error) {
         markContextLost();
         return;
     }
@@ -565,8 +565,8 @@ void RemoteGraphicsContextGLProxy::framebufferRenderbuffer(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::FramebufferRenderbuffer(target, attachment, renderbuffertarget, arg3));
+    if (error) {
         markContextLost();
         return;
     }
@@ -576,8 +576,8 @@ void RemoteGraphicsContextGLProxy::framebufferTexture2D(GCGLenum target, GCGLenu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::FramebufferTexture2D(target, attachment, textarget, arg3, level));
+    if (error) {
         markContextLost();
         return;
     }
@@ -587,8 +587,8 @@ void RemoteGraphicsContextGLProxy::frontFace(GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::FrontFace(mode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -598,8 +598,8 @@ void RemoteGraphicsContextGLProxy::generateMipmap(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::GenerateMipmap(target));
+    if (error) {
         markContextLost();
         return;
     }
@@ -951,8 +951,8 @@ void RemoteGraphicsContextGLProxy::hint(GCGLenum target, GCGLenum mode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Hint(target, mode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1053,8 +1053,8 @@ void RemoteGraphicsContextGLProxy::lineWidth(GCGLfloat arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::LineWidth(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1064,8 +1064,8 @@ void RemoteGraphicsContextGLProxy::linkProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::LinkProgram(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1075,8 +1075,8 @@ void RemoteGraphicsContextGLProxy::pixelStorei(GCGLenum pname, GCGLint param)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::PixelStorei(pname, param));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1086,8 +1086,8 @@ void RemoteGraphicsContextGLProxy::polygonOffset(GCGLfloat factor, GCGLfloat uni
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::PolygonOffset(factor, units));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1097,8 +1097,8 @@ void RemoteGraphicsContextGLProxy::renderbufferStorage(GCGLenum target, GCGLenum
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::RenderbufferStorage(target, internalformat, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1108,8 +1108,8 @@ void RemoteGraphicsContextGLProxy::sampleCoverage(GCGLclampf value, GCGLboolean 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::SampleCoverage(value, static_cast<bool>(invert)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1119,8 +1119,8 @@ void RemoteGraphicsContextGLProxy::scissor(GCGLint x, GCGLint y, GCGLsizei width
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Scissor(x, y, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1130,8 +1130,8 @@ void RemoteGraphicsContextGLProxy::shaderSource(PlatformGLObject arg0, const Str
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ShaderSource(arg0, arg1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1141,8 +1141,8 @@ void RemoteGraphicsContextGLProxy::stencilFunc(GCGLenum func, GCGLint ref, GCGLu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilFunc(func, ref, mask));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1152,8 +1152,8 @@ void RemoteGraphicsContextGLProxy::stencilFuncSeparate(GCGLenum face, GCGLenum f
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilFuncSeparate(face, func, ref, mask));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1163,8 +1163,8 @@ void RemoteGraphicsContextGLProxy::stencilMask(GCGLuint mask)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilMask(mask));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1174,8 +1174,8 @@ void RemoteGraphicsContextGLProxy::stencilMaskSeparate(GCGLenum face, GCGLuint m
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilMaskSeparate(face, mask));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1185,8 +1185,8 @@ void RemoteGraphicsContextGLProxy::stencilOp(GCGLenum fail, GCGLenum zfail, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilOp(fail, zfail, zpass));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1196,8 +1196,8 @@ void RemoteGraphicsContextGLProxy::stencilOpSeparate(GCGLenum face, GCGLenum fai
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::StencilOpSeparate(face, fail, zfail, zpass));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1207,8 +1207,8 @@ void RemoteGraphicsContextGLProxy::texParameterf(GCGLenum target, GCGLenum pname
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexParameterf(target, pname, param));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1218,8 +1218,8 @@ void RemoteGraphicsContextGLProxy::texParameteri(GCGLenum target, GCGLenum pname
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexParameteri(target, pname, param));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1229,8 +1229,8 @@ void RemoteGraphicsContextGLProxy::uniform1f(GCGLint location, GCGLfloat x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1f(location, x));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1240,8 +1240,8 @@ void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1251,8 +1251,8 @@ void RemoteGraphicsContextGLProxy::uniform1i(GCGLint location, GCGLint x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1i(location, x));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1262,8 +1262,8 @@ void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1273,8 +1273,8 @@ void RemoteGraphicsContextGLProxy::uniform2f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2f(location, x, y));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1284,8 +1284,8 @@ void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1295,8 +1295,8 @@ void RemoteGraphicsContextGLProxy::uniform2i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2i(location, x, y));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1306,8 +1306,8 @@ void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1317,8 +1317,8 @@ void RemoteGraphicsContextGLProxy::uniform3f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3f(location, x, y, z));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1328,8 +1328,8 @@ void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1339,8 +1339,8 @@ void RemoteGraphicsContextGLProxy::uniform3i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3i(location, x, y, z));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1350,8 +1350,8 @@ void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1361,8 +1361,8 @@ void RemoteGraphicsContextGLProxy::uniform4f(GCGLint location, GCGLfloat x, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4f(location, x, y, z, w));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1372,8 +1372,8 @@ void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, IPC::ArrayReference<float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1383,8 +1383,8 @@ void RemoteGraphicsContextGLProxy::uniform4i(GCGLint location, GCGLint x, GCGLin
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4i(location, x, y, z, w));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1394,8 +1394,8 @@ void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1405,8 +1405,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1416,8 +1416,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1427,8 +1427,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1438,8 +1438,8 @@ void RemoteGraphicsContextGLProxy::useProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UseProgram(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1449,8 +1449,8 @@ void RemoteGraphicsContextGLProxy::validateProgram(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ValidateProgram(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1460,8 +1460,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1f(GCGLuint index, GCGLfloat x)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib1f(index, x));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1471,8 +1471,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, IPC::ArrayReference<float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1482,8 +1482,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib2f(index, x, y));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1493,8 +1493,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, IPC::ArrayReference<float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1504,8 +1504,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib3f(index, x, y, z));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1515,8 +1515,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, IPC::ArrayReference<float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1526,8 +1526,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4f(GCGLuint index, GCGLfloat x, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib4f(index, x, y, z, w));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1537,8 +1537,8 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, IPC::ArrayReference<float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1548,8 +1548,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribPointer(GCGLuint index, GCGLint s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribPointer(index, size, type, static_cast<bool>(normalized), stride, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1559,8 +1559,8 @@ void RemoteGraphicsContextGLProxy::viewport(GCGLint x, GCGLint y, GCGLsizei widt
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Viewport(x, y, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1570,8 +1570,8 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, GCGLsizeiptr arg1
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BufferData0(target, static_cast<uint64_t>(arg1), usage));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1581,8 +1581,8 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, std::span<const u
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BufferData1(target, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1592,8 +1592,8 @@ void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr off
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1603,8 +1603,8 @@ void RemoteGraphicsContextGLProxy::readPixelsBufferObject(WebCore::IntRect arg0,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadPixelsBufferObject(arg0, format, type, static_cast<uint64_t>(offset), alignment, rowLength));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ReadPixelsBufferObject(arg0, format, type, static_cast<uint64_t>(offset), alignment, rowLength));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1614,8 +1614,8 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1625,8 +1625,8 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexImage2D1(target, level, internalformat, width, height, border, format, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1636,8 +1636,8 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1647,8 +1647,8 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexSubImage2D1(target, level, xoffset, yoffset, width, height, format, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1658,8 +1658,8 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1669,8 +1669,8 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D1(target, level, internalformat, width, height, border, imageSize, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1680,8 +1680,8 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1691,8 +1691,8 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D1(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1702,8 +1702,8 @@ void RemoteGraphicsContextGLProxy::drawArraysInstanced(GCGLenum mode, GCGLint fi
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawArraysInstanced(mode, first, count, primcount));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1713,8 +1713,8 @@ void RemoteGraphicsContextGLProxy::drawElementsInstanced(GCGLenum mode, GCGLsize
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawElementsInstanced(mode, count, type, static_cast<uint64_t>(offset), primcount));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1724,8 +1724,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribDivisor(GCGLuint index, GCGLuint 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribDivisor(index, divisor));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1748,8 +1748,8 @@ void RemoteGraphicsContextGLProxy::deleteVertexArray(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteVertexArray(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1772,8 +1772,8 @@ void RemoteGraphicsContextGLProxy::bindVertexArray(PlatformGLObject arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindVertexArray(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1783,8 +1783,8 @@ void RemoteGraphicsContextGLProxy::copyBufferSubData(GCGLenum readTarget, GCGLen
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CopyBufferSubData(readTarget, writeTarget, static_cast<uint64_t>(readOffset), static_cast<uint64_t>(writeOffset), static_cast<uint64_t>(arg4)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1807,8 +1807,8 @@ void RemoteGraphicsContextGLProxy::blitFramebuffer(GCGLint srcX0, GCGLint srcY0,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1818,8 +1818,8 @@ void RemoteGraphicsContextGLProxy::framebufferTextureLayer(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::FramebufferTextureLayer(target, attachment, texture, level, layer));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1829,8 +1829,8 @@ void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, std::s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1840,8 +1840,8 @@ void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, std
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1851,8 +1851,8 @@ void RemoteGraphicsContextGLProxy::readBuffer(GCGLenum src)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ReadBuffer(src));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1862,8 +1862,8 @@ void RemoteGraphicsContextGLProxy::renderbufferStorageMultisample(GCGLenum targe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisample(target, samples, internalformat, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1873,8 +1873,8 @@ void RemoteGraphicsContextGLProxy::texStorage2D(GCGLenum target, GCGLsizei level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexStorage2D(target, levels, internalformat, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1884,8 +1884,8 @@ void RemoteGraphicsContextGLProxy::texStorage3D(GCGLenum target, GCGLsizei level
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexStorage3D(target, levels, internalformat, width, height, depth));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1895,8 +1895,8 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1906,8 +1906,8 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexImage3D1(target, level, internalformat, width, height, depth, border, format, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1917,8 +1917,8 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1928,8 +1928,8 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1939,8 +1939,8 @@ void RemoteGraphicsContextGLProxy::copyTexSubImage3D(GCGLenum target, GCGLint le
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1950,8 +1950,8 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1961,8 +1961,8 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D1(target, level, internalformat, width, height, depth, border, imageSize, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1972,8 +1972,8 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, IPC::ArrayReference<uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -1983,8 +1983,8 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D1(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2007,8 +2007,8 @@ void RemoteGraphicsContextGLProxy::uniform1ui(GCGLint location, GCGLuint v0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1ui(location, v0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2018,8 +2018,8 @@ void RemoteGraphicsContextGLProxy::uniform2ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2ui(location, v0, v1));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2029,8 +2029,8 @@ void RemoteGraphicsContextGLProxy::uniform3ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3ui(location, v0, v1, v2));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2040,8 +2040,8 @@ void RemoteGraphicsContextGLProxy::uniform4ui(GCGLint location, GCGLuint v0, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4ui(location, v0, v1, v2, v3));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2051,8 +2051,8 @@ void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2062,8 +2062,8 @@ void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2073,8 +2073,8 @@ void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2084,8 +2084,8 @@ void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2095,8 +2095,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2106,8 +2106,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2117,8 +2117,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2128,8 +2128,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2139,8 +2139,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2150,8 +2150,8 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), IPC::ArrayReference<float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2161,8 +2161,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4i(GCGLuint index, GCGLint x, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribI4i(index, x, y, z, w));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2172,8 +2172,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, std::span<co
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, IPC::ArrayReference<int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2183,8 +2183,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4ui(GCGLuint index, GCGLuint x, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribI4ui(index, x, y, z, w));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2194,8 +2194,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, std::span<c
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, IPC::ArrayReference<uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2205,8 +2205,8 @@ void RemoteGraphicsContextGLProxy::vertexAttribIPointer(GCGLuint index, GCGLint 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::VertexAttribIPointer(index, size, type, stride, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2216,8 +2216,8 @@ void RemoteGraphicsContextGLProxy::drawRangeElements(GCGLenum mode, GCGLuint sta
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawRangeElements(mode, start, end, count, type, static_cast<uint64_t>(offset)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2227,8 +2227,8 @@ void RemoteGraphicsContextGLProxy::drawBuffers(std::span<const GCGLenum> bufs)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawBuffers(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2238,8 +2238,8 @@ void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, IPC::ArrayReference<int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2249,8 +2249,8 @@ void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawb
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2260,8 +2260,8 @@ void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, IPC::ArrayReference<float>(reinterpret_cast<const float*>(values.data()), values.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2271,8 +2271,8 @@ void RemoteGraphicsContextGLProxy::clearBufferfi(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClearBufferfi(buffer, drawbuffer, depth, stencil));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2295,8 +2295,8 @@ void RemoteGraphicsContextGLProxy::deleteQuery(PlatformGLObject query)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteQuery(query));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2319,8 +2319,8 @@ void RemoteGraphicsContextGLProxy::beginQuery(GCGLenum target, PlatformGLObject 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BeginQuery(target, query));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2330,8 +2330,8 @@ void RemoteGraphicsContextGLProxy::endQuery(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::EndQuery(target));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2380,8 +2380,8 @@ void RemoteGraphicsContextGLProxy::deleteSampler(PlatformGLObject sampler)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteSampler(sampler));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2404,8 +2404,8 @@ void RemoteGraphicsContextGLProxy::bindSampler(GCGLuint unit, PlatformGLObject s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindSampler(unit, sampler));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2415,8 +2415,8 @@ void RemoteGraphicsContextGLProxy::samplerParameteri(PlatformGLObject sampler, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::SamplerParameteri(sampler, pname, param));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2426,8 +2426,8 @@ void RemoteGraphicsContextGLProxy::samplerParameterf(PlatformGLObject sampler, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::SamplerParameterf(sampler, pname, param));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2489,8 +2489,8 @@ void RemoteGraphicsContextGLProxy::deleteSync(GCGLsync arg0)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0))));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2513,8 +2513,8 @@ void RemoteGraphicsContextGLProxy::waitSync(GCGLsync arg0, GCGLbitfield flags, G
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::WaitSync(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), flags, static_cast<int64_t>(timeout)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2550,8 +2550,8 @@ void RemoteGraphicsContextGLProxy::deleteTransformFeedback(PlatformGLObject id)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteTransformFeedback(id));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2574,8 +2574,8 @@ void RemoteGraphicsContextGLProxy::bindTransformFeedback(GCGLenum target, Platfo
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindTransformFeedback(target, id));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2585,8 +2585,8 @@ void RemoteGraphicsContextGLProxy::beginTransformFeedback(GCGLenum primitiveMode
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BeginTransformFeedback(primitiveMode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2596,8 +2596,8 @@ void RemoteGraphicsContextGLProxy::endTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::EndTransformFeedback());
+    if (error) {
         markContextLost();
         return;
     }
@@ -2607,8 +2607,8 @@ void RemoteGraphicsContextGLProxy::transformFeedbackVaryings(PlatformGLObject pr
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::TransformFeedbackVaryings(program, varyings, bufferMode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2631,8 +2631,8 @@ void RemoteGraphicsContextGLProxy::pauseTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::PauseTransformFeedback());
+    if (error) {
         markContextLost();
         return;
     }
@@ -2642,8 +2642,8 @@ void RemoteGraphicsContextGLProxy::resumeTransformFeedback()
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ResumeTransformFeedback());
+    if (error) {
         markContextLost();
         return;
     }
@@ -2653,8 +2653,8 @@ void RemoteGraphicsContextGLProxy::bindBufferBase(GCGLenum target, GCGLuint inde
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindBufferBase(target, index, buffer));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2664,8 +2664,8 @@ void RemoteGraphicsContextGLProxy::bindBufferRange(GCGLenum target, GCGLuint ind
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BindBufferRange(target, index, buffer, static_cast<uint64_t>(offset), static_cast<uint64_t>(arg4)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2727,8 +2727,8 @@ void RemoteGraphicsContextGLProxy::uniformBlockBinding(PlatformGLObject program,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::UniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2764,8 +2764,8 @@ void RemoteGraphicsContextGLProxy::drawBuffersEXT(std::span<const GCGLenum> bufs
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(IPC::ArrayReference<uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2788,8 +2788,8 @@ void RemoteGraphicsContextGLProxy::deleteQueryEXT(PlatformGLObject query)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DeleteQueryEXT(query));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DeleteQueryEXT(query));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2812,8 +2812,8 @@ void RemoteGraphicsContextGLProxy::beginQueryEXT(GCGLenum target, PlatformGLObje
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BeginQueryEXT(target, query));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BeginQueryEXT(target, query));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2823,8 +2823,8 @@ void RemoteGraphicsContextGLProxy::endQueryEXT(GCGLenum target)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EndQueryEXT(target));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::EndQueryEXT(target));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2834,8 +2834,8 @@ void RemoteGraphicsContextGLProxy::queryCounterEXT(PlatformGLObject query, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::QueryCounterEXT(query, target));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::QueryCounterEXT(query, target));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2897,8 +2897,8 @@ void RemoteGraphicsContextGLProxy::enableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::EnableiOES(target, index));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2908,8 +2908,8 @@ void RemoteGraphicsContextGLProxy::disableiOES(GCGLenum target, GCGLuint index)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DisableiOES(target, index));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2919,8 +2919,8 @@ void RemoteGraphicsContextGLProxy::blendEquationiOES(GCGLuint buf, GCGLenum mode
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendEquationiOES(buf, mode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2930,8 +2930,8 @@ void RemoteGraphicsContextGLProxy::blendEquationSeparateiOES(GCGLuint buf, GCGLe
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendEquationSeparateiOES(buf, modeRGB, modeAlpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2941,8 +2941,8 @@ void RemoteGraphicsContextGLProxy::blendFunciOES(GCGLuint buf, GCGLenum src, GCG
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendFunciOES(buf, src, dst));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2952,8 +2952,8 @@ void RemoteGraphicsContextGLProxy::blendFuncSeparateiOES(GCGLuint buf, GCGLenum 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2963,8 +2963,8 @@ void RemoteGraphicsContextGLProxy::colorMaskiOES(GCGLuint buf, GCGLboolean red, 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ColorMaskiOES(buf, static_cast<bool>(red), static_cast<bool>(green), static_cast<bool>(blue), static_cast<bool>(alpha)));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2974,8 +2974,8 @@ void RemoteGraphicsContextGLProxy::drawArraysInstancedBaseInstanceANGLE(GCGLenum
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2985,8 +2985,8 @@ void RemoteGraphicsContextGLProxy::drawElementsInstancedBaseVertexBaseInstanceAN
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::DrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<uint64_t>(offset), instanceCount, baseVertex, baseInstance));
+    if (error) {
         markContextLost();
         return;
     }
@@ -2996,8 +2996,8 @@ void RemoteGraphicsContextGLProxy::provokingVertexANGLE(GCGLenum provokeMode)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(provokeMode));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ProvokingVertexANGLE(provokeMode));
+    if (error) {
         markContextLost();
         return;
     }
@@ -3007,8 +3007,8 @@ void RemoteGraphicsContextGLProxy::polygonOffsetClampEXT(GCGLfloat factor, GCGLf
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::PolygonOffsetClampEXT(factor, units, clamp));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::PolygonOffsetClampEXT(factor, units, clamp));
+    if (error) {
         markContextLost();
         return;
     }
@@ -3018,8 +3018,8 @@ void RemoteGraphicsContextGLProxy::renderbufferStorageMultisampleANGLE(GCGLenum 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::RenderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height));
+    if (error) {
         markContextLost();
         return;
     }
@@ -3029,8 +3029,8 @@ void RemoteGraphicsContextGLProxy::blitFramebufferANGLE(GCGLint srcX0, GCGLint s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BlitFramebufferANGLE(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::BlitFramebufferANGLE(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter));
+    if (error) {
         markContextLost();
         return;
     }
@@ -3053,8 +3053,8 @@ void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::Des
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace(arg0));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::SetDrawingBufferColorSpace(arg0));
+    if (error) {
         markContextLost();
         return;
     }
@@ -3090,8 +3090,8 @@ void RemoteGraphicsContextGLProxy::clientWaitEGLSyncWithFlush(GCEGLSync arg0, ui
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClientWaitEGLSyncWithFlush(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), timeout));
-    if (sendResult != IPC::Error::NoError) {
+    auto error = send(Messages::RemoteGraphicsContextGL::ClientWaitEGLSyncWithFlush(static_cast<uint64_t>(reinterpret_cast<intptr_t>(arg0)), timeout));
+    if (error) {
         markContextLost();
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -167,7 +167,7 @@ ImageBufferBackend* RemoteImageBufferProxy::ensureBackendCreated() const
 {
     if (!m_backend && m_remoteRenderingBackendProxy) {
         auto error = streamConnection().waitForAndDispatchImmediately<Messages::RemoteImageBufferProxy::DidCreateBackend>(m_renderingResourceIdentifier, RemoteRenderingBackendProxy::defaultTimeout);
-        if (error != IPC::Error::NoError) {
+        if (error) {
 #if !RELEASE_LOG_DISABLED
             auto& parameters = m_remoteRenderingBackendProxy->parameters();
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -101,12 +101,12 @@ void RemoteRenderingBackendProxy::ensureGPUProcessConnection()
 template<typename T>
 auto RemoteRenderingBackendProxy::send(T&& message)
 {
-    auto result = streamConnection().send(WTFMove(message), renderingBackendIdentifier(), defaultTimeout);
-    if (UNLIKELY(result != IPC::Error::NoError)) {
+    auto error = streamConnection().send(WTFMove(message), renderingBackendIdentifier(), defaultTimeout);
+    if (UNLIKELY(error)) {
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::send - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result));
+            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(error));
     }
-    return result;
+    return error;
 }
 
 template<typename T>
@@ -115,7 +115,7 @@ auto RemoteRenderingBackendProxy::sendSync(T&& message)
     auto result = streamConnection().sendSync(WTFMove(message), renderingBackendIdentifier(), defaultTimeout);
     if (UNLIKELY(!result.succeeded())) {
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::sendSync - failed, name:%" PUBLIC_LOG_STRING ", error:%" PUBLIC_LOG_STRING,
-            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error));
+            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::description(T::name()), IPC::errorAsString(result.error()));
     }
     return result;
 }
@@ -363,7 +363,7 @@ auto RemoteRenderingBackendProxy::prepareBuffersForDisplay(const Vector<LayerPre
     if (!sendResult.succeeded()) {
         // GPU Process crashed. Set the output data to all null buffers, requiring a full display.
         RELEASE_LOG(RemoteLayerBuffers, "[pageProxyID=%" PRIu64 ", webPageID=%" PRIu64 ", renderingBackend=%" PRIu64 "] RemoteRenderingBackendProxy::prepareBuffersForDisplay - prepareBuffersForDisplay returned error: %" PUBLIC_LOG_STRING,
-            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::errorAsString(sendResult.error));
+            m_parameters.pageProxyID.toUInt64(), m_parameters.pageID.toUInt64(), m_parameters.identifier.toUInt64(), IPC::errorAsString(sendResult.error()));
         outputData.resize(inputData.size());
         for (auto& perLayerOutputData : outputData)
             perLayerOutputData.displayRequirement = SwapBuffersDisplayRequirement::NeedsFullDisplay;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -115,7 +115,7 @@ void RemoteGPUProxy::waitUntilInitialized()
 {
     if (m_didInitialize)
         return;
-    if (m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing, defaultSendTimeout) == IPC::Error::NoError)
+    if (!m_streamConnection->waitForAndDispatchImmediately<Messages::RemoteGPUProxy::WasCreated>(m_backing, defaultSendTimeout))
         return;
     m_lost = true;
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -62,7 +62,7 @@ HashSet<String, ASCIICaseInsensitiveHash>& RemoteMediaPlayerMIMETypeCache::suppo
             addSupportedTypes(types);
             m_hasPopulatedSupportedTypesCacheFromGPUProcess = true;
         } else
-            RELEASE_LOG_ERROR(Media, "RemoteMediaPlayerMIMETypeCache::supportedTypes: Sync IPC to the GPUProcess failed with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
+            RELEASE_LOG_ERROR(Media, "RemoteMediaPlayerMIMETypeCache::supportedTypes: Sync IPC to the GPUProcess failed with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
     }
     return m_supportedTypesCache;
 }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -533,7 +533,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     if (frame && !frame->settings().siteIsolationEnabled() && loadParameters.request.allowCookies() && !WebProcess::singleton().allowsFirstPartyForCookies(loadParameters.request.firstPartyForCookies()))
         RELEASE_LOG_FAULT(IPC, "scheduleLoad: Process will terminate due to failed allowsFirstPartyForCookies check");
 
-    if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters, existingNetworkResourceLoadIdentifierToResume), 0) != IPC::Error::NoError) {
+    if (WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ScheduleResourceLoad(loadParameters, existingNetworkResourceLoadIdentifierToResume), 0)) {
         WEBLOADERSTRATEGY_RELEASE_LOG_ERROR("scheduleLoad: Unable to schedule resource with the NetworkProcess (priority=%d)", static_cast<int>(resourceLoader.request().priority()));
         // We probably failed to schedule this load with the NetworkProcess because it had crashed.
         // This load will never succeed so we will schedule it to fail asynchronously.
@@ -778,7 +778,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
 
     auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::PerformSynchronousLoad(loadParameters), 0);
     if (!sendResult.succeeded()) {
-        WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
+        WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
         if (page)
             page->diagnosticLoggingClient().logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
         response = ResourceResponse();

--- a/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp
@@ -80,7 +80,7 @@ void WebMDNSRegister::registerMDNSName(ScriptExecutionContextIdentifier identifi
 
     // FIXME: Use async reply.
     auto& connection = WebProcess::singleton().ensureNetworkProcessConnection().connection();
-    if (connection.send(Messages::NetworkMDNSRegister::RegisterMDNSName { requestIdentifier, identifier, ipAddress }, 0) != IPC::Error::NoError)
+    if (connection.send(Messages::NetworkMDNSRegister::RegisterMDNSName { requestIdentifier, identifier, ipAddress }, 0))
         finishedRegisteringMDNSName(requestIdentifier, { }, MDNSRegisterError::Internal);
 }
 

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp
@@ -80,7 +80,7 @@ static bool sendMessage(WebPage* page, const Function<bool(IPC::Connection&, uin
 template<typename U> static bool sendNotificationMessage(U&& message, WebPage* page)
 {
     return sendMessage(page, [&] (auto& connection, auto destinationIdentifier) {
-        return connection.send(WTFMove(message), destinationIdentifier) == IPC::Error::NoError;
+        return !connection.send(WTFMove(message), destinationIdentifier);
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -152,7 +152,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     if (policyDecisionMode == PolicyDecisionMode::Synchronous) {
         auto sendResult = webPage->sendSync(Messages::WebPageProxy::DecidePolicyForNavigationActionSync(m_frame->frameID(), m_frame->isMainFrame(), m_frame->info(), requestIdentifier, documentLoader ? documentLoader->navigationID() : 0, navigationActionData, originatingFrameInfoData, originatingPageID, navigationAction.resourceRequest(), request, IPC::FormDataReference { request.httpBody() }, redirectResponse));
         if (!sendResult.succeeded()) {
-            WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
+            WebFrameLoaderClient_RELEASE_LOG_ERROR(Network, "dispatchDecidePolicyForNavigationAction: ignoring because of failing to send sync IPC with error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
             m_frame->didReceivePolicyDecision(listenerID, PolicyDecision { requestIdentifier });
             return;
         }

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -554,9 +554,9 @@ static JSValueRef sendSyncMessageWithJSArguments(IPC::Connection& connection, JS
     }
 
     auto replyDecoderOrError = connection.sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
-    if (replyDecoderOrError.decoder) {
+    if (replyDecoderOrError) {
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-        auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoderOrError.decoder);
+        auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, **replyDecoderOrError);
         if (scope.exception()) {
             *exception = toRef(globalObject, scope.exception());
             scope.clearException();
@@ -579,9 +579,9 @@ static JSValueRef waitForMessageWithJSArguments(IPC::Connection& connection, JSC
 
     auto [destinationID, messageName, timeout] = *info;
     auto decoderOrError = connection.waitForMessageForTesting(messageName, destinationID, timeout, { });
-    if (decoderOrError.decoder) {
+    if (decoderOrError) {
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-        auto jsResult = jsValueForArguments(globalObject, messageName, *decoderOrError.decoder);
+        auto jsResult = jsValueForArguments(globalObject, messageName, **decoderOrError);
         if (scope.exception()) {
             *exception = toRef(globalObject, scope.exception());
             scope.clearException();
@@ -1030,7 +1030,7 @@ bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(JSContextRef c
             return false;
     }
 
-    if (streamConnection.trySendDestinationIDIfNeeded(destinationID, timeout) != IPC::Error::NoError)
+    if (streamConnection.trySendDestinationIDIfNeeded(destinationID, timeout))
         return false;
 
     auto span = streamConnection.bufferForTesting().tryAcquire(timeout);
@@ -1093,9 +1093,9 @@ JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JS
         return JSValueMakeUndefined(context);
 
     auto replyDecoderOrError = connection.sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
-    if (replyDecoderOrError.decoder) {
+    if (replyDecoderOrError) {
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-        auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoderOrError.decoder);
+        auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, **replyDecoderOrError);
         if (scope.exception()) {
             *exception = toRef(globalObject, scope.exception());
             scope.clearException();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1168,7 +1168,7 @@ static NetworkProcessConnectionInfo getNetworkProcessConnection(IPC::Connection&
     auto requestConnection = [&]() -> bool {
         auto sendResult = connection.sendSync(Messages::WebProcessProxy::GetNetworkProcessConnection(), 0);
         if (!sendResult.succeeded()) {
-            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message: error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error));
+            RELEASE_LOG_ERROR(Process, "getNetworkProcessConnection: Failed to send message or receive invalid message: error %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()));
             failedToGetNetworkProcessConnection();
         }
         std::tie(connectionInfo) = sendResult.takeReply();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1436,7 +1436,7 @@ void WebProcess::didWriteToPasteboardAsynchronously(const String& pasteboardName
 void WebProcess::waitForPendingPasteboardWritesToFinish(const String& pasteboardName)
 {
     while (m_pendingPasteboardWriteCounts.contains(pasteboardName)) {
-        if (parentProcessConnection()->waitForAndDispatchImmediately<Messages::WebProcess::DidWriteToPasteboardAsynchronously>(0, 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) != IPC::Error::NoError) {
+        if (parentProcessConnection()->waitForAndDispatchImmediately<Messages::WebProcess::DidWriteToPasteboardAsynchronously>(0, 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives)) {
             m_pendingPasteboardWriteCounts.removeAll(pasteboardName);
             break;
         }

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -623,8 +623,8 @@ class webkit_ipc_cpp_proxy_impl(object):
             self.call_stmts += [ "    return { };"]
         if is_async:
             self.call_stmts += [
-                f"auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
-                "if (sendResult != IPC::Error::NoError) {",
+                f"auto error = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
+                "if (error) {",
             ]
         else:
             self.call_stmts += [

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -312,7 +312,7 @@ TEST_P(ConnectionTestABBA, ReceiveAlreadyInvalidatedClientNoAssert)
 TEST_P(ConnectionTestABBA, DISABLED_UnopenedWaitForAndDispatchImmediatelyIsInvalidConnection)
 {
     IPC::Error error = a()->waitForAndDispatchImmediately<MockTestMessage1>(0, kWaitForAbsenceTimeout);
-    EXPECT_EQ(IPC::Error::InvalidConnection, error);
+    EXPECT_EQ(IPC::ErrorType::InvalidConnection, *error);
 }
 
 TEST_P(ConnectionTestABBA, InvalidatedWaitForAndDispatchImmediatelyIsInvalidConnection)
@@ -320,14 +320,14 @@ TEST_P(ConnectionTestABBA, InvalidatedWaitForAndDispatchImmediatelyIsInvalidConn
     ASSERT_TRUE(openA());
     a()->invalidate();
     IPC::Error error = a()->waitForAndDispatchImmediately<MockTestMessage1>(0, kWaitForAbsenceTimeout);
-    EXPECT_EQ(IPC::Error::InvalidConnection, error);
+    EXPECT_EQ(IPC::ErrorType::InvalidConnection, *error);
 }
 
 TEST_P(ConnectionTestABBA, UnsentWaitForAndDispatchImmediatelyIsTimeout)
 {
     ASSERT_TRUE(openA());
     IPC::Error error = a()->waitForAndDispatchImmediately<MockTestMessage1>(0, kWaitForAbsenceTimeout);
-    EXPECT_EQ(IPC::Error::Timeout, error);
+    EXPECT_EQ(IPC::ErrorType::Timeout, *error);
 }
 
 template<typename C>
@@ -587,7 +587,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopWaitForAndDispatchImmediately)
 
         for (uint64_t i = 0u; i < 55u; ++i) {
             IPC::Error error = b()->waitForAndDispatchImmediately<MockTestMessage1>(i, kDefaultWaitForTimeout);
-            ASSERT_EQ(IPC::Error::NoError, error);
+            ASSERT_FALSE(error);
 
             auto message = bClient().waitForMessage(0_s);
             EXPECT_EQ(message.messageName, MockTestMessage1::name());
@@ -596,7 +596,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopWaitForAndDispatchImmediately)
     });
     for (uint64_t i = 100u; i < 160u; ++i) {
         IPC::Error error = a()->waitForAndDispatchImmediately<MockTestMessage1>(i, kDefaultWaitForTimeout);
-        ASSERT_EQ(IPC::Error::NoError, error);
+        ASSERT_FALSE(error);
 
         auto message = aClient().waitForMessage(0_s);
         EXPECT_EQ(message.messageName, MockTestMessage1::name());

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp
@@ -306,13 +306,13 @@ TEST_P(StreamMessageTest, Send)
     auto cleanup = localReferenceBarrier();
     for (uint64_t i = 0u; i < 55u; ++i) {
         auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
-        EXPECT_EQ(result, IPC::Error::NoError);
+        EXPECT_FALSE(result);
     }
     serverQueue().dispatch([&] {
         assertIsCurrent(serverQueue());
         for (uint64_t i = 100u; i < 160u; ++i) {
             auto result = m_serverConnection->send(MockTestMessage1 { }, ObjectIdentifier<TestObjectIdentifierTag>(i));
-            EXPECT_EQ(result, IPC::Error::NoError);
+            EXPECT_FALSE(result);
         }
     });
     for (uint64_t i = 100u; i < 160u; ++i) {
@@ -347,10 +347,10 @@ TEST_P(StreamMessageTest, SendWithSwitchingDestinationIDs)
 
     for (uint64_t i = 0u; i < 777u; ++i) {
         auto result = m_clientConnection->send(MockStreamTestMessage1 { }, defaultDestinationID(), defaultSendTimeout);
-        EXPECT_EQ(result, IPC::Error::NoError);
+        EXPECT_FALSE(result);
         if (i % 77) {
             result = m_clientConnection->send(MockStreamTestMessage1 { }, other, defaultSendTimeout);
-            EXPECT_EQ(result, IPC::Error::NoError);
+            EXPECT_FALSE(result);
         }
     }
     for (uint64_t i = 0u; i < 777u; ++i) {


### PR DESCRIPTION
#### 8c05b54bce4188b59f08147fcc5024a714c88411
<pre>
[IPC] Refactor ConnectionSendSyncResult so it&apos;s impossible to represent an invalid reply.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259266">https://bugs.webkit.org/show_bug.cgi?id=259266</a>
rdar://112442182

Reviewed by NOBODY (OOPS!).

We have a number of crash reports from an assert firing in std::optional when
unwrapping the result of a synchronous IPC call. This assert hints that we have
received a result where `succeeded()` returns true, yet we don&apos;t have a reply
payload in replyArguments. This is a violation of the prerequisites for
`ConnectionSendSyncReply`. This issue has been causes by improper handling of
`decoder` failure and has been fixed piecemeal, for example in
<a href="https://bugs.webkit.org/show_bug.cgi?id=259006.">https://bugs.webkit.org/show_bug.cgi?id=259006.</a>

Instead of fixing each location, this change makes it impossible to represent
invalid state by using `Expected&lt;T, Error&gt;` for ConnectionSendSyncReply and
DecoderOrError, instead of structs. This makes it impossible to represent the
error causing the assert to fire. In addition, Error has been changed from a raw
enum class into `Markable&lt;ErrorType, ...&gt;` with the `NoError` case
removed. (Markable was used so that 0 can represent the &quot;none&quot; case, but
`Expected&lt;void, Error` was also considered.)

This patch also implemented the monadic transform `and_then` for mapping one
Expected type to another, from C++23, as well as bugfixing an error in
`Expected(unexpect, E)` constructor.

Combined changes:
* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::expected::expected):
(std::experimental::fundamentals_v3::expected::and_then):
(std::experimental::fundamentals_v3::expected::and_then const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sendToServiceWorker):
(WebKit::ServiceWorkerFetchTask::sendToClient):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::sendMessage):
(IPC::Connection::sendMessageWithAsyncReply):
(IPC::Connection::waitForMessage):
(IPC::Connection::sendSyncMessage):
(IPC::Connection::waitForSyncReply):
(IPC::errorAsString):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::ConnectionSendSyncResult::succeeded const):
(IPC::ConnectionSendSyncResult::reply):
(IPC::ConnectionSendSyncResult::takeReply):
(IPC::ConnectionSendSyncResult::takeReplyOr):
(IPC::Connection::send):
(IPC::Connection::sendWithAsyncReply):
(IPC::Connection::sendSync):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::waitForAsyncReplyAndDispatchImmediately):
(IPC::Connection::DecoderOrError::DecoderOrError): Deleted.
* Source/WebKit/Platform/IPC/MessageSender.cpp:
(IPC::MessageSender::sendMessage):
(IPC::MessageSender::sendMessageWithAsyncReply):
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendSync):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::send):
(IPC::StreamClientConnection::sendWithAsyncReply):
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
(IPC::StreamClientConnection::trySendDestinationIDIfNeeded):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::sendMessage):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::acceptsFirstMouse):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::waitForDidInitialize):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::send):
(WebKit::RemoteDisplayListRecorderProxy::sendSync):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::markContextChanged):
(WebKit::RemoteGraphicsContextGLProxy::ensureExtensionEnabled):
(WebKit::RemoteGraphicsContextGLProxy::reshape):
(WebKit::RemoteGraphicsContextGLProxy::copyTextureFromVideoFrame):
(WebKit::RemoteGraphicsContextGLProxy::simulateEventForTesting):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGLProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
Automatically generated by generate-gpup-webgl script.

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::ensureBackendCreated const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::send):
(WebKit::RemoteRenderingBackendProxy::sendSync):
(WebKit::RemoteRenderingBackendProxy::prepareBuffersForDisplay):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportedTypes):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Network/webrtc/WebMDNSRegister.cpp:
(WebKit::WebMDNSRegister::registerMDNSName):
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendNotificationMessage):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::sendSyncMessageWithJSArguments):
(WebKit::IPCTestingAPI::waitForMessageWithJSArguments):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::getNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::waitForPendingPasteboardWritesToFinish):
* Tools/Scripts/generate-gpup-webgl:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/WTF/Expected.cpp:
- Add test for constructing an unexpected result using `Expected(unexpected, err)`.
- Add tests for `and_then` transformation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c05b54bce4188b59f08147fcc5024a714c88411

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13614 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15063 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15151 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11718 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18784 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11030 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15098 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12270 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10246 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13010 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11619 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3418 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15937 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13384 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12197 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3212 "Passed tests") | 
<!--EWS-Status-Bubble-End-->