### PR TITLE
Protect CachedResource in more places

### DIFF
--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -783,6 +783,7 @@ void SubresourceLoader::didFail(const ResourceError& error)
         return;
 
     ASSERT(!reachedTerminalState());
+    CachedResourceHandle protectedResource { m_resource.get() };
     LOG(ResourceLoading, "Failed to load '%s'.\n", m_resource->url().string().latin1().data());
 
     if (m_frame->document() && error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && m_resource->type() != CachedResource::Type::Ping)

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -98,6 +98,7 @@ void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const Network
 
 void CachedFont::setErrorAndDeleteData()
 {
+    CachedResourceHandle protectedThis { *this };
     setEncodedSize(0);
     error(Status::DecodeError);
     if (inCache())

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -483,6 +483,7 @@ inline void CachedImage::clearImage()
 
 void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 {
+    CachedResourceHandle protectedThis { *this };
     m_data = const_cast<FragmentedSharedBuffer*>(&data);
     setEncodedSize(m_data->size());
     createImage();

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -451,6 +451,7 @@ Seconds CachedResource::freshnessLifetime(const ResourceResponse& response) cons
 
 void CachedResource::redirectReceived(ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
+    CachedResourceHandle protectedThis { *this };
     CACHEDRESOURCE_RELEASE_LOG("redirectReceived:");
 
     // Remove redirect urls from the memory cache if they contain a fragment.

--- a/Source/WebCore/loader/cache/CachedResourceHandle.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.cpp
@@ -35,6 +35,12 @@ CachedResourceHandleBase::CachedResourceHandleBase()
 {
 }
 
+CachedResourceHandleBase::CachedResourceHandleBase(CachedResource& resource)
+    : m_resource(&resource)
+{
+    m_resource->registerHandle(this);
+}
+
 CachedResourceHandleBase::CachedResourceHandleBase(CachedResource* resource)
     : m_resource(resource)
 {

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -45,7 +45,8 @@ public:
 
 protected:
     CachedResourceHandleBase();
-    CachedResourceHandleBase(CachedResource*);
+    explicit CachedResourceHandleBase(CachedResource*);
+    explicit CachedResourceHandleBase(CachedResource&);
     CachedResourceHandleBase(const CachedResourceHandleBase&);
 
     void setResource(CachedResource*);
@@ -61,6 +62,7 @@ private:
 template <class R> class CachedResourceHandle : public CachedResourceHandleBase {
 public: 
     CachedResourceHandle() { }
+    CachedResourceHandle(R& res) : CachedResourceHandleBase(res) { }
     CachedResourceHandle(R* res) : CachedResourceHandleBase(res) { }
     CachedResourceHandle(const CachedResourceHandle<R>& o) : CachedResourceHandleBase(o) { }
     template<typename U> CachedResourceHandle(const CachedResourceHandle<U>& o) : CachedResourceHandleBase(o.get()) { }

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -168,7 +168,7 @@ public:
     WEBCORE_EXPORT void pruneLiveResourcesToSize(unsigned targetSize, bool shouldDestroyDecodedDataForAllLiveResources = false);
 
 private:
-    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, CachedResource*>;
+    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, WeakPtr<CachedResource>>;
     using LRUList = WeakListHashSet<CachedResource>;
 
     MemoryCache();


### PR DESCRIPTION
#### c7f1348de5c2f2408c007dfebbb77ade584970fa
<pre>
Protect CachedResource in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=259331">https://bugs.webkit.org/show_bug.cgi?id=259331</a>
rdar://80172764

Reviewed by David Kilzer.

Protect CachedResource in more places. In particular, a call to MemoryCache::remove()
may delete the resource it is passed so it is important to protect the resource if
we&apos;re going to use it after.

* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::didFail):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::setErrorAndDeleteData):
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::updateBufferInternal):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::redirectReceived):
* Source/WebCore/loader/cache/CachedResourceHandle.cpp:
(WebCore::CachedResourceHandleBase::CachedResourceHandleBase):
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WebCore::CachedResourceHandle::CachedResourceHandle):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::revalidationSucceeded):
(WebCore::MemoryCache::resourceForRequestImpl):
(WebCore::MemoryCache::forEachSessionResource):
(WebCore::MemoryCache::remove):
(WebCore::MemoryCache::removeResourcesWithOrigin):
(WebCore::MemoryCache::removeResourcesWithOrigins):
(WebCore::MemoryCache::getStatistics):
* Source/WebCore/loader/cache/MemoryCache.h:

Canonical link: <a href="https://commits.webkit.org/266163@main">https://commits.webkit.org/266163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d8af8c559a35668e54054817b5a181bd4d2dbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13054 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15137 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13913 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15246 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18858 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12276 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11965 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15171 "1 api test failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10321 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11707 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3200 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->