### PR TITLE
WKWebView Proxy API sometimes needs to recreate the NSURLSession

### DIFF
--- a/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2-expected.txt
+++ b/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2-expected.txt
@@ -1,0 +1,29 @@
+
+Upgraded form-associated custom elements without an owner:
+PASS $("noowner-upgrade1").restoredState is undefined
+PASS $("noowner-upgrade2").restoredState is "bar"
+PASS $("noowner-upgrade3").restoredState is undefined
+PASS isFormDataEqual($("noowner-upgrade4").restoredState, __formData1) is true
+
+Upgraded form-associated custom elements with a form owner:
+PASS $("upgrade1").restoredState is undefined
+PASS $("upgrade2").restoredState is undefined
+PASS isFormDataEqual($("upgrade3").restoredState, __formData1) is true
+PASS $("upgrade4").restoredState is "bar"
+
+Predefined form-associated custom elements without an owner:
+PASS $("noowner-predefined1").restoredState is undefined
+PASS $("noowner-predefined2").restoredState is "bar"
+PASS $("noowner-predefined3").restoredState is undefined
+PASS isFormDataEqual($("noowner-predefined4").restoredState, __formData2) is true
+
+Predefined form-associated custom elements with a form owner:
+PASS $("predefined1").restoredState is undefined
+PASS isFormDataEqual($("predefined2").restoredState, __formData1) is true
+PASS $("predefined3").restoredState is undefined
+PASS $("predefined4").restoredState is "foo"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html
+++ b/LayoutTests/fast/forms/state-restore-form-associated-custom-elements-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <script src="resources/common.js"></script>
 </head>
 <body>
