### PR TITLE
[WebGL] WebGL contexts drawn into canvas contexts are upside-down when premultipliedAlpha is false

### DIFF
--- a/LayoutTests/fast/canvas/webgl/canvas-drawImage-expected.html
+++ b/LayoutTests/fast/canvas/webgl/canvas-drawImage-expected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="resources/webgl-test.js"></script>
+    <script src="resources/webgl-test-utils.js"></script>
+    <script id="quadFragmentShader" type="x-shader/x-fragment">
+      precision highp float;
+      varying vec2 texCoord;
+
+      void main() {
+          gl_FragColor = vec4(texCoord, 0.5, 1.0);
+      }
+    </script>
+    <script>
+      "use strict";
+
+      var wtu = WebGLTestUtils;
+
+      function runTest(canvas)
+      {
+          const gl = wtu.create3DContext(canvas);
+          const program = wtu.setupProgram(gl,
+                                           [wtu.setupSimpleTextureVertexShader(gl), "quadFragmentShader"],
+                                           ['vPosition', 'texCoord0']);
+          const quadParameters = wtu.setupUnitQuad(gl);
+          wtu.clearAndDrawUnitQuad(gl);
+      }
+
+      function init()
+      {
+          runTest(document.getElementById("canvas0"));
+          runTest(document.getElementById("canvas1"));
+          finishTest();
+      }
+    </script>
+  </head>
+  <body onload="init()">
+    <canvas id="canvas0" width="256" height="256"></canvas>
+    <canvas id="canvas1" width="256" height="256"></canvas>
+  </body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/canvas-drawImage.html
+++ b/LayoutTests/fast/canvas/webgl/canvas-drawImage.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="resources/webgl-test.js"></script>
+    <script src="resources/webgl-test-utils.js"></script>
+    <script id="quadFragmentShader" type="x-shader/x-fragment">
+      precision highp float;
+      varying vec2 texCoord;
+
+      void main() {
+          gl_FragColor = vec4(texCoord, 0.5, 1.0);
+      }
+    </script>
+    <script>
+      "use strict";
+
+      var wtu = WebGLTestUtils;
+
+      function runTest(canvas, premultipliedAlpha)
+      {
+          const canvasGL = document.createElement("canvas");
+          canvasGL.width = 256;
+          canvasGL.height = 256;
+          const gl = wtu.create3DContext(canvasGL, { premultipliedAlpha: premultipliedAlpha });
+
+          const program = wtu.setupProgram(gl,
+                                           [wtu.setupSimpleTextureVertexShader(gl), "quadFragmentShader"],
+                                           ['vPosition', 'texCoord0']);
+          const quadParameters = wtu.setupUnitQuad(gl);
+          wtu.clearAndDrawUnitQuad(gl);
+
+          const context2D = canvas.getContext('2d');
+          /* 2D canvas is rendered upside-down if premultipliedAlpha is set to
+           * false above */
+          context2D.drawImage(canvasGL, 0, 0);
+      }
+
+      function init()
+      {
+          runTest(document.getElementById("canvas0"), true);
+          runTest(document.getElementById("canvas1"), false);
+          finishTest();
+      }
+    </script>
+  </head>
+  <body onload="init()">
+    <canvas id="canvas0" width="256" height="256"></canvas>
+    <canvas id="canvas1" width="256" height="256"></canvas>
+  </body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/canvas-getImageData-expected.html
+++ b/LayoutTests/fast/canvas/webgl/canvas-getImageData-expected.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="resources/webgl-test.js"></script>
+    <script src="resources/webgl-test-utils.js"></script>
+    <script id="quadFragmentShader" type="x-shader/x-fragment">
+      precision highp float;
+      varying vec2 texCoord;
+
+      void main() {
+          gl_FragColor = vec4(texCoord, 0.5, 1.0);
+      }
+    </script>
+    <script>
+      "use strict";
+
+      var wtu = WebGLTestUtils;
+
+      function runTest(canvas)
+      {
+          const gl = wtu.create3DContext(canvas);
+          const program = wtu.setupSimpleTextureProgram(gl);
+          const samplerLoc = gl.getUniformLocation(program, "tex");
+          const buffers = wtu.setupUnitQuad(gl);
+          const tex = gl.createTexture();
+          gl.bindTexture(gl.TEXTURE_2D, tex);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+          const pixels = new Uint8Array(256*256*4);
+          for (var y = 0; y < 256; y++)
+              for (var x = 0; x < 256; x++)
+                  pixels.set([x, y, 127, 255], 4 * (256 * y + x));
+
+          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 256, 0, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+          gl.uniform1i(samplerLoc, 0);
+          wtu.clearAndDrawUnitQuad(gl);
+      }
+
+      function init()
+      {
+          runTest(document.getElementById("canvas0"));
+          runTest(document.getElementById("canvas1"));
+          finishTest();
+      }
+    </script>
+  </head>
+  <body onload="init()">
+    <canvas id="canvas0" width="256" height="256"></canvas>
+    <canvas id="canvas1" width="256" height="256"></canvas>
+  </body>
+</html>

