### PR TITLE
UpdateScrollInfoAfterLayoutTransaction should belong to LocalFrameViewLayoutContext

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -52,6 +52,9 @@
 
 namespace WebCore {
 
+UpdateScrollInfoAfterLayoutTransaction::UpdateScrollInfoAfterLayoutTransaction() = default;
+UpdateScrollInfoAfterLayoutTransaction::~UpdateScrollInfoAfterLayoutTransaction() = default;
+
 void LocalFrameViewLayoutContext::layoutUsingFormattingContext()
 {
     if (!frame().settings().layoutFormattingContextEnabled())
@@ -162,6 +165,13 @@ LocalFrameViewLayoutContext::LocalFrameViewLayoutContext(LocalFrameView& frameVi
 
 LocalFrameViewLayoutContext::~LocalFrameViewLayoutContext()
 {
+}
+
+UpdateScrollInfoAfterLayoutTransaction& LocalFrameViewLayoutContext::updateScrollInfoAfterLayoutTransaction()
+{
+    if (!m_updateScrollInfoAfterLayoutTransaction)
+        m_updateScrollInfoAfterLayoutTransaction = makeUnique<UpdateScrollInfoAfterLayoutTransaction>();
+    return *m_updateScrollInfoAfterLayoutTransaction;
 }
 
 void LocalFrameViewLayoutContext::layout()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -27,6 +27,7 @@
 
 #include "LayoutUnit.h"
 #include "Timer.h"
+#include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -36,6 +37,7 @@ class LayoutScope;
 class LayoutSize;
 class LocalFrame;
 class LocalFrameView;
+class RenderBlock;
 class RenderBlockFlow;
 class RenderBox;
 class RenderObject;
@@ -46,6 +48,16 @@ namespace Layout {
 class LayoutState;
 class LayoutTree;
 }
+
+struct UpdateScrollInfoAfterLayoutTransaction {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    UpdateScrollInfoAfterLayoutTransaction();
+    ~UpdateScrollInfoAfterLayoutTransaction();
+
+    int nestedCount { 0 };
+    WeakHashSet<RenderBlock> blocks;
+};
 
 class LocalFrameViewLayoutContext {
 public:
@@ -113,6 +125,9 @@ public:
 
     const Layout::LayoutState* layoutFormattingState() const { return m_layoutState.get(); }
 
+    UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction();
+    UpdateScrollInfoAfterLayoutTransaction* updateScrollInfoAfterLayoutTransactionIfExists() { return m_updateScrollInfoAfterLayoutTransaction.get(); }
+
 private:
     friend class LayoutScope;
     friend class LayoutStateMaintainer;
@@ -176,6 +191,7 @@ private:
     LayoutStateStack m_layoutStateStack;
     std::unique_ptr<Layout::LayoutTree> m_layoutTree;
     std::unique_ptr<Layout::LayoutState> m_layoutState;
+    std::unique_ptr<UpdateScrollInfoAfterLayoutTransaction> m_updateScrollInfoAfterLayoutTransaction;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 74de0d0c4a6bf50151e9d37731d2e8686ae63b2c
<pre>
UpdateScrollInfoAfterLayoutTransaction should belong to LocalFrameViewLayoutContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=259387">https://bugs.webkit.org/show_bug.cgi?id=259387</a>

Reviewed by Alan Baradlay.

This patch makes UpdateScrollInfoAfterLayoutTransaction a member variable of LocalFrameViewLayoutContext
instead of belonging to a Vector&lt;UpdateScrollInfoAfterLayoutTransaction&gt; in a NeverDestroyed unique_ptr
for simplicity &amp; clarify.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::updateScrollInfoAfterLayoutTransaction):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
(WebCore::LocalFrameViewLayoutContext::updateScrollInfoAfterLayoutTransactionIfExists):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::UpdateScrollInfoAfterLayoutTransaction::UpdateScrollInfoAfterLayoutTransaction): Deleted.
(WebCore::updateScrollInfoAfterLayoutTransactionStack): Deleted.
(WebCore::currentUpdateScrollInfoAfterLayoutTransaction): Deleted.
(WebCore::RenderBlock::beginUpdateScrollInfoAfterLayoutTransaction):
(WebCore::RenderBlock::endAndCommitUpdateScrollInfoAfterLayoutTransaction):
(WebCore::RenderBlock::removeFromUpdateScrollInfoAfterLayoutTransaction):
(WebCore::RenderBlock::updateScrollInfoAfterLayout):
(WebCore::RenderBlock::layout):

Canonical link: <a href="https://commits.webkit.org/266353@main">https://commits.webkit.org/266353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8adacaf4e0412d0e649fddea933346d39218d6e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15268 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15504 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11922 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18974 "98 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15296 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12575 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10444 "2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16169 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1572 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12418 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->