@@ -32,10 +32,7 @@ function getXFooConstructor() {
             const value = this._parseFormValue(this.dataset.submissionValue);
             const state = this._parseFormValue(this.dataset.state);
 
-            if (state == null)
-                this._internals.setFormValue(value);
-            else
-                this._internals.setFormValue(value, state);
+            this._internals.setFormValue(value, state);
         }
 
         formStateRestoreCallback(state) {
@@ -115,27 +112,27 @@ function runTest()
         makeForms(2);
 
         debug('\nUpgraded form-associated custom elements without an owner:');
-        shouldBeEqualToString('$("noowner-upgrade1").restoredState', 'foo');
+        shouldBe('$("noowner-upgrade1").restoredState', 'undefined');
         shouldBeEqualToString('$("noowner-upgrade2").restoredState', 'bar');
-        shouldBeTrue('isFormDataEqual($("noowner-upgrade3").restoredState, __formData2)');
+        shouldBe('$("noowner-upgrade3").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("noowner-upgrade4").restoredState, __formData1)');
 
         debug('\nUpgraded form-associated custom elements with a form owner:');
-        shouldBeTrue('isFormDataEqual($("upgrade1").restoredState, __formData2)');
-        shouldBeEqualToString('$("upgrade2").restoredState', 'foo');
+        shouldBe('$("upgrade1").restoredState', 'undefined');
+        shouldBe('$("upgrade2").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("upgrade3").restoredState, __formData1)');
         shouldBeEqualToString('$("upgrade4").restoredState', 'bar');
 
         debug('\nPredefined form-associated custom elements without an owner:');
-        shouldBeEqualToString('$("noowner-predefined1").restoredState', 'foo');
+        shouldBe('$("noowner-predefined1").restoredState', 'undefined');
         shouldBeEqualToString('$("noowner-predefined2").restoredState', 'bar');
-        shouldBeTrue('isFormDataEqual($("noowner-predefined3").restoredState, __formData1)');
+        shouldBe('$("noowner-predefined3").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("noowner-predefined4").restoredState, __formData2)');
 
         debug('\nPredefined form-associated custom elements with a form owner:');
-        shouldBeEqualToString('$("predefined1").restoredState', 'foo');
+        shouldBe('$("predefined1").restoredState', 'undefined');
         shouldBeTrue('isFormDataEqual($("predefined2").restoredState, __formData1)');
-        shouldBeEqualToString('$("predefined3").restoredState', 'bar');
+        shouldBe('$("predefined3").restoredState', 'undefined');
         shouldBeEqualToString('$("predefined4").restoredState', 'foo');
 
         $('parent').innerHTML = '';
@@ -145,5 +142,4 @@ function runTest()
 
 runTest();
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value-expected.txt
@@ -1,0 +1,4 @@
+
+PASS ElementInternals.setFormValue(null) clears submission value
+PASS ElementInternals.setFormValue(undefined) clears submission value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-setFormValue-nullish-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ElementInternals.setFormValue(nullish value) should clear submission value</title>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-setformvalue">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script>
+        customElements.define("test-form-element", class extends HTMLElement {
+            static formAssociated = true;
+            constructor() {
+                super();
+                this.internals = this.attachInternals();
+            }
+        });
+    </script>
+</head>
+<body>
+    <form id="form-null">
+        <test-form-element id="input-null" name="input-null"></test-form-element>
+    </form>
+
+    <form id="form-undefined">
+        <test-form-element id="input-undefined" name="input-undefined"></test-form-element>
+    </form>
+
+    <script>
+      test(() => {
+        const input = document.getElementById("input-null");
+        input.internals.setFormValue("fail");
+        input.internals.setFormValue(null);
+        const formData = new FormData(document.getElementById("form-null"));
+        assert_false(formData.has("input-null"));
+      }, "ElementInternals.setFormValue(null) clears submission value");
+
+      test(() => {
+        const input = document.getElementById("input-undefined");
+        input.internals.setFormValue("fail");
+        input.internals.setFormValue(undefined);
+        const formData = new FormData(document.getElementById("form-undefined"));
+        assert_false(formData.has("input-undefined"));
+      }, "ElementInternals.setFormValue(undefined) clears submission value");
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1722,6 +1722,7 @@ webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 
 webrtc/video-av1.html [ Skip ]
+webrtc/video-maxFramerate.html [ Failure ]
 
 # GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
 webrtc/datachannel/dtls10.html [ Failure ]

--- a/LayoutTests/webrtc/video-maxFramerate-expected.txt
+++ b/LayoutTests/webrtc/video-maxFramerate-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Testing that maxFramerate has an effect
+

--- a/LayoutTests/webrtc/video-maxFramerate.html
+++ b/LayoutTests/webrtc/video-maxFramerate.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing macFramerate</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="video" autoplay=""></video>
+        <canvas id="canvas" width="640" height="480"></canvas>
+        <script src ="routines.js"></script>
+        <script>
+var pc1, pc2;
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video:true});
+    const stream = await new Promise((resolve, reject) => {
+        createConnections((firstConnection) => {
+            pc1 = firstConnection;
+            const sender = firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
+        }, (secondConnection) => {
+            pc2 = secondConnection;
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    video.srcObject = stream;
+    await video.play();
+
+    let settings = stream.getVideoTracks()[0].getSettings();
+    assert_equals(settings.width, 640, "remote track settings width");
+    assert_equals(settings.height, 480, "remote track settings height");
+
+    let counter = 0;
+    while (++counter < 100 && settings.frameRate < 5) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than(settings.frameRate, 5, "remote track settings frame rate");
+
+    const parameters = pc1.getSenders()[0].getParameters();
+    parameters.encodings[0].maxFramerate = 1;
+    await pc1.getSenders()[0].setParameters(parameters);
+
+    counter = 0;
+    while (++counter < 100 && settings.frameRate > 4) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_less_than(settings.frameRate, 4, "remote track settings reduced frame rate");
+}, "Testing that maxFramerate has an effect");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -391,6 +391,8 @@ void JSCustomElementInterface::invokeFormStateRestoreCallback(Element& element, 
             args.append(jsString(vm, state));
         }, [&](RefPtr<File>) {
             ASSERT_NOT_REACHED();
+        }, [](std::nullptr_t) {
+            ASSERT_NOT_REACHED();
         });
 
         args.append(jsNontrivialString(vm, "restore"_s));

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -31,12 +31,45 @@
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertSequences.h"
+#include "JSDOMFormData.h"
 #include "JSElement.h"
+#include "JSFile.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 
 namespace WebCore {
 using namespace JSC;
+
+JSValue JSElementInternals::setFormValue(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame)
+{
+    using JSCustomElementFormValue = IDLUnion<IDLNull, IDLInterface<File>, IDLUSVString, IDLInterface<DOMFormData>>;
+
+    auto& vm = lexicalGlobalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    if (UNLIKELY(callFrame.argumentCount() < 1)) {
+        throwException(&lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(&lexicalGlobalObject));
+        return { };
+    }
+
+    EnsureStillAliveScope argument0 = callFrame.uncheckedArgument(0);
+    auto value = convert<JSCustomElementFormValue>(lexicalGlobalObject, argument0.value());
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    std::optional<CustomElementFormValue> state;
+    if (callFrame.argumentCount() > 1) {
+        EnsureStillAliveScope argument1 = callFrame.argument(1);
+        state = convert<JSCustomElementFormValue>(lexicalGlobalObject, argument1.value());
+        RETURN_IF_EXCEPTION(throwScope, { });
+    }
+
+    auto result = wrapped().setFormValue(WTFMove(value), WTFMove(state));
+    if (UNLIKELY(result.hasException())) {
+        propagateException(lexicalGlobalObject, throwScope, result.releaseException());
+        return { };
+    }
+
+    return jsUndefined();
+}
 
 static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, const JSElementInternals& thisObject, const QualifiedName& attributeName)
 {

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -61,7 +61,7 @@ ExceptionOr<RefPtr<HTMLFormElement>> ElementInternals::form() const
     return Exception { NotSupportedError };
 }
 
-ExceptionOr<void> ElementInternals::setFormValue(std::optional<CustomElementFormValue>&& value, std::optional<CustomElementFormValue>&& state)
+ExceptionOr<void> ElementInternals::setFormValue(CustomElementFormValue&& value, std::optional<CustomElementFormValue>&& state)
 {
     if (RefPtr element = elementAsFormAssociatedCustom()) {
         element->setFormValue(WTFMove(value), WTFMove(state));

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -51,7 +51,7 @@ public:
 
     ExceptionOr<RefPtr<HTMLFormElement>> form() const;
 
-    ExceptionOr<void> setFormValue(std::optional<CustomElementFormValue>&&, std::optional<CustomElementFormValue>&& = std::nullopt);
+    ExceptionOr<void> setFormValue(CustomElementFormValue&&, std::optional<CustomElementFormValue>&& state);
 
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     ExceptionOr<bool> willValidate() const;

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef (File or USVString or DOMFormData) FormValue;
-
 [
     GenerateIsReachable=ImplElementRoot,
     GenerateAddOpaqueRoot=element,
@@ -33,7 +31,7 @@ typedef (File or USVString or DOMFormData) FormValue;
 ] interface ElementInternals {
     readonly attribute ShadowRoot? shadowRoot;
 
-    undefined setFormValue(FormValue? value, optional FormValue? state);
+    [Custom] undefined setFormValue(any value, optional any state);
 
     readonly attribute HTMLFormElement? form;
 

--- a/Source/WebCore/html/CustomElementFormValue.h
+++ b/Source/WebCore/html/CustomElementFormValue.h
@@ -31,6 +31,6 @@
 
 namespace WebCore {
 
-using CustomElementFormValue = std::variant<RefPtr<File>, String, RefPtr<DOMFormData>>;
+using CustomElementFormValue = std::variant<std::nullptr_t, RefPtr<File>, String, RefPtr<DOMFormData>>;
 
 } // namespace WebCore

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -88,13 +88,11 @@ ALWAYS_INLINE static CustomElementFormValue cloneIfIsFormData(CustomElementFormV
     });
 }
 
-void FormAssociatedCustomElement::setFormValue(std::optional<CustomElementFormValue>&& submissionValue, std::optional<CustomElementFormValue>&& state)
+void FormAssociatedCustomElement::setFormValue(CustomElementFormValue&& submissionValue, std::optional<CustomElementFormValue>&& state)
 {
     ASSERT(m_element->isPrecustomizedOrDefinedCustomElement());
 
-    if (submissionValue.has_value())
-        m_submissionValue = cloneIfIsFormData(WTFMove(submissionValue.value()));
-
+    m_submissionValue = cloneIfIsFormData(WTFMove(submissionValue));
     m_state = state.has_value() ? cloneIfIsFormData(WTFMove(state.value())) : m_submissionValue;
 }
 
@@ -114,10 +112,7 @@ bool FormAssociatedCustomElement::appendFormData(DOMFormData& formData)
 {
     ASSERT(m_element->isDefinedCustomElement());
 
-    if (!m_submissionValue.has_value())
-        return false;
-
-    WTF::switchOn(m_submissionValue.value(), [&](RefPtr<DOMFormData> value) {
+    WTF::switchOn(m_submissionValue, [&](RefPtr<DOMFormData> value) {
         for (const auto& item : value->items()) {
             WTF::switchOn(item.data, [&](const String& value) {
                 formData.append(item.name, value);
@@ -131,6 +126,8 @@ bool FormAssociatedCustomElement::appendFormData(DOMFormData& formData)
     }, [&](RefPtr<File> value) {
         if (!name().isEmpty())
             formData.append(name(), *value);
+    }, [](std::nullptr_t) {
+        // do nothing
     });
 
     return true;
@@ -226,33 +223,33 @@ FormControlState FormAssociatedCustomElement::saveFormControlState() const
 
     FormControlState savedState;
 
-    if (m_state.has_value()) {
-        // FIXME: Support File when saving / restoring state.
-        // https://bugs.webkit.org/show_bug.cgi?id=249895
-        bool didLogMessage = false;
-        auto logUnsupportedFileWarning = [&](RefPtr<File>) {
-            auto& document = asHTMLElement().document();
-            if (document.frame() && !didLogMessage) {
-                document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
-                didLogMessage = true;
-            }
-        };
+    // FIXME: Support File when saving / restoring state.
+    // https://bugs.webkit.org/show_bug.cgi?id=249895
+    bool didLogMessage = false;
+    auto logUnsupportedFileWarning = [&](RefPtr<File>) {
+        auto& document = asHTMLElement().document();
+        if (document.frame() && !didLogMessage) {
+            document.addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "File isn't currently supported when saving / restoring state."_s);
+            didLogMessage = true;
+        }
+    };
 
-        WTF::switchOn(m_state.value(), [&](RefPtr<DOMFormData> state) {
-            savedState.reserveInitialCapacity(state->items().size() * 2);
+    WTF::switchOn(m_state, [&](RefPtr<DOMFormData> state) {
+        savedState.reserveInitialCapacity(state->items().size() * 2);
 
-            for (const auto& item : state->items()) {
-                WTF::switchOn(item.data, [&](const String& value) {
-                    savedState.append(item.name);
-                    savedState.append(value);
-                }, logUnsupportedFileWarning);
-            }
+        for (const auto& item : state->items()) {
+            WTF::switchOn(item.data, [&](const String& value) {
+                savedState.append(item.name);
+                savedState.append(value);
+            }, logUnsupportedFileWarning);
+        }
 
-            savedState.shrinkToFit();
-        }, [&](const String& state) {
-            savedState.append(state);
-        }, logUnsupportedFileWarning);
-    }
+        savedState.shrinkToFit();
+    }, [&](const String& state) {
+        savedState.append(state);
+    }, [](std::nullptr_t) {
+        // do nothing
+    }, logUnsupportedFileWarning);
 
     return savedState;
 }

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -55,7 +55,7 @@ public:
     void reset() final;
     bool isEnumeratable() const final;
 
-    void setFormValue(std::optional<CustomElementFormValue>&& submissionValue, std::optional<CustomElementFormValue>&& state);
+    void setFormValue(CustomElementFormValue&& submissionValue, std::optional<CustomElementFormValue>&& state);
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     String validationMessage() const final;
 
@@ -97,8 +97,8 @@ private:
     WeakPtr<HTMLMaybeFormAssociatedCustomElement, WeakPtrImplWithEventTargetData> m_element;
     ValidityStateFlags m_validityStateFlags;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_validationAnchor { nullptr };
-    std::optional<CustomElementFormValue> m_submissionValue;
-    std::optional<CustomElementFormValue> m_state;
+    CustomElementFormValue m_submissionValue { nullptr };
+    CustomElementFormValue m_state { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -130,6 +130,7 @@ private:
 
     void sourceMutedChanged();
     void sourceEnabledChanged();
+    void startObservingVideoFrames();
 
     // MediaStreamTrackPrivate::Observer API
     void trackMutedChanged(MediaStreamTrackPrivate&) final { sourceMutedChanged(); }
@@ -152,6 +153,8 @@ private:
     bool m_muted { false };
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
+    std::optional<double> m_maxFrameRate;
+    bool m_isObservingVideoFrames { false };
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -60,6 +60,8 @@ class NetworkSessionCocoa;
 struct SessionWrapper : public CanMakeWeakPtr<SessionWrapper> {
     void initialize(NSURLSessionConfiguration *, NetworkSessionCocoa&, WebCore::StoredCredentialsPolicy, NavigatingToAppBoundDomain);
 
+    void recreateSessionWithUpdatedProxyConfigurations(NetworkSessionCocoa&);
+
     RetainPtr<NSURLSession> session;
     RetainPtr<WKNetworkSessionDelegate> delegate;
     HashMap<NetworkDataTaskCocoa::TaskIdentifier, NetworkDataTaskCocoa*> dataTaskMap;
@@ -153,6 +155,8 @@ public:
 
     void clearProxyConfigData() final;
     void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, WTF::UUID>>&&) final;
+
+    void applyProxyConfigurationToSessionConfiguration(NSURLSessionConfiguration *);
 #endif
 
 private:

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -95,10 +95,14 @@ void WebKit::NetworkSessionCocoa::removeNetworkWebsiteData(std::optional<WallTim
 #endif
 
 #if HAVE(NW_PROXY_CONFIG)
+#if __has_include(<Network/NSURLSession+Network.h>)
+#include <Network/NSURLSession+Network.h>
+#endif
 SOFT_LINK_LIBRARY_OPTIONAL(libnetwork)
 SOFT_LINK_OPTIONAL(libnetwork, nw_context_add_proxy, void, __cdecl, (nw_context_t, nw_proxy_config_t))
 SOFT_LINK_OPTIONAL(libnetwork, nw_context_clear_proxies, void, __cdecl, (nw_context_t))
 SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_create_with_agent_data, nw_proxy_config_t, __cdecl, (const uint8_t*, size_t, const uuid_t))
+SOFT_LINK_OPTIONAL(libnetwork, nw_proxy_config_stack_requires_http_protocols, bool, __cdecl, (nw_proxy_config_t))
 #endif
 
 #import "DeviceManagementSoftLink.h"
@@ -481,6 +485,7 @@ static String stringForSSLCipher(SSLCipherSuite cipher)
 > {
     WeakPtr<WebKit::NetworkSessionCocoa> _session;
     WeakPtr<WebKit::SessionWrapper> _sessionWrapper;
+@public
     bool _withCredentials;
 }
 
@@ -1328,6 +1333,23 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
+void SessionWrapper::recreateSessionWithUpdatedProxyConfigurations(NetworkSessionCocoa& networkSession)
+{
+    RELEASE_ASSERT(session);
+    RELEASE_ASSERT(delegate);
+
+    auto withCredentials = delegate->_withCredentials;
+    auto *configuration = session.get().configuration;
+
+#if HAVE(NW_PROXY_CONFIG)
+    networkSession.applyProxyConfigurationToSessionConfiguration(configuration);
+#endif
+
+    [delegate sessionInvalidated];
+    delegate = adoptNS([[WKNetworkSessionDelegate alloc] initWithNetworkSession:networkSession wrapper:*this withCredentials:withCredentials]);
+    session = [NSURLSession sessionWithConfiguration:configuration delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]];
+}
+
 void SessionWrapper::initialize(NSURLSessionConfiguration *configuration, NetworkSessionCocoa& networkSession, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain)
 {
     UNUSED_PARAM(isNavigatingToAppBoundDomain);
@@ -1340,24 +1362,12 @@ void SessionWrapper::initialize(NSURLSessionConfiguration *configuration, Networ
     if (!configuration._sourceApplicationSecondaryIdentifier && isFullBrowser)
         configuration._sourceApplicationSecondaryIdentifier = @"com.apple.WebKit.InAppBrowser";
 
+#if HAVE(NW_PROXY_CONFIG)
+    networkSession.applyProxyConfigurationToSessionConfiguration(configuration);
+#endif
+
     delegate = adoptNS([[WKNetworkSessionDelegate alloc] initWithNetworkSession:networkSession wrapper:*this withCredentials:storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::Use]);
     session = [NSURLSession sessionWithConfiguration:configuration delegate:delegate.get() delegateQueue:[NSOperationQueue mainQueue]];
-    
-#if HAVE(NW_PROXY_CONFIG)
-    auto* clearProxies = nw_context_clear_proxiesPtr();
-    auto* addProxy = nw_context_add_proxyPtr();
-    if (!clearProxies || !addProxy)
-        return;
-
-    if (auto networkContext = session.get()._networkContext) {
-        auto proxyConfigs = networkSession.proxyConfigs();
-        if (!proxyConfigs.isEmpty())
-            clearProxies(networkContext);
-
-        for (auto& proxyConfig : proxyConfigs)
-            addProxy(networkContext, proxyConfig.get());
-    }
-#endif
 }
 
 #if HAVE(SESSION_CLEANUP)
@@ -2209,8 +2219,36 @@ void NetworkSessionCocoa::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, W
     auto* clearProxies = nw_context_clear_proxiesPtr();
     auto* addProxy = nw_context_add_proxyPtr();
     auto* createProxyConfig = nw_proxy_config_create_with_agent_dataPtr();
-    if (!clearProxies || !addProxy || !createProxyConfig)
+    auto* requiresHTTPProtocols = nw_proxy_config_stack_requires_http_protocolsPtr();
+    if (!clearProxies || !addProxy || !createProxyConfig || !requiresHTTPProtocols)
         return;
+
+    m_nwProxyConfigs.clear();
+
+    // If any of the proxies pass the `nw_proxy_config_stack_requires_http_protocols` check,
+    // then we cannot set the proxy on the live nw_context_t and instead must destroy and recreate the NSURLSession
+    bool recreateSessions = false;
+    for (auto& config : proxyConfigurations) {
+        uuid_t identifier;
+        memcpy(identifier, config.second.toSpan().data(), sizeof(uuid_t));
+
+#if __has_include(<Network/proxy_config_private.h>)
+        auto nwProxyConfig = adoptNS(createProxyConfig(config.first.data(), config.first.size(), identifier));
+
+        if (requiresHTTPProtocols(nwProxyConfig.get()))
+            recreateSessions = true;
+
+        m_nwProxyConfigs.append(WTFMove(nwProxyConfig));
+#endif
+    }
+
+    if (recreateSessions) {
+        forEachSessionWrapper([this](SessionWrapper& sessionWrapper) {
+            if (sessionWrapper.session)
+                sessionWrapper.recreateSessionWithUpdatedProxyConfigurations(*this);
+        });
+        return;
+    }
 
     RetainPtr<NSMutableSet> contexts = adoptNS([[NSMutableSet alloc] init]);
     forEachSessionWrapper([&contexts] (SessionWrapper& sessionWrapper) {
@@ -2219,23 +2257,24 @@ void NetworkSessionCocoa::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, W
         [contexts.get() addObject:sessionWrapper.session.get()._networkContext];
     });
 
-    for (nw_context_t context in contexts.get())
-        clearProxies(context);
-    m_nwProxyConfigs.clear();
-
-    for (auto& config : proxyConfigurations) {
-        uuid_t identifier;
-        memcpy(identifier, config.second.toSpan().data(), sizeof(uuid_t));
-
-#if __has_include(<Network/proxy_config_private.h>)
-        m_nwProxyConfigs.append(adoptNS(createProxyConfig(config.first.data(), config.first.size(), identifier)));
-#endif
-    }
-    
     for (nw_context_t context in contexts.get()) {
+        clearProxies(context);
+
         for (auto& proxyConfig : m_nwProxyConfigs)
             addProxy(context, proxyConfig.get());
     }
+}
+
+void NetworkSessionCocoa::applyProxyConfigurationToSessionConfiguration(NSURLSessionConfiguration *configuration)
+{
+    if (!m_nwProxyConfigs.isEmpty()) {
+        RetainPtr nwProxyConfigurations = adoptNS([[NSMutableArray alloc] initWithCapacity:m_nwProxyConfigs.size()]);
+        for (auto& proxyConfig : m_nwProxyConfigs)
+            [nwProxyConfigurations addObject:proxyConfig.get()];
+
+        configuration.proxyConfigurations = nwProxyConfigurations.get();
+    } else
+        configuration.proxyConfigurations = @[ ];
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h
@@ -113,7 +113,10 @@ WK_CLASS_AVAILABLE(macos(10.11), ios(9.0))
     || ((TARGET_OS_IOS || TARGET_OS_MACCATALYST) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000) \
     || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MAX_ALLOWED >= 100000) \
     || (TARGET_OS_TV && __TV_OS_VERSION_MAX_ALLOWED >= 170000))
-/*! @abstract Gets or sets the proxy configurations to be used to override networking in all WKWebViews that use this WKWebsiteDataStore. */
+/*! @abstract Gets or sets the proxy configurations to be used to override networking in all WKWebViews that use this WKWebsiteDataStore.
+ @discussion Changing the proxy configurations might interupt current networking operations in any WKWebView that use this WKWebsiteDataStore,
+ so it is encouraged to finish setting the proxy configurations before starting any page loads.
+*/
 @property (nullable, nonatomic, copy) NSArray<nw_proxy_config_t> *proxyConfigurations NS_REFINED_FOR_SWIFT API_AVAILABLE(macos(14.0), ios(17.0));
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -86,6 +86,18 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()
 
 void RemoteRealtimeVideoSource::remoteVideoFrameAvailable(VideoFrame& frame, VideoFrameTimeMetadata metadata)
 {
+    MediaTime sampleTime = frame.presentationTime();
+
+    auto frameTime = sampleTime.toDouble();
+    m_observedFrameTimeStamps.append(frameTime);
+    m_observedFrameTimeStamps.removeAllMatching([&](auto time) {
+        return time <= frameTime - 2;
+    });
+
+    auto interval = m_observedFrameTimeStamps.last() - m_observedFrameTimeStamps.first();
+    if (interval > 1)
+        m_observedFrameRate = (m_observedFrameTimeStamps.size() / interval);
+
     setIntrinsicSize(expandedIntSize(frame.presentationSize()));
     videoFrameAvailable(frame, metadata);
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -55,6 +55,10 @@ private:
     Ref<RealtimeMediaSource> clone() final;
     void endProducingData() final;
     bool setShouldApplyRotation(bool) final;
+    double observedFrameRate() const final { return m_observedFrameRate; }
+
+    Deque<double> m_observedFrameTimeStamps;
+    double m_observedFrameRate { 0 };
 };
 
 } // namespace WebKit

--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -51,6 +51,12 @@ if (ENABLE_COG)
         set(COG_MESON_BUILDTYPE debugoptimized)
     endif ()
 
+    if (ENABLE_SANITIZERS)
+        set(COG_MESON_SANITIZE_OPTION "${ENABLE_SANITIZERS}")
+    else ()
+        set(COG_MESON_SANITIZE_OPTION "none")
+    endif ()
+
     ExternalProject_Add(cog
         GIT_REPOSITORY "${WPE_COG_REPO}"
         GIT_TAG "${WPE_COG_TAG}"
@@ -62,6 +68,7 @@ if (ENABLE_COG)
             --pkg-config-path ${WPE_COG_PKG_CONFIG_PATH}
             -Dwpe_api=${WPE_API_VERSION}
             -Dplatforms=${WPE_COG_PLATFORMS}
+            -Db_sanitize=${COG_MESON_SANITIZE_OPTION}
         BUILD_COMMAND
             meson compile -C <BINARY_DIR>
         INSTALL_COMMAND "")

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
@@ -35,11 +35,11 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         GRefPtr<JSCValue> jsInputElement = adoptGRef(jsc_context_evaluate(jsContext.get(), "document.getElementById('auto-fill')", -1));
         g_assert_true(JSC_IS_VALUE(jsInputElement.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsInputElement.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsInputElement.get()));
         g_assert_true(jsc_value_is_object(jsInputElement.get()));
         g_assert_true(jsc_value_object_is_instance_of(jsInputElement.get(), "HTMLInputElement"));
         g_assert_false(webkit_web_form_manager_input_element_is_auto_filled(jsInputElement.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
@@ -37,12 +37,12 @@ private:
 
         WebKitWebEditor* editor = webkit_web_page_get_editor(page);
         g_assert_true(WEBKIT_IS_WEB_EDITOR(editor));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(editor));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(editor));
         g_signal_connect_swapped(editor, "selection-changed", G_CALLBACK(selectionChangedCallback), &selectionChanged);
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(webkit_web_page_get_main_frame(page)));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         static const char* steps[] = {
             "document.execCommand('SelectAll')",

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
@@ -58,7 +58,7 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         return true;
     }
@@ -70,17 +70,17 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
 #if !ENABLE(2022_GLIB_API)
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<JSCValue> jsDocument = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(document)));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
         g_assert_true(jsc_value_get_context(jsDocument.get()) == jsContext.get());
         G_GNUC_END_IGNORE_DEPRECATIONS;
 
@@ -89,12 +89,12 @@ private:
 #else
         GRefPtr<JSCValue> jsDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
 #endif
 
         GRefPtr<JSCValue> jsP = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "paragraph", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(jsP.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsP.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsP.get()));
         g_assert_true(jsc_value_is_object(jsP.get()));
         g_assert_true(jsc_value_get_context(jsP.get()) == jsContext.get());
 
