### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.22.5

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -15,7 +15,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.22.5.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch
@@ -24,6 +24,8 @@ sources:
   path: patches/fdo-0008-components-Bump-g-i-to-version-1.76.patch
 - kind: patch
   path: patches/fdo-0009-gst-plugins-bad-Enable-x265-encoder.patch
+- kind: patch
+  path: patches/fdo-0001-gst-plugins-base-Vendor-patch-scheduled-for-1.22.6.patch
 config:
   options:
     target_arch: '%{arch}'

--- a/Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patch-scheduled-for-1.22.6.patch
+++ b/Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patch-scheduled-for-1.22.6.patch
@@ -1,0 +1,98 @@
+From 9678858a153749f62b52232617c9d7d4ad6d12ac Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Fri, 21 Jul 2023 09:02:56 +0100
+Subject: [PATCH] gst-plugins-base: Vendor patch scheduled for 1.22.6
+
+---
+ ...-identity-sinkpad-parsebin-leakage-w.patch | 79 +++++++++++++++++++
+ 1 file changed, 79 insertions(+)
+ create mode 100644 patches/gstreamer/0001-decodebin3-avoid-identity-sinkpad-parsebin-leakage-w.patch
+
+diff --git a/patches/gstreamer/0001-decodebin3-avoid-identity-sinkpad-parsebin-leakage-w.patch b/patches/gstreamer/0001-decodebin3-avoid-identity-sinkpad-parsebin-leakage-w.patch
+new file mode 100644
+index 000000000..a5fe5e2fc
+--- /dev/null
++++ b/patches/gstreamer/0001-decodebin3-avoid-identity-sinkpad-parsebin-leakage-w.patch
+@@ -0,0 +1,79 @@
++From 9f67b866b9fd56d97388bed280fe2e336e11c9ba Mon Sep 17 00:00:00 2001
++From: Haihua Hu <jared.hu@nxp.com>
++Date: Thu, 18 May 2023 16:08:03 +0800
++Subject: [PATCH] decodebin3: avoid identity, sinkpad, parsebin leakage when
++ reset input
++
++when reset_input, need remove identity/parsebin from decodebin3
++when release_pad, need call free or reset input if collection
++didn't change
++
++Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/4664>
++---
++ .../gst/playback/gstdecodebin3.c              | 28 ++++---------------
++ 1 file changed, 5 insertions(+), 23 deletions(-)
++
++diff --git a/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c b/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
++index a1a43ab64a..95efdbf924 100644
++--- a/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
+++++ b/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
++@@ -1129,37 +1129,17 @@ gst_decodebin3_release_pad (GstElement * element, GstPad * pad)
++   gst_element_post_message (GST_ELEMENT_CAST (dbin), msg);
++   update_requested_selection (dbin);
++ 
++-  gst_ghost_pad_set_target (GST_GHOST_PAD (input->ghost_sink), NULL);
++   if (input->parsebin) {
++-    gst_bin_remove (GST_BIN (dbin), input->parsebin);
++-    gst_element_set_state (input->parsebin, GST_STATE_NULL);
++-    g_signal_handler_disconnect (input->parsebin, input->pad_removed_sigid);
++-    g_signal_handler_disconnect (input->parsebin, input->pad_added_sigid);
++-    g_signal_handler_disconnect (input->parsebin, input->drained_sigid);
++     gst_pad_remove_probe (input->parsebin_sink, probe_id);
++-    gst_object_unref (input->parsebin);
++-    gst_object_unref (input->parsebin_sink);
++-
++-    input->parsebin = NULL;
++-    input->parsebin_sink = NULL;
++-  }
++-  if (input->identity) {
++-    GstPad *idpad = gst_element_get_static_pad (input->identity, "src");
++-    DecodebinInputStream *stream = find_input_stream_for_pad (dbin, idpad);
++-    gst_object_unref (idpad);
++-    remove_input_stream (dbin, stream);
++-    gst_element_set_state (input->identity, GST_STATE_NULL);
++-    gst_bin_remove (GST_BIN (dbin), input->identity);
++-    gst_object_unref (input->identity);
++-    input->identity = NULL;
++   }
++ 
+++beach:
++   if (!input->is_main) {
++     dbin->other_inputs = g_list_remove (dbin->other_inputs, input);
++     free_input (dbin, input);
++-  }
+++  } else
+++    reset_input (dbin, input);
++ 
++-beach:
++   INPUT_UNLOCK (dbin);
++   return;
++ }
++@@ -1177,6 +1157,7 @@ reset_input (GstDecodebin3 * dbin, DecodebinInput * input)
++     g_signal_handler_disconnect (input->parsebin, input->pad_added_sigid);
++     g_signal_handler_disconnect (input->parsebin, input->drained_sigid);
++     gst_element_set_state (input->parsebin, GST_STATE_NULL);
+++    gst_bin_remove (GST_BIN (dbin), input->parsebin);
++     gst_clear_object (&input->parsebin);
++     gst_clear_object (&input->parsebin_sink);
++   }
++@@ -1186,6 +1167,7 @@ reset_input (GstDecodebin3 * dbin, DecodebinInput * input)
++     gst_object_unref (idpad);
++     remove_input_stream (dbin, stream);
++     gst_element_set_state (input->identity, GST_STATE_NULL);
+++    gst_bin_remove (GST_BIN (dbin), input->identity);
++     gst_clear_object (&input->identity);
++   }
++   if (input->collection)
++-- 
++2.40.1
++
+-- 
+2.41.0
+

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.5.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.5.patch
@@ -49,7 +49,7 @@ index e73a056ab..ee16131c9 100644
    match:
    - 1.*[02468].*
 -  ref: 1.20.6-0-gb7d3037cca2fe72c5b7daab5e0617e61ae013dcc
-+  ref: 1.22.4-0-g064711d8b382c106afffe75cefbabe8f7bac8532
++  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/gst-libav-no-cache-generator.patch b/patches/gstreamer/gst-libav-no-cache-generator.patch


### PR DESCRIPTION
#### d16e5b7eb54ebb2dccd24f48c1d44dac7e8d5620
<pre>
[Buildstream SDK] Bump to GStreamer 1.22.5
<a href="https://bugs.webkit.org/show_bug.cgi?id=259358">https://bugs.webkit.org/show_bug.cgi?id=259358</a>

Reviewed by Carlos Alberto Lopez Perez.

The additional decodebin3 patch is required for fixing bug 254212.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patch-scheduled-for-1.22.6.patch: Added.
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.5.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.4.patch.

Canonical link: <a href="https://commits.webkit.org/266205@main">https://commits.webkit.org/266205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72a74462e03b3b5a7b1b14568626979ed85bc323

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12574 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15505 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11917 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/18973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12084 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15301 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12576 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16170 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1498 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->