### PR TITLE
Generate serialization of RemoteLayerTreeTransaction

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -95,6 +95,7 @@ template<typename> class StringBuffer;
 template<typename> class StringParsingBuffer;
 template<typename, typename = void> class StringTypeAdapter;
 template<typename> class UniqueRef;
+template<typename T, class... Args> UniqueRef<T> makeUniqueRef(Args&&...);
 template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename = VectorBufferMalloc> class Vector;
 template<typename, typename = DefaultWeakPtrImpl> class WeakPtr;
 
@@ -152,6 +153,7 @@ using WTF::LazyNeverDestroyed;
 using WTF::Lock;
 using WTF::Logger;
 using WTF::MachSendRight;
+using WTF::makeUniqueRef;
 using WTF::MonotonicTime;
 using WTF::NeverDestroyed;
 using WTF::ObjectIdentifier;

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -412,8 +412,6 @@ set(WebKit_SERIALIZATION_IN_FILES
 
     Shared/Gamepad/GamepadData.serialization.in
 
-    Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
-
     Shared/WebGPU/WebGPUBindGroupDescriptor.serialization.in
     Shared/WebGPU/WebGPUBindGroupEntry.serialization.in
     Shared/WebGPU/WebGPUBindGroupLayoutDescriptor.serialization.in

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -342,6 +342,24 @@ template<typename T> struct ArgumentCoder<std::unique_ptr<T>> {
     }
 };
 
+template<typename T> struct ArgumentCoder<UniqueRef<T>> {
+    template<typename Encoder, typename U>
+    static void encode(Encoder& encoder, U&& object)
+    {
+        static_assert(std::is_same_v<std::remove_cvref_t<U>, UniqueRef<T>>);
+        encoder << std::forward_like<U>(*object);
+    }
+
+    template<typename Decoder>
+    static std::optional<UniqueRef<T>> decode(Decoder& decoder)
+    {
+        auto object = decoder.template decode<T>();
+        if (!object)
+            return std::nullopt;
+        return makeUniqueRef<T>(WTFMove(*object));
+    }
+};
+
 template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
     template<typename Encoder, typename T>
     static void encode(Encoder& encoder, T&& tuple)

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -38,6 +38,7 @@ import sys
 # OptionSet - for enum classes, instead of only allowing deserialization of the exact values, allow deserialization of any bit combination of the values.
 # RValue - serializer takes an rvalue reference, instead of an lvalue.
 # WebKitPlatform - put serializer into a file built as part of WebKitPlatform
+# CustomEncoder - Only generate the decoder, not the encoder.
 #
 # Supported member attributes:
 #
@@ -66,6 +67,7 @@ class SerializedType(object):
         self.webkit_platform = False
         self.members_are_subclasses = False
         self.custom_member_layout = False
+        self.custom_encoder = False
         if attributes is not None:
             for attribute in attributes.split(', '):
                 if '=' in attribute:
@@ -89,6 +91,8 @@ class SerializedType(object):
                         self.custom_member_layout = True
                     elif attribute == 'LegacyPopulateFromEmptyConstructor':
                         self.populate_from_empty_constructor = True
+                    elif attribute == 'CustomEncoder':
+                        self.custom_encoder = True
         if other_metadata:
             if other_metadata == 'subclasses':
                 self.members_are_subclasses = True
@@ -607,6 +611,8 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             result.append('};')
             result.append('')
         for encoder in type.encoders:
+            if type.custom_encoder:
+                continue
             if type.rvalue:
                 result.append('void ArgumentCoder<' + type.namespace_and_name() + '>::encode(' + encoder + '& encoder, ' + type.namespace_and_name() + '&& instance)')
             else:

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
+#include "CustomEncoded.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
@@ -783,6 +784,18 @@ std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDeri
         WebCore::MoveOnlyDerivedClass {
             WTFMove(*firstMember),
             WTFMove(*secondMember)
+        }
+    };
+}
+
+std::optional<WebKit::CustomEncoded> ArgumentCoder<WebKit::CustomEncoded>::decode(Decoder& decoder)
+{
+    auto value = decoder.decode<int>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return {
+        WebKit::CustomEncoded {
+            WTFMove(*value)
         }
     };
 }

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -64,6 +64,7 @@ namespace Namespace { class AnotherCommonClass; }
 namespace WebCore { class MoveOnlyBaseClass; }
 namespace WebCore { class MoveOnlyDerivedClass; }
 namespace WebKit { class PlatformClass; }
