### PR TITLE
[css-easing-2] Implement linear(...) easing function for css animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative-expected.txt
@@ -1,0 +1,7 @@
+
+PASS linear function easing with output greater than 1
+PASS linear function easing with output less than 1
+PASS linear function easing, steps equivalent
+PASS linear function easing, input value being unspecified in the first entry implies zero
+PASS linear function easing, input value being unspecified in the last entry implies max input value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<meta name="assert" content="This test checks the output of linear timing functions" />
+<title>Tests for the output of linear timing functions</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/6533">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/util.js"></script>
+<script src="testcommon.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+function assert_style_left_at(animation, time, expected_y) {
+  animation.currentTime = time;
+  assert_approx_equals(pxToNum(getComputedStyle(animation.effect.target).left),
+                       expected_y * 100,
+                       0.01,
+                       'The left of the animation should be approximately ' +
+                       expected_y * 100 + ' at ' + time + 'ms');
+}
+
+function assert_animations_equal_at(actual_animation, expected_animation, time) {
+  actual_animation.currentTime = time;
+  var actual_left = pxToNum(getComputedStyle(actual_animation.effect.target).left);
+  expected_animation.currentTime = time;
+  var expected_left = pxToNum(getComputedStyle(expected_animation.effect.target).left);
+  assert_approx_equals(actual_left,
+                       expected_left,
+                       0.01,
+                       'The left of the animation should be approximately ' +
+                       expected_left + ' at ' + time + 'ms');
+}
+
+function create_animated_div(t, easing_function) {
+  var target = createDiv(t);
+  target.style.position = 'absolute';
+  return target.animate(
+    [ { left: '0px' },
+      { left: '100px' } ],
+      { duration: 1000,
+        fill: 'forwards',
+        easing: easing_function });
+}
+
+test(function(t) {
+  var anim = create_animated_div(t, 'linear(0, 1.5, 1)');
+
+  assert_style_left_at(anim, 0, 0.0);
+  assert_style_left_at(anim, 250, 0.75);
+  assert_style_left_at(anim, 500, 1.5);
+  assert_style_left_at(anim, 750, 1.25);
+  assert_style_left_at(anim, 1000, 1.00);
+}, 'linear function easing with output greater than 1');
+
+test(function(t) {
+  var anim = create_animated_div(t, 'linear(1, -0.5, 0)');
+
+  assert_style_left_at(anim, 0, 1.0);
+  assert_style_left_at(anim, 250, 0.25);
+  assert_style_left_at(anim, 500, -0.5);
+  assert_style_left_at(anim, 750, -0.25);
+  assert_style_left_at(anim, 1000, 0.00);
+}, 'linear function easing with output less than 1');
+
+test(function(t) {
+  var anim = create_animated_div(t, 'linear(0.2 0% 20%, 0.4 20% 40%, 0.6 40% 60%, 0.8 60% 80%, 1.0 80% 100%)');
+  var equiv = create_animated_div(t, 'steps(5, jump-start)');
+
+  assert_animations_equal_at(anim, equiv, 0);
+  assert_animations_equal_at(anim, equiv, 200);
+  assert_animations_equal_at(anim, equiv, 400);
+  assert_animations_equal_at(anim, equiv, 600);
+  assert_animations_equal_at(anim, equiv, 800);
+  assert_animations_equal_at(anim, equiv, 1000);
+}, 'linear function easing, steps equivalent');
+
+test(function(t) {
+  var anim = create_animated_div(t, 'linear(0, 0.1 -10%, 1)');
+  var equiv = create_animated_div(t, 'linear(0, 0.1 0%, 1)');
+
+  assert_animations_equal_at(anim, equiv, 0);
+  assert_animations_equal_at(anim, equiv, 100);
+  assert_animations_equal_at(anim, equiv, 550);
+  assert_animations_equal_at(anim, equiv, 1000);
+}, 'linear function easing, input value being unspecified in the first entry implies zero');
+
+test(function(t) {
+  var anim = create_animated_div(t, 'linear(0, 0.9 110%, 1)');
+  var equiv = create_animated_div(t, 'linear(0, 0.9 110%, 1 110%)');
+
+  assert_animations_equal_at(anim, equiv, 0);
+  assert_animations_equal_at(anim, equiv, 450);
+  assert_animations_equal_at(anim, equiv, 900);
+  assert_animations_equal_at(anim, equiv, 950);
+  assert_animations_equal_at(anim, equiv, 1000);
+}, 'linear function easing, input value being unspecified in the last entry implies max input value');
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt
@@ -1,0 +1,21 @@
+
+PASS e.style['animation-timing-function'] = "linear(0 0%, 1 100%)" should set the property value
+PASS e.style['animation-timing-function'] = "linear(0 0% 50%, 1 50% 100%)" should set the property value
+PASS e.style['animation-timing-function'] = "linear(0, 0.5 25% 75%, 1 100% 100%)" should set the property value
+PASS e.style['animation-timing-function'] = "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)" should set the property value
+PASS e.style['animation-timing-function'] = "linear()" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0)" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(100%)" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0% 1 50%)" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0 0% 100%)" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0% 100% 0)" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0 calc(50px - 50%), 0 calc(50em + 50em))" should not set the property value
+PASS e.style['animation-timing-function'] = "linear(0 calc(50%, 50%), 0 calc(50% + 50%))" should not set the property value
+PASS Property animation-timing-function value 'linear(0, 1)'
+PASS Property animation-timing-function value 'linear(0 calc(0%), 0 calc(100%))'
+PASS Property animation-timing-function value 'linear(0 calc(50% - 50%), 0 calc(50% + 50%))'
+PASS Property animation-timing-function value 'linear(0 calc(min(50%, 60%)), 0 100%)'
+PASS Property animation-timing-function value 'linear(0 0% 50%, 1 50% 100%)'
+PASS Property animation-timing-function value 'linear(0, 0.5 25% 75%, 1 100% 100%)'
+PASS Property animation-timing-function value 'linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: getComputedStyle().animationTimingFunction with linear(...)</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/pull/6533">
+<meta name="assert" content="animation-timing-function: linear(...) parsing tests">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_valid_value("animation-timing-function", "linear(0 0%, 1 100%)");
+test_valid_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)", "linear(0 0%, 0 50%, 1 50%, 1 100%)");
+test_valid_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)", "linear(0 0%, 0.5 25%, 0.5 75%, 1 100%, 1 100%)");
+test_valid_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 1.004, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 11.1111%, 1 22.2222%, 0.92 33.3333%, 1 44.4444%, 0.99 55.5556%, 1 66.6667%, 1.004 77.7778%, 0.998 88.8889%, 1 100%, 1 100%)");
+
+test_invalid_value("animation-timing-function", "linear()");
+test_invalid_value("animation-timing-function", "linear(0)");
+test_invalid_value("animation-timing-function", "linear(100%)");
+test_invalid_value("animation-timing-function", "linear(0% 1 50%)");
+test_invalid_value("animation-timing-function", "linear(0 0% 100%)");
+test_invalid_value("animation-timing-function", "linear(0% 100% 0)");
+test_invalid_value("animation-timing-function", "linear(0 calc(50px - 50%), 0 calc(50em + 50em))");
+test_invalid_value("animation-timing-function", "linear(0 calc(50%, 50%), 0 calc(50% + 50%))");
+
+test_computed_value("animation-timing-function", "linear(0, 1)", "linear(0 0%, 1 100%)");
+test_computed_value("animation-timing-function", "linear(0 calc(0%), 0 calc(100%))", "linear(0 0%, 0 100%)");
+test_computed_value("animation-timing-function", "linear(0 calc(50% - 50%), 0 calc(50% + 50%))", "linear(0 0%, 0 100%)");
+test_computed_value("animation-timing-function", "linear(0 calc(min(50%, 60%)), 0 100%)", "linear(0 50%, 0 100%)");
+test_computed_value("animation-timing-function", "linear(0 0% 50%, 1 50% 100%)", "linear(0 0%, 0 50%, 1 50%, 1 100%)");
+test_computed_value("animation-timing-function", "linear(0, 0.5 25% 75%, 1 100% 100%)", "linear(0 0%, 0.5 25%, 0.5 75%, 1 100%, 1 100%)");
+test_computed_value("animation-timing-function", "linear(0, 1.3, 1, 0.92, 1, 0.99, 1, 0.998, 1 100% 100%)", "linear(0 0%, 1.3 12.5%, 1 25%, 0.92 37.5%, 1 50%, 0.99 62.5%, 1 75%, 0.998 87.5%, 1 100%, 1 100%)");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Property animation-timing-function value 'linear'
+PASS Property animation-timing-function value 'ease'
+PASS Property animation-timing-function value 'ease-in'
+PASS Property animation-timing-function value 'ease-out'
+PASS Property animation-timing-function value 'ease-in-out'
+PASS Property animation-timing-function value 'cubic-bezier(0.1, 0.2, 0.8, 0.9)'
+PASS Property animation-timing-function value 'cubic-bezier(0, -2, 1, 3)'
+PASS Property animation-timing-function value 'cubic-bezier(0, 0.7, 1, 1.3)'
+PASS Property animation-timing-function value 'steps(4, start)'
+PASS Property animation-timing-function value 'steps(2, end)'
+PASS Property animation-timing-function value 'steps(2, jump-start)'
+PASS Property animation-timing-function value 'steps(2, jump-end)'
+PASS Property animation-timing-function value 'steps(2, jump-both)'
+PASS Property animation-timing-function value 'steps(2, jump-none)'
+PASS Property animation-timing-function value 'linear, ease, linear'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: getComputedStyle().animationTimingFunction</title>
+<link rel="help" href="https://drafts.csswg.org/css-easing/#timing-functions">
+<meta name="assert" content="animation-timing-function computed value is a computed <easing-function> list.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+</head>
+<body>
+<div id="target"></div>
+<script>
+test_computed_value("animation-timing-function", "linear");
+
+test_computed_value("animation-timing-function", "ease");
+test_computed_value("animation-timing-function", "ease-in");
+test_computed_value("animation-timing-function", "ease-out");
+test_computed_value("animation-timing-function", "ease-in-out");
+test_computed_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_computed_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_computed_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+
+
+test_computed_value("animation-timing-function", "steps(4, start)");
+test_computed_value("animation-timing-function", "steps(2, end)", "steps(2)");
+test_computed_value("animation-timing-function", "steps(2, jump-start)");
+test_computed_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
+test_computed_value("animation-timing-function", "steps(2, jump-both)");
+test_computed_value("animation-timing-function", "steps(2, jump-none)");
+
+test_computed_value("animation-timing-function", "linear, ease, linear");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid-expected.txt
@@ -1,0 +1,11 @@
+
+PASS e.style['animation-timing-function'] = "auto" should not set the property value
+PASS e.style['animation-timing-function'] = "ease-in ease-out" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(1, 2, 3)" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(1, 2, 3, infinite)" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(1, 2, 3, 4, 5)" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(-0.1, 0.1, 0.5, 0.9)" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0.5, 0.1, 1.1, 0.9)" should not set the property value
+PASS e.style['animation-timing-function'] = "initial, cubic-bezier(0, -2, 1, 3)" should not set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0, -2, 1, 3), initial" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: parsing animation-timing-function with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-easing/#timing-functions">
+<meta name="assert" content="animation-timing-function supports only the grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("animation-timing-function", "auto");
+test_invalid_value("animation-timing-function", "ease-in ease-out");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3)");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, infinite)");
+test_invalid_value("animation-timing-function", "cubic-bezier(1, 2, 3, 4, 5)");
+test_invalid_value("animation-timing-function", "cubic-bezier(-0.1, 0.1, 0.5, 0.9)");
+test_invalid_value("animation-timing-function", "cubic-bezier(0.5, 0.1, 1.1, 0.9)");
+
+test_invalid_value("animation-timing-function", "initial, cubic-bezier(0, -2, 1, 3)");
+test_invalid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3), initial");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt
@@ -1,0 +1,17 @@
+
+PASS e.style['animation-timing-function'] = "linear" should set the property value
+PASS e.style['animation-timing-function'] = "ease" should set the property value
+PASS e.style['animation-timing-function'] = "ease-in" should set the property value
+PASS e.style['animation-timing-function'] = "ease-out" should set the property value
+PASS e.style['animation-timing-function'] = "ease-in-out" should set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0.1, 0.2, 0.8, 0.9)" should set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0, -2, 1, 3)" should set the property value
+PASS e.style['animation-timing-function'] = "cubic-bezier(0, 0.7, 1, 1.3)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(4, start)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(2, end)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(2, jump-start)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(2, jump-end)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(2, jump-both)" should set the property value
+PASS e.style['animation-timing-function'] = "steps(2, jump-none)" should set the property value
+PASS e.style['animation-timing-function'] = "linear, ease, linear" should set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Easing: parsing animation-timing-function with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-easing/#timing-functions">
+<meta name="assert" content="animation-timing-function supports the full grammar '<timing-function> #'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("animation-timing-function", "linear");
+
+test_valid_value("animation-timing-function", "ease");
+test_valid_value("animation-timing-function", "ease-in");
+test_valid_value("animation-timing-function", "ease-out");
+test_valid_value("animation-timing-function", "ease-in-out");
+test_valid_value("animation-timing-function", "cubic-bezier(0.1, 0.2, 0.8, 0.9)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, -2, 1, 3)");
+test_valid_value("animation-timing-function", "cubic-bezier(0, 0.7, 1, 1.3)");
+
+
+test_valid_value("animation-timing-function", "steps(4, start)");
+test_valid_value("animation-timing-function", "steps(2, end)", "steps(2)");
+test_valid_value("animation-timing-function", "steps(2, jump-start)");
+test_valid_value("animation-timing-function", "steps(2, jump-end)", "steps(2)");
+test_valid_value("animation-timing-function", "steps(2, jump-both)");
+test_valid_value("animation-timing-function", "steps(2, jump-none)");
+
+test_valid_value("animation-timing-function", "linear, ease, linear");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log
@@ -16,6 +16,11 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/cubic-bezier-timing-functions-output.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-output.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/step-timing-functions-syntax.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-easing/testcommon.js
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/transition-timing-function.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/transition-timing-function.html
@@ -63,12 +63,13 @@
         promises.push(anim.ready);
       });
       Promise.all(promises).then(() => {
-        assert_equals(promises.length, 5, 'Unexpected animation count');
+        assert_equals(promises.length, 6, 'Unexpected animation count');
         verifyPosition('box1', 200);  // linear easing
         verifyPosition('box2', ease());
         verifyPosition('box3', easeIn());
         verifyPosition('box4', easeOut());
         verifyPosition('box5', easeInOut());
+        verifyPosition('box6', 400);
       });
     }, 'Ensure that transition easing functions are properly applied.');
   };
