### PR TITLE
[WPE][CMake] Pass enabled sanitizers to Cog build

### DIFF
--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -51,6 +51,12 @@ if (ENABLE_COG)
         set(COG_MESON_BUILDTYPE debugoptimized)
     endif ()
 
+    if (ENABLE_SANITIZERS)
+        set(COG_MESON_SANITIZE_OPTION "${ENABLE_SANITIZERS}")
+    else ()
+        set(COG_MESON_SANITIZE_OPTION "none")
+    endif ()
+
     ExternalProject_Add(cog
         GIT_REPOSITORY "${WPE_COG_REPO}"
         GIT_TAG "${WPE_COG_TAG}"
@@ -62,6 +68,7 @@ if (ENABLE_COG)
             --pkg-config-path ${WPE_COG_PKG_CONFIG_PATH}
             -Dwpe_api=${WPE_API_VERSION}
             -Dplatforms=${WPE_COG_PLATFORMS}
+            -Db_sanitize=${COG_MESON_SANITIZE_OPTION}
         BUILD_COMMAND
             meson compile -C <BINARY_DIR>
         INSTALL_COMMAND "")


### PR DESCRIPTION
#### a4457738b3bfff8856b29b4f83c28a453ff44396
<pre>
[WPE][CMake] Pass enabled sanitizers to Cog build
<a href="https://bugs.webkit.org/show_bug.cgi?id=259283">https://bugs.webkit.org/show_bug.cgi?id=259283</a>

Reviewed by Michael Catanzaro.

Previously if you built with `ENABLE_SANITIZERS` then Cog
could fail to link with libasan. Passing the option
through fixes this. All of the allowed values are supported.

* Tools/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/266125@main">https://commits.webkit.org/266125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/716367a4301486a3ad41244eb4375579a120680a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13289 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15048 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15133 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18768 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15082 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10231 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15919 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1471 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->