### PR TITLE
[Cocoa] Outline glyphs rendered with Apple Color Emoji are in the wrong place

### DIFF
--- a/LayoutTests/fast/text/apple-color-emoji-outline-positioning-2-expected.html
+++ b/LayoutTests/fast/text/apple-color-emoji-outline-positioning-2-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure glyphs rendered with Apple Color Emoji are in the right place. This test passes if the only thing you see on this page other than the text you're reading right now is a normal-looking emoji smiley face (without anything over it). This page renders some additional text, but covers up the locations where it's supposed to appear with white rectangles.
+<div style="position: relative;">
+<div style="font: 200px 'Apple Color Emoji'; position: absolute;">&#x1F60A;</div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/apple-color-emoji-outline-positioning-2.html
+++ b/LayoutTests/fast/text/apple-color-emoji-outline-positioning-2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure glyphs rendered with Apple Color Emoji are in the right place. This test passes if the only thing you see on this page other than the text you're reading right now is a normal-looking emoji smiley face (without anything over it). This page renders some additional text, but covers up the locations where it's supposed to appear with white rectangles.
+<div style="position: relative;">
+<div style="font: 200px 'Apple Color Emoji'; position: absolute;">&#x1F60A;&#x2640;M</div>
+<div style="position: absolute; width: 500px; height: 350px; top: 0px; left: 200px; background: white;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/apple-color-emoji-outline-positioning-expected.html
+++ b/LayoutTests/fast/text/apple-color-emoji-outline-positioning-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure glyphs rendered with Apple Color Emoji are in the right place. This test passes if the text you are reading right now is the only thing shown on this page. This page renders some text, but covers up the locations where it's supposed to appear with white rectangles.
+</body>
+</html>

--- a/LayoutTests/fast/text/apple-color-emoji-outline-positioning.html
+++ b/LayoutTests/fast/text/apple-color-emoji-outline-positioning.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+This test makes sure glyphs rendered with Apple Color Emoji are in the right place. This test passes if the text you are reading right now is the only thing shown on this page. This page renders some text, but covers up the locations where it's supposed to appear with white rectangles.
+<div style="position: relative;">
+<div style="font: 200px 'Apple Color Emoji'; position: absolute;">&#x2640;M&#x1F60A;</div>
+<div style="position: absolute; width: 200px; height: 170px; top: 63px; left: 0px; background: white;"></div>
+<div style="position: absolute; width: 160px; height: 155px; top: 50px; left: 200px; background: white;"></div>
+<div style="position: absolute; width: 200px; height: 195px; top: 27px; left: 375px; background: white;"></div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
+++ b/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
@@ -76,7 +76,7 @@ private:
 
     void populateInternalState(const GraphicsContextState&);
     void populateInternalContext(const GraphicsContextState&);
-    void prepareInternalContext(const Font&, FontSmoothingMode);
+    void prepareInternalContext(const Font&, FontSmoothingMode, const FloatPoint& startPoint);
     void recordInitialColors();
     void concludeInternalContext();
 
@@ -108,6 +108,8 @@ private:
     FontSmoothingMode m_smoothingMode { FontSmoothingMode::AutoSmoothing };
 
     AffineTransform m_originalTextMatrix;
+    FloatPoint m_originalStartPoint;
+    std::optional<FloatSize> m_startPointOffset;
 
     struct State {
         SourceBrush fillBrush;


### PR DESCRIPTION
#### 6416fd89e1c8a6340a84229d2809e585d02f9603
<pre>
[Cocoa] Outline glyphs rendered with Apple Color Emoji are in the wrong place
<a href="https://bugs.webkit.org/show_bug.cgi?id=259329">https://bugs.webkit.org/show_bug.cgi?id=259329</a>
rdar://112118104

Reviewed by NOBODY (OOPS!).

When rendering glyphs with Apple Color Emoji (and _only_ Apple Color Emoji), Core Text
may move the glyphs around itself. When implementing the DrawGlyphsRecorder originally,
I didn&apos;t expect that CT would ever do this. This patch simply watches the before/after
of what CT does, computes a diff based on what it sees, and then applies the diff to
all the outline characters.

* LayoutTests/fast/text/apple-color-emoji-outline-positioning-2-expected.html: Added.
* LayoutTests/fast/text/apple-color-emoji-outline-positioning-2.html: Added.
* LayoutTests/fast/text/apple-color-emoji-outline-positioning-expected.html: Added.
* LayoutTests/fast/text/apple-color-emoji-outline-positioning.html: Added.
* Source/WebCore/platform/graphics/DrawGlyphsRecorder.h:
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::prepareInternalContext):
(WebCore::DrawGlyphsRecorder::concludeInternalContext):
(WebCore::DrawGlyphsRecorder::recordDrawGlyphs):
(WebCore::DrawGlyphsRecorder::drawNonOTSVGRun):
(WebCore::DrawGlyphsRecorder::drawNativeText):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6416fd89e1c8a6340a84229d2809e585d02f9603

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15134 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13219 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13911 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15244 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11199 "2 flakes 7 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11792 "5 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18857 "6 flakes 151 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12274 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11959 "2 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12435 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10318 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11705 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11658 "Exiting early after 10 failures. 20 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12280 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->