@@ -80,6 +81,7 @@
   <div id="box3" class="box" style="transition-timing-function: ease-in;"></div>
   <div id="box4" class="box" style="transition-timing-function: ease-out;"></div>
   <div id="box5" class="box" style="transition-timing-function: ease-in-out;"></div>
+  <div id="box6" class="box" style="transition-timing-function: linear(0, 1, 0);"></div>
 </div>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid-expected.txt
@@ -1,5 +1,8 @@
 
 PASS e.style['transition-timing-function'] = "linear" should set the property value
+PASS e.style['transition-timing-function'] = "linear(0 0%, 0.5 50%, 1 100%)" should set the property value
+PASS e.style['transition-timing-function'] = "linear(0 0%, 10 10%, 10 50%, 25.4 75%, 100 100%)" should set the property value
+PASS e.style['transition-timing-function'] = "linear(0 0%, 1 100%)" should set the property value
 PASS e.style['transition-timing-function'] = "ease" should set the property value
 PASS e.style['transition-timing-function'] = "ease-in" should set the property value
 PASS e.style['transition-timing-function'] = "ease-out" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html
@@ -13,6 +13,9 @@
 <body>
 <script>
 test_valid_value("transition-timing-function", "linear");
+test_valid_value("transition-timing-function", "linear(0 0%, 0.5 50%, 1 100%)");
+test_valid_value("transition-timing-function", "linear(0 0%, 10 10%, 10 50%, 25.4 75%, 100 100%)");
+test_valid_value("transition-timing-function", "linear(0 0%, 1 100%)");
 
 test_valid_value("transition-timing-function", "ease");
 test_valid_value("transition-timing-function", "ease-in");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001-expected.txt
