### PR TITLE
[Cocoa] DumpRenderTree and WebKitTestRunner should not link against private WebCore symbols

### DIFF
--- a/Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig
+++ b/Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig
@@ -25,7 +25,7 @@
 
 OTHER_LDFLAGS = $(inherited) $(OTHER_LDFLAGS_$(WK_COCOA_TOUCH));
 OTHER_LDFLAGS_cocoatouch = -framework JavaScriptCore;
-OTHER_LDFLAGS_ = -lWebCoreTestSupport -force_load $(BUILT_PRODUCTS_DIR)/libDumpRenderTree.a -framework Carbon -framework Cocoa -framework JavaScriptCore -framework OpenGL -framework QuartzCore -framework WebKit;
+OTHER_LDFLAGS_ = -lWebCoreTestSupport -force_load $(BUILT_PRODUCTS_DIR)/libDumpRenderTree.a -framework Carbon -framework Cocoa -framework JavaScriptCore -framework OpenGL -framework QuartzCore -framework WebKitLegacy;
 
 LD_RUNPATH_SEARCH_PATHS = "@loader_path/.";
 STRIP_STYLE = debugging;

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1311,7 +1311,6 @@ int DumpRenderTreeMain(int argc, const char *argv[])
     atexit(atexitFunction);
 
     WTF::setProcessPrivileges(allPrivileges());
-    WebCore::NetworkStorageSession::permitProcessToUseCookieAPI(true);
     WebCoreTestSupport::setLinkedOnOrAfterEverythingForTesting();
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -67,6 +67,9 @@
 
 #if ENABLE(IMAGE_ANALYSIS)
 
+SOFT_LINK_PRIVATE_FRAMEWORK(VisionKitCore)
+SOFT_LINK_CLASS(VisionKitCore, VKCImageAnalyzer)
+
 static VKImageAnalysisRequestID gCurrentImageAnalysisRequestID = 0;
 
 VKImageAnalysisRequestID swizzledProcessImageAnalysisRequest(id, SEL, VKCImageAnalyzerRequest *, void (^progressHandler)(double), void (^completionHandler)(VKCImageAnalysis *, NSError *))
@@ -147,7 +150,7 @@ void TestController::cocoaPlatformInitialize(const Options& options)
 
 #if ENABLE(IMAGE_ANALYSIS)
     m_imageAnalysisRequestSwizzler = makeUnique<InstanceMethodSwizzler>(
-        PAL::getVKCImageAnalyzerClass(),
+        getVKCImageAnalyzerClass(),
         @selector(processRequest:progressHandler:completionHandler:),
         reinterpret_cast<IMP>(swizzledProcessImageAnalysisRequest)
     );


### PR DESCRIPTION
#### 0ffbcb2e923636eedeec6a35f2ebd4bd617c8d8e
<pre>
[Cocoa] DumpRenderTree and WebKitTestRunner should not link against private WebCore symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=259347">https://bugs.webkit.org/show_bug.cgi?id=259347</a>
rdar://112555298

Reviewed by NOBODY (OOPS!).

DumpRenderTree should not link against WebKit at all. It was, and was
getting re-exported WebCore symbols as a result. Fix the linkage, and
update call sites where it references non-reexported WebCore symbols.

Similarly, update one call site in WebKitTestRunner that refers to a
private WebCore symbol, in preparation for WebKit to stop
reexporting WebCore entirely.

* Tools/DumpRenderTree/mac/Configurations/DumpRenderTree.xcconfig: Link
  against WebKitLegacy, not WebKit.
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(DumpRenderTreeMain): Remove superfluous call to
  WebCore::NetworkStorageSession::permitProcessToUseCookieAPI. This same
  call is made when a WebView is initialized.
* Tools/DumpRenderTree/mac/ResourceLoadDelegate.mm:
(-[ResourceLoadDelegate webView:resource:canAuthenticateAgainstProtectionSpace:forDataSource:]):
  Reimplement authentication method logic using NSURLProtectionSpace.
  This class is wrapped by WebCore::ProtectionSpace.
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaPlatformInitialize): Instead of calling into
  PAL to get the class object for VKCImageAnalyzer, soft-link it
  directly.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ffbcb2e923636eedeec6a35f2ebd4bd617c8d8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13450 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15185 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15332 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11247 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11865 "4 flakes 5 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18899 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12322 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12032 "22 flakes 2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15214 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12484 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10361 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->