--- a/LayoutTests/fast/canvas/webgl/canvas-getImageData.html
+++ b/LayoutTests/fast/canvas/webgl/canvas-getImageData.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="resources/webgl-test.js"></script>
+    <script src="resources/webgl-test-utils.js"></script>
+    <script id="quadFragmentShader" type="x-shader/x-fragment">
+      precision highp float;
+      varying vec2 texCoord;
+
+      void main() {
+          gl_FragColor = vec4(texCoord, 0.5, 1.0);
+      }
+    </script>
+    <script>
+      "use strict";
+
+      var wtu = WebGLTestUtils;
+
+      function drawCanvasAsTexture(dest, source)
+      {
+          const gl = wtu.create3DContext(dest);
+          const program = wtu.setupSimpleTextureProgram(gl);
+          const samplerLoc = gl.getUniformLocation(program, "tex");
+          const buffers = wtu.setupUnitQuad(gl);
+          const tex = gl.createTexture();
+          gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+          gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+          gl.bindTexture(gl.TEXTURE_2D, tex);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+          gl.uniform1i(samplerLoc, 0);
+          wtu.clearAndDrawUnitQuad(gl);
+      }
+
+      function runTest(canvas, premultipliedAlpha)
+      {
+          const canvasGL = document.createElement("canvas");
+          canvasGL.width = 256;
+          canvasGL.height = 256;
+          const gl = wtu.create3DContext(canvasGL, { premultipliedAlpha: premultipliedAlpha });
+
+          const program = wtu.setupProgram(gl,
+                                           [wtu.setupSimpleTextureVertexShader(gl), "quadFragmentShader"],
+                                           ['vPosition', 'texCoord0']);
+          const quadParameters = wtu.setupUnitQuad(gl);
+          wtu.clearAndDrawUnitQuad(gl);
+
+          drawCanvasAsTexture(canvas, canvasGL);
+      }
+
+      function init()
+      {
+          runTest(document.getElementById("canvas0"), true);
+          runTest(document.getElementById("canvas1"), false);
+          finishTest();
+      }
+    </script>
+  </head>
+  <body onload="init()">
+    <canvas id="canvas0" width="256" height="256"></canvas>
+    <canvas id="canvas1" width="256" height="256"></canvas>
+  </body>
+</html>

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -791,7 +791,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
     if (document().settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logCanvasRead(document());
 
-    auto pixelBuffer = downcast<WebGLRenderingContextBase>(*m_context).paintRenderingResultsToPixelBuffer();
+    auto pixelBuffer = downcast<WebGLRenderingContextBase>(*m_context).paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY::Yes);
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return nullptr;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1123,12 +1123,12 @@ void WebGLRenderingContextBase::paintRenderingResultsToCanvas()
     }
 }
 
-RefPtr<PixelBuffer> WebGLRenderingContextBase::paintRenderingResultsToPixelBuffer()
+RefPtr<PixelBuffer> WebGLRenderingContextBase::paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY flipY)
 {
     if (isContextLost())
         return nullptr;
     clearIfComposited(CallerTypeOther);
-    return m_context->paintRenderingResultsToPixelBuffer();
+    return m_context->paintRenderingResultsToPixelBuffer(flipY);
 }
 
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -440,7 +440,7 @@ public:
 
     void prepareForDisplayWithPaint() final;
     void paintRenderingResultsToCanvas() final;
-    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer();
+    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(GraphicsContextGL::FlipY);
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<VideoFrame> paintCompositedResultsToVideoFrame();
 #endif

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1603,7 +1603,7 @@ public:
     // display buffer abstractions that the caller should hold separate to
     // the context.
     virtual void paintRenderingResultsToCanvas(ImageBuffer&) = 0;
