### PR TITLE
Web Inspector: Move details sidebar to bottom when narrow

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -515,6 +515,8 @@ localizedStrings["Details"] = "Details";
 localizedStrings["Details @ Sidebar"] = "Details";
 /* Category label for detail sidebar settings. */
 localizedStrings["Details Sidebars: @ Settings Elements Pane"] = "Details Sidebars:";
+/* Category label for detail sidebar settings. */
+localizedStrings["Details Sidebars: @ Settings General Pane"] = "Details Sidebars:";
 localizedStrings["Device %d"] = "Device %d";
 localizedStrings["Device Settings"] = "Device Settings";
 localizedStrings["Diagnoses common accessibility problems affecting screen readers and other assistive technology."] = "Diagnoses common accessibility problems affecting screen readers and other assistive technology.";
@@ -1498,6 +1500,8 @@ localizedStrings["Show hidden tabs\u2026"] = "Show hidden tabs\u2026";
 localizedStrings["Show independent Styles sidebar @ Settings Elements Pane"] = "Show independent Styles sidebar";
 localizedStrings["Show jump to effective property button"] = "Show jump to effective property button";
 localizedStrings["Show jump to variable declaration button"] = "Show jump to variable declaration button";
+/* Settings tab checkbox label for whether the details sidebars (on the right in LTR locales) are at the bottom */
+localizedStrings["Show on bottom when narrow @ Settings General Pane"] = "Show on bottom when narrow";
 localizedStrings["Show page rulers and node border lines"] = "Show page rulers and node border lines";
 localizedStrings["Show property syntax in documentation popover"] = "Show property syntax in documentation popover";
 localizedStrings["Show rulers"] = "Show rulers";

--- a/Source/WebInspectorUI/UserInterface/Base/Main.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Main.js
@@ -48,6 +48,13 @@ WI.LayoutDirection = {
     RTL: "rtl",
 };
 
+WI.LayoutMode = {
+    Default: "default",
+    Narrow: "narrow",
+};
+
+WI.NarrowLayoutMaximumWidth = 700;
+
 WI.loaded = function()
 {
     if (InspectorFrontendHost.connect)
@@ -283,14 +290,16 @@ WI.contentLoaded = function()
     WI.consoleLogViewController = WI.consoleContentView.logViewController;
 
     WI.navigationSidebar = new WI.SingleSidebar(document.getElementById("navigation-sidebar"), WI.Sidebar.Sides.Leading, WI.UIString("Navigation", "Navigation @ Sidebar", "Label for the navigation sidebar."));
-    WI.navigationSidebar.addEventListener(WI.Sidebar.Event.WidthDidChange, WI._sidebarWidthDidChange, WI);
-    WI.navigationSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, WI._sidebarWidthDidChange, WI);
+    WI.navigationSidebar.addEventListener(WI.Sidebar.Event.WidthDidChange, WI._sidebarSizeDidChange, WI);
+    WI.navigationSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, WI._sidebarSizeDidChange, WI);
 
     WI.detailsSidebar = new WI.MultiSidebar(document.getElementById("details-sidebar"), WI.Sidebar.Sides.Trailing, WI.UIString("Details", "Details @ Sidebar", "Label for the details sidebar."));
-    WI.detailsSidebar.addEventListener(WI.Sidebar.Event.WidthDidChange, WI._sidebarWidthDidChange, WI);
-    WI.detailsSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, WI._sidebarWidthDidChange, WI);
-    WI.detailsSidebar.addEventListener(WI.MultiSidebar.Event.MultipleSidebarsVisibleChanged, WI._sidebarWidthDidChange, WI);
-
+    WI.detailsSidebar.addEventListener(WI.Sidebar.Event.WidthDidChange, WI._sidebarSizeDidChange, WI);
+    WI.detailsSidebar.addEventListener(WI.Sidebar.Event.HeightDidChange, WI._sidebarSizeDidChange, WI);
+    WI.detailsSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, WI._sidebarSizeDidChange, WI);
+    WI.detailsSidebar.addEventListener(WI.MultiSidebar.Event.MultipleSidebarsVisibleChanged, WI._sidebarSizeDidChange, WI);
+    WI.detailsSidebar.canMoveToBottom = true;
+    
     WI.searchKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl | WI.KeyboardShortcut.Modifier.Shift, "F", WI._focusSearchField);
     WI._findKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl, "F", WI._find);
     WI.saveKeyboardShortcut = new WI.KeyboardShortcut(WI.KeyboardShortcut.Modifier.CommandOrControl, "S", WI._save);
