### PR TITLE
Images jiggle when swapping between bitmaps and CGDisplayList rendering

### DIFF
--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -1398,6 +1398,22 @@ AffineTransform GraphicsContextCG::getCTM(IncludeDeviceScale includeScale) const
     return CGContextGetCTM(platformContext());
 }
 
+std::optional<std::pair<float, float>> GraphicsContextCG::scaleForRoundingToDevicePixels() const
+{
+    if (m_userToDeviceTransformKnownToBeIdentity)
+        return std::nullopt;
+
+    CGAffineTransform deviceMatrix = CGContextGetUserSpaceToDeviceSpaceTransform(platformContext());
+    if (CGAffineTransformIsIdentity(deviceMatrix)) {
+        m_userToDeviceTransformKnownToBeIdentity = true;
+        return std::nullopt;
+    }
+
+    float deviceScaleX = std::hypot(deviceMatrix.a, deviceMatrix.b);
+    float deviceScaleY = std::hypot(deviceMatrix.c, deviceMatrix.d);
+    return { { deviceScaleX, deviceScaleY } };
+}
+
 FloatRect GraphicsContextCG::roundToDevicePixels(const FloatRect& rect, RoundingMode roundingMode) const
 {
     // It is not enough just to round to pixels in device space. The rotation part of the
@@ -1405,18 +1421,11 @@ FloatRect GraphicsContextCG::roundToDevicePixels(const FloatRect& rect, Rounding
     // rotating image like the hands of the world clock widget. We just need the scale, so
     // we get the affine transform matrix and extract the scale.
 
-    if (m_userToDeviceTransformKnownToBeIdentity)
+    auto deviceScale = scaleForRoundingToDevicePixels();
+    if (!deviceScale)
         return roundedIntRect(rect);
 
-    CGAffineTransform deviceMatrix = CGContextGetUserSpaceToDeviceSpaceTransform(platformContext());
-    if (CGAffineTransformIsIdentity(deviceMatrix)) {
-        m_userToDeviceTransformKnownToBeIdentity = true;
-        return roundedIntRect(rect);
-    }
-
-    float deviceScaleX = std::hypot(deviceMatrix.a, deviceMatrix.b);
-    float deviceScaleY = std::hypot(deviceMatrix.c, deviceMatrix.d);
-
+    auto [deviceScaleX, deviceScaleY] = *deviceScale;
     CGPoint deviceOrigin = CGPointMake(rect.x() * deviceScaleX, rect.y() * deviceScaleY);
     CGPoint deviceLowerRight = CGPointMake((rect.x() + rect.width()) * deviceScaleX,
         (rect.y() + rect.height()) * deviceScaleY);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -130,7 +130,8 @@ public:
 
     virtual bool canUseShadowBlur() const;
 
-    virtual FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) const;
+    virtual std::optional<std::pair<float, float>> scaleForRoundingToDevicePixels() const;
+    FloatRect roundToDevicePixels(const FloatRect&, RoundingMode = RoundAllSides) const;
 
     // Returns the platform context for draws.
     CGContextRef contextForDraw();

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm
@@ -79,9 +79,10 @@ public:
         return m_immutableBaseTransform * GraphicsContextCG::getCTM(includeDeviceScale);
     }
 
-    WebCore::FloatRect roundToDevicePixels(const WebCore::FloatRect& rect, RoundingMode = RoundAllSides) const final
+    std::optional<std::pair<float, float>> scaleForRoundingToDevicePixels() const final
     {
-        return rect;
+        auto scale = WebCore::GraphicsContextCG::scaleForRoundingToDevicePixels().value_or(std::make_pair<float>(1, 1));
+        return { { scale.first * m_resolutionScale, scale.second * m_resolutionScale } };
     }
 
     bool canUseShadowBlur() const final { return false; }


### PR DESCRIPTION
#### e281c3d178cb32c0c965879cac7c6f7322fcb7c9
<pre>
Images jiggle when swapping between bitmaps and CGDisplayList rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=259345">https://bugs.webkit.org/show_bug.cgi?id=259345</a>
rdar://107957041

Reviewed by Aditya Keerthi.

Instead of skipping pixel rounding entirely for CGDisplayList contexts, round
to their &quot;hidden&quot; scale (the scale of the bitmap tiles that they are shadowing).
This way, the rounding precisely matches between the 2x bitmaps and replayed
display list, regardless of target scale.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::scaleForRoundingToDevicePixels const):
(WebCore::GraphicsContextCG::roundToDevicePixels const):
Factor determination of the device scale out from roundToDevicePixels.

* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayListImageBufferBackend.mm:
Override it in the CGDisplayList case and multiply in the &quot;hidden&quot; resolutionScale.

Canonical link: <a href="https://commits.webkit.org/266172@main">https://commits.webkit.org/266172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ea0cfbdb0a3913a081692f3125f134b2c3f4bab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13172 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15328 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18896 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15211 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11751 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->