### PR TITLE
Youtube 360° video goes black

### DIFF
--- a/LayoutTests/media/media-source/media-source-paint-after-display-none-expected.txt
+++ b/LayoutTests/media/media-source/media-source-paint-after-display-none-expected.txt
@@ -1,0 +1,11 @@
+EVENT(sourceopen)
+EVENT(canplay)
+EXPECTED (canvas.getContext("2d").getImageData(1, 1, 1, 1).data[0] > '128') OK
+EXPECTED (canvas.getContext("2d").getImageData(1, 1, 1, 1).data[1] < '128') OK
+RUN(video.style.display = "none")
+EVENT(canplay)
+EVENT(playing)
+EXPECTED (canvas.getContext("2d").getImageData(1, 1, 1, 1).data[0] < '128') OK
+EXPECTED (canvas.getContext("2d").getImageData(1, 1, 1, 1).data[1] > '128') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-paint-after-display-none.html
+++ b/LayoutTests/media/media-source/media-source-paint-after-display-none.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-stalled-holds-sleep-assertion</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+
+    var canvas;
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    function requestVideoFramePromise(video) {
+        return new Promise(resolve => {
+            video.requestVideoFrameCallback(info => {
+                resolve(info);
+            });
+        });
+    }
+
+    async function runTest() {
+        findMediaElement();
+
+        var response = await fetch('content/test-red-3s-480x360.mp4');
+        let redMedia = await response.arrayBuffer();
+
+        response = await fetch('content/test-green-6s-320x240.mp4');
+        let greenMedia = await response.arrayBuffer();
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer('video/mp4');
+        sourceBuffer.appendBuffer(redMedia);
+        await Promise.all([
+            waitFor(sourceBuffer, 'update', true),
+            waitFor(video, 'canplay')
+        ]);
+
+        let createCanvas = () => {
+            canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth / 2;
+            canvas.height = video.videoHeight / 2;
+            canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+            return canvas;
+        }
+
+        canvas = createCanvas();
+        await runUntil(
+            () => canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height),
+            () => canvas.getContext("2d").getImageData(1, 1, 1, 1).data[0] != 0,
+            5000);
+
+        testExpected('canvas.getContext("2d").getImageData(1, 1, 1, 1).data[0]', '128', '>');
+        testExpected('canvas.getContext("2d").getImageData(1, 1, 1, 1).data[1]', '128', '<');
+
+        run('video.style.display = "none"');
+        sourceBuffer.remove(0, video.duration);
+        await waitFor(sourceBuffer, 'update', true);
+
+        sourceBuffer.appendBuffer(greenMedia);
+        await Promise.all([
+            waitFor(sourceBuffer, 'update', true),
+            waitFor(video, 'canplay')
+        ]);
+
+
+        video.play();
+        await waitFor(video, 'playing');
+
+        canvas = createCanvas();
+        await runUntil(
+            () => canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height),
+            () => canvas.getContext("2d").getImageData(1, 1, 1, 1).data[1] != 0,
+            5000);
+
+        testExpected('canvas.getContext("2d").getImageData(1, 1, 1, 1).data[0]', '128', '<');
+        testExpected('canvas.getContext("2d").getImageData(1, 1, 1, 1).data[1]', '128', '>');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video muted playsinline></video>
+    <div id="canvases"></canvas>
+</body>
+</html>

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -141,6 +141,16 @@ function testExpectedEventually(testFuncString, expected, comparison, timeout)
     });
 }
 
+async function runUntil(run, until, timeout) {
+    while (timeout === undefined || timeout--) {
+        run();
+        if (until())
+            return;
+        await sleepFor(1);
+    }
+    failTest("Did not end fast enough.");
+}
+
 function testArraysEqual(testFuncString, expected)
 {
     var observed;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2764,3 +2764,6 @@ webkit.org/b/258181 [ Debug ] inspector/debugger/async-stack-trace-truncate.html
 webkit.org/b/236128 imported/w3c/web-platform-tests/html/user-activation/activation-trigger-mouse-right.html [ Skip ]
 
 webkit.org/b/252322 [ X86_64 ] media/media-source/media-source-video-renders.html [ ImageOnlyFailure ]
+
+# Requires Ventura or later
+[ BigSur Monterey ] media/media-source/media-source-paint-after-display-none.html [ Skip ]

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -801,9 +801,11 @@ bool MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer() const
             return sourceBuffer->needsVideoLayer();
         }))
             return true;
+        auto player = m_player.get();
+        if (player && !player->renderingCanBeAccelerated())
+            return false;
         if (m_sampleBufferDisplayLayer)
             return !CGRectIsEmpty([m_sampleBufferDisplayLayer bounds]);
-        auto player = m_player.get();
         if (player && !player->videoInlineSize().isEmpty())
             return true;
         if (player && !player->playerContentBoxRect().isEmpty())


### PR DESCRIPTION
#### b2a7036dc8ddf82a440919da370702bd4c402854
<pre>
Youtube 360° video goes black
<a href="https://bugs.webkit.org/show_bug.cgi?id=259298">https://bugs.webkit.org/show_bug.cgi?id=259298</a>
rdar://112239644

Reviewed by Eric Carlson.

YouTube, when pre-rolling an advertisement before a 360 video, will start with
an element that&apos;s displayed normally, but will hide the video with display:none
when switching to canvas-based rendering for 360 videos. But at this point, the
MediaPlayerPrivate&apos;s layer has already been created and sized, and nothing will
force it to switch back to a decompression session (which is the only way for
frames to be extracted during playback).

When a video element&apos;s renderer is detached, queue a task to notify the media
player that the accelerated rendering state has changed. Similarly, do so when
changing the fullscreen mode. In MediaPlayerPrivateMediaSourceAVFObjC, use this
signal to tear down the AVSBDL when it is no longer needed.

* LayoutTests/media/media-source/media-source-paint-after-display-none-expected.txt: Added.
* LayoutTests/media/media-source/media-source-paint-after-display-none.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didDetachRenderers):
(WebCore::HTMLMediaElement::setFullscreenMode):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::shouldEnsureLayer const):

Canonical link: <a href="https://commits.webkit.org/266162@main">https://commits.webkit.org/266162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09366e2988adaaadd58d222ca98c5bd883b6375a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15214 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18827 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15140 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10293 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11677 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11629 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3199 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15995 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->