### PR TITLE
Merge GraphicsContextState::m_dropShadow with ::m_style

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1392,9 +1392,9 @@ void CanvasRenderingContext2DBase::applyShadow()
     if (shouldDrawShadows()) {
         float width = state().shadowOffset.width();
         float height = state().shadowOffset.height();
-        c->setDropShadow({ FloatSize(width, -height), state().shadowBlur, state().shadowColor, ShadowRadiusMode::Legacy });
+        c->setDropShadow({ { width, -height }, state().shadowBlur, state().shadowColor, ShadowRadiusMode::Legacy });
     } else
-        c->setDropShadow({ FloatSize(), 0, Color::transparentBlack, ShadowRadiusMode::Legacy });
+        c->setDropShadow({ { }, 0, Color::transparentBlack, ShadowRadiusMode::Legacy });
 }
 
 bool CanvasRenderingContext2DBase::shouldDrawShadows() const
@@ -2586,13 +2586,14 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
             FloatSize offset(0, 2 * maskRect.height());
 
             auto shadow = c->dropShadow();
+            ASSERT(shadow);
 
             FloatRect shadowRect(maskRect);
-            shadowRect.inflate(shadow.blurRadius * 1.4);
-            shadowRect.move(shadow.offset * -1);
+            shadowRect.inflate(shadow->radius * 1.4);
+            shadowRect.move(shadow->offset * -1);
             c->clip(shadowRect);
 
-            c->setDropShadow({ shadow.offset + offset, shadow.blurRadius, shadow.color, ShadowRadiusMode::Legacy });
+            c->setDropShadow({ shadow->offset + offset, shadow->radius, shadow->color, ShadowRadiusMode::Legacy });
 
             if (fill)
                 c->setFillColor(Color::black);