@@ -11,4 +11,5 @@ PASS parse '1s 2s width ease-in'
 PASS parse '1s ease-in 2s width'
 PASS parse 'width ease-in 1s 2s'
 PASS parse 'width .1s ease-in .2s'
+PASS parse '1s width linear(0, .5 10% 20%, 1, .5 50%, 1) 2s'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001.html
@@ -41,8 +41,8 @@
                 '1s 2s width ease-in' : ["width", "1s", "ease-in", "2s"],
                 '1s ease-in 2s width' : ["width", "1s", "ease-in", "2s"],
                 'width ease-in 1s 2s' : ["width", "1s", "ease-in", "2s"],
-                'width .1s ease-in .2s' : ["width", "0.1s", "ease-in", "0.2s"]
-            };
+                'width .1s ease-in .2s' : ["width", "0.1s", "ease-in", "0.2s"],
+                '1s width linear(0, .5 10% 20%, 1, .5 50%, 1) 2s' : ["width", "1s", "linear(0 0%, 0.5 10%, 0.5 20%, 1 35%, 0.5 50%, 1 100%)", "2s"]};
 
             for (var key in values) {
                 if (Object.prototype.hasOwnProperty.call(values, key)) {

--- a/Source/WebCore/css/CSSTimingFunctionValue.cpp
+++ b/Source/WebCore/css/CSSTimingFunctionValue.cpp
@@ -26,9 +26,33 @@
 #include "config.h"
 #include "CSSTimingFunctionValue.h"
 
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringConcatenateNumbers.h>
 
 namespace WebCore {
+
+String CSSLinearTimingFunctionValue::customCSSText() const
+{
+    if (m_points.isEmpty())
+        return "linear"_s;
+
+    StringBuilder builder;
+    builder.append("linear(");
+    for (size_t i = 0; i < m_points.size(); ++i) {
+        if (i)
+            builder.append(", ");
+
+        const auto& point = m_points[i];
+        builder.append(FormattedNumber::fixedPrecision(point.value), ' ', FormattedNumber::fixedPrecision(point.progress * 100.0), '%');
+    }
+    builder.append(')');
+    return builder.toString();
+}
+
+bool CSSLinearTimingFunctionValue::equals(const CSSLinearTimingFunctionValue& other) const
+{
+    return m_points == other.m_points;
+}
 
 String CSSCubicBezierTimingFunctionValue::customCSSText() const
 {

--- a/Source/WebCore/css/CSSTimingFunctionValue.h
+++ b/Source/WebCore/css/CSSTimingFunctionValue.h
@@ -30,6 +30,30 @@
 
 namespace WebCore {
 
+class CSSLinearTimingFunctionValue final : public CSSValue {
+public:
+    static Ref<CSSLinearTimingFunctionValue> create(const Vector<LinearTimingFunction::Point>& points)
+    {
+        return adoptRef(*new CSSLinearTimingFunctionValue(points));
+    }
+
+    const Vector<LinearTimingFunction::Point>& points() const { return m_points; }
+
+    String customCSSText() const;
+
+    bool equals(const CSSLinearTimingFunctionValue&) const;
+
+private:
+    CSSLinearTimingFunctionValue(const Vector<LinearTimingFunction::Point>& points)
+        : CSSValue(LinearTimingFunctionClass)
+        , m_points(points)
+    {
+        ASSERT(m_points.isEmpty() || m_points.size() >= 2);
+    }
+
+    Vector<LinearTimingFunction::Point> m_points;
+};
+
 class CSSCubicBezierTimingFunctionValue final : public CSSValue {
 public:
     static Ref<CSSCubicBezierTimingFunctionValue> create(double x1, double y1, double x2, double y2)
@@ -122,6 +146,7 @@ private:
 
 } // namespace WebCore
 
+SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSLinearTimingFunctionValue, isLinearTimingFunctionValue())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSCubicBezierTimingFunctionValue, isCubicBezierTimingFunctionValue())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSStepsTimingFunctionValue, isStepsTimingFunctionValue())
 SPECIALIZE_TYPE_TRAITS_CSS_VALUE(CSSSpringTimingFunctionValue, isSpringTimingFunctionValue())

--- a/Source/WebCore/css/CSSValue.cpp
+++ b/Source/WebCore/css/CSSValue.cpp
@@ -171,6 +171,8 @@ template<typename Visitor> constexpr decltype(auto) CSSValue::visitDerived(Visit
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLineBoxContainValue>(*this));
     case LinearGradientClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearGradientValue>(*this));
+    case LinearTimingFunctionClass:
+        return std::invoke(std::forward<Visitor>(visitor), downcast<CSSLinearTimingFunctionValue>(*this));
     case NamedImageClass:
         return std::invoke(std::forward<Visitor>(visitor), downcast<CSSNamedImageValue>(*this));
     case PrefixedLinearGradientClass:

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -103,6 +103,7 @@ public:
     bool isInsetShape() const { return m_classType == InsetShapeClass; }
     bool isLineBoxContainValue() const { return m_classType == LineBoxContainClass; }
     bool isLinearGradientValue() const { return m_classType == LinearGradientClass; }
+    bool isLinearTimingFunctionValue() const { return m_classType == LinearTimingFunctionClass; }
     bool isNamedImageValue() const { return m_classType == NamedImageClass; }
     bool isOffsetRotateValue() const { return m_classType == OffsetRotateClass; }
     bool isPair() const { return m_classType == ValuePairClass; }
@@ -206,6 +207,7 @@ protected:
         PrefixedRadialGradientClass,
 
         // Timing function classes.
+        LinearTimingFunctionClass,
         CubicBezierTimingFunctionClass,
         SpringTimingFunctionClass,
         StepsTimingFunctionClass,

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1574,8 +1574,12 @@ static Ref<CSSValue> valueForAnimationTimingFunction(const TimingFunction& timin
         auto& function = downcast<SpringTimingFunction>(timingFunction);
         return CSSSpringTimingFunctionValue::create(function.mass(), function.stiffness(), function.damping(), function.initialVelocity());
     }
-    case TimingFunction::Type::LinearFunction:
-        return CSSPrimitiveValue::create(CSSValueLinear);
+    case TimingFunction::Type::LinearFunction: {
+        auto& function = downcast<LinearTimingFunction>(timingFunction);
+        if (function.points().isEmpty())
+            return CSSPrimitiveValue::create(CSSValueLinear);
+        return CSSLinearTimingFunctionValue::create(function.points());
+    }
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -5902,6 +5902,84 @@ static RefPtr<CSSValue> consumeSteps(CSSParserTokenRange& range)
     return CSSStepsTimingFunctionValue::create(*stepsValue, stepPosition);
 }
 
