### PR TITLE
Regression(266113@main) Crash under WebKit::ProcessThrottlerActivity::invalidate()

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -352,10 +352,16 @@ void ProcessThrottler::setAllowsActivities(bool allow)
         return;
 
     PROCESSTHROTTLER_RELEASE_LOG("setAllowsActivities %d", allow);
-    m_allowsActivities = allow;
 
-    if (!allow)
+    if (!allow) {
+        // Invalidate the activities before setting m_allowsActivities to false, so that the activities
+        // are able to remove themselves from the map.
         invalidateAllActivities();
+    }
+
+    ASSERT(m_foregroundActivities.isEmpty());
+    ASSERT(m_backgroundActivities.isEmpty());
+    m_allowsActivities = allow;
 }
 
 void ProcessThrottler::setShouldTakeNearSuspendedAssertion(bool shouldTakeNearSuspendedAssertion)


### PR DESCRIPTION
#### 8c1fe1cdba42c095f6063418579c15d209320ea8
<pre>
Regression(266113@main) Crash under WebKit::ProcessThrottlerActivity::invalidate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259367">https://bugs.webkit.org/show_bug.cgi?id=259367</a>
rdar://112620147

Reviewed by Brent Fulgham.

setAllowsActivities(false) would set `m_allowsActivities` to false and then
call invalidateAllActivities(). When invalidating the activities, they would
try to remove themselves from the activity map via
ProcessThrottler::removeActivity(). However, 266113@main made removeActivity()
early return if `m_allowsActivities` is false, since there is supposed to be
no activities in the map.

To address the issue, I am reversing the order of operations in
setAllowsActivities() so that we first invalidate activities, and then
set `m_allowsActivities` to false.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::setAllowsActivities):

Canonical link: <a href="https://commits.webkit.org/266192@main">https://commits.webkit.org/266192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3df5ace80c34be976b1a7f27665e11f30d7529e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12534 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13322 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15399 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11287 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15260 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12529 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11799 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3225 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16120 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12373 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->