### PR TITLE
[content-visibility] Add support for ContentVisibilityAutoStateChangeEvent

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4942,10 +4942,6 @@ imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visib
 # off-screen selection
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-070.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-071.html [ Skip ]
-# c-v: auto contentvisibilityautostatechanged event
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ ImageOnlyFailure ]
 
 # Style containment

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-expected.txt
@@ -1,6 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT ContentVisibilityAutoStateChanged fires when skipped Test timed out
-NOTRUN ContentVisibilityAutoStateChanged fires when not skipped
+PASS ContentVisibilityAutoStateChange fires when relevant element gains `content-visibility:auto`
+PASS ContentVisibilityAutoStateChange fires when not relevant element gains `content-visibility:auto`
+PASS ContentVisibilityAutoStateChange fires when skipped
+PASS ContentVisibilityAutoStateChange fires when not skipped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation-expected.txt
@@ -1,0 +1,4 @@
+
+PASS ContentVisibilityAutoStateChange fires once when added (not skipped)
+PASS ContentVisibilityAutoStateChange fires once when added (skipped)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed-expected.txt
@@ -1,0 +1,3 @@
+
+PASS ContentVisibilityAutoStateChange does not fire on disconnected element
+

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -967,6 +967,7 @@ set(WebCore_NON_SVG_IDL_FILES
     dom/ClipboardEvent.idl
     dom/Comment.idl
     dom/CompositionEvent.idl
+    dom/ContentVisibilityAutoStateChangeEvent.idl
     dom/CustomElementRegistry.idl
     dom/CustomEvent.idl
     dom/DOMException.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1273,6 +1273,7 @@ $(PROJECT_DIR)/dom/ChildNode.idl
 $(PROJECT_DIR)/dom/ClipboardEvent.idl
 $(PROJECT_DIR)/dom/Comment.idl
 $(PROJECT_DIR)/dom/CompositionEvent.idl
+$(PROJECT_DIR)/dom/ContentVisibilityAutoStateChangeEvent.idl
 $(PROJECT_DIR)/dom/CustomElementRegistry.idl
 $(PROJECT_DIR)/dom/CustomEvent.idl
 $(PROJECT_DIR)/dom/DOMException.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -605,6 +605,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContactsManager.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContactsManager.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContactsSelectOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContactsSelectOptions.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContentVisibilityAutoStateChangeEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSContentVisibilityAutoStateChangeEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSConvolverNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSConvolverNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSConvolverOptions.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -979,6 +979,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/dom/ClipboardEvent.idl \
     $(WebCore)/dom/Comment.idl \
     $(WebCore)/dom/CompositionEvent.idl \
+    $(WebCore)/dom/ContentVisibilityAutoStateChangeEvent.idl \
     $(WebCore)/dom/CustomElementRegistry.idl \
     $(WebCore)/dom/CustomEvent.idl \
     $(WebCore)/dom/DOMException.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1039,6 +1039,7 @@ dom/CompositionEvent.cpp
 dom/ConstantPropertyMap.cpp
 dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
+dom/ContentVisibilityAutoStateChangeEvent.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/ContextDestructionObserver.cpp
 dom/CustomElementDefaultARIA.cpp
@@ -3290,6 +3291,7 @@ JSContactInfo.cpp
 JSContactProperty.cpp
 JSContactsManager.cpp
 JSContactsSelectOptions.cpp
+JSContentVisibilityAutoStateChangeEvent.cpp
 JSConvolverNode.cpp
 JSConvolverOptions.cpp
 JSCookieChangeEvent.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -117,6 +117,7 @@ namespace WebCore {
     macro(CompressionStreamTransform) \
     macro(ConstantSourceNode) \
     macro(ContactsManager) \
+    macro(ContentVisibilityAutoStateChangeEvent) \
     macro(ConvolverNode) \
     macro(Credential) \
     macro(CredentialsContainer) \

--- a/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp
+++ b/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ContentVisibilityAutoStateChangeEvent.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ContentVisibilityAutoStateChangeEvent);
+
+ContentVisibilityAutoStateChangeEvent::ContentVisibilityAutoStateChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+    : Event(type, initializer, isTrusted)
+    , m_skipped(initializer.skipped)
+{
+}
+
+ContentVisibilityAutoStateChangeEvent::~ContentVisibilityAutoStateChangeEvent() = default;
+
+}

