### PR TITLE
RELEASE_ASSERT(!resources.get(key)) hit in MemoryCache::revalidationSucceeded()

### DIFF
--- a/LayoutTests/http/tests/workers/memory-cache-crash-expected.txt
+++ b/LayoutTests/http/tests/workers/memory-cache-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/http/tests/workers/memory-cache-crash.html
+++ b/LayoutTests/http/tests/workers/memory-cache-crash.html
@@ -1,0 +1,19 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  onload = async () => {
+    document.createElement('audio').src = 'data:';
+    for (let i = 0; i < 1000; i++) {
+      new Worker('');
+      await navigator.storage.persist();
+    }
+    setTimeout(() => {
+      if (window.testRunner)
+        testRunner.notifyDone();
+    }, 50);
+  };
+</script>

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -755,6 +755,17 @@ void CachedResource::setResourceToRevalidate(CachedResource* resource)
     m_resourceToRevalidate = resource;
 }
 
+void CachedResource::replaceResourceToRevalidate(CachedResource& resource)
+{
+    ASSERT(m_resourceToRevalidate);
+
+    m_resourceToRevalidate->m_proxyResource = nullptr;
+    m_resourceToRevalidate->deleteIfPossible();
+    m_resourceToRevalidate = &resource;
+    ASSERT(!resource.m_proxyResource);
+    resource.m_proxyResource = this;
+}
+
 void CachedResource::clearResourceToRevalidate() 
 {
     ASSERT(m_resourceToRevalidate);

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -282,6 +282,7 @@ public:
 
     // HTTP revalidation support methods for CachedResourceLoader.
     void setResourceToRevalidate(CachedResource*);
+    void replaceResourceToRevalidate(CachedResource&);
     virtual void switchClientsToRevalidatedResource();
     void clearResourceToRevalidate();
     void updateResponseAfterRevalidation(const ResourceResponse& validatingResponse);


### PR DESCRIPTION
#### ef9aeb1646ff1bee0cd2b12460f83bace3f9ebd7
<pre>
RELEASE_ASSERT(!resources.get(key)) hit in MemoryCache::revalidationSucceeded()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259339">https://bugs.webkit.org/show_bug.cgi?id=259339</a>
rdar://112526836

Reviewed by Brent Fulgham.

When a resource needs network revalidation, we remove it from the memory cache,
add a &quot;proxy&quot; resource in the cache instead. Because revalidation happens
asynchronously, it is possible that another caller adds a resource back in the
cache with the same key (because they loaded the same URL). If this happened,
we&apos;d overwrite the existing resource MemoryCache::revalidationSucceeded(),
leaving this resource and the memory cache in a bad state. The resource would
still think it is in the cache and may remain in some containers (e.g. LRUList)
inside the memory cache.

To address the issue, upon successful revalidation, we now check if there is
already a resource with the same key in the cache. If there is such resource,
we ignore the revalidated resource and transfer the clients from the revalidation
resource to the resource that already exists in the cache.

* LayoutTests/http/tests/workers/memory-cache-crash-expected.txt: Added.
* LayoutTests/http/tests/workers/memory-cache-crash.html: Added.
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::revalidationSucceeded):

Canonical link: <a href="https://commits.webkit.org/266170@main">https://commits.webkit.org/266170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b7c2e1ece10e68ac2c3030750432a7acd779b41

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11835 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18894 "24 flakes 94 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12479 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11701 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->