--- a/Source/WebCore/platform/DictationCaretAnimator.cpp
+++ b/Source/WebCore/platform/DictationCaretAnimator.cpp
@@ -260,9 +260,9 @@ void DictationCaretAnimator::fillCaretTail(const FloatRect& rect, GraphicsContex
     gradient->addColorStop({ isLTR ? 1.f : 0.f, tailColor.colorWithAlpha(0.35f * glowOpacity) });
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=253139 - this should be computed based on the render area
     constexpr auto shadowOffset = 10000.f;
-    DropShadow dropShadow = {
-        .offset = FloatSize(shadowOffset, shadowOffset),
-        .blurRadius = tailBlurRadius(rect.height()),
+    GraphicsDropShadow dropShadow = {
+        .offset = { shadowOffset, shadowOffset },
+        .radius = tailBlurRadius(rect.height()),
         .color = tailColor.colorWithAlpha(glowOpacity),
         .radiusMode = ShadowRadiusMode::Default,
     };
@@ -300,14 +300,8 @@ void DictationCaretAnimator::paint(GraphicsContext& context, const FloatRect& re
     GraphicsContextStateSaver stateSaver(context);
     context.resetClip();
     const auto targetOpacity = (fillTail ? 1.0 : m_presentationProperties.opacity) - m_initialScale;
-    if (targetOpacity > 0 && !blinkingSuspended) {
-        context.setDropShadow({
-            .offset = { },
-            .blurRadius = caretBlurRadius(rect.height()),
-            .color = caretColor.colorWithAlpha(targetOpacity),
-            .radiusMode = ShadowRadiusMode::Default,
-        });
-    }
+    if (targetOpacity > 0 && !blinkingSuspended)
+        context.setDropShadow({ { }, caretBlurRadius(rect.height()), caretColor.colorWithAlpha(targetOpacity), ShadowRadiusMode::Default });
 
     context.fillRoundedRect(expandedCaretRect(rect, fillTail), caretColor);
 

--- a/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
+++ b/Source/WebCore/platform/graphics/DrawGlyphsRecorder.h
@@ -88,7 +88,7 @@ private:
         Yes,
         No
     };
-    void updateShadow(const DropShadow&, ShadowsIgnoreTransforms);
+    void updateShadow(const std::optional<GraphicsDropShadow>&, ShadowsIgnoreTransforms);
 
 #if USE(CORE_TEXT)
     void updateFillColor(CGColorRef);
@@ -113,7 +113,7 @@ private:
         SourceBrush fillBrush;
         SourceBrush strokeBrush;
         AffineTransform ctm;
-        DropShadow dropShadow;
+        std::optional<GraphicsDropShadow> dropShadow;
         bool ignoreTransforms { false };
     };
     State m_originalState;

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -596,6 +596,42 @@ Vector<FloatPoint> GraphicsContext::centerLineAndCutOffCorners(bool isVerticalLi
     return { point1, point2 };
 }
 
+void GraphicsContext::clearShadow()
+{
+    if (!m_state.style())
+        return;
+
+    if (!std::holds_alternative<GraphicsDropShadow>(*m_state.style()))
+        return;
+
+    m_state.setStyle(std::nullopt);
+    didUpdateState(m_state);
+}
+
+bool GraphicsContext::hasVisibleShadow() const
+{
+    if (const auto shadow = dropShadow())
+        return shadow->isVisible();
+
+    return false;
+}
+
+bool GraphicsContext::hasBlurredShadow() const
+{
+    if (const auto shadow = dropShadow())
+        return shadow->isBlurred();
+
+    return false;
+}
+
+bool GraphicsContext::hasShadow() const
+{
+    if (const auto shadow = dropShadow())
+        return shadow->hasOutsets();
+
+    return false;
+}
+
 #if ENABLE(VIDEO)
 void GraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
 {

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -117,16 +117,12 @@ public:
     StrokeStyle strokeStyle() const { return m_state.strokeStyle(); }
     void setStrokeStyle(StrokeStyle style) { m_state.setStrokeStyle(style); didUpdateState(m_state); }
 
-    const DropShadow& dropShadow() const { return m_state.dropShadow(); }
-    FloatSize shadowOffset() const { return dropShadow().offset; }
-    float shadowBlur() const { return dropShadow().blurRadius; }
-    const Color& shadowColor() const { return dropShadow().color; }
-    void setDropShadow(const DropShadow& dropShadow) { m_state.setDropShadow(dropShadow); didUpdateState(m_state); }
-    void clearShadow() { setDropShadow({ }); }
-
-    bool hasVisibleShadow() const { return dropShadow().isVisible(); }
-    bool hasBlurredShadow() const { return dropShadow().isBlurred(); }
-    bool hasShadow() const { return dropShadow().hasOutsets(); }
+    std::optional<GraphicsDropShadow> dropShadow() const { return m_state.dropShadow(); }
+    void setDropShadow(const GraphicsDropShadow& dropShadow) { m_state.setStyle(dropShadow); didUpdateState(m_state); }
+    WEBCORE_EXPORT void clearShadow();
+    bool hasVisibleShadow() const;
+    bool hasBlurredShadow() const;
+    bool hasShadow() const;
 
     std::optional<GraphicsStyle> style() const { return m_state.style(); }
     void setStyle(const std::optional<GraphicsStyle>& style) { m_state.setStyle(style); didUpdateState(m_state); }

--- a/Source/WebCore/platform/graphics/GraphicsContextState.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.cpp
@@ -37,6 +37,17 @@ GraphicsContextState::GraphicsContextState(const ChangeFlags& changeFlags, Inter
 {
 }
 
+std::optional<GraphicsDropShadow> GraphicsContextState::dropShadow() const
+{
+    if (!m_style)
+        return std::nullopt;
+
+    if (!std::holds_alternative<GraphicsDropShadow>(*m_style))
+        return std::nullopt;
+
+    return std::get<GraphicsDropShadow>(*m_style);
+}
+
 GraphicsContextState GraphicsContextState::cloneForRecording() const
 {
     auto clone = *this;
@@ -105,9 +116,6 @@ void GraphicsContextState::mergeLastChanges(const GraphicsContextState& state, c
         case toIndex(Change::CompositeMode):
             mergeChange(&GraphicsContextState::m_compositeMode);
             break;
-        case toIndex(Change::DropShadow):
-            mergeChange(&GraphicsContextState::m_dropShadow);
-            break;
         case toIndex(Change::Style):
             mergeChange(&GraphicsContextState::m_style);
             break;
@@ -165,7 +173,6 @@ void GraphicsContextState::mergeAllChanges(const GraphicsContextState& state)
     mergeChange(Change::StrokeStyle,                 &GraphicsContextState::m_strokeStyle);
 
     mergeChange(Change::CompositeMode,               &GraphicsContextState::m_compositeMode);
-    mergeChange(Change::DropShadow,                  &GraphicsContextState::m_dropShadow);
 
     mergeChange(Change::Alpha,                       &GraphicsContextState::m_alpha);
     mergeChange(Change::ImageInterpolationQuality,   &GraphicsContextState::m_textDrawingMode);
@@ -209,9 +216,6 @@ static const char* stateChangeName(GraphicsContextState::Change change)
 
     case GraphicsContextState::Change::CompositeMode:
         return "composite-mode";
-
-    case GraphicsContextState::Change::DropShadow:
-        return "drop-shadow";
 
     case GraphicsContextState::Change::Style:
         return "style";
@@ -266,7 +270,6 @@ TextStream& GraphicsContextState::dump(TextStream& ts) const
     dump(Change::StrokeStyle,                   &GraphicsContextState::m_strokeStyle);
 
     dump(Change::CompositeMode,                 &GraphicsContextState::m_compositeMode);
-    dump(Change::DropShadow,                    &GraphicsContextState::m_dropShadow);
     dump(Change::Style,                         &GraphicsContextState::m_style);
 
     dump(Change::Alpha,                         &GraphicsContextState::m_alpha);

--- a/Source/WebCore/platform/graphics/GraphicsContextState.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextState.h
@@ -45,20 +45,19 @@ public:
         StrokeStyle                 = 1 << 4,
 
         CompositeMode               = 1 << 5,
-        DropShadow                  = 1 << 6,
-        Style                       = 1 << 7,
+        Style                       = 1 << 6,
 
-        Alpha                       = 1 << 8,
-        TextDrawingMode             = 1 << 9,
-        ImageInterpolationQuality   = 1 << 10,
+        Alpha                       = 1 << 7,
+        TextDrawingMode             = 1 << 8,
+        ImageInterpolationQuality   = 1 << 9,
 
-        ShouldAntialias             = 1 << 11,
-        ShouldSmoothFonts           = 1 << 12,
-        ShouldSubpixelQuantizeFonts = 1 << 13,
-        ShadowsIgnoreTransforms     = 1 << 14,
-        DrawLuminanceMask           = 1 << 15,
+        ShouldAntialias             = 1 << 10,
+        ShouldSmoothFonts           = 1 << 11,
+        ShouldSubpixelQuantizeFonts = 1 << 12,
+        ShadowsIgnoreTransforms     = 1 << 13,
+        DrawLuminanceMask           = 1 << 14,
 #if HAVE(OS_DARK_MODE_SUPPORT)
-        UseDarkAppearance           = 1 << 16,
+        UseDarkAppearance           = 1 << 15,
 #endif
     };
     using ChangeFlags = OptionSet<Change>;
@@ -99,8 +98,7 @@ public:
     const CompositeMode& compositeMode() const { return m_compositeMode; }
     void setCompositeMode(CompositeMode compositeMode) { setProperty(Change::CompositeMode, &GraphicsContextState::m_compositeMode, compositeMode); }
 
-    const DropShadow& dropShadow() const { return m_dropShadow; }
-    void setDropShadow(const DropShadow& dropShadow) { setProperty(Change::DropShadow, &GraphicsContextState::m_dropShadow, dropShadow); }
+    WEBCORE_EXPORT std::optional<GraphicsDropShadow> dropShadow() const;
 
     const std::optional<GraphicsStyle>& style() const { return m_style; }
     void setStyle(const std::optional<GraphicsStyle>& style) { setProperty(Change::Style, &GraphicsContextState::m_style, style); }
@@ -179,7 +177,6 @@ private:
     StrokeStyle m_strokeStyle { StrokeStyle::SolidStroke };
 
     CompositeMode m_compositeMode { CompositeOperator::SourceOver, BlendMode::Normal };
-    DropShadow m_dropShadow;
     std::optional<GraphicsStyle> m_style;
 
     float m_alpha { 1 };
@@ -214,7 +211,6 @@ void GraphicsContextState::encode(Encoder& encoder) const
     encode(Change::StrokeStyle,                     &GraphicsContextState::m_strokeStyle);
 
     encode(Change::CompositeMode,                   &GraphicsContextState::m_compositeMode);
-    encode(Change::DropShadow,                      &GraphicsContextState::m_dropShadow);
     encode(Change::Style,                           &GraphicsContextState::m_style);
 
     encode(Change::Alpha,                           &GraphicsContextState::m_alpha);
@@ -269,8 +265,6 @@ std::optional<GraphicsContextState> GraphicsContextState::decode(Decoder& decode
 
     if (!decode(state, Change::CompositeMode,               &GraphicsContextState::m_compositeMode))
         return std::nullopt;
-    if (!decode(state, Change::DropShadow,                  &GraphicsContextState::m_dropShadow))
-        return std::nullopt;
     if (!decode(state, Change::Style,                       &GraphicsContextState::m_style))
         return std::nullopt;
 
@@ -317,7 +311,6 @@ template<> struct EnumTraits<WebCore::GraphicsContextState::Change> {
         WebCore::GraphicsContextState::Change::StrokeStyle,
 
         WebCore::GraphicsContextState::Change::CompositeMode,
-        WebCore::GraphicsContextState::Change::DropShadow,
         WebCore::GraphicsContextState::Change::Style,
 
         WebCore::GraphicsContextState::Change::Alpha,

--- a/Source/WebCore/platform/graphics/GraphicsStyle.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.cpp
@@ -35,6 +35,7 @@ TextStream& operator<<(TextStream& ts, const GraphicsDropShadow& dropShadow)
     ts.dumpProperty("offset", dropShadow.offset);
     ts.dumpProperty("radius", dropShadow.radius);
     ts.dumpProperty("color", dropShadow.color);
+    ts.dumpProperty("shadows-use-legacy-radius", dropShadow.radiusMode == ShadowRadiusMode::Legacy);
     return ts;
 }
 

--- a/Source/WebCore/platform/graphics/GraphicsStyle.h
+++ b/Source/WebCore/platform/graphics/GraphicsStyle.h
@@ -35,11 +35,23 @@ class TextStream;
 
 namespace WebCore {
 
+// Legacy shadow blur radius is used for canvas, and -webkit-box-shadow.
+// It has different treatment of radii > 8px.
+enum class ShadowRadiusMode : bool {
+    Default,
+    Legacy
+};
+
 struct GraphicsDropShadow {
     FloatSize offset;
-    FloatSize radius;
+    float radius;
     Color color;
-    
+    ShadowRadiusMode radiusMode;
+
+    bool isVisible() const { return color.isVisible(); }
+    bool isBlurred() const { return isVisible() && radius; }
+    bool hasOutsets() const { return isBlurred() || (isVisible() && !offset.isZero()); }
+
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<GraphicsDropShadow> decode(Decoder&);
 };
@@ -100,7 +112,7 @@ std::optional<GraphicsDropShadow> GraphicsDropShadow::decode(Decoder& decoder)
     if (!offset)
         return std::nullopt;
 
-    std::optional<FloatSize> radius;
+    std::optional<float> radius;
     decoder >> radius;
     if (!radius)
         return std::nullopt;
@@ -110,7 +122,13 @@ std::optional<GraphicsDropShadow> GraphicsDropShadow::decode(Decoder& decoder)
     if (!color)
         return std::nullopt;
 
-    return GraphicsDropShadow { *offset, *radius, *color };
+
+    std::optional<ShadowRadiusMode> radiusMode;
+    decoder >> radiusMode;
+    if (!radius)
+        return std::nullopt;
+
+    return GraphicsDropShadow { *offset, *radius, *color, *radiusMode };
 }
 
 template<class Encoder>

--- a/Source/WebCore/platform/graphics/GraphicsTypes.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.cpp
@@ -143,15 +143,6 @@ TextStream& operator<<(TextStream& ts, CompositeMode compositeMode)
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, const DropShadow& dropShadow)
-{
-    ts.dumpProperty("shadow-offset", dropShadow.offset);
-    ts.dumpProperty("shadow-blur", dropShadow.blurRadius);
-    ts.dumpProperty("shadow-color", dropShadow.color);
-    ts.dumpProperty("shadows-use-legacy-radius", dropShadow.radiusMode == ShadowRadiusMode::Legacy);
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, GradientSpreadMethod spreadMethod)
 {
     switch (spreadMethod) {

--- a/Source/WebCore/platform/graphics/GraphicsTypes.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.h
@@ -99,29 +99,6 @@ struct DocumentMarkerLineStyle {
     Color color;
 };
 
-// Legacy shadow blur radius is used for canvas, and -webkit-box-shadow.
-// It has different treatment of radii > 8px.
-enum class ShadowRadiusMode : bool {
-    Default,
-    Legacy
-};
-
-struct DropShadow {
-    FloatSize offset;
-    float blurRadius { 0 };
-    Color color;
-    ShadowRadiusMode radiusMode { ShadowRadiusMode::Default };
-
-    bool isVisible() const { return color.isVisible(); }
-    bool isBlurred() const { return isVisible() && blurRadius; }
-    bool hasOutsets() const { return isBlurred() || (isVisible() && !offset.isZero()); }
-};
-
-inline bool operator==(const DropShadow& a, const DropShadow& b)
-{
-    return a.offset == b.offset && a.blurRadius == b.blurRadius && a.color == b.color && a.radiusMode == b.radiusMode;
-}
-
 enum class GradientSpreadMethod : uint8_t {
     Pad,
     Reflect,
@@ -194,7 +171,6 @@ bool parseCompositeAndBlendOperator(const String&, WebCore::CompositeOperator&, 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WebCore::BlendMode);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, WebCore::CompositeOperator);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, CompositeMode);
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const DropShadow&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, GradientSpreadMethod);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, InterpolationQuality);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, LineCap);

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -191,19 +191,17 @@ ShadowBlur::ShadowBlur(const FloatSize& radius, const FloatSize& offset, const C
     updateShadowBlurValues();
 }
 
-ShadowBlur::ShadowBlur(const DropShadow& dropShadow, bool shadowsIgnoreTransforms)
+ShadowBlur::ShadowBlur(const GraphicsDropShadow& dropShadow, bool shadowsIgnoreTransforms)
     : m_color(dropShadow.color)
-    , m_blurRadius(dropShadow.blurRadius, dropShadow.blurRadius)
+    , m_blurRadius(dropShadow.radius, dropShadow.radius)
     , m_offset(dropShadow.offset)
     , m_shadowsIgnoreTransforms(shadowsIgnoreTransforms)
 {
 #if USE(CG)
     // Core Graphics incorrectly renders shadows with radius > 8px (<rdar://problem/8103442>),
     // but we need to preserve this buggy behavior for canvas and -webkit-box-shadow.
-    if (dropShadow.radiusMode == ShadowRadiusMode::Legacy) {
-        float shadowBlur = radiusToLegacyRadius(dropShadow.blurRadius);
-        m_blurRadius = FloatSize(shadowBlur, shadowBlur);
-    }
+    if (dropShadow.radiusMode == ShadowRadiusMode::Legacy)
+        m_blurRadius = { radiusToLegacyRadius(m_blurRadius.width()), radiusToLegacyRadius(m_blurRadius.height()) };
 #endif
     updateShadowBlurValues();
 }

--- a/Source/WebCore/platform/graphics/ShadowBlur.h
+++ b/Source/WebCore/platform/graphics/ShadowBlur.h
@@ -31,6 +31,7 @@
 #include "Color.h"
 #include "FloatRect.h"
 #include "FloatRoundedRect.h"
+#include "GraphicsStyle.h"
 #include <wtf/Function.h>
 #include <wtf/Noncopyable.h>
 
@@ -52,7 +53,7 @@ public:
 
     ShadowBlur();
     ShadowBlur(const FloatSize& radius, const FloatSize& offset, const Color&, bool shadowsIgnoreTransforms = false);
-    ShadowBlur(const DropShadow&, bool shadowsIgnoreTransforms = false);
+    ShadowBlur(const GraphicsDropShadow&, bool shadowsIgnoreTransforms = false);
 
     void setShadowValues(const FloatSize&, const FloatSize& , const Color&, bool ignoreTransforms = false);
 

--- a/Source/WebCore/platform/graphics/cairo/CairoOperations.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoOperations.h
@@ -138,7 +138,7 @@ void strokeRect(GraphicsContextCairo&, const FloatRect&, float, const StrokeSour
 void strokePath(GraphicsContextCairo&, const Path&, const StrokeSource&, const ShadowState&);
 void clearRect(GraphicsContextCairo&, const FloatRect&);
 
-void drawGlyphs(GraphicsContextCairo&, const FillSource&, const StrokeSource&, const ShadowState&, const FloatPoint&, cairo_scaled_font_t*, double, const Vector<cairo_glyph_t>&, float, TextDrawingModeFlags, float, const FloatSize&, const Color&, FontSmoothingMode);
+void drawGlyphs(GraphicsContextCairo&, const FillSource&, const StrokeSource&, const ShadowState&, const FloatPoint&, cairo_scaled_font_t*, double, const Vector<cairo_glyph_t>&, float, TextDrawingModeFlags, float, std::optional<GraphicsDropShadow>, FontSmoothingMode);
 
 void drawPlatformImage(GraphicsContextCairo&, cairo_surface_t*, const FloatRect&, const FloatRect&, const ImagePaintingOptions&, float, const ShadowState&);
 void drawPattern(GraphicsContextCairo&, cairo_surface_t*, const IntSize&, const FloatRect&, const FloatRect&, const AffineTransform&, const FloatPoint&, const FloatSize&, const ImagePaintingOptions&);

--- a/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairo.cpp
@@ -77,8 +77,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
     auto& state = context.state();
     Cairo::drawGlyphs(*context.platformContext(), Cairo::FillSource(state), Cairo::StrokeSource(state),
         Cairo::ShadowState(state), point, scaledFont, syntheticBoldOffset, cairoGlyphs, xOffset,
-        state.textDrawingMode(), state.strokeThickness(), state.dropShadow().offset, state.dropShadow().color,
-        fontSmoothingMode);
+        state.textDrawingMode(), state.strokeThickness(), state.dropShadow(), fontSmoothingMode);
 }
 
 Path Font::platformPathForGlyph(Glyph glyph) const

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -268,12 +268,12 @@ void GraphicsContextCairo::didUpdateState(GraphicsContextState& state)
         Cairo::State::setStrokeStyle(*this, state.strokeStyle());
 
     // FIXME: m_state should not be changed to flip the shadow offset. This can happen when the shadow is applied to the platform context.
-    if (state.changes().contains(GraphicsContextState::Change::DropShadow)) {
-        if (state.shadowsIgnoreTransforms()) {
+    if (state.changes().contains(GraphicsContextState::Change::Style)) {
+        auto dropShadow = state.dropShadow();
+        if (dropShadow && state.shadowsIgnoreTransforms()) {
             // Meaning that this graphics context is associated with a CanvasRenderingContext
             // We flip the height since CG and HTML5 Canvas have opposite Y axis
-            auto& shadowOffset = state.dropShadow().offset;
-            m_state.m_dropShadow.offset = { shadowOffset.width(), -shadowOffset.height() };
+            m_state.m_style = GraphicsDropShadow({ dropShadow->offset.width(), -dropShadow->offset.height() }, dropShadow->radius, dropShadow->color, dropShadow->radiusMode);
         }
     }
 

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -139,9 +139,10 @@ public:
     // Returns false if there has not been any potential draws since last call.
     // Returns true if there has been potential draws since last call.
     bool consumeHasDrawn();
-protected:
-    virtual void setCGShadow(RenderingMode, const FloatSize& offset, float blur, const Color&, bool shadowsIgnoreTransforms);
 
+protected:
+    virtual void setCGShadow(const GraphicsDropShadow&, bool shadowsIgnoreTransforms);
+    void setCGStyle(const std::optional<GraphicsStyle>&, bool shadowsIgnoreTransforms);
 
 private:
     void convertToDestinationColorSpaceIfNeeded(RetainPtr<CGImageRef>&);

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -361,16 +361,16 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
         }
     };
 
-    bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow.color.isValid() && !shadow.blurRadius && !platformData.isColorBitmapFont() && (!context.shadowsIgnoreTransforms() || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
+    bool hasSimpleShadow = context.textDrawingMode() == TextDrawingMode::Fill && shadow && shadow->color.isValid() && !shadow->radius && !platformData.isColorBitmapFont() && (!context.shadowsIgnoreTransforms() || contextCTM.isIdentityOrTranslationOrFlipped()) && !context.isInTransparencyLayer();
     if (hasSimpleShadow) {
         // Paint simple shadows ourselves instead of relying on CG shadows, to avoid losing subpixel antialiasing.
         context.clearShadow();
         Color fillColor = context.fillColor();
-        Color shadowFillColor = shadow.color.colorWithAlphaMultipliedBy(fillColor.alphaAsFloat());
+        Color shadowFillColor = shadow->color.colorWithAlphaMultipliedBy(fillColor.alphaAsFloat());
         context.setFillColor(shadowFillColor);
-        float shadowTextX = point.x() + shadow.offset.width();
+        float shadowTextX = point.x() + shadow->offset.width();
         // If shadows are ignoring transforms, then we haven't applied the Y coordinate flip yet, so down is negative.
-        float shadowTextY = point.y() + shadow.offset.height() * (context.shadowsIgnoreTransforms() ? -1 : 1);
+        float shadowTextY = point.y() + shadow->offset.height() * (context.shadowsIgnoreTransforms() ? -1 : 1);
         showGlyphsWithAdvances(FloatPoint(shadowTextX, shadowTextY), font, cgContext, glyphs, advances, numGlyphs, textMatrix);
         if (syntheticBoldOffset)
             showGlyphsWithAdvances(FloatPoint(shadowTextX + syntheticBoldOffset, shadowTextY), font, cgContext, glyphs, advances, numGlyphs, textMatrix);
@@ -383,7 +383,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, const G
         showGlyphsWithAdvances(FloatPoint(point.x() + syntheticBoldOffset, point.y()), font, cgContext, glyphs, advances, numGlyphs, textMatrix);
 
     if (hasSimpleShadow)
-        context.setDropShadow(shadow);
+        context.setDropShadow(*shadow);
 
 #if !PLATFORM(IOS_FAMILY)
     if (shouldSmoothFonts != originalShouldUseFontSmoothing)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -144,11 +144,13 @@ OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes() con
 
 std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(const Filter& filter) const
 {
+    ASSERT(m_stdX == m_stdY);
+
     auto offset = filter.resolvedSize({ m_dx, m_dy });
     auto radius = FEGaussianBlur::calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
     auto color = m_shadowColor.colorWithAlpha(m_shadowOpacity);
 
-    return GraphicsDropShadow { offset, radius, color };
+    return GraphicsDropShadow { offset, static_cast<float>(radius.width()), color, ShadowRadiusMode::Default };
 }
 
 std::unique_ptr<FilterEffectApplier> FEDropShadow::createSoftwareApplier() const

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -506,13 +506,13 @@ void CairoOperationRecorder::clearRect(const FloatRect& rect)
 
 void CairoOperationRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned numGlyphs, const FloatPoint& point, FontSmoothingMode fontSmoothing)
 {
-    struct DrawGlyphs final : PaintingOperation, OperationData<Cairo::FillSource, Cairo::StrokeSource, Cairo::ShadowState, FloatPoint, RefPtr<cairo_scaled_font_t>, float, Vector<cairo_glyph_t>, float, TextDrawingModeFlags, float, FloatSize, Color, FontSmoothingMode> {
+    struct DrawGlyphs final : PaintingOperation, OperationData<Cairo::FillSource, Cairo::StrokeSource, Cairo::ShadowState, FloatPoint, RefPtr<cairo_scaled_font_t>, float, Vector<cairo_glyph_t>, float, TextDrawingModeFlags, float, std::optional<GraphicsDropShadow>, FontSmoothingMode> {
         virtual ~DrawGlyphs() = default;
 
         void execute(PaintingOperationReplay& replayer) override
         {
             Cairo::drawGlyphs(contextForReplay(replayer), arg<0>(), arg<1>(), arg<2>(), arg<3>(), arg<4>().get(),
-                arg<5>(), arg<6>(), arg<7>(), arg<8>(), arg<9>(), arg<10>(), arg<11>(), arg<12>());
+                arg<5>(), arg<6>(), arg<7>(), arg<8>(), arg<9>(), arg<10>(), arg<11>());
         }
 
         void dump(TextStream& ts) override
@@ -539,7 +539,7 @@ void CairoOperationRecorder::drawGlyphs(const Font& font, const GlyphBufferGlyph
         Cairo::ShadowState(state), point,
         RefPtr<cairo_scaled_font_t>(font.platformData().scaledFont()),
         font.syntheticBoldOffset(), WTFMove(cairoGlyphs), xOffset, state.textDrawingMode(),
-        state.strokeThickness(), state.dropShadow().offset, state.dropShadow().color, fontSmoothing));
+        state.strokeThickness(), state.dropShadow(), fontSmoothing));
 }
 
 void CairoOperationRecorder::drawDecomposedGlyphs(const Font& font, const DecomposedGlyphs& decomposedGlyphs)

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -276,7 +276,7 @@ void TextDecorationPainter::paintBackgroundDecorations(const RenderStyle& style,
 
             auto shadowX = m_isHorizontal ? shadow->x().value() : shadow->y().value();
             auto shadowY = m_isHorizontal ? shadow->y().value() : -shadow->x().value();
-            m_context.setDropShadow({ FloatSize { shadowX, shadowY - extraOffset }, shadow->radius().value(), shadowColor, ShadowRadiusMode::Default });
+            m_context.setDropShadow({ { shadowX, shadowY - extraOffset }, shadow->radius().value(), shadowColor, ShadowRadiusMode::Default });
             shadow = shadow->next();
         };
         applyShadowIfNeeded();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4189,10 +4189,10 @@ header: <WebCore/GraphicsTypes.h>
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder]  enum class WebCore::ShadowRadiusMode : bool;
 
