### PR TITLE
[Win][MiniBrowser] Enable "Download linked file" and "Download Image"

### DIFF
--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -232,15 +232,6 @@ void NetworkDataTaskCurl::curlDidComplete(CurlRequest&, NetworkLoadMetrics&& net
     m_client->didCompleteWithError({ }, WTFMove(networkLoadMetrics));
 }
 
-void NetworkDataTaskCurl::deleteDownloadFile()
-{
-    if (FileSystem::isHandleValid(m_downloadDestinationFile)) {
-        FileSystem::closeFile(m_downloadDestinationFile);
-        FileSystem::deleteFile(m_pendingDownloadLocation);
-        m_downloadDestinationFile = FileSystem::invalidPlatformFileHandle;
-    }
-}
-
 void NetworkDataTaskCurl::curlDidFailWithError(CurlRequest& request, ResourceError&& resourceError, CertificateInfo&& certificateInfo)
 {
     if (state() == State::Canceling || state() == State::Completed || (!m_client && !isDownload()))
@@ -313,7 +304,7 @@ void NetworkDataTaskCurl::invokeDidReceiveResponse()
             invalidateAndCancel();
             break;
         case PolicyAction::Download: {
-            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate);
+            m_downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, !m_allowOverwriteDownload);
             if (!FileSystem::isHandleValid(m_downloadDestinationFile)) {
                 if (m_client)
                     m_client->didCompleteWithError(ResourceError(CURLE_WRITE_ERROR, m_response.url()));
@@ -557,18 +548,6 @@ void NetworkDataTaskCurl::handleCookieHeaders(const WebCore::ResourceRequest& re
     }
 }
 
