### PR TITLE
Add support for the extended attributes of Cookies in the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (string) "localhost" but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (undefined) undefined
-FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set defaults with positional name and value assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set defaults with name and value in options assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with expires set to a Date 10 years in the future assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with domain set to the current hostname assert_equals: expected (object) null but got (undefined) undefined
+FAIL CookieListItem - cookieStore.set with path set to the current directory assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set adds / to path if it does not end with / assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to strict assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to lax assert_equals: expected (object) null but got (string) "localhost"
+FAIL CookieListItem - cookieStore.set with sameSite set to none assert_equals: expected (object) null but got (string) "localhost"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -16,7 +16,7 @@ FAIL cookieStore.set default domain is null and differs from current hostname as
 PASS cookieStore.set with path set to the current directory
 FAIL cookieStore.set with path set to a subdirectory of the current directory assert_equals: expected null but got object "[object Object]"
 FAIL cookieStore.set default path is / assert_equals: expected 1 but got 2
-FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected (string) "/cookie-store/" but got (undefined) undefined
+FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected "/cookie-store/" but got "/cookie-store"
 FAIL cookieStore.set with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1788,6 +1788,20 @@ CookieStoreAPIEnabled:
     WebCore:
       default: false
 
+CookieStoreAPIExtendedAttributesEnabled:
+  type: bool
+  category: dom
+  status: testable
+  humanReadableName: "Cookie Store API Extended Attributes"
+  humanReadableDescription: "Enable Extended Attributes of the Cookie Store API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CoreMathMLEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -25,13 +25,46 @@
 
 #pragma once
 
+#include "Cookie.h"
+#include "CookieSameSite.h"
+#include "DOMHighResTimeStamp.h"
+#include <optional>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct CookieListItem {
+    CookieListItem() { };
+
+    CookieListItem(Cookie&& cookie)
+    {
+        name = WTFMove(cookie.name);
+        value = WTFMove(cookie.value);
+        domain = WTFMove(cookie.domain);
+        path = WTFMove(cookie.path);
+        expires = cookie.expires.has_value() ? std::optional { *cookie.expires } : std::nullopt;
+        secure = cookie.secure;
+
+        switch (cookie.sameSite) {
+        case Cookie::SameSitePolicy::Strict:
+            sameSite = CookieSameSite::Strict;
+            break;
+        case Cookie::SameSitePolicy::Lax:
+            sameSite = CookieSameSite::Lax;
+            break;
+        case Cookie::SameSitePolicy::None:
+            sameSite = CookieSameSite::None;
+            break;
+        }
+    }
+
     String name;
     String value;
+    String domain;
+    String path;
+    std::optional<DOMHighResTimeStamp> expires;
+    bool secure;
+    CookieSameSite sameSite;
 };
 
 }

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.idl
@@ -32,11 +32,9 @@ typedef double DOMHighResTimeStamp;
 ] dictionary CookieListItem {
     USVString name;
     USVString value;
-
-    // FIXME: These dictionary members are present in the specification. We should evaluate if we want to expose them.
-    // USVString? domain;
-    // USVString path;
-    // DOMHighResTimeStamp? expires;
-    // boolean secure;
-    // CookieSameSite sameSite;
+    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] USVString? domain;
+    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] USVString path;
+    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] DOMHighResTimeStamp? expires;
+    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] boolean secure;
+    [EnabledBySetting=CookieStoreAPIExtendedAttributesEnabled] CookieSameSite sameSite;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -111,8 +111,7 @@ void CookieStore::get(CookieStoreGetOptions&& options, Ref<DeferredPromise>&& pr
             return;
         }
 
-        auto& cookie = cookiesVector[0];
-        promise->resolve<IDLDictionary<CookieListItem>>(CookieListItem { WTFMove(cookie.name), WTFMove(cookie.value) });
+        promise->resolve<IDLDictionary<CookieListItem>>(CookieListItem(WTFMove(cookiesVector[0])));
     };
 
     cookieJar.getCookiesAsync(document, url, options, WTFMove(completionHandler));
@@ -170,8 +169,8 @@ void CookieStore::getAll(CookieStoreGetOptions&& options, Ref<DeferredPromise>&&
             return;
         }
 
-        promise->resolve<IDLSequence<IDLDictionary<CookieListItem>>>(cookies->map([](auto& cookie) {
-            return CookieListItem { cookie.name, cookie.value };
+        promise->resolve<IDLSequence<IDLDictionary<CookieListItem>>>(WTF::map(WTFMove(*cookies), [](auto&& cookie) {
+            return CookieListItem { WTFMove(cookie) };
         }));
     };
 


### PR DESCRIPTION
#### 0fd5d68a2b262b5899042bed3223e53c94f413cd
<pre>
Add support for the extended attributes of Cookies in the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259340">https://bugs.webkit.org/show_bug.cgi?id=259340</a>

Reviewed by Chris Dumez.

Cookies have more attributes besides just name and value. We want to add
support for gettting/setting these attributes. However, we are not yet
sure if we wish to expose these attributes to JavaScript. So this patch
adds support for the attributes and hides them behind the
CookieStoreAPIExtendedAttributesEnabled feature flag.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieListItem_attributes.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
(WebCore::CookieListItem::CookieListItem):
* Source/WebCore/Modules/cookie-store/CookieListItem.idl:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::get):
(WebCore::CookieStore::getAll):

Canonical link: <a href="https://commits.webkit.org/266171@main">https://commits.webkit.org/266171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26fca4d9ae81cd1b2ef4aabdfaf60faddb9642f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14849 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15334 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18902 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11152 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15217 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12407 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13161 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11756 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3458 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3205 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16075 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13535 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12331 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3252 "Passed tests") | 
<!--EWS-Status-Bubble-End-->