-header: <WebCore/GraphicsTypes.h>
-[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DropShadow {
+header: <WebCore/GraphicsStyle.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::GraphicsDropShadow {
     WebCore::FloatSize offset;
-    float blurRadius;
+    float radius;
     WebCore::Color color;
     WebCore::ShadowRadiusMode radiusMode;
 };

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -587,7 +587,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
 
     // Draw white frames around the holes.
     // We double the thickness because half of the stroke will be erased when we clear the holes.
-    graphicsContext.setDropShadow({ FloatSize(shadowOffsetX, shadowOffsetY), shadowBlurRadius, shadowColor, ShadowRadiusMode::Default });
+    graphicsContext.setDropShadow({ { shadowOffsetX, shadowOffsetY }, shadowBlurRadius, shadowColor, ShadowRadiusMode::Default });
     graphicsContext.setStrokeColor(Color::white);
     graphicsContext.setStrokeThickness(borderWidth * 2);
     for (auto& path : whiteFramePaths)

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -287,7 +287,7 @@ void WebFoundTextRangeController::drawRect(WebCore::PageOverlay&, WebCore::Graph
 
     WebCore::GraphicsContextStateSaver stateSaver(graphicsContext);
 
-    graphicsContext.setDropShadow({ WebCore::FloatSize(shadowOffsetX, shadowOffsetY), shadowBlurRadius, shadowColor, ShadowRadiusMode::Default });
+    graphicsContext.setDropShadow({ { shadowOffsetX, shadowOffsetY }, shadowBlurRadius, shadowColor, ShadowRadiusMode::Default });
     graphicsContext.setStrokeColor(foundColor);
     graphicsContext.setStrokeThickness(indicatorBorderWidth * 2);
     for (auto& path : foundFramePaths)


### PR DESCRIPTION
#### 6ee1cc81447684fde576e18b46ca2735dacd3db3
<pre>
Merge GraphicsContextState::m_dropShadow with ::m_style
<a href="https://bugs.webkit.org/show_bug.cgi?id=258630">https://bugs.webkit.org/show_bug.cgi?id=258630</a>
rdar://111461930

Reviewed by Simon Fraser.

This reduced the size of GraphicsContextState from 360 bytes to 328 (~8.8% reduction).

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::applyShadow):
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/platform/DictationCaretAnimator.cpp:
(WebCore::DictationCaretAnimator::fillCaretTail const):
(WebCore::DictationCaretAnimator::paint const):
* Source/WebCore/platform/graphics/DrawGlyphsRecorder.h:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::clearShadow): Only clear shadows if the style within the state is a drop shadow style.
(WebCore::GraphicsContext::hasVisibleShadow const):
(WebCore::GraphicsContext::hasBlurredShadow const):
(WebCore::GraphicsContext::hasShadow const):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::dropShadow const):
(WebCore::GraphicsContext::setDropShadow):
(WebCore::GraphicsContext::shadowOffset const): Deleted.
(WebCore::GraphicsContext::shadowBlur const): Deleted.
(WebCore::GraphicsContext::shadowColor const): Deleted.
(WebCore::GraphicsContext::clearShadow): Deleted.
(WebCore::GraphicsContext::hasVisibleShadow const): Deleted.
(WebCore::GraphicsContext::hasBlurredShadow const): Deleted.
(WebCore::GraphicsContext::hasShadow const): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextState.cpp:
(WebCore::GraphicsContextState::dropShadow const):
(WebCore::GraphicsContextState::mergeLastChanges):
(WebCore::GraphicsContextState::mergeAllChanges):
(WebCore::stateChangeName):
(WebCore::GraphicsContextState::dump const):
* Source/WebCore/platform/graphics/GraphicsContextState.h:
(WebCore::GraphicsContextState::encode const):
(WebCore::GraphicsContextState::decode):
(WebCore::GraphicsContextState::dropShadow const): Deleted.
(WebCore::GraphicsContextState::setDropShadow): Deleted.
* Source/WebCore/platform/graphics/GraphicsStyle.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/GraphicsStyle.h:
(WebCore::GraphicsDropShadow::isVisible const):
(WebCore::GraphicsDropShadow::isBlurred const):
(WebCore::GraphicsDropShadow::hasOutsets const):
(WebCore::GraphicsDropShadow::decode):
* Source/WebCore/platform/graphics/GraphicsTypes.cpp:
* Source/WebCore/platform/graphics/GraphicsTypes.h:
(WebCore::DropShadow::isVisible const): Deleted.
(WebCore::DropShadow::isBlurred const): Deleted.
(WebCore::DropShadow::hasOutsets const): Deleted.
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::ShadowBlur):
* Source/WebCore/platform/graphics/ShadowBlur.h:
* Source/WebCore/platform/graphics/cairo/CairoOperations.cpp:
(WebCore::Cairo::drawGlyphsShadow):
(WebCore::Cairo::ShadowState::ShadowState):
(WebCore::Cairo::drawGlyphs):
* Source/WebCore/platform/graphics/cairo/CairoOperations.h:
* Source/WebCore/platform/graphics/cairo/FontCairo.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp:
(WebCore::GraphicsContextCairo::didUpdateState):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::fillRect):
(WebCore::GraphicsContextCG::fillRoundedRectImpl):
(WebCore::GraphicsContextCG::fillRectWithRoundedHole):
(WebCore::GraphicsContextCG::setCGShadow): Set shadow using CGStyle API if available.
(WebCore::GraphicsContextCG::clearCGShadow): Clear shadow using CGStyle API if available.
(WebCore::GraphicsContextCG::setCGStyle):
(WebCore::GraphicsContextCG::didUpdateState):
(WebCore::setCGStyle): Deleted.
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::populateInternalContext):
(WebCore::DrawGlyphsRecorder::updateShadow):
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::createGraphicsStyle const):
* Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp:
(Nicosia::CairoOperationRecorder::drawGlyphs):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::TextDecorationPainter::paintBackgroundDecorations):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::drawRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::drawRect):

Canonical link: <a href="https://commits.webkit.org/266544@main">https://commits.webkit.org/266544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/764b7e278bb90d581e3496c4003d2135853e80b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13351 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16532 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19723 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16070 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11272 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12683 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3412 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13246 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->