+static RefPtr<CSSValue> consumeLinear(CSSParserTokenRange& range)
+{
+    ASSERT(range.peek().functionId() == CSSValueLinear);
+    auto rangeCopy = range;
+    auto args = consumeFunction(rangeCopy);
+
+    struct Step {
+        double output;
+        std::optional<double> input { std::nullopt };
+    };
+    Vector<Step> steps;
+    auto largestInput = -std::numeric_limits<double>::infinity();
+    bool lastPointIsExtraPoint = false;
+    while (true) {
+        auto output = consumeNumberRaw(args);
+        if (!output)
+            break;
+
+        steps.append({ output->value });
+        lastPointIsExtraPoint = false;
+
+        args.consumeWhitespace();
+        if (auto input = consumePercentRaw(args)) {
+            largestInput = std::max(input->value / 100.0, largestInput);
+            steps.last().input = largestInput;
+
+            args.consumeWhitespace();
+            if (auto extraPoint = consumePercentRaw(args)) {
+                largestInput = std::max(extraPoint->value / 100.0, largestInput);
+                steps.append({ steps.last().output, largestInput });
+                lastPointIsExtraPoint = true;
+            }
+        } else if (steps.size() == 1) {
+            largestInput = 0.0;
+            steps.last().input = largestInput;
+        }
+
+        if (!consumeCommaIncludingWhitespace(args))
+            break;
+    }
+
+    if (!args.atEnd() || steps.size() < 2 || (steps.size() == 2 && lastPointIsExtraPoint))
+        return nullptr;
+
+    if (!lastPointIsExtraPoint && !steps.last().input)
+        steps.last().input = std::max(1.0, largestInput);
+
+    Vector<LinearTimingFunction::Point> points;
+    points.reserveInitialCapacity(steps.size());
+
+    std::optional<size_t> missingInputRunStart;
+    for (size_t i = 0; i <= steps.size(); ++i) {
+        if (i < steps.size() && !steps[i].input) {
+            if (!missingInputRunStart)
+                missingInputRunStart = i;
+            continue;
+        }
+
+        if (missingInputRunStart) {
+            double inputLow = missingInputRunStart > 0 ? *steps[*missingInputRunStart - 1].input : 0.0;
+            double inputHigh = i < steps.size() ? *steps[i].input : std::max(1.0, largestInput);
+            double inputAverage = (inputLow + inputHigh) / (i - *missingInputRunStart + 1);
+            for (size_t j = *missingInputRunStart; j < i; ++j)
+                points.uncheckedAppend({ steps[j].output, inputAverage * (j - *missingInputRunStart + 1) });
+
+            missingInputRunStart = std::nullopt;
+        }
+
+        if (i < steps.size() && steps[i].input)
+            points.uncheckedAppend({ steps[i].output, *steps[i].input });
+    }
+    ASSERT(!missingInputRunStart);
+    ASSERT(points.size() == steps.size());
+
+    range = rangeCopy;
+    return CSSLinearTimingFunctionValue::create(WTFMove(points));
+}
+
 static RefPtr<CSSValue> consumeCubicBezier(CSSParserTokenRange& range)
 {
     ASSERT(range.peek().functionId() == CSSValueCubicBezier);
@@ -5996,13 +6074,23 @@ RefPtr<CSSValue> consumeTimingFunction(CSSParserTokenRange& range, const CSSPars
         break;
     }
 
-    CSSValueID function = range.peek().functionId();
-    if (function == CSSValueCubicBezier)
+    switch (range.peek().functionId()) {
+    case CSSValueLinear:
+        return consumeLinear(range);
+
+    case CSSValueCubicBezier:
         return consumeCubicBezier(range);
-    if (function == CSSValueSteps)
+
+    case CSSValueSteps:
         return consumeSteps(range);
-    if (context.springTimingFunctionEnabled && function == CSSValueSpring)
-        return consumeSpringFunction(range);
+
+    case CSSValueSpring:
+        return context.springTimingFunctionEnabled ? consumeSpringFunction(range) : nullptr;
+
+    default:
+        break;
+    }
+
     return nullptr;
 }
 

