### PR TITLE
RELEASE_ASSERT(isSuspensionImminent == IsSuspensionImminent::Yes) under ProcessThrottler::sendPrepareToSuspendIPC()

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -332,7 +332,8 @@ void AuxiliaryProcessProxy::wakeUpTemporarilyForIPC()
 {
     // If we keep trying to send IPC to a suspended process, the outgoing message queue may grow large and result
     // in increased memory usage. To avoid this, we wake up the process for a bit so we can drain the messages.
-    m_timedActivityForIPC = throttler().backgroundActivity("IPC sending due to large outgoing queue"_s);
+    if (!ProcessThrottler::isValidBackgroundActivity(m_timedActivityForIPC.activity()))
+        m_timedActivityForIPC = throttler().backgroundActivity("IPC sending due to large outgoing queue"_s);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -85,10 +85,21 @@ bool ProcessThrottler::addActivity(Activity& activity)
 void ProcessThrottler::removeActivity(Activity& activity)
 {
     ASSERT(isMainRunLoop());
+    if (!m_allowsActivities) {
+        ASSERT(m_foregroundActivities.isEmpty());
+        ASSERT(m_backgroundActivities.isEmpty());
+        return;
+    }
+
+    bool wasRemoved;
     if (activity.isForeground())
-        m_foregroundActivities.remove(&activity);
+        wasRemoved = m_foregroundActivities.remove(&activity);
     else
-        m_backgroundActivities.remove(&activity);
+        wasRemoved = m_backgroundActivities.remove(&activity);
+    ASSERT(wasRemoved);
+    if (!wasRemoved)
+        return;
+
     updateThrottleStateIfNeeded();
 }
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -93,6 +93,7 @@ class ProcessThrottlerTimedActivity {
     public:
         explicit ProcessThrottlerTimedActivity(Seconds timeout, ActivityVariant&& = nullptr);
         ProcessThrottlerTimedActivity& operator=(ActivityVariant&&);
+        const ActivityVariant& activity() const { return m_activity; }
 
     private:
         void activityTimedOut();


### PR DESCRIPTION
#### 30bf9977849af414fb4571037893986af04b19ac
<pre>
RELEASE_ASSERT(isSuspensionImminent == IsSuspensionImminent::Yes) under ProcessThrottler::sendPrepareToSuspendIPC()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259287">https://bugs.webkit.org/show_bug.cgi?id=259287</a>
rdar://110941932

Reviewed by Brent Fulgham.

Normally, when we try to send the PrepareToSuspend IPC and there is already one
in flight, it is because the assertion we were holding during the handshake was
invalidated by RunningBoard. We had an assertion to this effect in
ProcessThrottler::sendPrepareToSuspendIPC() which was getting hit in a very
specific scenario.

The scenario in question is:
1. A WebProcess is launching (we don&apos;t have a PID for it yet)
2. We detect that the UIProcess is about to suspend so we call
   ProcessThrottler::setAllowsActivities(false) which invalidates all
   activities
3. This causes us to try and send the prepareToSuspend IPC to the WebProcess
   which gets queued since the process is still launching.
4. Later on, the WebProcess finishes launching and we try to send the PrepareToSuspend
   IPC to the WebProcess. This causes AuxiliaryProcessProxy::wakeUpTemporarilyForIPC()
   to get called, which would create a new activity and potentially overwrite one it
   had already taken
5. Because new activities are not allowed, it would only clear the existing activity
   that was previously taken (but invalidated). ProcessThrottler::removeActivity() would
   fail to check if the activity was removed from the map and call
   updateThrottleStateIfNeeded() which would try to send the prepareToSuspend IPC again

This is when we fail the assertion since we&apos;re not in the imminent suspension case.
This is merely due to the bug in removeActivity() which called updateThrottleStateIfNeeded()
even though it did nothing.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::wakeUpTemporarilyForIPC):
Check if we already have a pending activity to avoid constructing a new one unnecessarily.
This is not critical but it is nice to avoid churn for something that should be a no-op.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::removeActivity):
In ProcessThrottler::addActivity(), we refuse to add the activity if `m_allowsActivities`
is true. However, we didn&apos;t have the same check in removeActivity(). As a result, we&apos;d
try to remove the activity from the map (even though it is not in there), then we would
call updateThrottleStateIfNeeded() which could try to send the prepareToSuspend() again
unnecessarily since our state hasn&apos;t changed.

* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottlerTimedActivity::activity const):

Canonical link: <a href="https://commits.webkit.org/266113@main">https://commits.webkit.org/266113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/042e4c1e83bc50b73a389688c457561ce1b95a76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14645 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12319 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15017 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15095 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11071 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18739 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15041 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12305 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10204 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11567 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3161 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->