### PR TITLE
[WPE][GTK] WebProcess crashes at the end of every GLib API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp
@@ -35,11 +35,11 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         GRefPtr<JSCValue> jsInputElement = adoptGRef(jsc_context_evaluate(jsContext.get(), "document.getElementById('auto-fill')", -1));
         g_assert_true(JSC_IS_VALUE(jsInputElement.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsInputElement.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsInputElement.get()));
         g_assert_true(jsc_value_is_object(jsInputElement.get()));
         g_assert_true(jsc_value_object_is_instance_of(jsInputElement.get(), "HTMLInputElement"));
         g_assert_false(webkit_web_form_manager_input_element_is_auto_filled(jsInputElement.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp
@@ -37,12 +37,12 @@ private:
 
         WebKitWebEditor* editor = webkit_web_page_get_editor(page);
         g_assert_true(WEBKIT_IS_WEB_EDITOR(editor));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(editor));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(editor));
         g_signal_connect_swapped(editor, "selection-changed", G_CALLBACK(selectionChangedCallback), &selectionChanged);
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(webkit_web_page_get_main_frame(page)));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         static const char* steps[] = {
             "document.execCommand('SelectAll')",

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp
@@ -58,7 +58,7 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         return true;
     }
@@ -70,17 +70,17 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(frame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
 #if !ENABLE(2022_GLIB_API)
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<JSCValue> jsDocument = adoptGRef(webkit_frame_get_js_value_for_dom_object(frame, WEBKIT_DOM_OBJECT(document)));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
         g_assert_true(jsc_value_get_context(jsDocument.get()) == jsContext.get());
         G_GNUC_END_IGNORE_DEPRECATIONS;
 
@@ -89,12 +89,12 @@ private:
 #else
         GRefPtr<JSCValue> jsDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         g_assert_true(JSC_IS_VALUE(jsDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsDocument.get()));
 #endif
 
         GRefPtr<JSCValue> jsP = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "paragraph", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(jsP.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsP.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsP.get()));
         g_assert_true(jsc_value_is_object(jsP.get()));
         g_assert_true(jsc_value_get_context(jsP.get()) == jsContext.get());
 
@@ -107,14 +107,14 @@ private:
 
         value = adoptGRef(jsc_value_object_get_property(jsP.get(), "innerText"));
         g_assert_true(JSC_IS_VALUE(value.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(value.get()));
         g_assert_true(jsc_value_is_string(value.get()));
         GUniquePtr<char> strValue(jsc_value_to_string(value.get()));
         g_assert_cmpstr(strValue.get(), ==, "This is a test");
 
         GRefPtr<JSCValue> jsImage = adoptGRef(jsc_value_object_invoke_method(jsDocument.get(), "getElementById", G_TYPE_STRING, "image", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(jsImage.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsImage.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsImage.get()));
         g_assert_true(jsc_value_is_object(jsImage.get()));
 
 #if !ENABLE(2022_GLIB_API)
@@ -122,7 +122,7 @@ private:
         WebKitDOMNode* image = webkit_dom_node_for_js_value(jsImage.get());
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(image));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(image));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(image));
 #endif
 #if PLATFORM(GTK) && !USE(GTK4)
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
@@ -149,19 +149,19 @@ private:
 
         GRefPtr<JSCContext> jsContext = adoptGRef(webkit_frame_get_js_context(mainFrame));
         g_assert_true(JSC_IS_CONTEXT(jsContext.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsContext.get()));
 
         GRefPtr<JSCValue> jsParentDocument = adoptGRef(jsc_context_get_value(jsContext.get(), "document"));
         g_assert_true(JSC_IS_VALUE(jsParentDocument.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsParentDocument.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(jsParentDocument.get()));
 
         GRefPtr<JSCValue> subframe = adoptGRef(jsc_value_object_invoke_method(jsParentDocument.get(), "getElementById", G_TYPE_STRING, "frame", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(subframe.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(subframe.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(subframe.get()));
 
         GRefPtr<JSCValue> contentWindow = adoptGRef(jsc_value_object_get_property(subframe.get(), "contentWindow"));
         g_assert_true(JSC_IS_VALUE(contentWindow.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contentWindow.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(contentWindow.get()));
 
         GRefPtr<JSCValue> undefined = adoptGRef(jsc_value_object_invoke_method(contentWindow.get(), "postMessage", G_TYPE_STRING, "submit the form!", G_TYPE_STRING, "*", G_TYPE_NONE));
         g_assert_true(JSC_IS_VALUE(undefined.get()));

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp
@@ -39,7 +39,7 @@ private:
         // Transfer none
         g_autoptr(WebKitWebPage) page = WEBKIT_WEB_PAGE(g_object_ref(G_OBJECT(webPage)));
         g_assert_true(WEBKIT_IS_WEB_PAGE(page));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(page));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(page));
 
 #if !USE(GTK4)
         // Transfer none
@@ -47,21 +47,21 @@ private:
         g_autoptr(WebKitDOMDocument) document = WEBKIT_DOM_DOCUMENT(g_object_ref(G_OBJECT(webkit_web_page_get_dom_document(page))));
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         // Transfer full
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_autoptr(WebKitDOMDOMWindow) window = webkit_dom_document_get_default_view(document);
         g_assert_true(WEBKIT_DOM_IS_DOM_WINDOW(window));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(window));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(window));
 
         // Transfer full
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
         g_autoptr(WebKitDOMRange) range = webkit_dom_document_create_range(document);
         g_assert_true(WEBKIT_DOM_IS_RANGE(range));
         G_GNUC_END_IGNORE_DEPRECATIONS;
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(range));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(range));
 #endif
 
         return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMClientRectTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMClientRectTest.cpp