--- a/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h
+++ b/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Event.h"
+
+namespace WebCore {
+
+class ContentVisibilityAutoStateChangeEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(ContentVisibilityAutoStateChangeEvent);
+public:
+    struct Init : EventInit {
+        bool skipped = false;
+    };
+
+    static Ref<ContentVisibilityAutoStateChangeEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    {
+        return adoptRef(*new ContentVisibilityAutoStateChangeEvent(type, initializer, isTrusted));
+    }
+
+    virtual ~ContentVisibilityAutoStateChangeEvent();
+
+    bool skipped() const { return m_skipped; }
+
+    EventInterface eventInterface() const override { return ContentVisibilityAutoStateChangeEventInterfaceType; }
+
+private:
+    ContentVisibilityAutoStateChangeEvent(const AtomString&, const Init&, IsTrusted);
+
+    bool m_skipped;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.idl
+++ b/Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.idl
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    EnabledBySetting=CSSContentVisibilityEnabled,
+    Exposed=Window
+] interface ContentVisibilityAutoStateChangeEvent : Event {
+    constructor([AtomString] DOMString type, optional ContentVisibilityAutoStateChangeEventInit eventInitDict = {});
+    readonly attribute boolean skipped;
+};
+
+dictionary ContentVisibilityAutoStateChangeEventInit : EventInit {
+    boolean skipped = false;
+};

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9596,7 +9596,7 @@ bool Document::isObservingContentVisibilityTargets() const
 
 void Document::updateRelevancyOfContentVisibilityElements()
 {
-    if (!isObservingContentVisibilityTargets())
+    if (m_contentRelevancyUpdate.isEmpty() || !isObservingContentVisibilityTargets())
         return;
     if (m_contentVisibilityDocumentState->updateRelevancyOfContentVisibilityElements(m_contentRelevancyUpdate) == DidUpdateAnyContentRelevancy::Yes)
         updateLayoutIgnorePendingStylesheets();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5378,13 +5378,15 @@ bool Element::isPopoverShowing() const
 // https://drafts.csswg.org/css-contain/#relevant-to-the-user
 bool Element::isRelevantToUser() const
 {
-    return !contentRelevancy().isEmpty();
+    if (auto relevancy = contentRelevancy())
+        return !relevancy->isEmpty();
+    return false;
 }
 
-OptionSet<ContentRelevancy> Element::contentRelevancy() const
+std::optional<OptionSet<ContentRelevancy>> Element::contentRelevancy() const
 {
     if (!hasRareData())
-        return { };
+        return std::nullopt;
     return elementRareData()->contentRelevancy();
 }
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -739,7 +739,7 @@ public:
 
     void contentVisibilityViewportChange(bool);
 
-    OptionSet<ContentRelevancy> contentRelevancy() const;
+    std::optional<OptionSet<ContentRelevancy>> contentRelevancy() const;
     void setContentRelevancy(OptionSet<ContentRelevancy>);
 
 protected:

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -145,7 +145,7 @@ public:
     PopoverData* popoverData() { return m_popoverData.get(); }
     void setPopoverData(std::unique_ptr<PopoverData>&& popoverData) { m_popoverData = WTFMove(popoverData); }
 
-    const OptionSet<ContentRelevancy>& contentRelevancy() const { return m_contentRelevancy; }
+    const std::optional<OptionSet<ContentRelevancy>>& contentRelevancy() const { return m_contentRelevancy; }
     void setContentRelevancy(OptionSet<ContentRelevancy>& contentRelevancy) { m_contentRelevancy = contentRelevancy; }
 
 #if DUMP_NODE_STATISTICS
@@ -206,7 +206,7 @@ private:
     unsigned short m_childIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
     int m_unusualTabIndex { 0 }; // Keep on top for better bit packing with NodeRareData.
 
-    OptionSet<ContentRelevancy> m_contentRelevancy;
+    std::optional<OptionSet<ContentRelevancy>> m_contentRelevancy;
 
     IntPoint m_savedLayerScrollPosition;
     std::unique_ptr<RenderStyle> m_computedStyle;

--- a/Source/WebCore/dom/EventNames.h
+++ b/Source/WebCore/dom/EventNames.h
@@ -98,6 +98,7 @@ namespace WebCore {
     macro(connect) \
     macro(connectionstatechange) \
     macro(connecting) \
+    macro(contentvisibilityautostatechange) \
     macro(contextmenu) \
     macro(controllerchange) \
     macro(cookiechange) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -103,3 +103,4 @@ XRInputSourcesChangeEvent conditional=WEBXR
 XRReferenceSpaceEvent conditional=WEBXR
 XRSessionEvent conditional=WEBXR
 NotificationEvent conditional=NOTIFICATION_EVENT
+ContentVisibilityAutoStateChangeEvent

--- a/Source/WebCore/dom/GlobalEventHandlers.idl
+++ b/Source/WebCore/dom/GlobalEventHandlers.idl
@@ -41,6 +41,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onchange;
     attribute EventHandler onclick;
     attribute EventHandler onclose;
+    attribute EventHandler oncontentvisibilityautostatechange;
     attribute EventHandler oncontextmenu;
     attribute EventHandler oncopy;
     attribute EventHandler oncuechange;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -223,6 +223,7 @@ oncanplaythrough
 onchange
 onclick
 onclose
+oncontentvisibilityautostatechange
 oncontextmenu
 oncopy
 oncuechange


### PR DESCRIPTION
#### 5b575ff841de2b2490b8707d303e068c48641e93
<pre>
[content-visibility] Add support for ContentVisibilityAutoStateChangeEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=258880">https://bugs.webkit.org/show_bug.cgi?id=258880</a>

Reviewed by Tim Nguyen.

Support ContentVisibilityAutoStateChangeEvent, see:
<a href="https://drafts.csswg.org/css-contain/#content-visibility-auto-state-change">https://drafts.csswg.org/css-contain/#content-visibility-auto-state-change</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-first-observation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-state-changed-removed-expected.txt: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.cpp: Added.
(WebCore::ContentVisibilityAutoStateChangeEvent::ContentVisibilityAutoStateChangeEvent):
* Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.h: Added.
* Source/WebCore/dom/ContentVisibilityAutoStateChangeEvent.idl: Added.
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateRelevancyOfContentVisibilityElements): bail out early if no update is specified
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isRelevantToUser const):
(WebCore::Element::contentRelevancy const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::contentRelevancy const):
* Source/WebCore/dom/EventNames.h:
* Source/WebCore/dom/EventNames.in:
* Source/WebCore/dom/GlobalEventHandlers.idl:
* Source/WebCore/html/HTMLAttributeNames.in:

Canonical link: <a href="https://commits.webkit.org/267340@main">https://commits.webkit.org/267340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f3e793502cb8310ec3a5f4e8b83ba09e5ea9713

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18841 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21577 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/18455 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15520 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13158 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14738 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3906 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->