### PR TITLE
CSS Custom Highlights text decoration does not respect priority

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Highlight API Test: ::highlight text-decoration paints over higher priority when not clashing</title>
+    <style>
+        #yellow-highlight {
+            background-color: yellow;
+            text-decoration: underline;
+            text-decoration-color: red;
+        }
+    </style>
+</head>
+<body>
+    <span id="yellow-highlight">Yellow</span>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Highlight API Test: ::highlight text-decoration paints over higher priority when not clashing</title>
+    <style>
+        #yellow-highlight {
+            background-color: yellow;
+            text-decoration: underline;
+            text-decoration-color: red;
+        }
+    </style>
+</head>
+<body>
+    <span id="yellow-highlight">Yellow</span>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Highlight API Test: ::highlight text-decoration paints over higher priority when not clashing</title>
+    <link rel="help" href="https://www.w3.org/TR/css-highlight-api-1/#priorities">
+    <link rel="match" href="custom-highlight-painting-priority-text-decoration-001-ref.html">
+    <style>
+    ::highlight(yellow-highlight) {
+        background-color: yellow;
+    }
+    ::highlight(underline-highlight) {
+        text-decoration: underline;
+        text-decoration-color: red;
+    }
+    </style>
+</head>
+<body>
+    <span id="yellow-highlight">Yellow</span>
+
+    <script>
+        let yellow = document.getElementById("yellow-highlight");
+        let highlightYellow = new Highlight(new StaticRange({
+            startContainer: yellow.childNodes[0],
+            startOffset: 0,
+            endContainer: yellow.childNodes[0],
+            endOffset: 6
+        }));
+        let highlightUnderline = new Highlight(new StaticRange({
+            startContainer: yellow.childNodes[0],
+            startOffset: 0,
+            endContainer: yellow.childNodes[0],
+            endOffset: 6
+        }));
+        CSS.highlights.set("yellow-highlight", highlightYellow);
+        CSS.highlights.set("underline-highlight", highlightUnderline);
+        highlightYellow.priority = 10;
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -122,6 +122,30 @@ StyledMarkedText::Style StyledMarkedText::computeStyleForUnmarkedMarkedText(cons
     return style;
 }
 
+static TextDecorationPainter::Styles computeStylesForTextDecorations(const TextDecorationPainter::Styles& previousTextDecorationStyles, const TextDecorationPainter::Styles& currentTextDecorationStyles)
+{
+    auto textDecorations = TextDecorationPainter::textDecorationsInEffectForStyle(currentTextDecorationStyles);
+
+    if (textDecorations.isEmpty())
+        return previousTextDecorationStyles;
+
+    auto textDecorationStyles = previousTextDecorationStyles;
+
+    if (textDecorations.contains(TextDecorationLine::Underline)) {
+        textDecorationStyles.underline.color = currentTextDecorationStyles.underline.color;
+        textDecorationStyles.underline.decorationStyle = currentTextDecorationStyles.underline.decorationStyle;
+    }
+    if (textDecorations.contains(TextDecorationLine::Overline)) {
+        textDecorationStyles.overline.color = currentTextDecorationStyles.overline.color;
+        textDecorationStyles.overline.decorationStyle = currentTextDecorationStyles.overline.decorationStyle;
+    }
+    if (textDecorations.contains(TextDecorationLine::LineThrough)) {
+        textDecorationStyles.linethrough.color = currentTextDecorationStyles.linethrough.color;
+        textDecorationStyles.linethrough.decorationStyle = currentTextDecorationStyles.linethrough.decorationStyle;
+    }
+    return textDecorationStyles;
+}
+
 static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMarkedText>&& styledTexts)
 {
     ASSERT(!styledTexts.isEmpty());
@@ -146,10 +170,10 @@ static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMark
 
             if (previousStyledMarkedText.priority <= it->priority) {
                 previousStyledMarkedText.priority = it->priority;
-                // If highlight, take textDecorationStyles of latest StyledMarkedText.
-                // FIXME: Check for taking textDecorationStyles needs to be changed to accommodate other MarkedText type.
+                // If highlight, combine textDecorationStyles accordingly.
+                // FIXME: Check for taking textDecorationStyles needs to accommodate other MarkedText type.
                 if (!it->highlightName.isNull())
-                    previousStyledMarkedText.style.textDecorationStyles = it->style.textDecorationStyles;
+                    previousStyledMarkedText.style.textDecorationStyles = computeStylesForTextDecorations(previousStyledMarkedText.style.textDecorationStyles, it->style.textDecorationStyles);
                 // If higher or same priority and opaque, override background color.
                 if (it->style.backgroundColor.isOpaque())
                     previousStyledMarkedText.style.backgroundColor = it->style.backgroundColor;


### PR DESCRIPTION
#### bf94cf5ead9445f859403a3d6035ad493a1f52f4
<pre>
CSS Custom Highlights text decoration does not respect priority
<a href="https://bugs.webkit.org/show_bug.cgi?id=259321">https://bugs.webkit.org/show_bug.cgi?id=259321</a>
rdar://112494779

Reviewed by Wenson Hsieh.

Before if StyledMarkedText was of higher priority, just overrides textDecorationStyles.
Added a function to compute the textDecorationStyles.
Added WPT ref test for painting unclashing lower priority text decoration
over higher priority highlight without text decorations.

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-priority-text-decoration-001.html: Added.
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::computeStylesForTextDecorations):
(WebCore::coalesceAdjacentWithSameRanges):

Canonical link: <a href="https://commits.webkit.org/266184@main">https://commits.webkit.org/266184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bee93ca01d75f072b99246674e133ecae70f44a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15177 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15297 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18886 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12306 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12476 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10351 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3216 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->