### PR TITLE
[WTF] Shrink sizeof(JSON::Value)

### DIFF
--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -56,20 +56,21 @@ class WTF_EXPORT_PRIVATE Value : public RefCounted<Value> {
 public:
     static constexpr int maxDepth = 1000;
 
-    virtual ~Value()
+    void operator delete(Value*, std::destroying_delete_t);
+
+    ~Value()
     {
         switch (m_type) {
         case Type::Null:
         case Type::Boolean:
         case Type::Double:
         case Type::Integer:
+        case Type::Object:
+        case Type::Array:
             break;
         case Type::String:
             if (m_value.string)
                 m_value.string->deref();
-            break;
-        case Type::Object:
-        case Type::Array:
             break;
         }
     }
@@ -100,23 +101,23 @@ public:
     std::optional<double> asDouble() const;
     String asString() const;
     RefPtr<Value> asValue();
-    virtual RefPtr<Object> asObject();
-    virtual RefPtr<const Object> asObject() const;
-    virtual RefPtr<Array> asArray();
+    RefPtr<Object> asObject();
+    RefPtr<const Object> asObject() const;
+    RefPtr<Array> asArray();
 
     static RefPtr<Value> parseJSON(StringView);
 
     String toJSONString() const;
-    virtual void writeJSON(StringBuilder& output) const;
 
     void dump(PrintStream&) const;
-
-    virtual size_t memoryCost() const;
 
     // FIXME: <http://webkit.org/b/179847> remove these functions when legacy InspectorObject symbols are no longer needed.
     bool asDouble(double&) const;
     bool asInteger(int&) const;
     bool asString(String&) const;
+
+    size_t memoryCost() const;
+    void writeJSON(StringBuilder& output) const;
 
 protected:
     Value()
@@ -155,6 +156,11 @@ protected:
             m_value.string->ref();
     }
 
+    template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&);
+    template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&) const;
+    size_t memoryCostImpl() const;
+    void writeJSONImpl(StringBuilder& output) const;
+
 private:
     Type m_type { Type::Null };
     union {
@@ -174,13 +180,8 @@ public:
     using iterator = DataStorage::iterator;
     using const_iterator = DataStorage::const_iterator;
 
-    WTF_EXPORT_PRIVATE RefPtr<Object> asObject() final;
-    WTF_EXPORT_PRIVATE RefPtr<const Object> asObject() const final;
-
-    WTF_EXPORT_PRIVATE size_t memoryCost() const final;
-
 protected:
-    ~ObjectBase() override;
+    ~ObjectBase();
 
     // FIXME: use templates to reduce the amount of duplicated set*() methods.
     void setBoolean(const String& name, bool);
@@ -204,8 +205,6 @@ protected:
 
     WTF_EXPORT_PRIVATE void remove(const String& name);
 
-    void writeJSON(StringBuilder& output) const final;
-
     iterator begin() { return m_map.begin(); }
     iterator end() { return m_map.end(); }
     const_iterator begin() const { return m_map.begin(); }
@@ -224,6 +223,9 @@ protected:
     ObjectBase();
 
 private:
+    size_t memoryCostImpl() const;
+    void writeJSONImpl(StringBuilder& output) const;
+
     DataStorage m_map;
     OrderStorage m_order;
 };
@@ -272,12 +274,8 @@ public:
 
     Ref<Value> get(size_t index) const;
 
-    size_t memoryCost() const final;
-
-    RefPtr<Array> asArray() final;
-
 protected:
-    ~ArrayBase() override;
+    ~ArrayBase();
 
     void pushBoolean(bool);
     void pushInteger(int);
@@ -291,12 +289,14 @@ protected:
     iterator end() { return m_map.end(); }
     const_iterator begin() const { return m_map.begin(); }
     const_iterator end() const { return m_map.end(); }
-    void writeJSON(StringBuilder& output) const final;
 
 protected:
     ArrayBase();
 
 private:
+    size_t memoryCostImpl() const;
+    void writeJSONImpl(StringBuilder& output) const;
+
     DataStorage m_map;
 };
 
@@ -466,6 +466,66 @@ public:
     using ArrayBase::begin;
     using ArrayBase::end;
 };
