### PR TITLE
Multiple in-flight CacheStorage.open calls create duplicate responses in CacheStorageCache

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageCache.h
@@ -39,6 +39,7 @@ class CacheStorageCache : public CanMakeWeakPtr<CacheStorageCache> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     CacheStorageCache(CacheStorageManager&, const String& name, const String& uniqueName, const String& path, Ref<WorkQueue>&&);
+    ~CacheStorageCache();
     WebCore::DOMCacheIdentifier identifier() const { return m_identifier; }
     const String& name() const { return m_name; }
     const String& uniqueName() const { return m_uniqueName; }
@@ -65,6 +66,7 @@ private:
 
     WeakPtr<CacheStorageManager> m_manager;
     bool m_isInitialized { false };
+    Vector<WebCore::DOMCacheEngine::CacheIdentifierCallback> m_pendingInitializationCallbacks;
     WebCore::DOMCacheIdentifier m_identifier;
     String m_name;
     String m_uniqueName;


### PR DESCRIPTION
#### 392584f2a30c0055e53f5509bc3c2af2c9ac7c8c
<pre>
Multiple in-flight CacheStorage.open calls create duplicate responses in CacheStorageCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=259348">https://bugs.webkit.org/show_bug.cgi?id=259348</a>
rdar://112483324

Reviewed by Chris Dumez.

We&apos;ve seen webpages that call `CacheStorage.open` with the same cache name hundreds of times in
quick succession.

This triggers a bug in `CacheStorageCache::open`. Each call to `CacheStorage::open` will enqueue a
block that essentially reads the entire contents of a directory into memory (via
`readAllRecordInfos`) until m_isInitialized is set. We then take the contents of that directory and
parse it into the `m_records` hash map, once for each time that block executes.

The end result is that `m_records` contains duplicate cached responses (one set of duplicate
responses each time `readAllRecordInfos` executes), which then makes all subsequent DOMCache use
much more memory than necessary.

To fix this, only execute the block in `CacheStorageCache::open` once. Subsequent calls to
`CacheStorageCache::open` now just append to a list of pending callbacks.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::~CacheStorageCache):
(WebKit::CacheStorageCache::open):
* Source/WebKit/NetworkProcess/storage/CacheStorageCache.h:

Canonical link: <a href="https://commits.webkit.org/266174@main">https://commits.webkit.org/266174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ece17b87b1f4b520a5882518a24fcad0470e39e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15187 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11249 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18900 "2 flakes 93 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12324 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15215 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12485 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10364 "1 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11755 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3209 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16074 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12330 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->