@@ -107,14 +107,14 @@ private:
 
         value = adoptGRef(jsc_value_object_get_property(jsP.get(), "innerText"));
         g_assert_true(JSC_IS_VALUE(value.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value.get()));
         g_assert_true(jsc_value_is_string(value.get()));
         GUniquePtr<char> strValue(jsc_value_to_string(value.get()));
         g_assert_cmpstr(strValue.get(), ==, "This is a test");
 
         GRefPtr<JSCValue> jsImage = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "image", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(jsImage.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsImage.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsImage.get()));
         g_assert_true(jsc_value_is_object(jsImage.get()));
 
 #if !ENABLE(2022_GLIB_API)
@@ -122,7 +122,7 @@ private:
         WebKitDOMNode* image = webkit_dom_node_for_js_value(jsImage.get());
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(image));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(image));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(image));
 #endif
 #if PLATFORM(GTK) && !USE(GTK4)
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
@@ -149,19 +149,19 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(mainFrame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         GRefPtr<JSCValue> jsParentDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         g_assert_true(JSC_IS_VALUE(jsParentDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsParentDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsParentDocument.get()));
 
         GRefPtr<JSCValue> subframe = adoptGRef(jsc_value_object_invoke_method(jsParentDocument.get(), "getElementById", G_TYPE_STRING, "frame", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(subframe.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(subframe.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(subframe.get()));
 
         GRefPtr<JSCValue> contentWindow = adoptGRef(jsc_value_object_get_property(subframe.get(), "contentWindow"));
         g_assert_true(JSC_IS_VALUE(contentWindow.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contentWindow.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contentWindow.get()));
 
         GRefPtr<JSCValue> undefined = adoptGRef(jsc_value_object_invoke_method(contentWindow.get(), "postMessage", G_TYPE_STRING, "submit the form!", G_TYPE_STRING, "*", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(undefined.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
@@ -39,7 +39,7 @@ private:
         // Transfer none
         g_autoptr(WebKitWebPage) page = WEBKIT_WEB_PAGE(g_object_ref(G_OBJECT(webPage)));
         g_assert_true(WEBKIT_IS_WEB_PAGE(page));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(page));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(page));
 
 #if !USE(GTK4)
         // Transfer none
@@ -47,21 +47,21 @@ private:
         g_autoptr(WebKitDOMDocument) document = WEBKIT_DOM_DOCUMENT(g_object_ref(G_OBJECT(webkit_web_page_get_dom_document(page))));
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         // Transfer full
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_autoptr(WebKitDOMDOMWindow) window = webkit_dom_document_get_default_view(document);
         g_assert_true(WEBKIT_DOM_IS_DOM_WINDOW(window));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(window));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(window));
 
         // Transfer full
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_autoptr(WebKitDOMRange) range = webkit_dom_document_create_range(document);
         g_assert_true(WEBKIT_DOM_IS_RANGE(range));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(range));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(range));
 #endif
 
         return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMClientRectTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMClientRectTest.cpp
@@ -51,15 +51,15 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "rect");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         GRefPtr<WebKitDOMClientRect> clientRect = adoptGRef(webkit_dom_element_get_bounding_client_rect(div));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT(clientRect.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
         checkClientRectPosition(clientRect.get());
 
         return true;
@@ -69,21 +69,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "rect");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         GRefPtr<WebKitDOMClientRectList> clientRectList = adoptGRef(webkit_dom_element_get_client_rects(div));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT_LIST(clientRectList.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRectList.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRectList.get()));
 
         g_assert_cmpuint(webkit_dom_client_rect_list_get_length(clientRectList.get()), ==, 1);
 
         GRefPtr<WebKitDOMClientRect> clientRect = adoptGRef(webkit_dom_client_rect_list_item(clientRectList.get(), 0));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT(clientRect.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
         checkClientRectPosition(clientRect.get());
 
         // Getting the clientRect twice should return the same pointer.

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeFilterTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeFilterTest.cpp
@@ -73,21 +73,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* root = webkit_dom_document_get_element_by_id(document, "root");
         g_assert_true(WEBKIT_DOM_IS_NODE(root));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
 
         // No filter.
         GRefPtr<WebKitDOMTreeWalker> walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
         g_assert_null(webkit_dom_tree_walker_get_filter(walker.get()));
 
         unsigned i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesAll));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesAll[i]);
