### PR TITLE
Bump process priority during WebPageProxy::getContentsAsAttributedString()

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5073,7 +5073,9 @@ void WebPageProxy::getContentsAsAttributedString(CompletionHandler<void(const We
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::GetContentsAsAttributedString(), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPage::GetContentsAsAttributedString(), [completionHandler = WTFMove(completionHandler), activity = process().throttler().foregroundActivity("getContentsAsAttributedString"_s)](const WebCore::AttributedString& string) mutable {
+        completionHandler(string);
+    });
 }
 #endif
 


### PR DESCRIPTION
#### 886fe1f3fec6f6755204233c6a31e446f1d1b874
<pre>
Bump process priority during WebPageProxy::getContentsAsAttributedString()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259294">https://bugs.webkit.org/show_bug.cgi?id=259294</a>
rdar://110464974

Reviewed by Brent Fulgham.

Bump process priority during WebPageProxy::getContentsAsAttributedString() so
that the app doesn&apos;t hang waiting for a reply if the view is background.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getContentsAsAttributedString):

Canonical link: <a href="https://commits.webkit.org/266115@main">https://commits.webkit.org/266115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ba22d3e080d6c395a66315dfbe9403c8515e7ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12330 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15026 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15108 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11078 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15055 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12317 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10212 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11579 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3165 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->