-    virtual RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer() = 0;
+    virtual RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(FlipY) = 0;
     virtual void paintCompositedResultsToCanvas(ImageBuffer&) = 0;
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     virtual RefPtr<VideoFrame> paintCompositedResultsToVideoFrame() = 0;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3230,13 +3230,13 @@ void GraphicsContextGLANGLE::withDisplayBufferAsNativeImage(Function<void(Native
     func(*displayImage);
 }
 
-RefPtr<PixelBuffer> GraphicsContextGLANGLE::paintRenderingResultsToPixelBuffer()
+RefPtr<PixelBuffer> GraphicsContextGLANGLE::paintRenderingResultsToPixelBuffer(FlipY flipY)
 {
     // Reading premultiplied alpha would involve unpremultiplying, which is lossy.
     if (contextAttributes().premultipliedAlpha)
         return nullptr;
     auto results = readRenderingResultsForPainting();
-    if (results && !results->size().isEmpty()) {
+    if (flipY == FlipY::Yes && results && !results->size().isEmpty()) {
         ASSERT(results->format().pixelFormat == PixelFormat::RGBA8 || results->format().pixelFormat == PixelFormat::BGRA8);
         // FIXME: Make PixelBufferConversions support negative rowBytes and in-place conversions.
         const auto size = results->size();

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -345,7 +345,7 @@ public:
     void deleteTexture(PlatformGLObject) final;
     void simulateEventForTesting(SimulatedEventForTesting) override;
     void paintRenderingResultsToCanvas(ImageBuffer&) override;
-    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer() override;
+    RefPtr<PixelBuffer> paintRenderingResultsToPixelBuffer(FlipY) override;
     void paintCompositedResultsToCanvas(ImageBuffer&) override;
 
     RefPtr<PixelBuffer> readRenderingResultsForPainting();

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -964,7 +964,7 @@ void GraphicsContextGLCocoa::withDrawingBufferAsNativeImage(Function<void(Native
         // that does the conversion.
         //
         // FIXME: Can the IOSurface be read into a buffer to avoid the read back via GL?
-        auto drawingPixelBuffer = paintRenderingResultsToPixelBuffer();
+        auto drawingPixelBuffer = paintRenderingResultsToPixelBuffer(FlipY::No);
         if (!drawingPixelBuffer)
             return;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -327,7 +327,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void BlitFramebufferANGLE(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (IPC::ArrayReference<int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
-    void PaintRenderingResultsToPixelBuffer() -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
+    void PaintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0) -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
     void DestroyEGLSync(uint64_t arg0) -> (bool returnValue) Synchronous
     void ClientWaitEGLSyncWithFlush(uint64_t arg0, uint64_t timeout)
     void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1482,11 +1482,11 @@
         assertIsCurrent(workQueue());
         m_context->setDrawingBufferColorSpace(arg0);
     }
-    void paintRenderingResultsToPixelBuffer(CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
+    void paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY&& arg0, CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
     {
         RefPtr<WebCore::PixelBuffer> returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->paintRenderingResultsToPixelBuffer();
+        returnValue = m_context->paintRenderingResultsToPixelBuffer(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void destroyEGLSync(uint64_t arg0, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -365,7 +365,7 @@ public:
     void blitFramebufferANGLE(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter) final;
     void getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, std::span<GCGLint> params) final;
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
-    RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer() final;
+    RefPtr<WebCore::PixelBuffer> paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY) final;
     bool destroyEGLSync(GCEGLSync) final;
     void clientWaitEGLSyncWithFlush(GCEGLSync, uint64_t timeout) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3060,11 +3060,11 @@ void RemoteGraphicsContextGLProxy::setDrawingBufferColorSpace(const WebCore::Des
     }
 }
 
-RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer()
+RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer(WebCore::GraphicsContextGL::FlipY arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer());
+    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::PaintRenderingResultsToPixelBuffer(arg0));
     if (!sendResult.succeeded()) {
         markContextLost();
         return { };


### PR DESCRIPTION
#### ae8167890120f40300bca996c18227adc4ca1f9a
<pre>
[WebGL] WebGL contexts drawn into canvas contexts are upside-down when premultipliedAlpha is false
<a href="https://bugs.webkit.org/show_bug.cgi?id=259306">https://bugs.webkit.org/show_bug.cgi?id=259306</a>
rdar://112472666

Reviewed by Mike Wyrzykowski and Dean Jackson.

After the changes in 262518@main, the drawing buffer no longer needs to be
flipped before creating a native image to be used by drawImage.

GraphicsContextGL::paintRenderingResultsToPixelBuffer has been updated to take a
boolean specifying whether the image should be flipped when returning the
PixelBuffer. This is because the HTMLCanvasElement::getImageData() function,
used when using a canvas as a source to gl.texImage2D(), still requires the data
to be flipped.

Added new tests that exercise both code paths to catch any future regressions.

* LayoutTests/fast/canvas/webgl/canvas-drawImage-expected.html: Added.
* LayoutTests/fast/canvas/webgl/canvas-drawImage.html: Added.
* LayoutTests/fast/canvas/webgl/canvas-getImageData-expected.html: Added.
* LayoutTests/fast/canvas/webgl/canvas-getImageData.html: Added.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::paintRenderingResultsToPixelBuffer):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::paintRenderingResultsToPixelBuffer):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::withDrawingBufferAsNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(paintRenderingResultsToPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::paintRenderingResultsToPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/266225@main">https://commits.webkit.org/266225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cb122fc41e25dcc9b2db0cd7f7974928d82147e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15320 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15626 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19028 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12137 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15354 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11909 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3237 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->