@@ -51,15 +51,15 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "rect");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         GRefPtr<WebKitDOMClientRect> clientRect = adoptGRef(webkit_dom_element_get_bounding_client_rect(div));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT(clientRect.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
         checkClientRectPosition(clientRect.get());
 
         return true;
@@ -69,21 +69,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "rect");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         GRefPtr<WebKitDOMClientRectList> clientRectList = adoptGRef(webkit_dom_element_get_client_rects(div));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT_LIST(clientRectList.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRectList.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRectList.get()));
 
         g_assert_cmpuint(webkit_dom_client_rect_list_get_length(clientRectList.get()), ==, 1);
 
         GRefPtr<WebKitDOMClientRect> clientRect = adoptGRef(webkit_dom_client_rect_list_item(clientRectList.get(), 0));
         g_assert_true(WEBKIT_DOM_IS_CLIENT_RECT(clientRect.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(clientRect.get()));
         checkClientRectPosition(clientRect.get());
 
         // Getting the clientRect twice should return the same pointer.

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeFilterTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeFilterTest.cpp
@@ -73,21 +73,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* root = webkit_dom_document_get_element_by_id(document, "root");
         g_assert_true(WEBKIT_DOM_IS_NODE(root));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
 
         // No filter.
         GRefPtr<WebKitDOMTreeWalker> walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
         g_assert_null(webkit_dom_tree_walker_get_filter(walker.get()));
 
         unsigned i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesAll));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesAll[i]);
@@ -98,12 +98,12 @@ private:
         GRefPtr<WebKitDOMNodeFilter> filter = adoptGRef(static_cast<WebKitDOMNodeFilter*>(g_object_new(webkit_node_filter_get_type(), nullptr)));
         walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(filter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(filter.get()));
         g_assert_true(webkit_dom_tree_walker_get_filter(walker.get()) == filter.get());
 
         i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesNoInput[i]);
@@ -113,12 +113,12 @@ private:
         // Show only elements, reusing the input filter.
         walker = adoptGRef(webkit_dom_document_create_tree_walker(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_TREE_WALKER(walker.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(walker.get()));
         g_assert_true(webkit_dom_tree_walker_get_filter(walker.get()) == filter.get());
 
         i = 0;
         for (WebKitDOMNode* node = WEBKIT_DOM_NODE(root); node; node = webkit_dom_tree_walker_next_node(walker.get()), ++i) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedElementsNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedElementsNoInput[i]);
@@ -132,21 +132,21 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMElement* root = webkit_dom_document_get_element_by_id(document, "root");
         g_assert_true(WEBKIT_DOM_IS_NODE(root));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(root));
 
         // No filter.
         GRefPtr<WebKitDOMNodeIterator> iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_null(webkit_dom_node_iterator_get_filter(iter.get()));
 
         unsigned i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesAll));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesAll[i]);
@@ -158,12 +158,12 @@ private:
         GRefPtr<WebKitDOMNodeFilter> filter = adoptGRef(static_cast<WebKitDOMNodeFilter*>(g_object_new(webkit_node_filter_get_type(), nullptr)));
         iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_true(webkit_dom_node_iterator_get_filter(iter.get()) == filter.get());
 
         i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedNodesNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedNodesNoInput[i]);
