### PR TITLE
[WebXR] Unify all paths for requesting required ANGLE extensions for WebXR

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3279,12 +3279,8 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         m_isXRCompatible = true;
 
 #if PLATFORM(COCOA)
-        // FIXME: This is ugly. It's something needed at the GraphicsContextGL
-        // level, not WebGLRenderingContext. We should move this down to a
-        // virtual makeXRCompatible or something on GCGL.
-        enableSupportedExtension("GL_OES_EGL_image"_s);
-        enableSupportedExtension("GL_EXT_sRGB"_s);
-        enableSupportedExtension("GL_ANGLE_framebuffer_multisample"_s);
+        if (!m_context->enableRequiredWebXRExtensions())
+            return;
 #endif
 
         promise.resolve();

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1520,6 +1520,8 @@ public:
     // Has no other side-effects.
     virtual bool isExtensionEnabled(const String&) = 0;
 
+    virtual bool enableRequiredWebXRExtensions() { return true; }
+
     // GL_ANGLE_translated_shader_source
     virtual String getTranslatedShaderSourceANGLE(PlatformGLObject) = 0;
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -75,6 +75,8 @@ public:
     // Short term support for in-process WebGL.
     GCEGLSync createEGLSync(id, uint64_t);
 
+    bool enableRequiredWebXRExtensions() final;
+
     void waitUntilWorkScheduled();
 
     // GraphicsContextGLANGLE overrides.

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -407,11 +407,8 @@ bool GraphicsContextGLCocoa::platformInitialize()
     }
 #endif // PLATFORM(MAC) || PLATFORM(MACCATALYST)
 #if ENABLE(WEBXR)
-    if (attributes.xrCompatible) {
-        requiredExtensions.append("GL_OES_EGL_image"_s);
-        requiredExtensions.append("GL_EXT_sRGB"_s);
-        requiredExtensions.append("GL_ANGLE_framebuffer_multisample"_s);
-    }
+    if (attributes.xrCompatible && !enableRequiredWebXRExtensions())
+        return false;
 #endif
     if (m_isForWebGL2)
         requiredExtensions.append("GL_ANGLE_framebuffer_multisample"_s);
@@ -764,6 +761,26 @@ GCEGLSync GraphicsContextGLCocoa::createEGLSync(ExternalEGLSyncEvent syncEvent)
     }
 
     return createEGLSync(sharedEvent.get(), signalValue);
+}
+
+bool GraphicsContextGLCocoa::enableRequiredWebXRExtensions()
+{
+#if ENABLE(WEBXR)
+    String requiredExtensions[] = {
+        "GL_ANGLE_framebuffer_multisample"_str,
+        "GL_ANGLE_framebuffer_blit"_str,
+        "GL_EXT_sRGB"_str,
+        "GL_OES_EGL_image"_str,
+        "GL_OES_rgb8_rgba8"_str
+    };
+
+    for (const auto& ext : requiredExtensions) {
+        if (!supportsExtension(ext))
+            return false;
+        ensureExtensionEnabled(ext);
+    }
+#endif
+    return true;
 }
 
 GCEGLSync GraphicsContextGLCocoa::createEGLSync(id sharedEvent, uint64_t signalValue)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -330,6 +330,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void PaintRenderingResultsToPixelBuffer() -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
     void DestroyEGLSync(uint64_t arg0) -> (bool returnValue) Synchronous
     void ClientWaitEGLSyncWithFlush(uint64_t arg0, uint64_t timeout)
+    void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1501,4 +1501,11 @@
         assertIsCurrent(workQueue());
         m_context->clientWaitEGLSyncWithFlush(reinterpret_cast<GCEGLSync>(static_cast<intptr_t>(arg0)), timeout);
     }
+    void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
+    {
+        bool returnValue = { };
+        assertIsCurrent(workQueue());
+        returnValue = m_context->enableRequiredWebXRExtensions();
+        completionHandler(returnValue);
+    }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -368,6 +368,8 @@ public:
     RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer() final;
     bool destroyEGLSync(GCEGLSync) final;
     void clientWaitEGLSyncWithFlush(GCEGLSync, uint64_t timeout) final;
+
+    bool enableRequiredWebXRExtensions() final;
     // End of list used by generate-gpup-webgl script.
 
     static bool handleMessageToRemovedDestination(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3097,6 +3097,19 @@ void RemoteGraphicsContextGLProxy::clientWaitEGLSyncWithFlush(GCEGLSync arg0, ui
     }
 }
 
+bool RemoteGraphicsContextGLProxy::enableRequiredWebXRExtensions()
+{
+    if (isContextLost())
+        return { };
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::EnableRequiredWebXRExtensions());
+    if (!sendResult.succeeded()) {
+        markContextLost();
+        return { };
+    }
+    auto& [returnValue] = sendResult.reply();
+    return returnValue;
+}
+
 }
 
 #endif


### PR DESCRIPTION
#### 99ec0890587733fe26468772955c82e66edcf5ed
<pre>
[WebXR] Unify all paths for requesting required ANGLE extensions for WebXR
<a href="https://bugs.webkit.org/show_bug.cgi?id=259354">https://bugs.webkit.org/show_bug.cgi?id=259354</a>
rdar://109814502

Reviewed by Dean Jackson.

There are two ways to create a WebXR compatible WebGL context. These paths have
a habit of getting out-of-sync. This patch unifies the two paths in calling
`enableRequiredWebXRExtensions` on the underlying GraphicsContextGL. This
function enables all the extensions required to support any combination of
WebXRLayer attributes, which can be independent of the attributes used to create
the WebGLRenderingContext.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::platformInitialize):
(WebCore::GraphicsContextGLCocoa::enableRequiredWebXRExtensions):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(enableRequiredWebXRExtensions):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::enableRequiredWebXRExtensions):

Canonical link: <a href="https://commits.webkit.org/266189@main">https://commits.webkit.org/266189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/731b74291d523220c2abb994a2bf94c47dcd0d98

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15202 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15356 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18914 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15231 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12499 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10375 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11770 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3223 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->