### PR TITLE
[content-visibility] Add support for selection

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4940,9 +4940,6 @@ webanimations/translate-property-and-translate-animation-with-delay-on-forced-la
 imported/w3c/web-platform-tests/css/css-contain/contain-inline-size-bfc-floats-001.html [ ImageOnlyFailure ]
 # forced layout
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-035.html [ Skip ]
-# off-screen selection
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
 
 # Style containment

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Fragment navigation with content-visibility; single text assert_equals: expected "text" but got "top"
-FAIL Fragment navigation with content-visibility; range across blocks assert_equals: expected "text2" but got "top"
+FAIL Fragment navigation with content-visibility; single text assert_equals: expected "text" but got "undefined"
+FAIL Fragment navigation with content-visibility; range across blocks assert_equals: expected "text2" but got "unknown"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Content Visibility: off-screen selection assert_equals: step3 height expected 10 but got 100
+PASS Content Visibility: off-screen selection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt
@@ -1,8 +1,9 @@
+hello
 
-FAIL One elements selected:  assert_false: 2 expected false got true
-FAIL Range extended to cover more elements:  assert_false: 2 expected false got true
-FAIL Range shrunk to cover fewer elements:  assert_false: 2 expected false got true
-FAIL Range flipped from back to front:  assert_false: 2 expected false got true
-FAIL Range flipped from front to back:  assert_false: 3 expected false got true
-FAIL Range goes back and forth:  assert_false: test_0, container_1 expected false got true
+PASS One elements selected:
+PASS Range extended to cover more elements:
+PASS Range shrunk to cover fewer elements:
+PASS Range flipped from back to front:
+PASS Range flipped from front to back:
+PASS Range goes back and forth:
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -29,11 +29,14 @@
 #include "ContentVisibilityAutoStateChangeEvent.h"
 #include "Element.h"
 #include "EventNames.h"
+#include "FrameSelection.h"
 #include "IntersectionObserverCallback.h"
 #include "IntersectionObserverEntry.h"
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
 #include "RenderStyleInlines.h"
+#include "SimpleRange.h"
+#include "VisibleSelection.h"
 
 namespace WebCore {
 
@@ -116,6 +119,14 @@ DidUpdateAnyContentRelevancy ContentVisibilityDocumentState::updateRelevancyOfCo
 
             if (relevancyToCheck.contains(ContentRelevancy::Focused))
                 setRelevancyValue(ContentRelevancy::Focused, target->hasFocusWithin());
+
+            auto targetContainsSelection = [](Element& target) {
+                auto selectionRange = target.document().selection().selection().range();
+                return selectionRange && intersects<ComposedTree>(*selectionRange, target);
+            };
+
+            if (relevancyToCheck.contains(ContentRelevancy::Selected))
+                setRelevancyValue(ContentRelevancy::Selected, targetContainsSelection(*target));
 
             auto hasTopLayerinSubtree = [](const Element& target) {
                 for (auto& element : target.document().topLayerElements()) {

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -110,7 +110,7 @@ enum class ContentRelevancy : uint8_t {
     OnScreen = 1 << 0,
     Focused = 1 << 1,
     IsInTopLayer = 1 << 2,
-    // FIXME: add Selected (see https://bugs.webkit.org/show_bug.cgi?id=258194).
+    Selected = 1 << 3,
 };
 
 namespace Style {

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -473,6 +473,8 @@ void FrameSelection::setSelection(const VisibleSelection& selection, OptionSet<S
     m_selectionRevealIntent = intent;
     m_pendingSelectionUpdate = true;
 
+    protectedDocument->scheduleContentRelevancyUpdate(ContentRelevancy::Selected);
+
     if (protectedDocument->hasPendingStyleRecalc())
         return;
 


### PR DESCRIPTION
#### e61b784a19ec8b6283afe2614730b9d4dfa79559
<pre>
[content-visibility] Add support for selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=258194">https://bugs.webkit.org/show_bug.cgi?id=258194</a>

Reviewed by Tim Nguyen.

Make selection of skipped content a reason to make an element relevant to the user as specified here:
<a href="https://drafts.csswg.org/css-contain/#relevant-to-the-user">https://drafts.csswg.org/css-contain/#relevant-to-the-user</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-048-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071-expected.txt:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements):
* Source/WebCore/dom/Element.h:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelection):

Canonical link: <a href="https://commits.webkit.org/267474@main">https://commits.webkit.org/267474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46db0171ae31f57ae9ab615c5852efb6c7ac1737

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19228 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14490 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15107 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19569 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15872 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15062 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3996 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->