@@ -560,6 +569,9 @@ WI.contentLoaded = function()
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemAdded, WI._rememberOpenTabs, WI);
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemRemoved, WI._rememberOpenTabs, WI);
     WI.tabBar.addEventListener(WI.TabBar.Event.TabBarItemsReordered, WI._rememberOpenTabs, WI);
+    
+    WI._updateLayoutMode();
+    WI.settings.enableNarrowLayoutMode.addEventListener(WI.Setting.Event.Changed, WI._updateLayoutMode, WI);
 
     function updateConsoleSavedResultPrefixCSSVariable() {
         document.body.style.setProperty("--console-saved-result-prefix", "\"" + WI.RuntimeManager.preferredSavedResultPrefix() + "\"");
@@ -1370,6 +1382,12 @@ WI.getMaximumSidebarWidth = function(sidebar)
     return minimumWidth;
 };
 
+WI.getMaximumSidebarHeight = function(sidebar)
+{
+    console.assert(sidebar instanceof WI.Sidebar);
+    return WI._contentElement.offsetHeight - WI.TabBrowser.MinimumHeight;
+};
+
 WI.tabContentViewClassForRepresentedObject = function(representedObject)
 {
     if (representedObject instanceof WI.DOMTree)
@@ -1825,9 +1843,25 @@ WI._updateWindowInactiveState = function(event)
 
 WI._windowResized = function(event)
 {
+    WI._updateLayoutMode();
     WI.tabBar.updateLayout(WI.View.LayoutReason.Resize);
-    WI._tabBrowserSizeDidChange();
     WI._updateSheetRect();
+};
+
+WI._updateLayoutMode = function()
+{
+    let computedMode = WI.LayoutMode.Default;
+    
+    if (WI.settings.enableNarrowLayoutMode.value && window.innerWidth < WI.NarrowLayoutMaximumWidth)
+        computedMode = WI.LayoutMode.Narrow;
+    
+    if (WI.layoutMode !== computedMode) {
+        WI.layoutMode = computedMode;
+        document.body.classList.toggle("narrow", WI.layoutMode === WI.LayoutMode.Narrow);
+        WI.detailsSidebar.updateLayout(WI.View.LayoutReason.Resize);
+    }
+    
+    WI._tabBrowserSizeDidChange();
 };
 
 WI._updateSheetRect = function()
@@ -2004,7 +2038,7 @@ WI._consoleDrawerDidResize = function(event)
     WI.tabBrowser.updateLayout(WI.View.LayoutReason.Resize);
 };
 
