### PR TITLE
Implement the getAll function in the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt
@@ -1,6 +1,8 @@
 
-FAIL document.cookie set/overwrite/delete observed by CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore set/overwrite/delete observed by document.cookie promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore agrees with document.cookie on encoding non-ASCII cookies promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL document.cookie agrees with CookieStore on encoding non-ASCII cookies promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT document.cookie set/overwrite/delete observed by CookieStore Test timed out
+NOTRUN CookieStore set/overwrite/delete observed by document.cookie
+NOTRUN CookieStore agrees with document.cookie on encoding non-ASCII cookies
+NOTRUN document.cookie agrees with CookieStore on encoding non-ASCII cookies
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt
@@ -1,7 +1,9 @@
 
-FAIL HTTP set/overwrite/delete observed in CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL CookieStore set/overwrite/delete observed in HTTP headers promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL HTTP headers agreed with CookieStore on encoding non-ASCII cookies promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL Binary HTTP set/overwrite/delete observed in CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT HTTP set/overwrite/delete observed in CookieStore Test timed out
+NOTRUN CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies
+NOTRUN CookieStore set/overwrite/delete observed in HTTP headers
+NOTRUN HTTP headers agreed with CookieStore on encoding non-ASCII cookies
+NOTRUN Binary HTTP set/overwrite/delete observed in CookieStore
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify behavior of no-name and no-value cookies. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL Verify behavior of no-name and no-value cookies. promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify that attempting to set a cookie with no name and with '=' in the value does not work. promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL Verify that attempting to set a cookie with no name and with '=' in the value does not work. promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify behavior of multiple no-name cookies promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL Verify behavior of multiple no-name cookies promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt
@@ -1,15 +1,11 @@
 
-FAIL cookieStore.getAll with no arguments promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with empty options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with positional name promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with name in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with name in both positional arguments and options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with absolute url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with relative url in options promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL cookieStore.getAll with invalid url path in options promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
-FAIL cookieStore.getAll with invalid url host in options promise_rejects_js: function "function() { throw e }" threw object "NotSupportedError: The operation is not supported." ("NotSupportedError") expected instance of function "function TypeError() {
-    [native code]
-}" ("TypeError")
+PASS cookieStore.getAll with no arguments
+PASS cookieStore.getAll with empty options
+PASS cookieStore.getAll with positional name
+PASS cookieStore.getAll with name in options
+PASS cookieStore.getAll with name in both positional arguments and options
+PASS cookieStore.getAll with absolute url in options
+PASS cookieStore.getAll with relative url in options
+PASS cookieStore.getAll with invalid url path in options
+PASS cookieStore.getAll with invalid url host in options
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.getAll returns multiple cookies written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.getAll returns multiple cookies written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL cookieStore.getAll returns the cookie written by cookieStore.set promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+PASS cookieStore.getAll returns the cookie written by cookieStore.set
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL cookieStore in non-sandboxed iframe should not throw assert_equals: cookieStore ${apiCall} should not throw expected "no exception" but got "NotSupportedError"
-FAIL cookieStore in sandboxed iframe should throw SecurityError assert_equals: cookieStore ${apiCall} should throw SecurityError expected "SecurityError" but got "NotSupportedError"
+PASS cookieStore in non-sandboxed iframe should not throw
+PASS cookieStore in sandboxed iframe should throw SecurityError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -12,10 +12,10 @@ FAIL cookieStore.set with domain that is not equal current host assert_unreached
 PASS cookieStore.set with domain set to the current hostname
 FAIL cookieStore.set with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set default domain is null and differs from current hostname promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set default domain is null and differs from current hostname assert_array_equals: expected property 0 to be "cookie-value1" but got "cookie-value" (expected array ["cookie-value1", "cookie-value2"] got ["cookie-value", "cookie-value2"])
 PASS cookieStore.set with path set to the current directory
 FAIL cookieStore.set with path set to a subdirectory of the current directory assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.set default path is / promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL cookieStore.set default path is / assert_equals: expected 1 but got 2
 FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected (string) "/cookie-store/" but got (undefined) undefined
 FAIL cookieStore.set with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt
@@ -1,5 +1,7 @@
 
-FAIL HttpOnly cookies are not observed promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL HttpOnly cookies can not be set by document.cookie promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
-FAIL HttpOnly cookies can not be set by CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT HttpOnly cookies are not observed Test timed out
+NOTRUN HttpOnly cookies can not be set by document.cookie
+NOTRUN HttpOnly cookies can not be set by CookieStore
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt
@@ -1,9 +1,9 @@
 
 FAIL Partitioned cookies accessible on the top-level site they are created in via HTTP assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
 FAIL Partitioned cookies accessible on the top-level site they are created in via DOM assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
-FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL Partitioned cookies accessible on the top-level site they are created in via CookieStore assert_equals: Expected __Host-pccookistore to be available on the top-level site it was created in expected true but got false
 PASS Cross-site window opened correctly
 FAIL Partitioned cookies are not accessible on a different top-level site via HTTP assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
 FAIL Partitioned cookies are not accessible on a different top-level site via DOM assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
-FAIL Partitioned cookies are not accessible on a different top-level site via CookieStore promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
+FAIL Partitioned cookies are not accessible on a different top-level site via CookieStore assert_equals: Expected __Host-pchttp to not be available on a different top-level site expected false but got true
 

--- a/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/encoding.https.any-expected.txt
+++ b/LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/encoding.https.any-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL BOM not stripped from name promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.name')"
-FAIL BOM not stripped from value assert_equals: expected "﻿value" but got "ï»¿value"
+FAIL BOM not stripped from value promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.name')"
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.h
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.h
@@ -47,7 +47,7 @@ public:
     void get(String&& name, Ref<DeferredPromise>&&);
     void get(CookieStoreGetOptions&&, Ref<DeferredPromise>&&);
 
-    void getAll(const String& name, Ref<DeferredPromise>&&);
+    void getAll(String&& name, Ref<DeferredPromise>&&);
     void getAll(CookieStoreGetOptions&&, Ref<DeferredPromise>&&);
 
     void set(String&& name, String&& value, Ref<DeferredPromise>&&);


### PR DESCRIPTION
#### 70923b0491297aa141f7dd6ea55206d417e6b30d
<pre>
Implement the getAll function in the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259295">https://bugs.webkit.org/show_bug.cgi?id=259295</a>

Reviewed by Chris Dumez.

The getAll function follows the same code path as the get
function (where the Web process sends an async IPC to the
Network process which responds with a vector of cookies that
match the options that were passed in) to return the relevant
cookies.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_and_no_value.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_equals_in_value.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_no_name_multiple_values.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_multiple.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_getAll_set_basic.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/encoding.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/httponly_cookies.https.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https-expected.txt:
* LayoutTests/platform/mac-monterey/imported/w3c/web-platform-tests/cookie-store/encoding.https.any-expected.txt: Added.
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::getAll):
* Source/WebCore/Modules/cookie-store/CookieStore.h:

Canonical link: <a href="https://commits.webkit.org/266153@main">https://commits.webkit.org/266153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53953d3ec18b920cc19385d77c30b29c76aebe00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14777 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15230 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18841 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12258 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15154 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10306 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11692 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3195 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16010 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->