@@ -174,12 +174,12 @@ private:
         // Show only elements, reusing the input filter.
         iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(root), WEBKIT_DOM_NODE_FILTER_SHOW_ELEMENT, filter.get(), FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
         g_assert_true(webkit_dom_node_iterator_get_filter(iter.get()) == filter.get());
 
         i = 0;
         while (WebKitDOMNode* node = webkit_dom_node_iterator_next_node(iter.get(), nullptr)) {
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             g_assert_cmpuint(i, <, G_N_ELEMENTS(expectedElementsNoInput));
             GUniquePtr<char> nodeName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(nodeName.get(), ==, expectedElementsNoInput[i]);

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeTest.cpp
@@ -40,26 +40,26 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMHTMLHeadElement* head = webkit_dom_document_get_head(document);
         g_assert_true(WEBKIT_DOM_IS_HTML_HEAD_ELEMENT(head));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(head));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(head));
 
         // Title, head's child.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(head)));
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(head)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_TITLE_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
 
         // Body, Head sibling.
         node = webkit_dom_node_get_next_sibling(WEBKIT_DOM_NODE(head));
         g_assert_true(WEBKIT_DOM_IS_HTML_BODY_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         WebKitDOMHTMLBodyElement* body = WEBKIT_DOM_HTML_BODY_ELEMENT(node);
 
         // There is no third sibling
@@ -68,13 +68,13 @@ private:
         // Body's previous sibling is Head.
         node = webkit_dom_node_get_previous_sibling(WEBKIT_DOM_NODE(body));
         g_assert_true(WEBKIT_DOM_IS_HTML_HEAD_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
 
         // Body has 3 children.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         unsigned long length = webkit_dom_node_list_get_length(list.get());
         g_assert_cmpint(length, ==, 3);
 
@@ -82,7 +82,7 @@ private:
         for (unsigned long i = 0; i < length; i++) {
             node = webkit_dom_node_list_item(list.get(), i);
             g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         }
 
         // Go backwards
@@ -97,11 +97,11 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         WebKitDOMHTMLElement* body = webkit_dom_document_get_body(document);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(body));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(body));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(body));
 
         // Body shouldn't have any children at this point.
         g_assert_false(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
@@ -112,74 +112,74 @@ private:
         // Insert one P element.
         WebKitDOMElement* p = webkit_dom_document_create_element(document, "P", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
         webkit_dom_node_append_child(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(p), 0);
 
         // Now it should have one, the same that we inserted.
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(p), node));
 
         // Replace the P tag with a DIV tag.
         WebKitDOMElement* div = webkit_dom_document_create_element(document, "DIV", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
         webkit_dom_node_replace_child(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(p), 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         // Now remove the tag.
         webkit_dom_node_remove_child(WEBKIT_DOM_NODE(body), node, 0);
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 0);
 
         // Test insert before. If refChild is null, insert newChild as last element of parent.
         div = webkit_dom_document_create_element(document, "DIV", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
         webkit_dom_node_insert_before(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(div), 0, 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 1);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         // Now insert a 'p' before 'div'.
         p = webkit_dom_document_create_element(document, "P", 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
         webkit_dom_node_insert_before(WEBKIT_DOM_NODE(body), WEBKIT_DOM_NODE(p), WEBKIT_DOM_NODE(div), 0);
         g_assert_true(webkit_dom_node_has_child_nodes(WEBKIT_DOM_NODE(body)));
         list = adoptGRef(webkit_dom_node_get_child_nodes(WEBKIT_DOM_NODE(body)));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         g_assert_cmpint(webkit_dom_node_list_get_length(list.get()), ==, 2);
         node = webkit_dom_node_list_item(list.get(), 0);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(p), node));
         node = webkit_dom_node_list_item(list.get(), 1);
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(node));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
         g_assert_true(webkit_dom_node_is_same_node(WEBKIT_DOM_NODE(div), node));
 
         return true;