--- a/Source/WebCore/platform/animation/TimingFunction.h
+++ b/Source/WebCore/platform/animation/TimingFunction.h
@@ -60,28 +60,56 @@ public:
 
 class LinearTimingFunction final : public TimingFunction {
 public:
+    struct Point {
+        double value;
+        double progress;
+
+        bool operator==(const Point& other) const
+        {
+            return value == other.value && progress == other.progress;
+        }
+    };
+
     static Ref<LinearTimingFunction> create()
     {
-        return adoptRef(*new LinearTimingFunction);
+        return create({ });
+    }
+
+    static Ref<LinearTimingFunction> create(const Vector<Point>& points)
+    {
+        return adoptRef(*new LinearTimingFunction(points));
     }
     
     bool operator==(const TimingFunction& other) const final
     {
-        return is<LinearTimingFunction>(other);
+        if (!is<LinearTimingFunction>(other))
+            return false;
+        auto& otherLinear = downcast<LinearTimingFunction>(other);
+        return m_points == otherLinear.m_points;
     }
 
-    static const LinearTimingFunction& sharedLinearTimingFunction()
+    const Vector<Point>& points() const { return m_points; }
+
+    static const LinearTimingFunction& identity()
     {
         static NeverDestroyed<Ref<LinearTimingFunction>> function { create() };
         return function.get();
     }
 
 private:
+    LinearTimingFunction(const Vector<Point>& points)
+        : m_points(points)
+    {
+        ASSERT(m_points.isEmpty() || m_points.size() >= 2);
+    }
+
     Type type() const final { return Type::LinearFunction; }
     Ref<TimingFunction> clone() const final
     {
-        return adoptRef(*new LinearTimingFunction);
+        return adoptRef(*new LinearTimingFunction(m_points));
     }
+
+    const Vector<Point> m_points;
 };
 
 class CubicBezierTimingFunction final : public TimingFunction {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1051,8 +1051,13 @@ static bool keyframeValueListHasSingleIntervalWithLinearOrEquivalentTimingFuncti
         return false;
 
     auto* timingFunction = valueList.at(0).timingFunction();
-    if (!timingFunction || is<LinearTimingFunction>(timingFunction))
+    if (!timingFunction)
         return true;
+
+    if (is<LinearTimingFunction>(timingFunction)) {
+        ASSERT(LinearTimingFunction::identity() == *timingFunction);
+        return true;
+    }
 
     return is<CubicBezierTimingFunction>(timingFunction) && downcast<CubicBezierTimingFunction>(*timingFunction).isLinear();
 }
