### PR TITLE
[Cocoa] Small canvases, which aren't supposed to get compositing layers, get compositing layers if they have a 3D-but-could-be-2D transform

### DIFF
--- a/LayoutTests/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
+++ b/LayoutTests/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
@@ -1,0 +1,19 @@
+Tests whether an accelerated canvas creates a compositing layer.
+
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 68.00)
+          (bounds 15.00 15.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/canvas/accelerated-small-canvas-compositing.html
+++ b/LayoutTests/compositing/canvas/accelerated-small-canvas-compositing.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><html>
+<head>
+<style>
+canvas {
+    transform: translateZ(0px);
+}
+div {
+    will-change: transform;
+    width: 15px;
+    height: 15px;
+}
+</style>
+<script>
+    if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+    }
+
+    function doTest() {
+        var c = document.getElementById('cvs_img2');
+        var ctx = c.getContext('2d');
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0,0,c.width, c.height);
+
+        if (window.testRunner) {
+            document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+            testRunner.notifyDone();
+        }
+    }
+
+    window.addEventListener('load', doTest, false);
+</script>
+</head>
+<body>
+<p>Tests whether an accelerated canvas creates a compositing layer.</p>
+<canvas id="cvs_img2" width="10" height="10"></canvas>
+<div></div>
+<pre id="layers">Layer tree goes here in DRT</pre>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
+++ b/LayoutTests/platform/gtk/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
@@ -1,0 +1,24 @@
+Tests whether an accelerated canvas creates a compositing layer.
+
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 54.00)
+          (bounds 10.00 10.00)
+          (drawsContent 1)
+        )
+        (GraphicsLayer
+          (position 8.00 68.00)
+          (bounds 15.00 15.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/ios/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
+++ b/LayoutTests/platform/ios/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
@@ -1,0 +1,19 @@
+Tests whether an accelerated canvas creates a compositing layer.
+
+ (GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 8.00 72.00)
+          (bounds 15.00 15.00)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3246,8 +3246,18 @@ bool RenderLayerCompositor::requiresCompositingForTransform(RenderLayerModelObje
     // but the renderer may be an inline that doesn't suppport them.
     if (!renderer.isTransformed())
         return false;
+
+    auto compositingPolicy = m_compositingPolicy;
+#if !USE(COMPOSITING_FOR_SMALL_CANVASES)
+    if (is<HTMLCanvasElement>(renderer.element())) {
+        auto* canvas = downcast<HTMLCanvasElement>(renderer.element());
+        auto canvasArea = canvas->size().area<RecordOverflow>();
+        if (!canvasArea.hasOverflowed() && canvasArea < canvasAreaThresholdRequiringCompositing)
+            compositingPolicy = CompositingPolicy::Conservative;
+    }
+#endif
     
-    switch (m_compositingPolicy) {
+    switch (compositingPolicy) {
     case CompositingPolicy::Normal:
         return styleHas3DTransformOperation(renderer.style());
     case CompositingPolicy::Conservative:


### PR DESCRIPTION
#### 3dfb58beb2151d8039d5e56f6ddccddc9cd9d1ce
<pre>
[Cocoa] Small canvases, which aren&apos;t supposed to get compositing layers, get compositing layers if they have a 3D-but-could-be-2D transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=259297">https://bugs.webkit.org/show_bug.cgi?id=259297</a>
rdar://112439265

Reviewed by Simon Fraser.

We already have existing code which will avoid compositing small canvases. However, if
the small canvas has a 3D-but-could-be-2D transform, we&apos;ll composite it regardless. This
patch extends the current logic to not composite small canvases in this case.

This patch causes a 41% - 48% progression on the Images subtest in MotionMark. Layers
have cost, y&apos;all.

* LayoutTests/compositing/canvas/accelerated-small-canvas-compositing-expected.txt
* LayoutTests/compositing/canvas/accelerated-small-canvas-compositing.html
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForTransform const): This patch doesn&apos;t
modify m_compositingPolicy, because that&apos;s global for the whole RenderLayerCompositor. We
only want to change the policy in this specific case.

Canonical link: <a href="https://commits.webkit.org/266135@main">https://commits.webkit.org/266135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9c0f4b75bfe7f09ead6c29e35e7c1e4ed0a6f4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15089 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15186 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18808 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11057 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15121 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12301 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10271 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13042 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11609 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3426 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15970 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13419 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12229 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3221 "Passed tests") | 
<!--EWS-Status-Bubble-End-->