-WI._sidebarWidthDidChange = function(event)
+WI._sidebarSizeDidChange = function(event)
 {
     WI._tabBrowserSizeDidChange();
 };

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -198,6 +198,7 @@ WI.settings = {
     enableControlFlowProfiler: new WI.Setting("enable-control-flow-profiler", false),
     enableElementsTabIndependentStylesDetailsSidebarPanel: new WI.Setting("elements-tab-independent-styles-details-panel", true),
     enableLineWrapping: new WI.Setting("enable-line-wrapping", true),
+    enableNarrowLayoutMode: new WI.Setting("enable-narrow-layout-mode", true),
     flexOverlayShowOrderNumbers: new WI.Setting("flex-overlay-show-order-numbers", false),
     frontendAppearance: new WI.Setting("frontend-appearance", "system"),
     gridOverlayShowAreaNames: new WI.Setting("grid-overlay-show-area-names", false),

--- a/Source/WebInspectorUI/UserInterface/Images/ToggleBottomSidebar.svg
+++ b/Source/WebInspectorUI/UserInterface/Images/ToggleBottomSidebar.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright © 2023 Apple Inc. All rights reserved. -->
+<svg xmlns="http://www.w3.org/2000/svg" id="root" version="1.1" viewBox="0 0 16 16">
+    <rect stroke="currentColor" fill="none" x="2.5" y="1.5" width="11" height="13"/>
+    <rect fill="currentColor" x="4" y="11" width="8" height="2"/>
+</svg>

--- a/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js
@@ -65,9 +65,8 @@ WI.ContentBrowserTabContentView = class ContentBrowserTabContentView extends WI.
         if (this._detailsSidebarPanelConstructors.length) {
             let showToolTip = WI.UIString("Show the details sidebar (%s)").format(WI.detailsSidebarKeyboardShortcut.displayName);
             let hideToolTip = WI.UIString("Hide the details sidebar (%s)").format(WI.detailsSidebarKeyboardShortcut.displayName);
-            let image = WI.resolvedLayoutDirection() === WI.LayoutDirection.RTL ? "Images/ToggleLeftSidebar.svg" : "Images/ToggleRightSidebar.svg";
 
-            this._showDetailsSidebarItem = new WI.ActivateButtonNavigationItem("toggle-details-sidebar", showToolTip, hideToolTip, image, 16, 16);
+            this._showDetailsSidebarItem = new WI.ActivateButtonNavigationItem("toggle-details-sidebar", showToolTip, hideToolTip, "Images/ToggleRightSidebar.svg", 16, 16);
             this._showDetailsSidebarItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, WI.toggleDetailsSidebar, this);
             this._showDetailsSidebarItem.activated = !WI.detailsSidebar.collapsed;
             this._showDetailsSidebarItem.enabled = false;
@@ -75,7 +74,8 @@ WI.ContentBrowserTabContentView = class ContentBrowserTabContentView extends WI.
 
             this._contentBrowser.navigationBar.addNavigationItem(new WI.DividerNavigationItem);
             this._contentBrowser.navigationBar.addNavigationItem(this._showDetailsSidebarItem);
-
+            
+            WI.detailsSidebar.addEventListener(WI.Sidebar.Event.PositionDidChange, this._detailsSidebarPositionDidChange, this);
             WI.detailsSidebar.addEventListener(WI.Sidebar.Event.CollapsedStateDidChange, this._detailsSidebarCollapsedStateDidChange, this);
             WI.detailsSidebar.addEventListener(WI.Sidebar.Event.SidebarPanelSelected, this._detailsSidebarPanelSelected, this);
         }
@@ -238,6 +238,16 @@ WI.ContentBrowserTabContentView = class ContentBrowserTabContentView extends WI.
      }
 
     // Private
+    
+    _detailsSidebarPositionDidChange()
+    {
+        if (WI.layoutMode === WI.LayoutMode.Narrow)
+            this._showDetailsSidebarItem.image = "Images/ToggleBottomSidebar.svg";
+        else if (WI.resolvedLayoutDirection() === WI.LayoutDirection.RTL)
+            this._showDetailsSidebarItem.image = "Images/ToggleLeftSidebar.svg";
+        else
+            this._showDetailsSidebarItem.image = "Images/ToggleRightSidebar.svg";
+    }
 
     _navigationSidebarCollapsedStateDidChange(event)
     {

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -165,6 +165,7 @@ input[type=range]::-webkit-slider-runnable-track {
 #navigation-sidebar {
     width: 300px;
     height: 100%;
+    grid-area: navigation-sidebar;
 }
 
 body.docked:is(.right, .left) #navigation-sidebar.collapsed > .resizer {
@@ -172,19 +173,41 @@ body.docked:is(.right, .left) #navigation-sidebar.collapsed > .resizer {
 }
 
 #content {
-    display: flex;
+    display: grid;
     height: 100%; /* This reduces paint areas when typing in the console. http://webkit.org/b/145324 */
-    flex: 1;
+}
+
+body:not(.narrow) #content {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: "navigation-sidebar tab-browser details-sidebar";
+}
+
+body[dir="rtl"]:not(.narrow) #content {
+    grid-template-areas: "details-sidebar tab-browser navigation-sidebar";
+}
+
+body.narrow #content {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: 1fr auto;
+    grid-template-areas: "navigation-sidebar tab-browser" "details-sidebar details-sidebar";
+}
+
+body[dir="rtl"].narrow #content {
+    grid-template-columns: 1fr auto;
+    grid-template-areas: "tab-browser navigation-sidebar" "details-sidebar details-sidebar";
 }
 
 #tab-browser {
     flex: 1;
     min-width: 200px; /* Keep in sync with `WI.getMaximumSidebarWidth(...) -> const minimumContentBrowserWidth` */
+    min-height: 110px; /* Keep in sync with `WI.TabBrowser.MinimumHeight` */
+    grid-area: tab-browser;
 }
 
 #details-sidebar {
     min-width: 250px; /* Keep in sync with `WI.Sidebar.AbsoluteMinimumWidth` */
     height: 100%;