@@ -191,17 +191,17 @@ private:
 
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMNodeList> list = adoptGRef(webkit_dom_document_query_selector_all(document, "*", nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_LIST(list.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(list.get()));
         gulong nodeCount = webkit_dom_node_list_get_length(list.get());
         g_assert_cmpuint(nodeCount, ==, G_N_ELEMENTS(expectedTagNames));
         for (unsigned i = 0; i < nodeCount; i++) {
             WebKitDOMNode* node = webkit_dom_node_list_item(list.get(), i);
             g_assert_true(WEBKIT_DOM_IS_NODE(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             GUniquePtr<char> tagName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(tagName.get(), ==, expectedTagNames[i]);
         }
@@ -215,17 +215,17 @@ private:
 
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMHTMLCollection> collection = adoptGRef(webkit_dom_document_get_elements_by_tag_name_as_html_collection(document, "*"));
         g_assert_true(WEBKIT_DOM_IS_HTML_COLLECTION(collection.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(collection.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(collection.get()));
         gulong nodeCount = webkit_dom_html_collection_get_length(collection.get());
         g_assert_cmpuint(nodeCount, ==, G_N_ELEMENTS(expectedTagNames));
         for (unsigned i = 0; i < nodeCount; i++) {
             WebKitDOMNode* node = webkit_dom_html_collection_item(collection.get(), i);
             g_assert_true(WEBKIT_DOM_IS_NODE(node));
-            assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
+            s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(node));
             GUniquePtr<char> tagName(webkit_dom_node_get_node_name(node));
             g_assert_cmpstr(tagName.get(), ==, expectedTagNames[i]);
         }
@@ -237,12 +237,12 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         // DOM objects already in the document should be automatically handled by the cache.
         WebKitDOMElement* div = webkit_dom_document_get_element_by_id(document, "container");
         g_assert_true(WEBKIT_DOM_IS_HTML_ELEMENT(div));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(div));
 
         // Get the same elment twice should return the same pointer.
         g_assert_true(div == webkit_dom_document_get_element_by_id(document, "container"));
@@ -250,28 +250,28 @@ private:
         // A new DOM object created that is derived from Node should be automatically handled by the cache.
         WebKitDOMElement* p = webkit_dom_document_create_element(document, "P", nullptr);
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p));
 
         // A new DOM object created that isn't derived from Node should be manually handled.
         GRefPtr<WebKitDOMNodeIterator> iter = adoptGRef(webkit_dom_document_create_node_iterator(document, WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE_FILTER_SHOW_ALL, nullptr, FALSE, nullptr));
         g_assert_true(WEBKIT_DOM_IS_NODE_ITERATOR(iter.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(iter.get()));
 
         // We can also manually handle a DOM object handled by the cache.
         GRefPtr<WebKitDOMElement> p2 = adoptGRef(webkit_dom_document_create_element(document, "P", nullptr));
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p2.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p2.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p2.get()));
 
         // Manually handling a DOM object owned by the cache shouldn't crash when the cache has more than one reference.
         GRefPtr<WebKitDOMElement> p3 = adoptGRef(webkit_dom_document_create_element(document, "P", nullptr));
         g_assert_true(WEBKIT_DOM_IS_HTML_PARAGRAPH_ELEMENT(p3.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p3.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(p3.get()));
         webkit_dom_node_append_child(WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(p3.get()), nullptr);
 
         // DOM objects removed from the document are also correctly handled by the cache.
         WebKitDOMElement* a = webkit_dom_document_create_element(document, "A", nullptr);
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(a));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(a));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(a));
         webkit_dom_node_remove_child(WEBKIT_DOM_NODE(div), WEBKIT_DOM_NODE(a), nullptr);
 
         return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMXPathNSResolverTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/DOMXPathNSResolverTest.cpp
@@ -71,15 +71,15 @@ private:
     {
         WebKitDOMElement* documentElement = webkit_dom_document_get_document_element(document);
         g_assert_true(WEBKIT_DOM_IS_ELEMENT(documentElement));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(documentElement));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(documentElement));
 
         GRefPtr<WebKitDOMXPathResult> result = adoptGRef(webkit_dom_document_evaluate(document, "foo:child/text()", WEBKIT_DOM_NODE(documentElement), resolver, WEBKIT_DOM_XPATH_RESULT_ORDERED_NODE_ITERATOR_TYPE, nullptr, nullptr));
         g_assert_true(WEBKIT_DOM_IS_XPATH_RESULT(result.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(result.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(result.get()));
 
         WebKitDOMNode* nodeResult = webkit_dom_xpath_result_iterate_next(result.get(), nullptr);
         g_assert_true(WEBKIT_DOM_IS_NODE(nodeResult));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(nodeResult));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(nodeResult));
 
         GUniquePtr<char> nodeValue(webkit_dom_node_get_node_value(nodeResult));
         g_assert_cmpstr(nodeValue.get(), ==, "SUCCESS");
@@ -89,11 +89,11 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMXPathNSResolver> resolver = adoptGRef(webkit_dom_document_create_ns_resolver(document, WEBKIT_DOM_NODE(webkit_dom_document_get_document_element(document))));
         g_assert_true(WEBKIT_DOM_IS_XPATH_NS_RESOLVER(resolver.get()));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
         evaluateFooChildTextAndCheckResult(document, resolver.get());
 
         return true;
