### PR TITLE
Regression(265678@main) Unable to send a MessagePort to an AudioWorklet

### DIFF
--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https-expected.txt
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS # AUDIT TASK RUNNER STARTED.
+PASS Executing "Test postMessage of MessagePort from AudioWorkletNode to AudioWorkletProcessor"
+PASS Audit report
+PASS > [Test postMessage of MessagePort from AudioWorkletNode to AudioWorkletProcessor]
+PASS   audio worklet was created is equal to created.
+PASS   audio worklet received the MessagePort is equal to port-received.
+PASS < [Test postMessage of MessagePort from AudioWorkletNode to AudioWorkletProcessor] All assertions passed. (total 2 assertions)
+PASS # AUDIT TASK RUNNER FINISHED: 1 tasks ran successfully.
+

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https.html
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>
+    Test passing a MessagePort to an AudioWorklet
+  </title>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+   <script src="/webaudio/resources/audit.js"></script>
+ </head>
+ <body>
+   <script id="layout-test-code">
+     let audit = Audit.createTaskRunner();
+
+     let context = new AudioContext();
+     let module = null;
+
+     let filePath = 'processors/message-port-processor.js';
+
+     audit.define(
+         'Test postMessage of MessagePort from AudioWorkletNode to AudioWorkletProcessor',
+         (task, should) => {
+           let workletNode = new AudioWorkletNode(context, 'message-port-processor');
+
+           workletNode.port.onmessage = (event) => {
+             let data = event.data;
+             should(data.state, 'audio worklet was created').beEqualTo('created');
+             // Send a MessagePort back to the worklet.
+             channel = new MessageChannel();
+             channel.port1.onmessage = (event) => {
+               should(event.data.state, 'audio worklet received the MessagePort').beEqualTo('port-received');
+               task.done();
+             };
+             workletNode.port.postMessage({ port: channel.port2 }, [channel.port2]);
+           };
+
+           workletNode.port.onmessageerror = (event) => {
+             should(false, 'Got messageerror from worklet').beTrue();
+             task.done();
+           };
+         });
+
+       context.audioWorklet.addModule(filePath).then(() => {
+         audit.run();
+       });
+   </script>
+ </body>
+</html>

--- a/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/message-port-processor.js
+++ b/LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/message-port-processor.js
@@ -1,0 +1,32 @@
+/**
+ * @class MessagePortProcessor
+ * @extends AudioWorkletProcessor
+ *
+ * This processor class demonstrates passing a MessagePort to audio worklets.
+ */
+class MessagePortProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.port.onmessage = this.handleMessage.bind(this);
+    this.port.onmessageerror = this.handleMessageError.bind(this);
+    this.port.postMessage({state: 'created'});
+  }
+
+  handleMessage(event) {
+    event.data.port.postMessage({
+      state: 'port-received',
+    });
+  }
+
+  handleMessageError(event) {
+    this.port.postMessage({
+      state: 'received messageerror'
+    });
+  }
+
+  process() {
+    return true;
+  }
+}
+
+registerProcessor('message-port-processor', MessagePortProcessor);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -283,12 +283,12 @@ static bool isTypeExposedToGlobalObject(JSC::JSGlobalObject& globalObject, Seria
     case ResizableArrayBufferTag:
     case ErrorInstanceTag:
     case ErrorTag:
+    case MessagePortReferenceTag:
         return true;
     case FileTag:
     case FileListTag:
     case ImageDataTag:
     case BlobTag:
-    case MessagePortReferenceTag:
 #if ENABLE(WEB_CRYPTO)
     case CryptoKeyTag:
 #endif


### PR DESCRIPTION
#### 2511c07012f55458e14773bb204fe4f87f1dc081
<pre>
Regression(265678@main) Unable to send a MessagePort to an AudioWorklet
<a href="https://bugs.webkit.org/show_bug.cgi?id=259383">https://bugs.webkit.org/show_bug.cgi?id=259383</a>
rdar://112624534

Reviewed by Dean Jackson.

In 265678@main, we started validating types being sent via postMessage() to
AudioWorklets, to make sure that these types are actually supposed to be
exposed to AudioWorklet contexts.

Unfortunately, the allow-list was missing the MessagePort type, which is
supposed to be exposed to AudioWorklets. As a result, we were no longer able
to send MessagePorts to AudioWorklets.

This broke the following experiment:
- <a href="https://artsandculture.google.com/experiment/viola-the-bird/nAEJVwNkp-FnrQ">https://artsandculture.google.com/experiment/viola-the-bird/nAEJVwNkp-FnrQ</a>

* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https-expected.txt: Added.
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/audioworklet-postmessage-message-port.https.html: Added.
* LayoutTests/http/wpt/webaudio/the-audio-api/the-audioworklet-interface/processors/message-port-processor.js: Added.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::isTypeExposedToGlobalObject):

Canonical link: <a href="https://commits.webkit.org/266197@main">https://commits.webkit.org/266197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4b5326bd3af42d216eca94b02f4afdab773599a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12554 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15467 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11898 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12386 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12065 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12553 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3228 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->