@@ -98,12 +98,12 @@ private:
         GRefPtr<WebKitDOMNodeFilter> filter = adoptGRef(static_cast<WebKitDOMNodeFilter*>(g_object_new(webkit_node_filter_get_type(), nullptr)));
         walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(filter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(filter.get()));
         g_assert_true(webkit_dom_tree_walker_get_filter(walker.get()) == filter.get());
 
         i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesNoInput[i]);
@@ -113,12 +113,12 @@ private:
         // Show only elements, reusing the input filter.
         walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
         g_assert_true(webkit_dom_tree_walker_get_filter(walker.get()) == filter.get());
 
         i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedElementsNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedElementsNoInput[i]);
@@ -132,21 +132,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* root = webkit_dom_document_get_element_by_id(document, "root");
         g_assert_true(WEBKIT_DOM_IS_NODE(root));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
 
         // No filter.
         GRefPtr<WebKitDOMNodeIterator> iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_null(webkit_dom_node_iterator_get_filter(iter.get()));
 
         unsigned i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesAll));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesAll[i]);
@@ -158,12 +158,12 @@ private:
         GRefPtr<WebKitDOMNodeFilter> filter = adoptGRef(static_cast<WebKitDOMNodeFilter*>(g_object_new(webkit_node_filter_get_type(), nullptr)));
         iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_true(webkit_dom_node_iterator_get_filter(iter.get()) == filter.get());
 
         i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesNoInput[i]);
