### PR TITLE
absoluteRects are computed incorrectly for some continuations

### DIFF
--- a/LayoutTests/fast/block/continuations-bounding-box-expected.txt
+++ b/LayoutTests/fast/block/continuations-bounding-box-expected.txt
@@ -1,0 +1,7 @@
+Bounding box is {"x":17,"y":17,"width":766,"height":70}
+PASS successfullyParsed is true
+
+TEST COMPLETE
+container pre span before
+child
+span after container post

--- a/LayoutTests/fast/block/continuations-bounding-box.html
+++ b/LayoutTests/fast/block/continuations-bounding-box.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .container {
+            border: 1px solid black;
+            padding: 8px;
+            font-family: ahem;
+        }
+        
+        #target {
+            color: blue;
+            outline: 2px solid blue;
+        }
+        
+        .child {
+            border: 1px solid gray;
+            margin: 10px;
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+    <div class="container">
+        container pre
+        <span id="target">span before
+            <div class="child">
+                child
+            </div>
+        span after</span>
+        container post
+    </div>
+    <script>
+        const target = document.getElementById('target');
+        const targetBoundingBox = internals.boundingBox(target);
+        const actualBounds = {x: targetBoundingBox.y, y:targetBoundingBox.y, width: targetBoundingBox.width, height: targetBoundingBox.height };
+        debug(`Bounding box is ${JSON.stringify(actualBounds)}`);
+    </script>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/fast/block/continuations-bounding-box-expected.txt
+++ b/LayoutTests/platform/ios/fast/block/continuations-bounding-box-expected.txt
@@ -1,0 +1,7 @@
+Bounding box is {"x":17,"y":17,"width":766,"height":73}
+PASS successfullyParsed is true
+
+TEST COMPLETE
+container pre span before
+child
+span after container post

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2794,7 +2794,8 @@ void RenderBlock::absoluteRects(Vector<IntRect>& rects, const LayoutPoint& accum
         // FIXME: This is wrong for block-flows that are horizontal.
         // https://bugs.webkit.org/show_bug.cgi?id=46781
         rects.append(snappedIntRect(accumulatedOffset.x(), accumulatedOffset.y() - collapsedMarginBefore(), width(), height() + collapsedMarginBefore() + collapsedMarginAfter()));
-        continuation->absoluteRects(rects, accumulatedOffset - toLayoutSize(location() + inlineContinuation()->containingBlock()->location()));
+        auto* containingBlock = inlineContinuation()->containingBlock();
+        continuation->absoluteRects(rects, accumulatedOffset - locationOffset() + containingBlock->locationOffset());
     } else
         rects.append(snappedIntRect(accumulatedOffset, size()));
 }


### PR DESCRIPTION
#### 6ddbb226ce39d39523d1807bdc4189448ad0621d
<pre>
absoluteRects are computed incorrectly for some continuations
<a href="https://bugs.webkit.org/show_bug.cgi?id=259279">https://bugs.webkit.org/show_bug.cgi?id=259279</a>
rdar://112413956

Reviewed by Alan Baradlay.

A &lt;div&gt; inside a &lt;span&gt; triggers continutations, and if you call RenderInline::absoluteRects() on that span,
the rect for the last continuation is wrong. RenderBlock::absoluteRects() needs to subtract its own
location() and add that of the containing block, just like RenderInline::absoluteRects() does.

* LayoutTests/fast/block/continuations-bounding-box-expected.txt: Added.
* LayoutTests/fast/block/continuations-bounding-box.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::absoluteRects const):

Canonical link: <a href="https://commits.webkit.org/266169@main">https://commits.webkit.org/266169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f4c59c58472ae86a55871c8dac7f0a65236f764

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15051 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15138 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18771 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12180 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15084 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3203 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15924 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->