### PR TITLE
REGRESSION (macOS 14): Force clicking text selection in Books often shows blank highlight

### DIFF
--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -235,6 +235,10 @@ TemporarySelectionChange::TemporarySelectionChange(Document& document, std::opti
 
     if (temporarySelection) {
         m_selectionToRestore = document.selection().selection();
+#if PLATFORM(IOS_FAMILY)
+        if (document.selection().isUpdateAppearanceEnabled())
+            document.selection().setNeedsSelectionUpdate();
+#endif
         setSelection(temporarySelection.value(), IsTemporarySelection::Yes);
     }
 }


### PR DESCRIPTION
#### 1d42b8b66d7257fe7bb67f29bb8288d5261398ca
<pre>
REGRESSION (macOS 14): Force clicking text selection in Books often shows blank highlight
<a href="https://bugs.webkit.org/show_bug.cgi?id=259344">https://bugs.webkit.org/show_bug.cgi?id=259344</a>
rdar://110178512

Reviewed by Wenson Hsieh.

On macOS, force clicking the text selection presents a highlight, implemented
using `TextIndicator`. In order to capture a snapshot of the selection, the
`RenderView`&apos;s `SelectionRangeData` must be up-to-date.

On iOS family platforms, including Mac Catalyst (which is used by Books)
appearance updates are almost always elided, as UIKit is responsible for
drawing the selection highlight. This means that the current
`SelectionRangeData` is often incorrect, which is fine since it is often
unused. However, since it needs to be up-to-date for the selection snapshot,
`FrameSelection::setUpdateAppearanceEnabled` is set to true for the scope of
the snapshot, via `TemporarySelectionChange`.

While appearance updates are enabled, `FrameSelection` bails from making
updates if the selection is unchanged. In the case of this bug, the text is
already selected prior to force clicking. Consequently, the selection used
for the highlight in `TemporarySelectionChange` is equivalent to the current
selection, and the appearance update never occurs. Finally, since the
`SelectionRangeData` is incorrect, a blank selection snapshot is obtained.

To fix, ensure an appearance update occurs prior to taking a selection snapshot
using `TextIndicator` and `TemporarySelectionChange`.

* Source/WebCore/editing/Editor.cpp:
(WebCore::TemporarySelectionChange::TemporarySelectionChange):

Call `FrameSelection::setNeedsSelectionUpdate` to ensure that an appearance
update occurs even if the current selection and temporary selection are equal.

Canonical link: <a href="https://commits.webkit.org/266168@main">https://commits.webkit.org/266168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bcca5ad20d27f81af5cb25f40cd38974dc06f5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13432 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15165 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15290 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11821 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12471 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11740 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3202 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12316 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->