### PR TITLE
Get GPU Process running on PlayStation build

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -217,6 +217,7 @@ FontPlatformData* FontCache::cachedFontPlatformData(const FontDescription& fontD
     FontPlatformDataCache::iterator it = addResult.iterator;
     if (addResult.isNewEntry) {
         it->value = createFontPlatformData(fontDescription, familyName, fontCreationContext);
+//        __debugbreak();
         if (!it->value && !checkingAlternateName) {
             // We were unable to find a font. We have a small set of fonts that we alias to other names,
             // e.g., Arial/Helvetica, Courier/Courier New, etc. Try looking up the font under the aliased name.

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -47,6 +47,11 @@
 #include <X11/Xutil.h>
 #endif
 
+#if PLATFORM(PLAYSTATION)
+#include<compositor.h> 
+#pragma comment(lib, "SceComposite_stub_weak")
+#endif
+
 namespace WebCore {
 
 static ThreadSpecific<GLContext*>& currentContext()
@@ -395,6 +400,10 @@ std::unique_ptr<GLContext> GLContext::createOffscreen(PlatformDisplay& platformD
 
 std::unique_ptr<GLContext> GLContext::createSharing(PlatformDisplay& platformDisplay)
 {
+    //__debugbreak();
+    if (!initializeOpenGLShimsIfNeeded())
+        return nullptr;
+
     if (platformDisplay.eglDisplay() == EGL_NO_DISPLAY) {
         WTFLogAlways("Cannot create EGL sharing context: invalid display (last error: %s)", lastErrorString());
         return nullptr;
@@ -526,6 +535,11 @@ void GLContext::swapBuffers()
         return;
 
     ASSERT(m_surface);
+#if PLATFORM(PLAYSTATION)
+    sceCompositorSetPostEventCommand(0);
+    uint32_t handle;
+    sceCompositorGetCanvasHandle(0, &handle);
+#endif
     eglSwapBuffers(m_display.eglDisplay(), m_surface);
 }
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -30,6 +30,7 @@
 #include "Font.h"
 #include "FontDescription.h"
 #include "FontCacheFreeType.h"
+#include "FontCustomPlatformData.h"
 #include FT_SFNT_NAMES_H
 #include FT_TRUETYPE_IDS_H
 #include "RefPtrCairo.h"
@@ -413,6 +414,10 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
             break;
         }
     }
+
+    FcChar8* fontFile = nullptr;
+    FcPatternGetString(resultPattern.get(), FC_FILE, 0, &fontFile);
+    auto fontFaceData = SharedBuffer::createWithContentsOfFile(String::fromLatin1((char*)fontFile));
 #else
     // Loop through each font family of the result to see if it fits the one we requested.
     bool matchedFontFamily = false;
@@ -464,9 +469,10 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 #endif
 
     auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
-    FontPlatformData platformData(fontFace.get(), WTFMove(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation());
+    FontPlatformData platformData(fontFace.get(), WTFMove(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation(), createFontCustomPlatformData(*fontFaceData, ""_s).get());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
+//    __debugbreak();
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedPixelSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);
 
     // Verify that this font has an encoding compatible with Fontconfig. Fontconfig currently

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -47,6 +47,7 @@ FontCustomPlatformData::FontCustomPlatformData(FT_Face freeTypeFace, FontPlatfor
     , creationData(WTFMove(data))
     , m_renderingResourceIdentifier(RenderingResourceIdentifier::generate())
 {
+//    __debugbreak();
     // Cairo doesn't do FreeType reference counting, so we need to ensure that when
     // this cairo_font_face_t is destroyed, it cleans up the FreeType face as well.
     cairo_font_face_set_user_data(m_fontFace.get(), &freeTypeFaceKey, freeTypeFace,
@@ -134,6 +135,7 @@ static bool initializeFreeTypeLibrary(FT_Library& library)
 
 RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer, const String& itemInCollection)
 {
+   // __debugbreak();
     static FT_Library library;
     if (!library && !initializeFreeTypeLibrary(library)) {
         library = nullptr;
@@ -143,6 +145,7 @@ RefPtr<FontCustomPlatformData> createFontCustomPlatformData(SharedBuffer& buffer
     FT_Face freeTypeFace;
     if (FT_New_Memory_Face(library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(), 0, &freeTypeFace))
         return nullptr;
+    
     FontPlatformData::CreationData creationData = { buffer, itemInCollection };
     return adoptRef(new FontCustomPlatformData(freeTypeFace, WTFMove(creationData)));
 }

--- a/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
+++ b/Source/WebKit/GPUProcess/EntryPoint/playstation/GPUProcessMain.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "GPUProcessMain.h"
 
-#include <EnvVarUtils.h>
 #include <dlfcn.h>
 #include <process-initialization/nk-gpuprocess.h>
 #include <stdio.h>
@@ -44,12 +43,20 @@ static void loadLibraryOrExit(const char* name)
 int main(int argc, char** argv)
 {
     loadLibraryOrExit(WebKitRequirements_LOAD_AT);
+    loadLibraryOrExit(ICU_LOAD_AT);
+#if defined(Brotli_LOAD_AT)
+    loadLibraryOrExit(Brotli_LOAD_AT);
+#endif
+    loadLibraryOrExit(Freetype_LOAD_AT);
+    loadLibraryOrExit(Fontconfig_LOAD_AT);
     loadLibraryOrExit(Cairo_LOAD_AT);
+#if defined(WPE_LOAD_AT)
+    loadLibraryOrExit(WPE_LOAD_AT);
+#endif
     loadLibraryOrExit("libWebKit");
     // load backend libraries as needed here
 
     char* coreProcessIdentifier = argv[1];
-    WebKit::parseAndSetEnvVars(argv[2]);
 
     char connectionIdentifier[16];
     snprintf(connectionIdentifier, sizeof(connectionIdentifier), "%d", PlayStation::getConnectionIdentifier());

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -236,6 +236,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 {
     applyProcessCreationParameters(parameters.auxiliaryProcessParameters);
     RELEASE_LOG(Process, "%p - GPUProcess::initializeGPUProcess:", this);
+    platformInitializeGPUProcess(parameters);
     WTF::Thread::setCurrentThreadIsUserInitiated();
     WebCore::initializeCommonAtomStrings();
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -147,6 +147,7 @@ private:
 
     // Message Handlers
     void initializeGPUProcess(GPUProcessCreationParameters&&);
+    void platformInitializeGPUProcess(GPUProcessCreationParameters&);
     void updateGPUProcessPreferences(GPUProcessPreferences&&);
     void createGPUConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&, CompletionHandler<void()>&&);
     void updateWebGPUEnabled(WebCore::ProcessIdentifier, bool webGPUEnabled);

--- a/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCSceneContext.cpp
@@ -31,11 +31,14 @@
 #include <WebCore/GLContext.h>
 #include <WebCore/TextureMapperGL.h>
 
+#include <EGL/egl.h>
+
 namespace WebKit {
 
 WCSceneContext::WCSceneContext(uint64_t nativeWindow)
 {
-    m_glContext = WebCore::GLContext::create(reinterpret_cast<GLNativeWindowType>(nativeWindow), WebCore::PlatformDisplay::sharedDisplay());
+    _EGLNativeWindowType window { 255, 1920, 1080 };
+    m_glContext = WebCore::GLContext::create(reinterpret_cast<GLNativeWindowType>(&window), WebCore::PlatformDisplay::sharedDisplay());
 }
 
 WCSceneContext::~WCSceneContext() = default;

--- a/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
+++ b/Source/WebKit/GPUProcess/playstation/GPUProcessPlayStation.cpp
@@ -25,12 +25,22 @@
 
 #include "config.h"
 #include "GPUProcess.h"
+#include <WebCore/PlatformDisplay.h>
+#include <WebCore/PlatformDisplayLibWPE.h>
 
 #if ENABLE(GPU_PROCESS)
 
 #include "GPUProcessCreationParameters.h"
 
 namespace WebKit {
+
+void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters&)
+{
+#if USE(WPE_RENDERER)
+    RELEASE_ASSERT(is<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()));
+    downcast<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()).initialize(0);
+#endif
+}
 
 void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameters&)
 {

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -31,9 +31,11 @@
 #include "WebPageProxy.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/NotImplemented.h>
+#include "WebPreferences.h"
 
 #if USE(GRAPHICS_LAYER_WC)
 #include "DrawingAreaProxyWC.h"
+#include <EGL/egl.h>
 #endif
 
 #if USE(WPE_RENDERER)
@@ -350,6 +352,17 @@ void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, cons
 UnixFileDescriptor PageClientImpl::hostFileDescriptor()
 {
     return UnixFileDescriptor { wpe_view_backend_get_renderer_host_fd(m_view.backend()), UnixFileDescriptor::Adopt };
+}
+#endif
+
+#if USE(GRAPHICS_LAYER_WC)
+uint64_t PageClientImpl::viewWidget()
+{
+    static _EGLNativeWindowType window;
+    window.uHeight = 1920;
+    window.uWidth = 1080;
+    window.uID = 255;
+    return reinterpret_cast<uint64_t>(&window);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -44,6 +44,10 @@ class PageClientImpl final : public PageClient
 public:
     PageClientImpl(PlayStationWebView&);
 
+#if USE(GRAPHICS_LAYER_WC)
+    uint64_t viewWidget();
+#endif
+
 private:
     // Create a new drawing area proxy for the given page.
     std::unique_ptr<DrawingAreaProxy> createDrawingAreaProxy() override;

--- a/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/NotImplemented.h>
 #include <WebCore/SearchPopupMenu.h>
 #include <WebCore/UserAgent.h>
+#include "PageClientImpl.h"
 
 namespace WebKit {
 
@@ -68,5 +69,12 @@ void WebPageProxy::loadRecentSearches(const String&, CompletionHandler<void(Vect
 void WebPageProxy::didUpdateEditorState(const EditorState&, const EditorState&)
 {
 }
+
+#if USE(GRAPHICS_LAYER_WC)
+uint64_t WebPageProxy::viewWidget()
+{
+    return static_cast<PageClientImpl&>(pageClient()).viewWidget();
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/playstation/WebProcessPoolPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebProcessPoolPlayStation.cpp
@@ -46,7 +46,7 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
 
 void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process, WebProcessCreationParameters& parameters)
 {
-#if USE(WPE_RENDERER)
+#if USE(WPE_RENDERER) && !ENABLE(GPU_PROCESS)
     parameters.isServiceWorkerProcess = process.isRunningServiceWorkers();
 
     if (!parameters.isServiceWorkerProcess)

--- a/Source/WebKit/WebProcess/playstation/WebProcessPlayStation.cpp
+++ b/Source/WebKit/WebProcess/playstation/WebProcessPlayStation.cpp
@@ -38,7 +38,7 @@ namespace WebKit {
 
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
-#if USE(WPE_RENDERER)
+#if USE(WPE_RENDERER) && !ENABLE(GPU_PROCESS)
     if (!parameters.isServiceWorkerProcess) {
         RELEASE_ASSERT(is<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()));
         downcast<WebCore::PlatformDisplayLibWPE>(WebCore::PlatformDisplay::sharedDisplay()).initialize(parameters.hostClientFileDescriptor.release());

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -338,7 +338,7 @@
 
 /* BENABLE(LIBPAS) is enabling libpas build. But this does not mean we use libpas for bmalloc replacement. */
 #if !defined(BENABLE_LIBPAS)
-#if BCPU(ADDRESS64) && (BOS(DARWIN) || (BOS(LINUX) && (BCPU(X86_64) || BCPU(ARM64))) || BPLATFORM(PLAYSTATION))
+#if BCPU(ADDRESS64) && (BOS(DARWIN) || (BOS(LINUX) && (BCPU(X86_64) || BCPU(ARM64))))
 #define BENABLE_LIBPAS 1
 #ifndef PAS_BMALLOC
 #define PAS_BMALLOC 1

--- a/Tools/MiniBrowser/playstation/MainWindow.cpp
+++ b/Tools/MiniBrowser/playstation/MainWindow.cpp
@@ -109,7 +109,8 @@ MainWindow::MainWindow(const std::vector<std::string>& options)
 
     createNewWebView(nullptr);
 
-    std::string requestedURL = "https://webkit.org";
+    std::string requestedURL = "http://10.125.167.9:8080/morphing_cubes";
+    //std::string requestedURL = "http://www.google.com";
 
     parseOptions(options, requestedURL);
 

--- a/Tools/MiniBrowser/playstation/WebViewWindow.cpp
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.cpp
@@ -84,7 +84,7 @@ WebViewWindow::WebViewWindow(WKPageConfigurationRef configuration, Client&& wind
     m_preferences = WKPreferencesCreateCopy(m_context->preferences());
     WKPageConfigurationSetPreferences(configuration, m_preferences.get());
 
-    WKPreferencesSetAcceleratedCompositingEnabled(m_preferences.get(), false);
+    WKPreferencesSetAcceleratedCompositingEnabled(m_preferences.get(), true);
     WKPreferencesSetFullScreenEnabled(m_preferences.get(), true);
 
 #if defined(USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
@@ -94,6 +94,8 @@ WebViewWindow::WebViewWindow(WKPageConfigurationRef configuration, Client&& wind
     m_view = WKViewCreate(configuration);
 #endif
     m_context->addWindow(this);
+
+    setCanvasHandle(5);
 
     WKViewClientV0 viewClient {
         { 0, this },


### PR DESCRIPTION
#### 62c5497ab709a7619b15a997c41a444b52a02070
<pre>
Get GPU Process running on PlayStation build
<a href="https://bugs.webkit.org/show_bug.cgi?id=259351">https://bugs.webkit.org/show_bug.cgi?id=259351</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c5497ab709a7619b15a997c41a444b52a02070

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13147 "10 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13461 "Failed to compile WebKit") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/13795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/14885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/13215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15969 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13488 "Failed to compile WebKit") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/14885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13314 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/15969 "Failed to compile WebKit") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/13795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/15969 "Failed to compile WebKit") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/13795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/15969 "Failed to compile WebKit") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/13795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12442 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/13488 "Failed to compile WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13196 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11791 "Failed to compile WebKit") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/13795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16111 "Failed to compile WebKit") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/13577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12365 "Failed to compile WebKit") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/13577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->