### PR TITLE
RTCRtpSender maxFramerate encoding parameter has no effect

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1722,6 +1722,7 @@ webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 
 webrtc/video-av1.html [ Skip ]
+webrtc/video-maxFramerate.html [ Failure ]
 
 # GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
 webrtc/datachannel/dtls10.html [ Failure ]

--- a/LayoutTests/webrtc/video-maxFramerate-expected.txt
+++ b/LayoutTests/webrtc/video-maxFramerate-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Testing that maxFramerate has an effect
+

--- a/LayoutTests/webrtc/video-maxFramerate.html
+++ b/LayoutTests/webrtc/video-maxFramerate.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing macFramerate</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <canvas id="canvas" width="640" height="480"></canvas>
+        <script src ="routines.js"></script>
+        <script>
+var pc1, pc2;
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:true});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            pc1 = firstConnection;
+            const sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    let settings = stream.getVideoTracks()[0].getSettings();
+    assert_equals(settings.width, 640, "remote track settings width");
+    assert_equals(settings.height, 480, "remote track settings height");
+
+    let counter = 0;
+    while (++counter < 100 && settings.frameRate < 5) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than(settings.frameRate, 5, "remote track settings frame rate");
+
+    const parameters = pc1.getSenders()[0].getParameters();
+    parameters.encodings[0].maxFramerate = 1;
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    counter = 0;
+    while (++counter < 100 && settings.frameRate > 4) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_less_than(settings.frameRate, 4, "remote track settings reduced frame rate");
+}, "Testing that maxFramerate has an effect");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -130,6 +130,7 @@ private:
 
     void sourceMutedChanged();
     void sourceEnabledChanged();
+    void startObservingVideoFrames();
 
     // MediaStreamTrackPrivate::Observer API
     void trackMutedChanged(MediaStreamTrackPrivate&) final { sourceMutedChanged(); }
@@ -152,6 +153,8 @@ private:
     bool m_muted { false };
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
+    std::optional<double> m_maxFrameRate;
+    bool m_isObservingVideoFrames { false };
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -86,6 +86,18 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()
 
 void RemoteRealtimeVideoSource::remoteVideoFrameAvailable(VideoFrame& frame, VideoFrameTimeMetadata metadata)
 {
+    MediaTime sampleTime = frame.presentationTime();
+
+    auto frameTime = sampleTime.toDouble();
+    m_observedFrameTimeStamps.append(frameTime);
+    m_observedFrameTimeStamps.removeAllMatching([&](auto time) {
+        return time <= frameTime - 2;
+    });
+
+    auto interval = m_observedFrameTimeStamps.last() - m_observedFrameTimeStamps.first();
+    if (interval > 1)
+        m_observedFrameRate = (m_observedFrameTimeStamps.size() / interval);
+
     setIntrinsicSize(expandedIntSize(frame.presentationSize()));
     videoFrameAvailable(frame, metadata);
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -55,6 +55,10 @@ private:
     Ref<RealtimeMediaSource> clone() final;
     void endProducingData() final;
     bool setShouldApplyRotation(bool) final;
+    double observedFrameRate() const final { return m_observedFrameRate; }
+
+    Deque<double> m_observedFrameTimeStamps;
+    double m_observedFrameRate { 0 };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 3f6cf3be66c5ae9b67dd9335773eda572f17a69c
<pre>
RTCRtpSender maxFramerate encoding parameter has no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=259271">https://bugs.webkit.org/show_bug.cgi?id=259271</a>
rdar://problem/112397603

Reviewed by Eric Carlson.

React to AddOrUpdateSink max_frame_rate_bps signal to enforce maxFramerate by decimating at the source level.
Update RemoteRealtimeVideoSource::remoteVideoFrameAvailable to compute the observed frame rate so that decimation can happen in WebProcess.
Update RealtimeOutgoingVideoSource to call addVideoFrameObserve with specified frame rate.

* LayoutTests/webrtc/video-maxFramerate-expected.txt: Added.
* LayoutTests/webrtc/video-maxFramerate.html: Added.
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp:
(WebCore::RealtimeOutgoingVideoSource::startObservingVideoFrames):
(WebCore::RealtimeOutgoingVideoSource::updateBlackFramesSending):
(WebCore::RealtimeOutgoingVideoSource::AddOrUpdateSink):
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::remoteVideoFrameAvailable):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/266128@main">https://commits.webkit.org/266128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/525cfc6938303d546e000540c1334c31f26bad88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12371 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13311 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15068 "124 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15155 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18785 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15099 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->