-String NetworkDataTaskCurl::suggestedFilename() const
-{
-    if (!m_suggestedFilename.isEmpty())
-        return m_suggestedFilename;
-
-    String suggestedFilename = m_response.suggestedFilename();
-    if (!suggestedFilename.isEmpty())
-        return suggestedFilename;
-
-    return PAL::decodeURLEscapeSequences(m_response.url().lastPathComponent());
-}
-
 void NetworkDataTaskCurl::blockCookies()
 {
 #if ENABLE(TRACKING_PREVENTION)
@@ -617,6 +596,33 @@ void NetworkDataTaskCurl::updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics& 
     networkLoadMetrics.redirectCount = m_redirectCount;
     networkLoadMetrics.failsTAOCheck = m_failsTAOCheck;
     networkLoadMetrics.hasCrossOriginRedirect = m_hasCrossOriginRedirect;
+}
+
+void NetworkDataTaskCurl::setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)
+{
+    NetworkDataTask::setPendingDownloadLocation(filename, WTFMove(sandboxExtensionHandle), allowOverwrite);
+    m_allowOverwriteDownload = allowOverwrite;
+}
+
+String NetworkDataTaskCurl::suggestedFilename() const
+{
+    if (!m_suggestedFilename.isEmpty())
+        return m_suggestedFilename;
+
+    String suggestedFilename = m_response.suggestedFilename();
+    if (!suggestedFilename.isEmpty())
+        return suggestedFilename;
+
+    return PAL::decodeURLEscapeSequences(m_response.url().lastPathComponent());
+}
+
+void NetworkDataTaskCurl::deleteDownloadFile()
+{
+    if (FileSystem::isHandleValid(m_downloadDestinationFile)) {
+        FileSystem::closeFile(m_downloadDestinationFile);
+        FileSystem::deleteFile(m_pendingDownloadLocation);
+        m_downloadDestinationFile = FileSystem::invalidPlatformFileHandle;
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h
@@ -83,9 +83,8 @@ private:
 
     void tryHttpAuthentication(WebCore::AuthenticationChallenge&&);
     void tryProxyAuthentication(WebCore::AuthenticationChallenge&&);
-    void restartWithCredential(const WebCore::ProtectionSpace&, const WebCore::Credential&);
-
     void tryServerTrustEvaluation(WebCore::AuthenticationChallenge&&);
+    void restartWithCredential(const WebCore::ProtectionSpace&, const WebCore::Credential&);
 
     void appendCookieHeader(WebCore::ResourceRequest&);
     void handleCookieHeaders(const WebCore::ResourceRequest&, const WebCore::CurlResponse&);
@@ -97,6 +96,7 @@ private:
 
     void updateNetworkLoadMetrics(WebCore::NetworkLoadMetrics&);
 
+    void setPendingDownloadLocation(const String&, SandboxExtension::Handle&&, bool /*allowOverwrite*/) override;
     String suggestedFilename() const override;
     void deleteDownloadFile();
 
@@ -112,6 +112,7 @@ private:
     unsigned m_redirectCount { 0 };
     unsigned m_authFailureCount { 0 };
 
+    bool m_allowOverwriteDownload { false };
     FileSystem::PlatformFileHandle m_downloadDestinationFile { FileSystem::invalidPlatformFileHandle };
 
     bool m_blockingCookies { false };

--- a/Tools/MiniBrowser/win/Common.cpp
+++ b/Tools/MiniBrowser/win/Common.cpp
@@ -78,6 +78,18 @@ bool getAppDataFolder(_bstr_t& directory)
     return true;
 }
 
+bool getKnownFolderPath(REFKNOWNFOLDERID id, std::wstring& knownFolderPath)
+{
+    PWSTR path = nullptr;
+
+    if (FAILED(SHGetKnownFolderPath(id, KF_FLAG_CREATE, 0, &path)))
+        return false;
+
+    knownFolderPath = std::wstring(path);
+    CoTaskMemFree(path);
+    return true;
+}
+
 void createCrashReport(EXCEPTION_POINTERS* exceptionPointers)
 {
     _bstr_t directory;

--- a/Tools/MiniBrowser/win/Common.h
+++ b/Tools/MiniBrowser/win/Common.h
@@ -27,6 +27,7 @@
 
 #include "stdafx.h"
 #include "MainWindow.h"
+#include <knownfolders.h>
 
 struct CommandLineOptions {
     bool usesLayeredWebView { };
@@ -48,6 +49,7 @@ struct ProxySettings {
 
 void computeFullDesktopFrame();
 bool getAppDataFolder(_bstr_t& directory);
+bool getKnownFolderPath(REFKNOWNFOLDERID, std::wstring&);
 CommandLineOptions parseCommandLine();
 void createCrashReport(EXCEPTION_POINTERS*);
 std::optional<Credential> askCredential(HWND, const std::wstring& realm);

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.h
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.h
@@ -77,6 +77,13 @@ private:
     static void decidePolicyForNavigationResponse(WKPageRef, WKNavigationResponseRef, WKFramePolicyListenerRef, WKTypeRef, const void*);
     static void didFailProvisionalNavigation(WKPageRef, WKNavigationRef, WKErrorRef, WKTypeRef, const void*);
     static void didReceiveAuthenticationChallenge(WKPageRef, WKAuthenticationChallengeRef, const void*);
+    static void navigationActionDidBecomeDownload(WKPageRef, WKNavigationActionRef, WKDownloadRef, const void*);
+    static void navigationResponseDidBecomeDownload(WKPageRef, WKNavigationResponseRef, WKDownloadRef, const void*);
+    static void contextMenuDidCreateDownload(WKPageRef, WKDownloadRef, const void*);
+    static void setDownloadClient(WKDownloadRef, const void*);
+    static WKStringRef downloadDecideDestinationWithResponse(WKDownloadRef, WKURLResponseRef, WKStringRef, const void*);
+    static void downloadDidFinish(WKDownloadRef, const void*);
+    static void downloadDidFailWithError(WKDownloadRef, WKErrorRef, WKDataRef, const void*);
     static WKPageRef createNewPage(WKPageRef, WKPageConfigurationRef, WKNavigationActionRef, WKWindowFeaturesRef, const void *);
     static void didNotHandleKeyEvent(WKPageRef, WKNativeEventPtr, const void*);
     static void runJavaScriptAlert(WKPageRef, WKStringRef, WKFrameRef, WKSecurityOriginRef, WKPageRunJavaScriptAlertResultListenerRef, const void *);


### PR DESCRIPTION
#### b98c2d1c85b607d1d7a5836e6948bde2bc9d6294
<pre>
[Win][MiniBrowser] Enable &quot;Download linked file&quot; and &quot;Download Image&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=234887">https://bugs.webkit.org/show_bug.cgi?id=234887</a>

Reviewed by Fujii Hironori.

WinCairo WebKit2 now supports downloading files with 250472@main.
So, we enable &quot;Download linked file&quot; and &quot;Download Image&quot; in MiniBrowser.

* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::invokeDidReceiveResponse):
(WebKit::NetworkDataTaskCurl::setPendingDownloadLocation):
(WebKit::NetworkDataTaskCurl::suggestedFilename const):
(WebKit::NetworkDataTaskCurl::deleteDownloadFile):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.h:
* Tools/MiniBrowser/win/Common.cpp:
(getKnownFolderPath):
* Tools/MiniBrowser/win/Common.h:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::WebKitBrowserWindow):
(WebKitBrowserWindow::navigationActionDidBecomeDownload):
(WebKitBrowserWindow::navigationResponseDidBecomeDownload):
(WebKitBrowserWindow::contextMenuDidCreateDownload):
(WebKitBrowserWindow::setDownloadClient):
(WebKitBrowserWindow::downloadDecideDestinationWithResponse):
(WebKitBrowserWindow::downloadDidFinish):
(WebKitBrowserWindow::downloadDidFailWithError):
* Tools/MiniBrowser/win/WebKitBrowserWindow.h:

Canonical link: <a href="https://commits.webkit.org/266281@main">https://commits.webkit.org/266281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed11fed36361044789546fcf0d4842f8c79133bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15134 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16219 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15433 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15822 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12091 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15472 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12032 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->