### PR TITLE
Use mapped files in CacheStorageDiskStore

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -27,6 +27,7 @@
 
 #include "CacheStorageStore.h"
 #include "NetworkCacheKey.h"
+#include <wtf/FileSystem.h>
 #include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
 
@@ -52,8 +53,8 @@ private:
     String recordBlobFilePath(const String&) const;
     String blobsDirectoryPath() const;
     String blobFilePath(const String&) const;
-    std::optional<CacheStorageRecord> readRecordFromFileData(const Vector<uint8_t>&, const Vector<uint8_t>&);
-    using FileDatas = Vector<Vector<uint8_t>>;
+    std::optional<CacheStorageRecord> readRecordFromFileData(std::span<const uint8_t>, FileSystem::MappedFileData&&);
+    using FileDatas = Vector<FileSystem::MappedFileData>;
     void readAllRecordInfosInternal(CompletionHandler<void(FileDatas&&)>&&);
     void readRecordsInternal(Vector<String>&&, CompletionHandler<void(FileDatas&&, FileDatas&&)>&&);
 


### PR DESCRIPTION
#### 470bd54de983712380aa5478840b0fe53e566f76
<pre>
Use mapped files in CacheStorageDiskStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=259371">https://bugs.webkit.org/show_bug.cgi?id=259371</a>
rdar://problem/112623177

Reviewed by Chris Dumez.

Currently CacheStorageDiskStore reads entire files into dirty memory. When many DOMCache operations
in flight, this can lead to a temporary explosion in NetworkProcess memory usage (in the gigabytes
of footprint).

To fix this issue, we use read-only mapped files in CacheStorageDiskStore instead, as we do with the
regular network cache. This trades dirty footprint for higher vnode usage. But that should be okay
as the number of vnodes consumed by DOMCache should be much lower than the number of vnodes used by
NetworkCache, which is already mmap&apos;ing everything.

I also removed some unnecessary cross-thread copies, as the data we&apos;re passing across threads isn&apos;t
affined to a particular thread (e.g. no non-atomic ref counts).

* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::toSpan):
(WTF::FileSystemImpl::MappedFileData::create):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::readRecordInfoFromFileData):
(WebKit::CacheStorageDiskStore::readRecordFromFileData):
(WebKit::CacheStorageDiskStore::readAllRecordInfosInternal):
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
(WebKit::CacheStorageDiskStore::readRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:

Canonical link: <a href="https://commits.webkit.org/266199@main">https://commits.webkit.org/266199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfcbb91ddb4aba05937aa29fad7ee04b4197897b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14905 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/15988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13507 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15233 "127 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18944 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11204 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15274 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12539 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10413 "1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13215 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11809 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3471 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3230 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16130 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13596 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12382 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3266 "Passed tests") | 
<!--EWS-Status-Bubble-End-->