+    grid-area: details-sidebar;
 }
 
 #layout-measurement-container {

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -255,7 +255,11 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         searchGroup.addSetting(WI.settings.searchFromSelection, WI.UIString("%s from selection", "Global Search From Selection @ Settings", "Settings tab checkbox label for whether the global search should populate from the current selection.").format(WI.searchKeyboardShortcut.displayName));
 
         generalSettingsView.addSeparator();
-
+        
+        generalSettingsView.addSetting(WI.UIString("Details Sidebars:", "Details Sidebars: @ Settings General Pane", "Category label for detail sidebar settings."), WI.settings.enableNarrowLayoutMode, WI.UIString("Show on bottom when narrow", "Show on bottom when narrow @ Settings General Pane", "Settings tab checkbox label for whether the details sidebars (on the right in LTR locales) are at the bottom"));
+        
+        generalSettingsView.addSeparator();
+        
         const zoomLevels = [0.6, 0.8, 1, 1.2, 1.4, 1.6, 1.8, 2, 2.2, 2.4];
         const zoomValues = zoomLevels.map((level) => [level, Number.percentageString(level, 0)]);
 

--- a/Source/WebInspectorUI/UserInterface/Views/Sidebar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Sidebar.css
@@ -48,3 +48,12 @@
 .sidebar.collapsed {
     display: none;
 }
+
+body.narrow .sidebar.trailing {
+    border-top: 1px solid var(--border-color);
+    min-height: 200px; /* keep in sync with WI.Sidebar.AbsoluteMinimumHeight in Sidebar.js */
+}
+
+body:not(.narrow) .sidebar > .resizer.horizontal-rule {
+    display: none;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/Sidebar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Sidebar.js
@@ -46,6 +46,12 @@ WI.Sidebar = class Sidebar extends WI.View
 
         this._sidebarPanels = [];
         this._selectedSidebarPanel = null;
+        
+        this._heightResizer = new WI.Resizer(WI.Resizer.RuleOrientation.Horizontal, this);
+        this.element.insertBefore(this._heightResizer.element, this.element.firstChild);
+
+        this.canMoveToBottom = false;
+        this._didMoveToBottom = false;
     }
 
     // Public
@@ -159,6 +165,20 @@ WI.Sidebar = class Sidebar extends WI.View
         return WI.getMaximumSidebarWidth(this);
     }
 
+    get height()
+    {
+        return this.element.offsetHeight;
+    }
+
+    set height(newHeight)
+    {
+        if (newHeight === this.height)
+            return;
+        
+        if (WI.layoutMode === WI.LayoutMode.Narrow)
+            this._recalculateHeight(newHeight);
+    }
+
     // Protected
 
     shouldInsertSidebarPanel(sidebarPanel, index)
@@ -191,6 +211,50 @@ WI.Sidebar = class Sidebar extends WI.View
     {
         // Implemented by subclasses if needed.
     }
+    
+    sizeDidChange()
+    {
+        super.sizeDidChange();
+
+        if (this._side !== WI.Sidebar.Sides.Trailing || !this.canMoveToBottom)
+            return;
+        
+        if (WI.layoutMode === WI.LayoutMode.Narrow && !this._didMoveToBottom) {
+            this._didMoveToBottom = true;
+            this.element.style.width = "";
+            this.dispatchEventToListeners(WI.Sidebar.Event.PositionDidChange);
+        } else if (WI.layoutMode !== WI.LayoutMode.Narrow && this._didMoveToBottom) {
+            this._didMoveToBottom = false;
+            this.element.style.height = "";
+            this.dispatchEventToListeners(WI.Sidebar.Event.PositionDidChange);
+        }
+    }
+    
+    // WI.Resizer delegate
+
+    resizerDragStarted(resizer)
+    {
+        if (resizer !== this._heightResizer)
+            return;
+
+        this._heightBeforeResize = this.height;
+    }
+
+    resizerDragging(resizer, positionDelta)
+    {
+        if (resizer !== this._heightResizer)
+            return;
+        
+        this.height = positionDelta + this._heightBeforeResize;
+    }
+
+    resizerDragEnded(resizer)
+    {
+        if (resizer !== this._heightResizer || this._heightBeforeResize === this.width)
+            return;
+        
+        this.updateLayout(WI.View.LayoutReason.Resize);
+    }
 
     // Private
 
@@ -209,11 +273,26 @@ WI.Sidebar = class Sidebar extends WI.View
 
         return sidebarPanel;
     }