@@ -174,12 +174,12 @@ private:
         // Show only elements, reusing the input filter.
         iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_true(webkit_dom_node_iterator_get_filter(iter.get()) == filter.get());
 
         i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedElementsNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedElementsNoInput[i]);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeTest.cpp
@@ -40,26 +40,26 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMHTMLHeadElement* head = webkit_dom_document_get_head(document);
         g_assert_true(WEBKIT_DOM_IS_HTML_HEAD_ELEMENT(head));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(head));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(head));
 
         // Title, head's child.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(head)));
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(head)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_TITLE_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
 
         // Body, Head sibling.
         node = webkit_dom_node_get_next_sibling(WEBKIT_DOM_NODE(head));
         g_assert_true(WEBKIT_DOM_IS_HTML_BODY_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         WebKitDOMHTMLBodyElement* body = WEBKIT_DOM_HTML_BODY_ELEMENT(node);
 
         // There is no third sibling
@@ -68,13 +68,13 @@ private:
         // Body's previous sibling is Head.
         node = webkit_dom_node_get_previous_sibling(WEBKIT_DOM_NODE(body));
         g_assert_true(WEBKIT_DOM_IS_HTML_HEAD_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
 
         // Body has 3 children.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         unsigned long length = webkit_dom_node_list_get_length(list.get());
         g_assert_cmpint(length, ==, 3);
 
@@ -82,7 +82,7 @@ private:
         for (unsigned long i = 0; i < length; i++) {
             node = webkit_dom_node_list_item(list.get(), i);
             g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         }
 
         // Go backwards
@@ -97,11 +97,11 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMHTMLElement* body = webkit_dom_document_get_body(document);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(body));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(body));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(body));
 
         // Body shouldn't have any children at this point.
         g_assert_false(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
@@ -112,74 +112,74 @@ private:
         // Insert one P element.
         WebKitDOMElement* p = webkit_dom_document_create_element(document, "P", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
         webkit_dom_node_append_child(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(p), 0);
 
         // Now it should have one, the same that we inserted.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(p), node));
 
         // Replace the P tag with a DIV tag.
         WebKitDOMElement* div = webkit_dom_document_create_element(document, "DIV", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
         webkit_dom_node_replace_child(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(p), 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         // Now remove the tag.
         webkit_dom_node_remove_child(WEBKIT_DOM_NODE(body), node, 0);
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 0);
 
         // Test insert before. If refChild is null, insert newChild as last element of parent.
         div = webkit_dom_document_create_element(document, "DIV", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
         webkit_dom_node_insert_before(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(div), 0, 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         // Now insert a 'p' before 'div'.
         p = webkit_dom_document_create_element(document, "P", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
         webkit_dom_node_insert_before(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(p), WEBKIT_DOM_NODE(div), 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 2);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(p), node));
         node = webkit_dom_node_list_item(list.get(), 1);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         return true;
@@ -191,17 +191,17 @@ private:
 
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_document_query_selector_all(document, "*", nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         gulong nodeCount = webkit_dom_node_list_get_length(list.get());
         g_assert_cmpuint(nodeCount, ==, G_N_ELEMENTS(expectedTagNames));
         for (unsigned i = 0; i < nodeCount; i++) {
             WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), i);
             g_assert_true(WEBKIT_DOM_IS_NODE(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             GUniquePtr<char> tagName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(tagName.get(), ==, expectedTagNames[i]);
         }
@@ -215,17 +215,17 @@ private:
 
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMHTMLCollection> collection = adoptGRef(webkit_dom_document_get_elements_by_tag_name_as_html_collection(document, "*"));
         g_assert_true(WEBKIT_DOM_IS_HTML_COLLECTION(collection.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(collection.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(collection.get()));
         gulong nodeCount = webkit_dom_html_collection_get_length(collection.get());
         g_assert_cmpuint(nodeCount, ==, G_N_ELEMENTS(expectedTagNames));
         for (unsigned i = 0; i < nodeCount; i++) {
             WebKitDOMNode* node = webkit_dom_html_collection_item(collection.get(), i);
             g_assert_true(WEBKIT_DOM_IS_NODE(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             GUniquePtr<char> tagName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(tagName.get(), ==, expectedTagNames[i]);
         }
@@ -237,12 +237,12 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         // DOM objects already in the document should be automatically handled by the cache.
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "container");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         // Get the same elment twice should return the same pointer.
         g_assert_true(div == webkit_dom_document_get_element_by_id(document, "container"));
@@ -250,28 +250,28 @@ private:
         // A new DOM object created that is derived from Node should be automatically handled by the cache.
         WebKitDOMElement* p = webkit_dom_document_create_element(document, "P", nullptr);
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
 
         // A new DOM object created that isn't derived from Node should be manually handled.
         GRefPtr<WebKitDOMNodeIterator> iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
 
         // We can also manually handle a DOM object handled by the cache.
         GRefPtr<WebKitDOMElement> p2 = adoptGRef(webkit_dom_document_create_element(document, "P", nullptr));
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p2.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p2.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p2.get()));
 
         // Manually handling a DOM object owned by the cache shouldn't crash when the cache has more than one reference.
         GRefPtr<WebKitDOMElement> p3 = adoptGRef(webkit_dom_document_create_element(document, "P", nullptr));
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p3.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p3.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p3.get()));
         webkit_dom_node_append_child(WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(p3.get()), nullptr);
 
         // DOM objects removed from the document are also correctly handled by the cache.
         WebKitDOMElement* a = webkit_dom_document_create_element(document, "A", nullptr);
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(a));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(a));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(a));
         webkit_dom_node_remove_child(WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(a), nullptr);
 
         return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMXPathNSResolverTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMXPathNSResolverTest.cpp
@@ -71,15 +71,15 @@ private:
     {
         WebKitDOMElement* documentElement = webkit_dom_document_get_document_element(document);
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(documentElement));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(documentElement));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(documentElement));
 
         GRefPtr<WebKitDOMXPathResult> result = adoptGRef(webkit_dom_document_evaluate(document, "foo:child/text()", WEBKIT_DOM_NODE(documentElement), resolver, WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE, nullptr, nullptr));
         g_assert_true(WEBKIT_DOM_IS_XPATH_RESULT(result.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(result.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(result.get()));
 
         WebKitDOMNode* nodeResult = webkit_dom_xpath_result_iterate_next(result.get(), nullptr);
         g_assert_true(WEBKIT_DOM_IS_NODE(nodeResult));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(nodeResult));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(nodeResult));
 
         GUniquePtr<char> nodeValue(webkit_dom_node_get_node_value(nodeResult));
         g_assert_cmpstr(nodeValue.get(), ==, "SUCCESS");
