### PR TITLE
Regression (256785@main) Mimeo Photos plugin is broken

### DIFF
--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -37,6 +37,7 @@
 #include "NavigationScheduler.h"
 #include "OriginAccessPatterns.h"
 #include "Page.h"
+#include "Quirks.h"
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
 #include <wtf/CheckedArithmetic.h>
@@ -213,6 +214,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
 #if PLATFORM(COCOA)
         && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
 #endif
+        && !frame->document()->quirks().shouldDisablePushStateFilePathRestrictions()
         && fullURL.fileSystemPath() != documentURL.fileSystemPath()) {
         return createBlockedURLSecurityErrorWithMessageSuffix("Only differences in query and fragment are allowed for file: URLs.");
     }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1591,6 +1591,19 @@ bool Quirks::shouldDisableFetchMetadata() const
     return equalLettersIgnoringASCIICase(host, "victoriassecret.com"_s) || host.endsWithIgnoringASCIICase(".victoriassecret.com"_s);
 }
 
+// Push state file path restrictions break Mimeo Photo Plugin (rdar://112445672).
+bool Quirks::shouldDisablePushStateFilePathRestrictions() const
+{
+    if (!needsQuirks())
+        return false;
+
+#if PLATFORM(MAC)
+    return MacApplication::isMimeoPhotoProject();
+#else
+    return false;
+#endif
+}
+
 #if PLATFORM(COCOA)
 bool Quirks::shouldAdvertiseSupportForHLSSubtitleTypes() const
 {

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -160,6 +160,7 @@ public:
     bool shouldDisableLazyIframeLoadingQuirk() const;
 
     bool shouldDisableFetchMetadata() const;
+    bool shouldDisablePushStateFilePathRestrictions() const;
 
 #if PLATFORM(COCOA)
     bool shouldAdvertiseSupportForHLSSubtitleTypes() const;

--- a/Source/WebCore/platform/RuntimeApplicationChecks.h
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.h
@@ -91,6 +91,7 @@ WEBCORE_EXPORT bool isVersions();
 WEBCORE_EXPORT bool isHRBlock();
 WEBCORE_EXPORT bool isIAdProducer();
 WEBCORE_EXPORT bool isEpsonSoftwareUpdater();
+WEBCORE_EXPORT bool isMimeoPhotoProject();
 
 } // MacApplication
 

--- a/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -188,6 +188,12 @@ bool MacApplication::isEpsonSoftwareUpdater()
     return isEpsonSoftwareUpdater;
 }
 
+bool MacApplication::isMimeoPhotoProject()
+{
+    static bool isMimeoPhotoProject = applicationBundleIsEqualTo("com.mimeo.Mimeo.PhotoProject"_s);
+    return isMimeoPhotoProject;
+}
+
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7664,8 +7664,12 @@ void WebPageProxy::backForwardAddItemShared(Ref<WebProcessProxy>&& process, Back
 {
     URL itemURL { itemState.pageState.mainFrameState.urlString };
 #if PLATFORM(COCOA)
-    if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)) {
-#endif
+    if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
+#if PLATFORM(MAC)
+        && !MacApplication::isMimeoPhotoProject() // rdar://112445672.
+#endif // PLATFORM(MAC)
+    ) {
+#endif // PLATFORM(COCOA)
         ASSERT(!itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
         MESSAGE_CHECK(process, !itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 96c49e041ac290ef903a7feff0542ad4f09be86c
<pre>
Regression (256785@main) Mimeo Photos plugin is broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=259353">https://bugs.webkit.org/show_bug.cgi?id=259353</a>
rdar://112445672

Reviewed by Brent Fulgham.

We added file path restrictions to the history.pushState() API in 256785@main
to match the specification and other browsers. The new behavior was behind a
linked-on-after check but the Mimeo Photos app plugin got updated recently
and it now broken by these new restrictions.

To address the issue, I am adding a quirk to opt Mimeo out of these new
restrictions.

* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisablePushStateFilePathRestrictions const):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/platform/RuntimeApplicationChecks.h:
* Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm:
(WebCore::MacApplication::isMimeoPhotoProject):

Canonical link: <a href="https://commits.webkit.org/266185@main">https://commits.webkit.org/266185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ed0ba6de95ac55c6697ff0620443692d6d2e951

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15214 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15378 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11870 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18927 "2 flakes 93 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12353 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15244 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12517 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11787 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12361 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->