+    
+    _recalculateHeight(newHeight)
+    {
+        console.assert(newHeight);
+        
+        // Need to add 1 because of the 1px border-top.
+        newHeight = Math.ceil(Number.constrain(newHeight, this.minimumHeight + 1, WI.getMaximumSidebarHeight(this)));
+        this.element.style.height = `${newHeight}px`;
+
+        if (this.collapsed)
+            return;
+        
+        this.needsLayout(WI.View.LayoutReason.Resize);
+        this.dispatchEventToListeners(WI.Sidebar.Event.HeightDidChange, {newHeight});
+    }
 };
 
 WI.Sidebar.CollapsedStyleClassName = "collapsed";
 WI.Sidebar.AbsoluteMinimumWidth = 250; // Keep in sync with `#details-sidebar` in `Main.css`
-
+WI.Sidebar.AbsoluteMinimumHeight = 200; // Keep in sync with `body.narrow #content > .sidebar.trailing` in `Sidebar.css`
 WI.Sidebar.Sides = {
     Leading: "leading",
     Trailing: "trailing",
@@ -223,4 +302,6 @@ WI.Sidebar.Event = {
     SidebarPanelSelected: "sidebar-panel-selected",
     CollapsedStateDidChange: "sidebar-collapsed-state-did-change",
     WidthDidChange: "sidebar-width-did-change",
+    HeightDidChange: "sidebar-height-did-change",
+    PositionDidChange: "sidebar-position-did-change",
 };

--- a/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.css
@@ -35,11 +35,11 @@
     top: var(--navigation-bar-height);
 }
 
