### PR TITLE
[visionOS] Autohide system chrome after entering fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -31,12 +31,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WKFullScreenViewController : UIViewController
-@property (retain, nonatomic) id target;
-@property (assign, nonatomic) SEL exitFullScreenAction;
+@protocol WKFullScreenViewControllerDelegate
+- (void)requestExitFullScreen;
+- (void)showUI;
+- (void)hideUI;
 #if PLATFORM(VISION)
-@property (assign, nonatomic) SEL toggleDimmingAction;
+- (void)toggleDimming;
 #endif
+@end
+
+@interface WKFullScreenViewController : UIViewController
+@property (nonatomic, weak) id <WKFullScreenViewControllerDelegate> delegate;
 @property (copy, nonatomic) NSString *location;
 @property (assign, nonatomic) BOOL prefersStatusBarHidden;
 @property (assign, nonatomic) BOOL prefersHomeIndicatorAutoHidden;


### PR DESCRIPTION
#### 71f8a0326d29045ef19df3f362a65e067ad24772
<pre>
[visionOS] Autohide system chrome after entering fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=259363">https://bugs.webkit.org/show_bug.cgi?id=259363</a>
rdar://110958152

Reviewed by Wenson Hsieh.

Autohide system chrome after entering fullscreen, similar to hiding other
fullscreen controls.

Refactor `WKFullScreenViewController` to use the delegate pattern to call into
`WKFullScreenWindowController`, rather than target-action, as there is an
ever-growing list of &quot;actions&quot;.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController dealloc]):
(-[WKFullScreenViewController delegate]):
(-[WKFullScreenViewController setDelegate:]):
(-[WKFullScreenViewController showUI]):
(-[WKFullScreenViewController hideUI]):
(-[WKFullScreenViewController _cancelAction:]):
(-[WKFullScreenViewController _toggleDimmingAction:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController toggleDimming]):
(-[WKFullScreenWindowController showUI]):
(-[WKFullScreenWindowController hideUI]):
(-[WKFullScreenWindowController _toggleSceneDimming]): Deleted.

Canonical link: <a href="https://commits.webkit.org/266191@main">https://commits.webkit.org/266191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c4a225a808879a8acc0caa8e93bd41bff5c2bd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11284 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18931 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12524 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11794 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3224 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16115 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->