### PR TITLE
[prepare-commit-msg] Automatically de-duplicate cherry-pick messages

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -7,6 +7,7 @@ import sys
 
 LOCATION = r'{{ location }}'
 SPACING = 8
+IDENT = 4
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
 CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
 CHERRY_PICK_COMMIT_RE = re.compile(r'^(?P<a>\S+)( \((?P<b>\S+)\))?$')
@@ -18,6 +19,15 @@ PREFER_RADAR = {{ prefer_radar }}
 DEFAULT_BRANCH = '{{ default_branch }}'
 SOURCE_REMOTES = {{ source_remotes }}
 TRAILERS_TO_STRIP = {{ trailers_to_strip }}
+
+COMMIT_REF_BASE = r'r?R?[a-f0-9A-F]+(\.\d+)?@?([0-9a-zA-z\-\/\.]+[0-9a-zA-z\-\/])?'
+COMPOUND_COMMIT_REF = r'(?P<primary>{})(?P<secondary> \({}\))?'.format(COMMIT_REF_BASE, COMMIT_REF_BASE)
+CHERRY_PICK_RE = [
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]ick of {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]ick {}'.format(COMPOUND_COMMIT_REF)),
+    re.compile(r'\S* ?[Cc]herry[- ][Pp]icked {}'.format(COMPOUND_COMMIT_REF)),
+]
+UNPACK_SECONDARY_RE = re.compile(r' \(({})\)'.format(COMMIT_REF_BASE))
 
 ENCODING_KWARGS = dict()
 if sys.version_info >= (3, 6):
@@ -239,15 +249,33 @@ def cherry_pick(content):
 
     is_trunk_bound = DEFAULT_BRANCH in source_branches()
     in_suffix = False
-    cherry_pick_metadata = '{}. {}'.format(cherry_picked or '???', bug or '<bug>')
     result = []
-    if not is_trunk_bound and production_hash:
+    unindent = False
+
+    lines = list(content.splitlines())
+    for header in CHERRY_PICK_RE:
+        match = header.match(lines[0])
+        if not match:
+            continue
+        cherry_picked = '{}{}'.format(match.group('primary'), match.group('secondary') or '')
+        unindent = True
+        lines = lines[1:]
+        while not lines[0].rstrip():
+            lines = lines[1:]
+        break
+
+    cherry_pick_metadata = '{}. {}'.format(cherry_picked or '???', bug or '<bug>')
+    if not is_trunk_bound:
         result += ['Cherry-pick {}'.format(cherry_pick_metadata), '']
-    for line in content.splitlines():
+
+    for line in lines:
         line = line.rstrip()
         if not line:
             result.append('')
             continue
+        if unindent and line.startswith(IDENT*' '):
+            line = line[IDENT:]
+
         if line[0] == '#' and not in_suffix:
             in_suffix = True
             if is_trunk_bound and production_hash:
@@ -255,7 +283,7 @@ def cherry_pick(content):
                     del result[-1]
                 result += ['', 'Originally-landed-as: {}'.format(cherry_pick_metadata)]
         if line[0] != '#' and not is_trunk_bound and production_hash:
-            result.append(4*' ' + line)
+            result.append(IDENT*' ' + line)
         else:
             result.append(line)
     return '\n'.join(result)

--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.6.5',
+    version='6.6.6',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 6, 5)
+version = Version(6, 6, 6)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py
@@ -45,7 +45,7 @@ class CherryPick(Command):
         )
         parser.add_argument(
             '--use-original', '--no-original',
-            dest='original', default=True,
+            dest='original', default=None,
             help='When cherry-picking a cherry-pick, use the original commit instead of a double cherry-pick.',
             action=arguments.NoAction,
         )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py
@@ -75,7 +75,7 @@ class TestCherryPick(testing.PathTestCase):
         self.assertEqual(captured.stdout.getvalue(), '')
         self.assertEqual(captured.stderr.getvalue(), '')
 
-    def test_resolve(self):
+    def test_resolve_default(self):
         with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime:
             repo.head = repo.commits['branch-a'][-1]
             self.assertEqual(0, program.main(
@@ -88,6 +88,32 @@ class TestCherryPick(testing.PathTestCase):
             repo.head = repo.commits['branch-b'][-1]
             self.assertEqual(0, program.main(
                 args=('cherry-pick', '5848f06de77d'),
+                path=self.path,
+            ))
+            self.assertEqual(repo.head.hash, 'ec36de1acb4f71ede1a63c40eb55d2472f70e949')
+            self.assertEqual(
+                repo.head.message,
+                'Cherry-pick 2.3@branch-a (5848f06de77d). <bug>\n'
+                '    Cherry-pick 5@main (d8bce26fa65c). <bug>\n'
+                '        Patch Series\n',
+            )
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_resolve(self):
+        with OutputCapture() as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn(), MockTime:
+            repo.head = repo.commits['branch-a'][-1]
+            self.assertEqual(0, program.main(
+                args=('cherry-pick', 'd8bce26fa65c'),
+                path=self.path,
+            ))
+            self.assertEqual(repo.head.hash, '5848f06de77d306791b7410ff2197bf3dd82b9e9')
+            self.assertEqual(repo.head.message, 'Cherry-pick 5@main (d8bce26fa65c). <bug>\n    Patch Series\n')
+
+            repo.head = repo.commits['branch-b'][-1]
+            self.assertEqual(0, program.main(
+                args=('cherry-pick', '5848f06de77d', '--use-original'),
                 path=self.path,
             ))
             self.assertEqual(repo.head.hash, '5848f06de77d306791b7410ff2197bf3dd82b9e9')


### PR DESCRIPTION
#### 81d929e4e8c077d0fb4793aeb7f589f1de7a8ebb
<pre>
[prepare-commit-msg] Automatically de-duplicate cherry-pick messages
<a href="https://bugs.webkit.org/show_bug.cgi?id=259370">https://bugs.webkit.org/show_bug.cgi?id=259370</a>
rdar://112621977

Reviewed by Dewei Zhu.

Un-indent cherry-picks of cherry-picks.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/hooks/prepare-commit-msg: Un-indent cherry-picks of cherry-picks.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/cherry_pick.py:
(CherryPick.parser): Set &apos;original&apos; to &apos;None&apos;.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/cherry_pick_unittest.py:
(TestCherryPick.test_resolve_default): Test the default arguments to cherry-pick.
(TestCherryPick.test_resolve): Pass &apos;--use-original&apos;.

Canonical link: <a href="https://commits.webkit.org/266527@main">https://commits.webkit.org/266527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f478bb51e9d04a45d216480d07ec0d91894ba43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/14065 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/14380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/14716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/15804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/14150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/16890 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/14464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/15804 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/14236 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/16890 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/14716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16515 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/14161 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/16890 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/14716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/16515 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/16890 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/14716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16515 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/14464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/13953 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/12668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/14716 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1661 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->