@@ -3707,7 +3712,7 @@ const TimingFunction& GraphicsLayerCA::timingFunctionForAnimationValue(const Ani
         return *animValue.timingFunction();
     if (anim.defaultTimingFunctionForKeyframes())
         return *anim.defaultTimingFunctionForKeyframes();
-    return LinearTimingFunction::sharedLinearTimingFunction();
+    return LinearTimingFunction::identity();
 }
 
 bool GraphicsLayerCA::setAnimationEndpoints(const KeyframeValueList& valueList, const Animation* animation, PlatformCAAnimation* basicAnim)

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -146,6 +146,7 @@ CAMediaTimingFunction* toCAMediaTimingFunction(const TimingFunction& timingFunct
     }
     
     ASSERT(timingFunction.type() == TimingFunction::Type::LinearFunction);
+    ASSERT(LinearTimingFunction::identity() == timingFunction);
     return [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
 }
 

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -817,10 +817,10 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
         "auto", "alphabetic", "under"
     ],
     "transition": [
-        "none", "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "spring()", "all", WI.CSSKeywordCompletions.AllPropertyNamesPlaceholder
+        "none", "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "linear()", "spring()", "all", WI.CSSKeywordCompletions.AllPropertyNamesPlaceholder
     ],
     "transition-timing-function": [
-        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "spring()"
+        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "linear()", "spring()"
     ],
     "transition-property": [
         "all", "none", WI.CSSKeywordCompletions.AllPropertyNamesPlaceholder
@@ -838,7 +838,7 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
         "paused", "running"
     ],
     "animation-timing-function": [
-        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "spring()"
+        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "linear()", "spring()"
     ],
     "align-content": [
         "auto",
@@ -1006,7 +1006,7 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
         "paused", "running",
     ],
     "-webkit-animation-timing-function": [
-        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "spring()",
+        "ease", "linear", "ease-in", "ease-out", "ease-in-out", "step-start", "step-end", "steps()", "cubic-bezier()", "linear()", "spring()",
     ],
     "-webkit-appearance": [
         "none", "checkbox", "radio", "push-button", "square-button", "button", "button-bevel", "default-button", "inner-spin-button", "listbox", "listitem", "media-controls-background", "media-controls-dark-bar-background", "media-controls-fullscreen-background", "media-controls-light-bar-background", "media-current-time-display", "media-enter-fullscreen-button", "media-exit-fullscreen-button", "media-fullscreen-volume-slider", "media-fullscreen-volume-slider-thumb", "media-mute-button", "media-overlay-play-button", "media-play-button", "media-return-to-realtime-button", "media-rewind-button", "media-seek-back-button", "media-seek-forward-button", "media-slider", "media-sliderthumb", "media-time-remaining-display", "media-toggle-closed-captions-button", "media-volume-slider", "media-volume-slider-container", "media-volume-slider-mute-button", "media-volume-sliderthumb", "menulist", "menulist-button", "menulist-text", "menulist-textfield", "meter", "progress-bar", "progress-bar-value", "slider-horizontal", "slider-vertical", "sliderthumb-horizontal", "sliderthumb-vertical", "caret", "searchfield", "searchfield-decoration", "searchfield-results-decoration", "searchfield-results-button", "searchfield-cancel-button", "snapshotted-plugin-overlay", "textfield", "relevancy-level-indicator", "continuous-capacity-level-indicator", "discrete-capacity-level-indicator", "rating-level-indicator", "-apple-pay-button", "textarea", "attachment", "borderless-attachment", "caps-lock-indicator",

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -718,7 +718,13 @@ struct CGAffineTransform {
     WebCore::FloatSize size()
 }
 
+[Nested] struct WebCore::LinearTimingFunction::Point {
+    double value
+    double progress
+}
+
 [RefCounted, CustomHeader] class WebCore::LinearTimingFunction {
+    Vector<WebCore::LinearTimingFunction::Point> points()
 };
 
 [Nested] enum class WebCore::CubicBezierTimingFunction::TimingFunctionPreset : uint8_t {


### PR DESCRIPTION
#### 2b0ebfa3b59e02766ae58688d3b0e576367f9d16
<pre>
[css-easing-2] Implement linear(...) easing function for css animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=240061">https://bugs.webkit.org/show_bug.cgi?id=240061</a>
&lt;rdar://problem/93088094&gt;

Reviewed by Dean Jackson.

Add support for the `linear()` CSS timing function &lt;<a href="https://drafts.csswg.org/css-easing-2/#the-linear-easing-function">https://drafts.csswg.org/css-easing-2/#the-linear-easing-function</a>&gt;.

* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::consumeLinear): Added.
(WebCore::CSSPropertyParserHelpers::consumeTimingFunction):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnimationTimingFunction):
Implement parsing logic for CSS `linear()` &lt;<a href="https://drafts.csswg.org/css-easing-2/#linear-easing-function-parsing">https://drafts.csswg.org/css-easing-2/#linear-easing-function-parsing</a>&gt;.