@@ -89,11 +89,11 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMXPathNSResolver> resolver = adoptGRef(webkit_dom_document_create_ns_resolver(document, WEBKIT_DOM_NODE(webkit_dom_document_get_document_element(document))));
         g_assert_true(WEBKIT_DOM_IS_XPATH_NS_RESOLVER(resolver.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
         evaluateFooChildTextAndCheckResult(document, resolver.get());
 
         return true;
@@ -103,10 +103,10 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMXPathNSResolver> resolver = adoptGRef(WEBKIT_DOM_XPATH_NS_RESOLVER(g_object_new(webkit_xpath_ns_resolver_get_type(), nullptr)));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
         evaluateFooChildTextAndCheckResult(document, resolver.get());
 
         return true;


### PR DESCRIPTION
#### f47ea0d22deb3d982ce241df7adf2d68ca9d771b
<pre>
WKWebView Proxy API sometimes needs to recreate the NSURLSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=259300">https://bugs.webkit.org/show_bug.cgi?id=259300</a>
rdar://112164614

Reviewed by Chris Dumez.

Certain types of nw_proxy_config_t objects need to be set at NSURLSession creation time.
When one of them is in the proxy config array, recreate the NSURLSession if it exists.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::SessionWrapper::recreateSessionWithUpdatedProxyConfigurations):
(WebKit::SessionWrapper::initialize):
(WebKit::NetworkSessionCocoa::setProxyConfigData):
(WebKit::NetworkSessionCocoa::applyProxyConfigurationToSessionConfiguration):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.h:

Canonical link: <a href="https://commits.webkit.org/266129@main">https://commits.webkit.org/266129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5df47d5d2e76046464fa08363c9f7f67550920cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12366 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15061 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15149 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11116 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18780 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12191 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15094 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11617 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3179 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->