@@ -103,10 +103,10 @@ private:
     {
         WebKitDOMDocument* document = webkit_web_page_get_dom_document(page);
         g_assert_true(WEBKIT_DOM_IS_DOCUMENT(document));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(document));
 
         GRefPtr<WebKitDOMXPathNSResolver> resolver = adoptGRef(WEBKIT_DOM_XPATH_NS_RESOLVER(g_object_new(webkit_xpath_ns_resolver_get_type(), nullptr)));
-        assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
+        s_watcher.assertObjectIsDeletedWhenTestFinishes(G_OBJECT(resolver.get()));
         evaluateFooChildTextAndCheckResult(document, resolver.get());
 
         return true;


### PR DESCRIPTION
#### 4b27f17f5ade44bc02f5d8707c8140a762bb9253
<pre>
[WPE][GTK] WebProcess crashes at the end of every GLib API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=259303">https://bugs.webkit.org/show_bug.cgi?id=259303</a>

Reviewed by Michael Catanzaro.

To run web process API tests we need to be able to execute code in
the web process. This is done by using web process extensions.

`WebProcessTest.cpp ` is a base class that implements the initialization
of a web process extension. This class also provides an API for
asserting that the `GObject` objects allocated in the web process during
test execution are deleted at the end of the test.

These `GObject` objects are stored in a static `HashSet`
`s_watchedObjects`. When the web process is terminating
`static void __attribute__((destructor)) checkLeaksAtExit()`
is called to verify that `s_watchedObjects` is empty, meaning
no objects were leaked.

The problem is that static variable destructors are invoking *before*
any `__attribute__((destructor))` functions. So by the time
`checkLeaksAtExit` is called, `s_watchedObjects` is already deallocated,
leading the web process to crash.

Because the web process extension modules we need for some tests are
located in the default directory, there are being loaded with every
API test. So we got the crash even if we don&apos;t run a web process test.

The solution to this problem is to wrap the watched objects hash set
into a static class and check for leaks in its destructor, before the
hash set is deallocated.

* Tools/TestWebKitAPI/Tests/WebKitGLib/DOMElementTest.cpp:
(DOMElementTest::testAutoFill):
* Tools/TestWebKitAPI/Tests/WebKitGLib/EditorTest.cpp:
(WebKitWebEditorTest::testSelectionChanged):
* Tools/TestWebKitAPI/Tests/WebKitGLib/FrameTest.cpp:
(WebKitFrameTest::testJavaScriptContext):
(WebKitFrameTest::testJavaScriptValues):
(WebKitFrameTest::testSubframe):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.cpp:
(runTest):
(webProcessTestRunnerFinalize):
(windowObjectClearedCallback):
(webkit_web_extension_initialize):
(checkLeaks): Deleted.
(WebProcessTest::assertObjectIsDeletedWhenTestFinishes): Deleted.
(checkLeaksAtExit): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessTest.h:
(Watcher::~Watcher):
(Watcher::assertObjectIsDeletedWhenTestFinishes):
(Watcher::checkLeaks):
* Tools/TestWebKitAPI/Tests/WebKitGtk/AutocleanupsTest.cpp:
(AutocleanupsTest::testWebProcessAutocleanups):
* Tools/TestWebKitAPI/Tests/WebKitGtk/DOMClientRectTest.cpp:
(WebKitDOMClientRectTest::testDivBoundingClientRectPosition):
(WebKitDOMClientRectTest::testDivClientRectsPositionAndLength):
* Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeFilterTest.cpp:
(WebKitDOMNodeFilterTest::testTreeWalker):
(WebKitDOMNodeFilterTest::testNodeIterator):
* Tools/TestWebKitAPI/Tests/WebKitGtk/DOMNodeTest.cpp:
(WebKitDOMNodeTest::testHierarchyNavigation):
(WebKitDOMNodeTest::testInsertion):
(WebKitDOMNodeTest::testTagNamesNodeList):
(WebKitDOMNodeTest::testTagNamesHTMLCollection):
(WebKitDOMNodeTest::testDOMCache):
* Tools/TestWebKitAPI/Tests/WebKitGtk/DOMXPathNSResolverTest.cpp:
(WebKitDOMXPathNSResolverTest::evaluateFooChildTextAndCheckResult):
(WebKitDOMXPathNSResolverTest::testXPathNSResolverNative):
(WebKitDOMXPathNSResolverTest::testXPathNSResolverCustom):

Canonical link: <a href="https://commits.webkit.org/266127@main">https://commits.webkit.org/266127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b67879ba10115abceee21af9127cf9f5526970

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12381 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15077 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15166 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18794 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10260 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11634 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3177 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->