* Source/WebCore/platform/animation/TimingFunction.h:
(WebCore::LinearTimingFunction::Point::operator== const): Added.
(WebCore::LinearTimingFunction::create): Added.
(WebCore::LinearTimingFunction::operator== const): Added.
(WebCore::LinearTimingFunction::points const): Added.
(WebCore::LinearTimingFunction::identity): Renamed from `sharedLinearTimingFunction`.
(WebCore::LinearTimingFunction::LinearTimingFunction): Added.
(WebCore::LinearTimingFunction::clone):
* Source/WebCore/platform/animation/TimingFunction.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::TimingFunction::transformProgress const):
(WebCore::TimingFunction::createFromCSSValue):
(WebCore::TimingFunction::cssText const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebCore/css/CSSTimingFunctionValue.h:
(WebCore::CSSLinearTimingFunctionValue::create): Added.
(WebCore::CSSLinearTimingFunctionValue::points const): Added.
(WebCore::CSSLinearTimingFunctionValue::CSSLinearTimingFunctionValue): Added.
* Source/WebCore/css/CSSTimingFunctionValue.cpp:
(WebCore::CSSLinearTimingFunctionValue::customCSSText const): Added.
(WebCore::CSSLinearTimingFunctionValue::equals const): Added.
* Source/WebCore/css/CSSValue.h:
(WebCore::CSSValue::isLinearTimingFunctionValue const): Added.
* Source/WebCore/css/CSSValue.cpp:
(WebCore::CSSValue::visitDerived):
Add subclasses and member variables to support CSS `linear()`.
Implement the logic to calculate the current value of a CSS `linear()` given the current progress &lt;<a href="https://drafts.csswg.org/css-easing-2/#linear-easing-function-output">https://drafts.csswg.org/css-easing-2/#linear-easing-function-output</a>&gt;.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::keyframeValueListHasSingleIntervalWithLinearOrEquivalentTimingFunction):
(WebCore::GraphicsLayerCA::timingFunctionForAnimationValue):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
(WebCore::toCAMediaTimingFunction):
Use renamed `identity` instead of `sharedLinearTimingFunction` since `LinearTimingFunction` can now be more than just an identity function.

* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
Add basic autocompletion support for `linear()` in Web Inspector.

* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-output.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/linear-timing-functions-syntax.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-computed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-invalid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/timing-functions-syntax-valid-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-easing/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/animations/transition-timing-function.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/parsing/transition-timing-function-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/transition-001-expected.txt:

Canonical link: <a href="https://commits.webkit.org/266195@main">https://commits.webkit.org/266195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06346cb529e923e6f44a4e81c08222f0dddd8237

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18933 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15252 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12520 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10397 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11737 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3226 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16110 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12364 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->