+
+
+inline RefPtr<Value> Value::asValue()
+{
+    return this;
+}
+
+inline RefPtr<Object> Value::asObject()
+{
+    switch (m_type) {
+    case Type::Null:
+    case Type::Boolean:
+    case Type::Double:
+    case Type::Integer:
+    case Type::String:
+    case Type::Array:
+        return nullptr;
+    case Type::Object:
+        static_assert(sizeof(Object) == sizeof(ObjectBase));
+        return static_cast<Object*>(this);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+inline RefPtr<const Object> Value::asObject() const
+{
+    switch (m_type) {
+    case Type::Null:
+    case Type::Boolean:
+    case Type::Double:
+    case Type::Integer:
+    case Type::String:
+    case Type::Array:
+        return nullptr;
+    case Type::Object:
+        static_assert(sizeof(Object) == sizeof(ObjectBase));
+        return static_cast<const Object*>(this);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+inline RefPtr<Array> Value::asArray()
+{
+    switch (m_type) {
+    case Type::Null:
+    case Type::Boolean:
+    case Type::Double:
+    case Type::Integer:
+    case Type::Object:
+    case Type::String:
+        return nullptr;
+    case Type::Array:
+        static_assert(sizeof(ArrayBase) == sizeof(Array));
+        return static_cast<Array*>(this);
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+    return nullptr;
+}
 
 } // namespace JSONImpl
 

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -671,28 +671,28 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::null();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 16U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(true);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 16U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1.0);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 16U);
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(1);
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 16U);
     }
 
     {
@@ -700,9 +700,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 44U);
+        EXPECT_LE(memoryCost, 52U);
 #else
-        EXPECT_LE(memoryCost, 36U);
+        EXPECT_LE(memoryCost, 44U);
 #endif
     }
 
@@ -711,9 +711,9 @@ TEST(JSONValue, MemoryCost)
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
 #if HAVE(36BIT_ADDRESS)
-        EXPECT_LE(memoryCost, 40U);
+        EXPECT_LE(memoryCost, 48U);
 #else
-        EXPECT_LE(memoryCost, 32U);
+        EXPECT_LE(memoryCost, 40U);
 #endif
     }
 
@@ -721,7 +721,7 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::create(String());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 16U);
     }
 
     {
@@ -745,14 +745,14 @@ TEST(JSONValue, MemoryCost)
         value->setValue("test"_s, JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 20U);
+        EXPECT_LE(memoryCost, 60U);
     }
 
     {
         Ref<JSON::Object> value = JSON::Object::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 40U);
     }
 
     {
@@ -780,14 +780,14 @@ TEST(JSONValue, MemoryCost)
         value->pushValue(JSON::Value::null());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 16U);
+        EXPECT_LE(memoryCost, 48U);
     }
 
     {
         Ref<JSON::Array> value = JSON::Array::create();
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-        EXPECT_LE(memoryCost, 8U);
+        EXPECT_LE(memoryCost, 32U);
     }
 
     {


### PR DESCRIPTION
#### 1e2385d6ab1270307f31561a7f9ff2343f7b09a9
<pre>
[WTF] Shrink sizeof(JSON::Value)
<a href="https://bugs.webkit.org/show_bug.cgi?id=259384">https://bugs.webkit.org/show_bug.cgi?id=259384</a>
rdar://112637340

Reviewed by Devin Rousso and Darin Adler.

It makes sizeof(JSON::Value) optimized, and wipe all virtual functions for that.
We would like to use this class more widely, for easy-to-use JSON without any JSC contexts.
One target is many toolings, and for example, JSC bytecode profiler is now using this.

* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::visitDerived):
(WTF::JSONImpl::Value::visitDerived const):
(WTF::JSONImpl::Value::operator delete):
(WTF::JSONImpl::Value::asObject):
(WTF::JSONImpl::Value::asObject const):
(WTF::JSONImpl::Value::asArray):
(WTF::JSONImpl::Value::writeJSON const):
(WTF::JSONImpl::Value::writeJSONImpl const):
(WTF::JSONImpl::Value::memoryCost const):
(WTF::JSONImpl::Value::memoryCostImpl const):
(WTF::JSONImpl::ObjectBase::memoryCostImpl const):
(WTF::JSONImpl::ObjectBase::writeJSONImpl const):
(WTF::JSONImpl::ArrayBase::writeJSONImpl const):
(WTF::JSONImpl::ArrayBase::memoryCostImpl const):
(WTF::JSONImpl::ObjectBase::~ObjectBase): Deleted.
(WTF::JSONImpl::ObjectBase::asObject): Deleted.
(WTF::JSONImpl::ObjectBase::asObject const): Deleted.
(WTF::JSONImpl::ObjectBase::memoryCost const): Deleted.
(WTF::JSONImpl::ObjectBase::writeJSON const): Deleted.
(WTF::JSONImpl::ArrayBase::~ArrayBase): Deleted.
(WTF::JSONImpl::ArrayBase::asArray): Deleted.
(WTF::JSONImpl::ArrayBase::writeJSON const): Deleted.
(WTF::JSONImpl::ArrayBase::memoryCost const): Deleted.
* Source/WTF/wtf/JSONValues.h:

Canonical link: <a href="https://commits.webkit.org/266204@main">https://commits.webkit.org/266204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8dfc5615f3ef9619318d4a7cc1439788fdecf104

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15262 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15497 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11913 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15299 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12492 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12569 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13249 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11842 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3483 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16163 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13630 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1497 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12412 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3279 "Passed tests") | 
<!--EWS-Status-Bubble-End-->