### PR TITLE
[IPC] Don't unwrap invalid SendSyncResult replies

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -160,7 +160,20 @@ template<typename T> struct ConnectionSendSyncResult {
     std::optional<typename T::ReplyArguments> replyArguments;
     Error error { Error::NoError };
 
-    bool succeeded() const { return error == Error::NoError; }
+    ConnectionSendSyncResult(Error error)
+        : error(error)
+    {
+        ASSERT(error != Error::NoError);
+    }
+
+    ConnectionSendSyncResult(std::unique_ptr<Decoder>&& decoder, std::optional<typename T::ReplyArguments>&& replyArguments)
+        : decoder(WTFMove(decoder)), replyArguments(WTFMove(replyArguments))
+    {
+        ASSERT(this->replyArguments.has_value());
+        error = !this->replyArguments ? Error::Unspecified : Error::NoError;
+    }
+
+    bool succeeded() const { return error == Error::NoError && replyArguments.has_value(); }
 
     typename T::ReplyArguments& reply()
     {
@@ -707,16 +720,15 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
     auto replyDecoderOrError = sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, sendSyncOptions);
     if (!replyDecoderOrError.decoder) {
         ASSERT(replyDecoderOrError.error != Error::NoError);
-        return { nullptr, std::nullopt, replyDecoderOrError.error };
+        return { replyDecoderOrError.error };
     }
 
-    SendSyncResult<T> result;
-    *replyDecoderOrError.decoder >> result.replyArguments;
-    if (!result.replyArguments)
-        return { nullptr, std::nullopt, Error::FailedToDecodeReplyArguments };
+    std::optional<typename T::ReplyArguments> replyArguments;
+    *replyDecoderOrError.decoder >> replyArguments;
+    if (!replyArguments)
+        return { Error::FailedToDecodeReplyArguments };
 
-    result.decoder = WTFMove(replyDecoderOrError.decoder);
-    return result;
+    return { WTFMove(replyDecoderOrError.decoder), WTFMove(replyArguments) };
 }
 
 template<typename T> Error Connection::waitForAndDispatchImmediately(uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -43,7 +43,7 @@ template<typename MessageType> inline auto MessageSender::sendSync(MessageType&&
     static_assert(MessageType::isSync);
     if (auto* connection = messageSenderConnection())
         return connection->sendSync(std::forward<MessageType>(message), destinationID, timeout, options);
-    return { nullptr, std::nullopt, Error::NoMessageSenderConnection };
+    return { Error::NoMessageSenderConnection };
 }
 
 template<typename MessageType, typename C> inline AsyncReplyID MessageSender::sendWithAsyncReply(MessageType&& message, C&& completionHandler, uint64_t destinationID, OptionSet<SendOption> options)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -246,7 +246,7 @@ AuxiliaryProcessProxy::SendSyncResult<T> AuxiliaryProcessProxy::sendSync(T&& mes
     static_assert(T::isSync, "Sync message expected");
 
     if (!m_connection)
-        return { };
+        return { IPC::Error::InvalidConnection };
 
     TraceScope scope(SyncMessageStart, SyncMessageEnd);
 


### PR DESCRIPTION
#### 5d3f12cc83daa4b96f7d3563646af53dbe5273e1
<pre>
[IPC] Don&apos;t unwrap invalid SendSyncResult replies
<a href="https://bugs.webkit.org/show_bug.cgi?id=259301">https://bugs.webkit.org/show_bug.cgi?id=259301</a>
rdar://111895837

Reviewed by Dean Jackson.

We have a number of crash reports from an assert firing in std::optional when
unwrapping the result of a synchronous IPC call. This assert hints that we have
received a result where `succeeded()` returns true, yet we don&apos;t have a reply
payload in replyArguments. This is a violation of the prerequisites for
`ConnectionSendSyncReply`. This issue has been causes by improper handling of
`decoder` failure and has been fixed piecemeal, for example in
<a href="https://bugs.webkit.org/show_bug.cgi?id=259006.">https://bugs.webkit.org/show_bug.cgi?id=259006.</a>

This change extends the succeeded check to include checking for non-none
replyArguments to avoid asserting when using `if (sendResult.succeeded()) {
... = sendResult.reply(); }` pattern.

As an extra level of protection, the new ConnecttionSendSyncResult will set
error to Error::Unspecified if passed replyArguments that are none.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::ConnectionSendSyncResult::ConnectionSendSyncResult):
(IPC::ConnectionSendSyncResult::succeeded const):
(IPC::Connection::sendSync):
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendSync):
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::sendSync):
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendSync):

Canonical link: <a href="https://commits.webkit.org/266147@main">https://commits.webkit.org/266147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7c94e146fab1abd8e14e582f5557f3dbb797173

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12361 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15056 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15144 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11111 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18775 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12186 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15089 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10240 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11612 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->