### PR TITLE
[ Monterey+ WK2 ] http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html is a flaky TEXT failure

### DIFF
--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
@@ -86,31 +86,35 @@ onload = () => {
     }, 0);
 }
 
-function validateResult(result)
+function expectedCacheMode(url)
 {
-    if (result.url === "http://localhost:8800/WebKit/service-workers/cache-mode-hard-reload-serviceworker.html")
-        return result.cache === "reload";
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?first-script-static")
-        return result.cache === "reload";
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic")
-        return result.cache === "reload";
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?third-script-async")
-        return result.cache === "reload";
+    if (url === "http://localhost:8800/WebKit/service-workers/cache-mode-hard-reload-serviceworker.html")
+        return "reload";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?first-script-static")
+        return "reload";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?second-script-dynamic")
+        return "reload";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?third-script-async")
+        return "reload";
 
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fourth-script-during-onload")
-        return result.cache === "reload";
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fifth-script-just-after-onload")
-        return result.cache === "reload";
-    if (result.url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async")
-        return result.cache === "reload";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fourth-script-during-onload")
+        return "default";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?fifth-script-just-after-onload")
+        return "default";
+    if (url === "http://localhost:8800/WebKit/service-workers/resources/cache-mode-hard-reload-serviceworker.py?sixth-script-async")
+        return "default";
 
 }
 
 function validateResults(results)
 {
     clearLog();
-    for (let result of results)
-        log((validateResult(result) ? "PASS" : "FAIL") + " : " + JSON.stringify(result));
+    for (let result of results) {
+        if (expectedCacheMode(result.url) === "reload")
+            log((result.cache === "reload" ? "PASS" : "FAIL") + " : " + JSON.stringify(result));
+        else if (result.cache !== "default")
+            log("FAIL : " + JSON.stringify(result));
+    }
 }
 
 </script>


### PR DESCRIPTION
#### 40825ec29338f0099218fbdfd4b78a23ec31afc8
<pre>
[ Monterey+ WK2 ] http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html is a flaky TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259382">https://bugs.webkit.org/show_bug.cgi?id=259382</a>
rdar://112630912

Reviewed by Alex Christensen.

fourth, fifth and sixth script resources were expected to be in the memory cache thus avoiding the service worker since cache mode should be default.
But memory cache may not always kick in in which case the loads will hit service worker.
In that case, it is important to validate that the cache mode is default but we do not log those loads since they might not reliably hit the service worker.

* LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html:

Canonical link: <a href="https://commits.webkit.org/266240@main">https://commits.webkit.org/266240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85426e2672cc882c05fa5ef45a97c3523e8645eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15702 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19082 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15410 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10559 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3245 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->