-.single-sidebar.trailing > .resizer {
+.single-sidebar.trailing > .resizer.vertical-rule {
     inset-inline-start: -3px;
 }
 
-.single-sidebar.leading > .resizer {
+.single-sidebar.leading > .resizer.vertical-rule {
     inset-inline-end: -3px;
 }
 
@@ -47,6 +47,16 @@
     border-inline-end: 1px solid var(--border-color);
 }
 
-.single-sidebar.trailing {
+body:not(.narrow) .single-sidebar.trailing {
     border-inline-start: 1px solid var(--border-color);
+}
+
+body.narrow .single-sidebar.trailing {
+    border-top: none;
+    flex-grow: 1;
+}
+
+.single-sidebar.trailing .resizer.horizontal-rule,
+body.narrow .single-sidebar.trailing .resizer.vertical-rule {
+    display: none;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js
@@ -43,8 +43,8 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
             this.addSubview(this._navigationBar);
         }
 
-        this._resizer = new WI.Resizer(WI.Resizer.RuleOrientation.Vertical, this);
-        this.element.insertBefore(this._resizer.element, this.element.firstChild);
+        this._widthResizer = new WI.Resizer(WI.Resizer.RuleOrientation.Vertical, this);
+        this.element.insertBefore(this._widthResizer.element, this.element.firstChild);
     }
 
     // Public
@@ -146,11 +146,21 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
 
     resizerDragStarted(resizer)
     {
+        super.resizerDragStarted(resizer);
+        
+        if (resizer !== this._widthResizer)
+            return;
+        
         this._widthBeforeResize = this.width;
     }
 
     resizerDragging(resizer, positionDelta)
     {
+        super.resizerDragging(resizer);
+        
+        if (resizer !== this._widthResizer)
+            return;
+        
         if (this._side === WI.Sidebar.Sides.Leading)
             positionDelta *= -1;
 
@@ -166,7 +176,9 @@ WI.SingleSidebar = class SingleSidebar extends WI.Sidebar
 
     resizerDragEnded(resizer)
     {
-        if (this._widthBeforeResize === this.width)
+        super.resizerDragEnded(resizer);
+        
+        if (resizer !== this._widthResizer || this._widthBeforeResize === this.width)
             return;
 
         if (!this.collapsed && this._navigationBar)

--- a/Source/WebInspectorUI/UserInterface/Views/TabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TabContentView.js
@@ -42,6 +42,7 @@ WI.TabContentView = class TabContentView extends WI.ContentView
         this._detailsSidebarCollapsedSetting = new WI.Setting(this._identifier + "-details-sidebar-collapsed", !this.detailsSidebarExpandedByDefault);
         this._detailsSidebarSelectedPanelSetting = new WI.Setting(this._identifier + "-details-sidebar-selected-panel", null);
         this._detailsSidebarWidthSetting = new WI.Setting(this._identifier + "-details-sidebar-widths", {});
+        this._detailsSidebarHeightSetting = new WI.Setting(this._identifier + "-details-sidebar-height", null);
 
         this._cookieSetting = new WI.Setting(this._identifier + "-tab-cookie", {});
 
@@ -205,6 +206,8 @@ WI.TabContentView = class TabContentView extends WI.ContentView
     get detailsSidebarCollapsedSetting() { return this._detailsSidebarCollapsedSetting; }
     get detailsSidebarSelectedPanelSetting() { return this._detailsSidebarSelectedPanelSetting; }
     get detailsSidebarWidthSetting() { return this._detailsSidebarWidthSetting; }
+    get detailsSidebarHeightSetting() { return this._detailsSidebarHeightSetting; }
 };
 
 WI.TabContentView.DefaultSidebarWidth = 300;
+WI.TabContentView.DefaultSidebarHeight = 400;


### PR DESCRIPTION
#### cfbd8f5ff5d3376688299cfe672e0bba44725372
<pre>
Web Inspector: Move details sidebar to bottom when narrow

<a href="https://bugs.webkit.org/show_bug.cgi?id=259391">https://bugs.webkit.org/show_bug.cgi?id=259391</a>

Reviewed by Devin Rousso.

When the Inspector is very narrow (around 500px or less wide) it is difficult to use.
This patch adds WI.LayoutMode, which specifies a narrow layout which is instated below a certain width. The layout can be queried by subsidiary views so they can be displayed differently.
Currently, this changes the details sidebar so it appears at the bottom when the Inspector is below a certain width, similar to Blink and Gecko&apos;s developer tools.

Combined changes:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Main.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Images/ToggleBottomSidebar.svg: Added.
* Source/WebInspectorUI/UserInterface/Views/ContentBrowserTabContentView.js:
(WI.ContentBrowserTabContentView.prototype._detailsSidebarPositionDidChange):
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(#navigation-sidebar):
(#content):
(body[dir=&quot;rtl&quot;] #content):
(body.narrow #content):
(body[dir=&quot;rtl&quot;].narrow #content):
(#tab-browser):
(#details-sidebar):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createGeneralSettingsView):
* Source/WebInspectorUI/UserInterface/Views/Sidebar.css:
(body.narrow .sidebar.trailing):
* Source/WebInspectorUI/UserInterface/Views/Sidebar.js:
(WI.Sidebar):
(WI.Sidebar.prototype.get height):
(WI.Sidebar.prototype.set height):
(WI.Sidebar.prototype.sizeDidChange):
(WI.Sidebar.prototype.resizerDragStarted):
(WI.Sidebar.prototype.resizerDragging):
(WI.Sidebar.prototype.resizerDragEnded):
(WI.Sidebar.prototype._recalculateHeight):
* Source/WebInspectorUI/UserInterface/Views/SingleSidebar.css:
(body:not(.narrow) .single-sidebar.trailing):
(body.narrow .sidebar.trailing .single-sidebar):
(body.narrow .sidebar.trailing .single-sidebar .resizer):
(.single-sidebar.trailing): Deleted.
* Source/WebInspectorUI/UserInterface/Views/SingleSidebar.js:
(WI.SingleSidebar):
(WI.SingleSidebar.prototype.get widthResizer):
(WI.SingleSidebar.prototype.resizerDragStarted):
(WI.SingleSidebar.prototype.resizerDragging):
(WI.SingleSidebar.prototype.resizerDragEnded):
* Source/WebInspectorUI/UserInterface/Views/TabBrowser.js:
(WI.TabBrowser):
(WI.TabBrowser.prototype._handleSidebarSizeDidChange):
(WI.TabBrowser.prototype._handleSidebarPositionDidChange):
(WI.TabBrowser.prototype._showDetailsSidebarPanelsForTabContentView):
(WI.TabBrowser.prototype._handleSidebarWidthDidChange): Deleted.
* Source/WebInspectorUI/UserInterface/Views/TabContentView.js:
(WI.TabContentView.prototype.get detailsSidebarHeightSetting):
(WI.TabContentView):

Canonical link: <a href="https://commits.webkit.org/266784@main">https://commits.webkit.org/266784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d0ab61bc8a0df1ba01a3dd27f2d883997f20ae1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16515 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17189 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20258 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16669 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11818 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13275 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3557 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->