### PR TITLE
Add back inline storage to WebCore::Path

### DIFF
--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -36,11 +36,13 @@ namespace WebCore {
 class PathStream final : public PathImpl {
 public:
     static UniqueRef<PathStream> create();
+    static UniqueRef<PathStream> create(PathSegment&&);
     static UniqueRef<PathStream> create(const Vector<FloatPoint>&);
     static UniqueRef<PathStream> create(Vector<PathSegment>&&);
 
     PathStream();
     PathStream(const PathStream&);
+    PathStream(PathSegment&&);
     PathStream(Vector<PathSegment>&&);
     PathStream(const Vector<PathSegment>&);
 
@@ -71,6 +73,9 @@ public:
     FloatRect fastBoundingRect() const final;
     FloatRect boundingRect() const final;
 
+    static FloatRect computeFastBoundingRect(std::span<const PathSegment>);
+    static FloatRect computeBoundingRect(std::span<const PathSegment>);
+
 private:
     struct SegmentsData : public ThreadSafeRefCounted<SegmentsData> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
@@ -78,6 +83,13 @@ private:
         static Ref<SegmentsData> create()
         {
             return adoptRef(*new SegmentsData);
+        }
+
+        static Ref<SegmentsData> create(PathSegment&& segment)
+        {
+            auto result = adoptRef(*new SegmentsData);
+            result->segments.append(WTFMove(segment));
+            return result;
         }
 
         static Ref<SegmentsData> create(Vector<PathSegment>&& segments)


### PR DESCRIPTION
#### 816baea44df683e2518b805a5dc65697c8e70492
<pre>
Add back inline storage to WebCore::Path
<a href="https://bugs.webkit.org/show_bug.cgi?id=259326">https://bugs.webkit.org/show_bug.cgi?id=259326</a>
rdar://112501668

Reviewed by Simon Fraser.

After <a href="https://commits.webkit.org/265569@main">https://commits.webkit.org/265569@main</a>, we have three separate
heap allocations when creating a WebCore::Path with a single segment.
(The PathStream, the SegmentsData, and its Vector buffer.) These heap
allocations show up on profiles, and were part of a MotionMark Canvas
Lines regression.

* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::Path):
(WebCore::Path::operator=):
(WebCore::Path::operator== const):
(WebCore::Path::setImpl):
(WebCore::Path::ensurePlatformPathImpl):
(WebCore::Path::ensureImpl):
(WebCore::Path::asImpl):
(WebCore::Path::asImpl const):
(WebCore::Path::moveTo):
(WebCore::Path::asSingleMoveTo const):
(WebCore::Path::addLineTo):
(WebCore::Path::addQuadCurveTo):
(WebCore::Path::addBezierCurveTo):
(WebCore::Path::addArcTo):
(WebCore::Path::addArc):
(WebCore::Path::addEllipse):
(WebCore::Path::addEllipseInRect):
(WebCore::Path::addRect):
(WebCore::Path::addRoundedRect):
(WebCore::Path::closeSubpath):
(WebCore::Path::applySegments const):
(WebCore::Path::clear):
(WebCore::Path::singleSegment const):
(WebCore::Path::singleDataLine const):
(WebCore::Path::singleArc const):
(WebCore::Path::singleQuadCurve const):
(WebCore::Path::singleBezierCurve const):
(WebCore::Path::isEmpty const):
(WebCore::Path::segmentsIfExists const):
(WebCore::Path::isClosed const):
(WebCore::Path::currentPoint const):
(WebCore::Path::fastBoundingRect const):
(WebCore::Path::boundingRect const):
* Source/WebCore/platform/graphics/Path.h:
(WebCore::Path::singleSegmentIfExists const):
(WebCore::Path::asSingle):
(WebCore::Path::asSingle const):
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::create):
(WebCore::PathStream::PathStream):
(WebCore::PathStream::addArc):
* Source/WebCore/platform/graphics/PathStream.h:

Canonical link: <a href="https://commits.webkit.org/266156@main">https://commits.webkit.org/266156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1e102d160ab8a4916bd0b2e9321b8d801303d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15252 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18862 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12280 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15176 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16031 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1480 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->