### PR TITLE
[JSC] We should have accept-any-value case generation for IC

### DIFF
--- a/JSTests/stress/proxy-get-with-complex-string.js
+++ b/JSTests/stress/proxy-get-with-complex-string.js
@@ -1,0 +1,11 @@
+function test(object, value) {
+    return object[value];
+}
+noInline(test);
+
+var proxy = new Proxy({}, {});
+var object = { hello: 42 };
+for (var i = 0; i < 1e6; ++i) {
+    test(proxy, "hello");
+    test(object, "hello");
+}


### PR DESCRIPTION
#### eaa5055b2d7c51fb00f980a69892baa69efd9dff
<pre>
[JSC] We should have accept-any-value case generation for IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=259327">https://bugs.webkit.org/show_bug.cgi?id=259327</a>
rdar://112502090

Reviewed by Michael Saboff.

When we generate IC for get-by-val / get-by-val-with-this, we check whether each IC needs Int32 / String / Symbol checks.
And if we find some of IC case requires it, then we do this check and generating code. But we are missing that we generate
accept-any-value case in this path (which is IndexedProxyObjectLoad). This is clearly wrong, and attached script is repeatedly
compiling IC because we are not generating IndexedProxyObjectLoad case.
And if this IC site is requiring some register spills, then it leads to release-assert-crash because

    1. It says doesJSCalls = true
    2. But not setting spillStateForJSCall

So, we will encounter empty spillStateForJSCall.
It is actually super hard to reproduce this issue, and we cannot find a case. But anyway, this fixes the obvious issue, which is
not generating listed IC, which is tested in the attached test.

* JSTests/stress/proxy-get-with-complex-string.js: Added.
(test):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):

Canonical link: <a href="https://commits.webkit.org/266164@main">https://commits.webkit.org/266164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1411e3549afa8d0d452565212d56896f9c8291

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14785 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12441 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15129 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15238 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18851 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11100 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15164 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10314 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13090 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11700 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3440 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16018 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13469 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1482 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12275 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3235 "Passed tests") | 
<!--EWS-Status-Bubble-End-->