+namespace WebKit { class CustomEncoded; }
 
 namespace IPC {
 
@@ -170,6 +171,11 @@ template<> struct ArgumentCoder<WebCore::MoveOnlyDerivedClass> {
 template<> struct ArgumentCoder<WebKit::PlatformClass> {
     static void encode(Encoder&, const WebKit::PlatformClass&);
     static std::optional<WebKit::PlatformClass> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::CustomEncoded> {
+    static void encode(Encoder&, const WebKit::CustomEncoded&);
+    static std::optional<WebKit::CustomEncoded> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
+#include "CustomEncoded.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
@@ -207,6 +208,12 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             }
         } },
         { "WebKit::PlatformClass"_s, {
+            {
+                "int"_s,
+                "value"_s
+            }
+        } },
+        { "WebKit::CustomEncoded"_s, {
             {
                 "int"_s,
                 "value"_s

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -168,3 +168,7 @@ webkit_platform_headers: "PlatformClass.h"
 [CustomHeader, WebKitPlatform] class WebKit::PlatformClass {
   int value;
 };
+
+[CustomEncoder] class WebKit::CustomEncoded {
+  int value;
+};

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PlatformCAAnimationRemote.h"
+#include <WebCore/PlatformCALayer.h>
+
+namespace WebKit {
+
+class RemoteLayerBackingStore;
+class RemoteLayerBackingStoreProperties;
+
+enum class LayerChange : uint64_t {
+    NameChanged                         = 1LLU << 1,
+    ChildrenChanged                     = 1LLU << 2,
+    PositionChanged                     = 1LLU << 3,
+    BoundsChanged                       = 1LLU << 4,
+    BackgroundColorChanged              = 1LLU << 5,
+    AnchorPointChanged                  = 1LLU << 6,
+    BorderWidthChanged                  = 1LLU << 7,
+    BorderColorChanged                  = 1LLU << 8,
+    OpacityChanged                      = 1LLU << 9,
+    TransformChanged                    = 1LLU << 10,
+    SublayerTransformChanged            = 1LLU << 11,
+    HiddenChanged                       = 1LLU << 12,
+    GeometryFlippedChanged              = 1LLU << 13,
+    DoubleSidedChanged                  = 1LLU << 14,
+    MasksToBoundsChanged                = 1LLU << 15,
+    OpaqueChanged                       = 1LLU << 16,
+    ContentsHiddenChanged               = 1LLU << 17,
+    MaskLayerChanged                    = 1LLU << 18,
+    ClonedContentsChanged               = 1LLU << 19,
+    ContentsRectChanged                 = 1LLU << 20,
+    ContentsScaleChanged                = 1LLU << 21,
+    CornerRadiusChanged                 = 1LLU << 22,
+    ShapeRoundedRectChanged             = 1LLU << 23,
+    ShapePathChanged                    = 1LLU << 24,
+    MinificationFilterChanged           = 1LLU << 25,
+    MagnificationFilterChanged          = 1LLU << 26,
+    BlendModeChanged                    = 1LLU << 27,
+    WindRuleChanged                     = 1LLU << 28,
+    SpeedChanged                        = 1LLU << 29,
+    TimeOffsetChanged                   = 1LLU << 30,
+    BackingStoreChanged                 = 1LLU << 31,
+    BackingStoreAttachmentChanged       = 1LLU << 32,
+    FiltersChanged                      = 1LLU << 33,
+    AnimationsChanged                   = 1LLU << 34,
+    AntialiasesEdgesChanged             = 1LLU << 35,
+    CustomAppearanceChanged             = 1LLU << 36,
+    UserInteractionEnabledChanged       = 1LLU << 37,
+    EventRegionChanged                  = 1LLU << 38,
+    ScrollingNodeIDChanged              = 1LLU << 39,
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    SeparatedChanged                    = 1LLU << 40,
+#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
+    SeparatedPortalChanged              = 1LLU << 41,
+    DescendentOfSeparatedPortalChanged  = 1LLU << 42,
+#endif
+#endif
+    VideoGravityChanged                 = 1LLU << 44,
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    CoverageRectChanged                 = 1LLU << 45,
+#endif
+};
+
+struct LayerProperties {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    LayerProperties();
+    LayerProperties(LayerProperties&&);
+
+    void encode(IPC::Encoder&) const;
+    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, LayerProperties&);
+
+    void notePropertiesChanged(OptionSet<LayerChange> changeFlags)
+    {
+        changedProperties.add(changeFlags);
+        everChangedProperties.add(changeFlags);
+    }
+
+    void resetChangedProperties()
+    {
+        changedProperties = { };
+    }
+
+    OptionSet<LayerChange> changedProperties;
+    OptionSet<LayerChange> everChangedProperties;
+
+    String name;
+    std::unique_ptr<WebCore::TransformationMatrix> transform;
+    std::unique_ptr<WebCore::TransformationMatrix> sublayerTransform;
+    std::unique_ptr<WebCore::FloatRoundedRect> shapeRoundedRect;
+
+    Vector<WebCore::PlatformLayerIdentifier> children;
+
+    Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
+    HashSet<String> keysOfAnimationsToRemove;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    Vector<Ref<WebCore::AcceleratedEffect>> effects;
+    WebCore::AcceleratedEffectValues baseValues;
+#endif
+
+    WebCore::FloatPoint3D position;
+    WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };
+    WebCore::FloatRect bounds;
+    WebCore::FloatRect contentsRect { 0, 0, 1, 1 };
+    // Used in the WebContent process.
+    std::unique_ptr<RemoteLayerBackingStore> backingStore;
+    // Used in the UI process.
+    std::unique_ptr<RemoteLayerBackingStoreProperties> backingStoreProperties;
+    std::unique_ptr<WebCore::FilterOperations> filters;
+    WebCore::Path shapePath;
+    Markable<WebCore::PlatformLayerIdentifier> maskLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> clonedLayerID;
+#if ENABLE(SCROLLING_THREAD)
+    WebCore::ScrollingNodeID scrollingNodeID { 0 };
+#endif
+    double timeOffset { 0 };
+    float speed { 1 };
+    float contentsScale { 1 };
+    float cornerRadius { 0 };
+    float borderWidth { 0 };
+    float opacity { 1 };
+    WebCore::Color backgroundColor { WebCore::Color::transparentBlack };
+    WebCore::Color borderColor { WebCore::Color::black };
+    WebCore::GraphicsLayer::CustomAppearance customAppearance { WebCore::GraphicsLayer::CustomAppearance::None };
+    WebCore::PlatformCALayer::FilterType minificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
+    WebCore::PlatformCALayer::FilterType magnificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
+    WebCore::BlendMode blendMode { WebCore::BlendMode::Normal };
+    WebCore::WindRule windRule { WebCore::WindRule::NonZero };
+    WebCore::MediaPlayerVideoGravity videoGravity { WebCore::MediaPlayerVideoGravity::ResizeAspect };
+    bool antialiasesEdges { true };
+    bool hidden { false };
+    bool backingStoreAttached { true };
+    bool geometryFlipped { false };
+    bool doubleSided { false };
+    bool masksToBounds { false };
+    bool opaque { false };
+    bool contentsHidden { false };
+    bool userInteractionEnabled { true };
+    WebCore::EventRegion eventRegion;
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    WebCore::FloatRect coverageRect;
+#endif
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    bool isSeparated { false };
+#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
+    bool isSeparatedPortal { false };
+    bool isDescendentOfSeparatedPortal { false };
+#endif
+#endif
+};
+
+}

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -20,7 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if PLATFORM(COCOA)
 header: "RemoteLayerTreeTransaction.h"
 [OptionSet] enum class WebKit::LayerChange : uint64_t {
     NameChanged
@@ -74,7 +73,6 @@ header: "RemoteLayerTreeTransaction.h"
     CoverageRectChanged
 #endif
 };
-#endif
 
 header: "SwapBuffersDisplayRequirement.h"
 enum class WebKit::SwapBuffersDisplayRequirement : uint8_t {
@@ -88,3 +86,60 @@ header: "RemoteScrollingUIState.h"
     ScrollSnapNodes
     UserScrollNodes
 };
+
+[LegacyPopulateFromEmptyConstructor] class WebKit::RemoteLayerTreeTransaction {
+{
+    WebCore::PlatformLayerIdentifier m_rootLayerID;
+    WebKit::ChangedLayers m_changedLayers;
+
+    Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
+
+    Vector<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties> m_createdLayers;
+    Vector<WebCore::PlatformLayerIdentifier> m_destroyedLayerIDs;
+    Vector<WebCore::PlatformLayerIdentifier> m_videoLayerIDsPendingFullscreen;
+    Vector<WebCore::PlatformLayerIdentifier> m_layerIDsWithNewlyUnreachableBackingStore;
+
+    Vector<IPC::AsyncReplyID> m_callbackIDs;
+
+    WebCore::IntSize m_contentsSize;
+    WebCore::IntPoint m_scrollOrigin;
+    WebCore::LayoutSize m_baseLayoutViewportSize;
+    WebCore::LayoutPoint m_minStableLayoutViewportOrigin;
+    WebCore::LayoutPoint m_maxStableLayoutViewportOrigin;
+    WebCore::IntPoint m_scrollPosition;
+    WebCore::Color m_themeColor;
+    WebCore::Color m_pageExtendedBackgroundColor;
+    WebCore::Color m_sampledPageTopColor;
+
+#if PLATFORM(MAC)
+    Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;
+    Markable<WebCore::PlatformLayerIdentifier> m_scrolledContentsLayerID;
+#endif
+
+    double m_pageScaleFactor;
+    double m_minimumScaleFactor;
+    double m_maximumScaleFactor;
+    double m_initialScaleFactor;
+    double m_viewportMetaTagWidth;
+    uint64_t m_renderTreeSize;
+    WebKit::TransactionID m_transactionID;
+    WebKit::ActivityStateChangeID m_activityStateChangeID;
+    OptionSet<WebCore::LayoutMilestone> m_newlyReachedPaintingMilestones;
+    bool m_scaleWasSetByUIProcess;
+    bool m_allowsUserScaling;
+    bool m_avoidsUnsafeArea;
+    bool m_viewportMetaTagWidthWasExplicit;
+    bool m_viewportMetaTagCameFromImageDocument;
+    bool m_isInStableState;
+
+    std::optional<WebKit::EditorState> m_editorState;
+#if PLATFORM(IOS_FAMILY)
+    std::optional<uint64_t> m_dynamicViewportSizeUpdateID;
+#endif
+}
+
+headers: "LayerProperties.h" "PlatformCALayerRemote.h"
+[CustomEncoder, CustomHeader] struct WebKit::ChangedLayers {
+    [NotSerialized] HashSet<Ref<PlatformCALayerRemote>> changedLayers;
+    HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<WebKit::LayerProperties>> changedLayerProperties;
+}

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h
@@ -37,14 +37,14 @@ class RemoteLayerTreePropertyApplier {
 public:
     using RelatedLayerMap = HashMap<WebCore::PlatformLayerIdentifier, std::unique_ptr<RemoteLayerTreeNode>>;
     
-    static void applyHierarchyUpdates(RemoteLayerTreeNode&, const RemoteLayerTreeTransaction::LayerProperties&, const RelatedLayerMap&);
-    static void applyProperties(RemoteLayerTreeNode&, RemoteLayerTreeHost*, const RemoteLayerTreeTransaction::LayerProperties&, const RelatedLayerMap&, RemoteLayerBackingStoreProperties::LayerContentsType);
-    static void applyPropertiesToLayer(CALayer *, RemoteLayerTreeNode*, RemoteLayerTreeHost*, const RemoteLayerTreeTransaction::LayerProperties&, RemoteLayerBackingStoreProperties::LayerContentsType);
+    static void applyHierarchyUpdates(RemoteLayerTreeNode&, const LayerProperties&, const RelatedLayerMap&);
+    static void applyProperties(RemoteLayerTreeNode&, RemoteLayerTreeHost*, const LayerProperties&, const RelatedLayerMap&, RemoteLayerBackingStoreProperties::LayerContentsType);
+    static void applyPropertiesToLayer(CALayer *, RemoteLayerTreeNode*, RemoteLayerTreeHost*, const LayerProperties&, RemoteLayerBackingStoreProperties::LayerContentsType);
 
 private:
-    static void updateMask(RemoteLayerTreeNode&, const RemoteLayerTreeTransaction::LayerProperties&, const RelatedLayerMap&);
+    static void updateMask(RemoteLayerTreeNode&, const LayerProperties&, const RelatedLayerMap&);
 #if PLATFORM(IOS_FAMILY)
-    static void applyPropertiesToUIView(UIView *, const RemoteLayerTreeTransaction::LayerProperties&, const RelatedLayerMap&);
+    static void applyPropertiesToUIView(UIView *, const LayerProperties&, const RelatedLayerMap&);
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -149,7 +149,7 @@ static void updateCustomAppearance(CALayer *layer, GraphicsLayer::CustomAppearan
 #endif
 }
 
-static void applyCommonPropertiesToLayer(CALayer *layer, const RemoteLayerTreeTransaction::LayerProperties& properties)
+static void applyCommonPropertiesToLayer(CALayer *layer, const LayerProperties& properties)
 {
     if (properties.changedProperties & LayerChange::PositionChanged) {
         layer.position = CGPointMake(properties.position.x(), properties.position.y());
@@ -188,7 +188,7 @@ static void applyCommonPropertiesToLayer(CALayer *layer, const RemoteLayerTreeTr
         layer.masksToBounds = properties.masksToBounds;
 }
 
-void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, RemoteLayerTreeNode* layerTreeNode, RemoteLayerTreeHost* layerTreeHost, const RemoteLayerTreeTransaction::LayerProperties& properties, RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType)
+void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, RemoteLayerTreeNode* layerTreeNode, RemoteLayerTreeHost* layerTreeHost, const LayerProperties& properties, RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType)
 {
     applyCommonPropertiesToLayer(layer, properties);
 
@@ -308,7 +308,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 #endif
 }
 
-void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, RemoteLayerTreeHost* layerTreeHost, const RemoteLayerTreeTransaction::LayerProperties& properties, const RelatedLayerMap& relatedLayers, RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType)
+void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, RemoteLayerTreeHost* layerTreeHost, const LayerProperties& properties, const RelatedLayerMap& relatedLayers, RemoteLayerBackingStoreProperties::LayerContentsType layerContentsType)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -341,7 +341,7 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
 }
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-static void applyInteractionRegionsHierarchyUpdate(RemoteLayerTreeNode& node, const RemoteLayerTreeTransaction::LayerProperties& properties, const RemoteLayerTreePropertyApplier::RelatedLayerMap& relatedLayers)
+static void applyInteractionRegionsHierarchyUpdate(RemoteLayerTreeNode& node, const LayerProperties& properties, const RemoteLayerTreePropertyApplier::RelatedLayerMap& relatedLayers)
 {
     auto sublayers = createNSArray(properties.children, [&] (auto& child) -> CALayer * {
         auto* childNode = relatedLayers.get(child);
@@ -356,7 +356,7 @@ static void applyInteractionRegionsHierarchyUpdate(RemoteLayerTreeNode& node, co
 }
 #endif
 
-void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& node, const RemoteLayerTreeTransaction::LayerProperties& properties, const RelatedLayerMap& relatedLayers)
+void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& node, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -411,7 +411,7 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const RemoteLayerTreeTransaction::LayerProperties& properties, const RelatedLayerMap& relatedLayers)
+void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)
 {
     if (!properties.changedProperties.contains(LayerChange::MaskLayerChanged))
         return;
@@ -435,7 +435,7 @@ void RemoteLayerTreePropertyApplier::updateMask(RemoteLayerTreeNode& node, const
 }
 
 #if PLATFORM(IOS_FAMILY)
-void RemoteLayerTreePropertyApplier::applyPropertiesToUIView(UIView *view, const RemoteLayerTreeTransaction::LayerProperties& properties, const RelatedLayerMap& relatedLayers)
+void RemoteLayerTreePropertyApplier::applyPropertiesToUIView(UIView *view, const LayerProperties& properties, const RelatedLayerMap& relatedLayers)
 {
     if (properties.changedProperties.containsAny({ LayerChange::ContentsHiddenChanged, LayerChange::UserInteractionEnabledChanged }))
         view.userInteractionEnabled = !properties.contentsHidden && properties.userInteractionEnabled;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -64,57 +64,18 @@ class Encoder;
 
 namespace WebKit {
 
-enum class LayerChange : uint64_t {
-    NameChanged                         = 1LLU << 1,
-    ChildrenChanged                     = 1LLU << 2,
-    PositionChanged                     = 1LLU << 3,
-    BoundsChanged                       = 1LLU << 4,
-    BackgroundColorChanged              = 1LLU << 5,
-    AnchorPointChanged                  = 1LLU << 6,
-    BorderWidthChanged                  = 1LLU << 7,
-    BorderColorChanged                  = 1LLU << 8,
-    OpacityChanged                      = 1LLU << 9,
-    TransformChanged                    = 1LLU << 10,
-    SublayerTransformChanged            = 1LLU << 11,
-    HiddenChanged                       = 1LLU << 12,
-    GeometryFlippedChanged              = 1LLU << 13,
-    DoubleSidedChanged                  = 1LLU << 14,
-    MasksToBoundsChanged                = 1LLU << 15,
-    OpaqueChanged                       = 1LLU << 16,
-    ContentsHiddenChanged               = 1LLU << 17,
-    MaskLayerChanged                    = 1LLU << 18,
-    ClonedContentsChanged               = 1LLU << 19,
-    ContentsRectChanged                 = 1LLU << 20,
-    ContentsScaleChanged                = 1LLU << 21,
-    CornerRadiusChanged                 = 1LLU << 22,
-    ShapeRoundedRectChanged             = 1LLU << 23,
-    ShapePathChanged                    = 1LLU << 24,
-    MinificationFilterChanged           = 1LLU << 25,
-    MagnificationFilterChanged          = 1LLU << 26,
-    BlendModeChanged                    = 1LLU << 27,
-    WindRuleChanged                     = 1LLU << 28,
-    SpeedChanged                        = 1LLU << 29,
-    TimeOffsetChanged                   = 1LLU << 30,
-    BackingStoreChanged                 = 1LLU << 31,
-    BackingStoreAttachmentChanged       = 1LLU << 32,
-    FiltersChanged                      = 1LLU << 33,
-    AnimationsChanged                   = 1LLU << 34,
-    AntialiasesEdgesChanged             = 1LLU << 35,
-    CustomAppearanceChanged             = 1LLU << 36,
-    UserInteractionEnabledChanged       = 1LLU << 37,
-    EventRegionChanged                  = 1LLU << 38,
-    ScrollingNodeIDChanged              = 1LLU << 39,
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    SeparatedChanged                    = 1LLU << 40,
-#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    SeparatedPortalChanged              = 1LLU << 41,
-    DescendentOfSeparatedPortalChanged  = 1LLU << 42,
-#endif
-#endif
-    VideoGravityChanged                 = 1LLU << 44,
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CoverageRectChanged                 = 1LLU << 45,
-#endif
+struct LayerProperties;
+using LayerPropertiesMap = HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<LayerProperties>>;
+
+struct ChangedLayers {
+    HashSet<Ref<PlatformCALayerRemote>> changedLayers; // Only used in the Web process.
+    LayerPropertiesMap changedLayerProperties; // Only used in the UI process.
+
+    ChangedLayers();
+    ChangedLayers(ChangedLayers&&);
+    ChangedLayers& operator=(ChangedLayers&&);
+    ChangedLayers(LayerPropertiesMap&&);
+    ~ChangedLayers();
 };
 
 class RemoteLayerTreeTransaction {
@@ -145,101 +106,10 @@ public:
 #endif
     };
 
-    struct LayerProperties {
-        WTF_MAKE_STRUCT_FAST_ALLOCATED;
-        LayerProperties();
-        LayerProperties(const LayerProperties& other);
-
-        void encode(IPC::Encoder&) const;
-        static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, LayerProperties&);
-
-        void notePropertiesChanged(OptionSet<LayerChange> changeFlags)
-        {
-            changedProperties.add(changeFlags);
-            everChangedProperties.add(changeFlags);
-        }
-
-        void resetChangedProperties()
-        {
-            changedProperties = { };
-        }
-
-        OptionSet<LayerChange> changedProperties;
-        OptionSet<LayerChange> everChangedProperties;
-
-        String name;
-        std::unique_ptr<WebCore::TransformationMatrix> transform;
-        std::unique_ptr<WebCore::TransformationMatrix> sublayerTransform;
-        std::unique_ptr<WebCore::FloatRoundedRect> shapeRoundedRect;
-
-        Vector<WebCore::PlatformLayerIdentifier> children;
-
-        Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
-        HashSet<String> keysOfAnimationsToRemove;
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-        Vector<Ref<WebCore::AcceleratedEffect>> effects;
-        WebCore::AcceleratedEffectValues baseValues;
-#endif
-
-        WebCore::FloatPoint3D position;
-        WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };
-        WebCore::FloatRect bounds;
-        WebCore::FloatRect contentsRect { 0, 0, 1, 1 };
-        // Used in the WebContent process.
-        std::unique_ptr<RemoteLayerBackingStore> backingStore;
-        // Used in the UI process.
-        std::unique_ptr<RemoteLayerBackingStoreProperties> backingStoreProperties;
-        std::unique_ptr<WebCore::FilterOperations> filters;
-        WebCore::Path shapePath;
-        Markable<WebCore::PlatformLayerIdentifier> maskLayerID;
-        Markable<WebCore::PlatformLayerIdentifier> clonedLayerID;
-#if ENABLE(SCROLLING_THREAD)
-        WebCore::ScrollingNodeID scrollingNodeID { 0 };
-#endif
-        double timeOffset { 0 };
-        float speed { 1 };
-        float contentsScale { 1 };
-        float cornerRadius { 0 };
-        float borderWidth { 0 };
-        float opacity { 1 };
-        WebCore::Color backgroundColor { WebCore::Color::transparentBlack };
-        WebCore::Color borderColor { WebCore::Color::black };
-        WebCore::GraphicsLayer::CustomAppearance customAppearance { WebCore::GraphicsLayer::CustomAppearance::None };
-        WebCore::PlatformCALayer::FilterType minificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
-        WebCore::PlatformCALayer::FilterType magnificationFilter { WebCore::PlatformCALayer::FilterType::Linear };
-        WebCore::BlendMode blendMode { WebCore::BlendMode::Normal };
-        WebCore::WindRule windRule { WebCore::WindRule::NonZero };
-        WebCore::MediaPlayerVideoGravity videoGravity { WebCore::MediaPlayerVideoGravity::ResizeAspect };
-        bool antialiasesEdges { true };
-        bool hidden { false };
-        bool backingStoreAttached { true };
-        bool geometryFlipped { false };
-        bool doubleSided { false };
-        bool masksToBounds { false };
-        bool opaque { false };
-        bool contentsHidden { false };
-        bool userInteractionEnabled { true };
-        WebCore::EventRegion eventRegion;
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        WebCore::FloatRect coverageRect;
-#endif
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-        bool isSeparated { false };
-#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-        bool isSeparatedPortal { false };
-        bool isDescendentOfSeparatedPortal { false };
-#endif
-#endif
-    };
-
     explicit RemoteLayerTreeTransaction();
     ~RemoteLayerTreeTransaction();
     RemoteLayerTreeTransaction(RemoteLayerTreeTransaction&&);
     RemoteLayerTreeTransaction& operator=(RemoteLayerTreeTransaction&&);
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteLayerTreeTransaction&);
 
     WebCore::PlatformLayerIdentifier rootLayerID() const { return m_rootLayerID; }
     void setRootLayerID(WebCore::PlatformLayerIdentifier);
@@ -252,22 +122,17 @@ public:
     String description() const;
     void dump() const;
 #endif
-
-    typedef HashMap<WebCore::PlatformLayerIdentifier, std::unique_ptr<LayerProperties>> LayerPropertiesMap;
     
-    bool hasAnyLayerChanges() const
-    {
-        return m_changedLayerProperties.size() || m_changedLayers.size() || m_createdLayers.size() || m_destroyedLayerIDs.size() || m_layerIDsWithNewlyUnreachableBackingStore.size();
-    }
+    bool hasAnyLayerChanges() const;
 
     const Vector<LayerCreationProperties>& createdLayers() const { return m_createdLayers; }
     const Vector<WebCore::PlatformLayerIdentifier>& destroyedLayers() const { return m_destroyedLayerIDs; }
     const Vector<WebCore::PlatformLayerIdentifier>& layerIDsWithNewlyUnreachableBackingStore() const { return m_layerIDsWithNewlyUnreachableBackingStore; }
 
-    HashSet<RefPtr<PlatformCALayerRemote>>& changedLayers() { return m_changedLayers; }
+    HashSet<Ref<PlatformCALayerRemote>>& changedLayers();
 
-    const LayerPropertiesMap& changedLayerProperties() const { return m_changedLayerProperties; }
-    LayerPropertiesMap& changedLayerProperties() { return m_changedLayerProperties; }
+    const LayerPropertiesMap& changedLayerProperties() const;
+    LayerPropertiesMap& changedLayerProperties();
 
     void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }
@@ -367,9 +232,10 @@ public:
 #endif
 
 private:
+    friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
+
     WebCore::PlatformLayerIdentifier m_rootLayerID;
-    HashSet<RefPtr<PlatformCALayerRemote>> m_changedLayers; // Only used in the Web process.
-    LayerPropertiesMap m_changedLayerProperties; // Only used in the UI process.
+    ChangedLayers m_changedLayers;
 
     Markable<WebCore::LayerHostingContextIdentifier> m_remoteContextHostedIdentifier;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -28,6 +28,7 @@
 
 #import "DrawingAreaMessages.h"
 #import "DrawingAreaProxyMessages.h"
+#import "LayerProperties.h"
 #import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "RemoteLayerTreeDrawingAreaProxyMessages.h"

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -155,7 +155,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
 #endif
     auto layerContentsType = this->layerContentsType();
     for (auto& [layerID, propertiesPointer] : transaction.changedLayerProperties()) {
-        const RemoteLayerTreeTransaction::LayerProperties& properties = *propertiesPointer;
+        const auto& properties = *propertiesPointer;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
         if (layerID == transaction.rootLayerID())
@@ -183,7 +183,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const RemoteLayerTreeTransaction& tran
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {
         auto layerID = changedLayer.key;
-        const RemoteLayerTreeTransaction::LayerProperties& properties = *changedLayer.value;
+        const auto& properties = *changedLayer.value;
 
         auto* node = nodeForID(layerID);
         ASSERT(node);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5306,6 +5306,7 @@
 		5C157A0B2717CA1C00ED5280 /* WebPushDaemonMain.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebPushDaemonMain.mm; sourceTree = "<group>"; };
 		5C19A51E1FD0B14600EEA323 /* URLSchemeTaskParameters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLSchemeTaskParameters.cpp; sourceTree = "<group>"; };
 		5C19A51F1FD0B14700EEA323 /* URLSchemeTaskParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = URLSchemeTaskParameters.h; sourceTree = "<group>"; };
+		5C19EF1A2A6657DA0022B4B3 /* LayerProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LayerProperties.h; sourceTree = "<group>"; };
 		5C1B38DF2667140700B1545B /* WebPageNetworkParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageNetworkParameters.h; sourceTree = "<group>"; };
 		5C1B38E02667140700B1545B /* WebPageNetworkParameters.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageNetworkParameters.cpp; sourceTree = "<group>"; };
 		5C20CB9B1BB0DCD200895BB1 /* NetworkSessionCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NetworkSessionCocoa.mm; sourceTree = "<group>"; };
@@ -9203,6 +9204,7 @@
 				2D478B8F288F333500F3B73A /* CGDisplayList.h */,
 				BCE579A42634836700F5C5E9 /* CGDisplayListImageBufferBackend.h */,
 				BCE579A52634836700F5C5E9 /* CGDisplayListImageBufferBackend.mm */,
+				5C19EF1A2A6657DA0022B4B3 /* LayerProperties.h */,
 				2D47B56B1810714E003A3AEE /* RemoteLayerBackingStore.h */,
 				2D47B56A1810714E003A3AEE /* RemoteLayerBackingStore.mm */,
 				2DDF731318E95060004F5A66 /* RemoteLayerBackingStoreCollection.h */,

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "LayerProperties.h"
 #include "RemoteLayerTreeTransaction.h"
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/PlatformCALayer.h>
@@ -228,8 +229,8 @@ public:
 
     void setClonedLayer(const PlatformCALayer*);
 
-    RemoteLayerTreeTransaction::LayerProperties& properties() { return m_properties; }
-    const RemoteLayerTreeTransaction::LayerProperties& properties() const { return m_properties; }
+    LayerProperties& properties() { return m_properties; }
+    const LayerProperties& properties() const { return m_properties; }
 
     void didCommit();
 
@@ -259,7 +260,7 @@ private:
 
     WebCore::LayerPool& layerPool() override;
 
-    RemoteLayerTreeTransaction::LayerProperties m_properties;
+    LayerProperties m_properties;
     WebCore::PlatformCALayerList m_children;
     PlatformCALayerRemote* m_superlayer { nullptr };
     PlatformCALayerRemote* m_maskLayer { nullptr };


### PR DESCRIPTION
#### c94a19745dcb20e781a8fa3ca3fe72aca98c5113
<pre>
Generate serialization of RemoteLayerTreeTransaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=259316">https://bugs.webkit.org/show_bug.cgi?id=259316</a>
rdar://112491333

Reviewed by Simon Fraser.

This removes a lot of boilerplate code and replaces it with generated code with static_asserts
that verify we didn&apos;t forget anything.  It also exposes the structure to the IPC testing API.
The collections of changed layers were a little tricky, but by adding the new attribute CustomEncoder
we can manually write the encoder and it keeps all the complexity in one small class.

* Source/WTF/wtf/Forward.h:
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;UniqueRef&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;UniqueRef&lt;T&gt;&gt;::decode):
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::CustomEncoded&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h: Added.
(WebKit::LayerProperties::notePropertiesChanged):
(WebKit::LayerProperties::resetChangedProperties):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::applyCommonPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
(WebKit::applyInteractionRegionsHierarchyUpdate):
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
(WebKit::RemoteLayerTreePropertyApplier::updateMask):
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToUIView):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::LayerProperties::notePropertiesChanged): Deleted.
(WebKit::RemoteLayerTreeTransaction::LayerProperties::resetChangedProperties): Deleted.
(WebKit::RemoteLayerTreeTransaction::hasAnyLayerChanges const): Deleted.
(WebKit::RemoteLayerTreeTransaction::changedLayers): Deleted.
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties const): Deleted.
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::LayerProperties::encode const):
(WebKit::LayerProperties::decode):
(WebKit::RemoteLayerTreeTransaction::layerPropertiesChanged):
(WebKit::dumpChangedLayers):
(WebKit::RemoteLayerTreeTransaction::description const):
(WebKit::RemoteLayerTreeTransaction::hasAnyLayerChanges const):
(WebKit::RemoteLayerTreeTransaction::changedLayers):
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties const):
(WebKit::RemoteLayerTreeTransaction::changedLayerProperties):
(WebKit::ChangedLayers::ChangedLayers):
(IPC::ArgumentCoder&lt;WebKit::ChangedLayers&gt;::encode):
(WebKit::RemoteLayerTreeTransaction::LayerProperties::LayerProperties): Deleted.
(WebKit::RemoteLayerTreeTransaction::LayerProperties::encode const): Deleted.
(WebKit::RemoteLayerTreeTransaction::LayerProperties::decode): Deleted.
(WebKit::RemoteLayerTreeTransaction::encode const): Deleted.
(WebKit::RemoteLayerTreeTransaction::decode): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateLayerTree):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
(WebKit::PlatformCALayerRemote::properties):
(WebKit::PlatformCALayerRemote::properties const):

Canonical link: <a href="https://commits.webkit.org/266149@main">https://commits.webkit.org/266149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0425566c2e63a7b8ec7c1cdcff3c6b371a71fa38

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14763 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12417 "Failed to compile WebKit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15216 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13118 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11766 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11081 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15147 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12328 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10297 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13069 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11679 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3434 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15997 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13447 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1476 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12254 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3229 "Passed tests") | 
<!--EWS-Status-Bubble-End-->