### PR TITLE
[WPE] Fix clang-14 build

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -138,7 +138,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     GCGLint boundRenderbuffer = gl.getInteger(GL::RENDERBUFFER_BINDING);
     GCGLint boundTexture = gl.getInteger(textureTargetBinding);
 
-    auto scopedBindings = makeScopeExit([=, &gl]() {
+    auto scopedBindings = makeScopeExit([=, textureTarget = textureTarget, &gl]() {
         gl.bindFramebuffer(GL::FRAMEBUFFER, boundFBO);
         gl.bindRenderbuffer(GL::RENDERBUFFER, boundRenderbuffer);
         gl.bindTexture(textureTarget, boundTexture);

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c
@@ -99,8 +99,9 @@ find_first_eligible_consider_view(
         <= pas_segregated_shared_page_directory_probability_of_ineligibility) {
         if (verbose)
             pas_log("cannot bump at %zu, clearing eligibility.\n", config->index);
-        PAS_SEGREGATED_DIRECTORY_BIT_REFERENCE_SET(
+        bool result = PAS_SEGREGATED_DIRECTORY_BIT_REFERENCE_SET(
             config->directory, config->bit_reference, eligible, false);
+        PAS_UNUSED_PARAM(result);
     }
 
     if (verbose)
@@ -388,7 +389,8 @@ take_last_empty_consider_view(
     }
 
     /* It's possible that the empty bit had gotten set again; clear it. */
-    PAS_SEGREGATED_DIRECTORY_BIT_REFERENCE_SET(directory, bit_reference, empty, false);
+    bool set_bit_result = PAS_SEGREGATED_DIRECTORY_BIT_REFERENCE_SET(directory, bit_reference, empty, false);
+    PAS_UNUSED_PARAM(set_bit_result);
 
     page = pas_segregated_page_for_boundary(shared_handle->page_boundary, page_config);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c
@@ -728,7 +728,8 @@ take_last_empty_consider_view(pas_segregated_directory_iterate_config* config)
     PAS_ASSERT(!PAS_SEGREGATED_DIRECTORY_GET_BIT(directory, index, eligible));
 
     /* It's totally possible that the empty bit got set again. We should clear it for sure now. */
-    PAS_SEGREGATED_DIRECTORY_SET_BIT(directory, index, empty, false);
+    bool result = PAS_SEGREGATED_DIRECTORY_SET_BIT(directory, index, empty, false);
+    PAS_UNUSED_PARAM(result);
 
     PAS_TESTING_ASSERT(pas_segregated_page_qualifies_for_decommit(page, my_page_config));
     


### PR DESCRIPTION
#### 643dde579279e5eb3281493d6708556f30089fac
<pre>
[WPE] Fix clang-14 build
<a href="https://bugs.webkit.org/show_bug.cgi?id=259395">https://bugs.webkit.org/show_bug.cgi?id=259395</a>

Unreviewed.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame): Structured binding capture in lambda is not supported
until c++-20, the workaround is to use a dedicated initializer. This was broken since 265606@main.
* Source/bmalloc/libpas/src/libpas/pas_segregated_shared_page_directory.c: Add PAS_UNUSED_PARAM()
for unused macro result expansions.
(find_first_eligible_consider_view):
(take_last_empty_consider_view):
* Source/bmalloc/libpas/src/libpas/pas_segregated_size_directory.c: Ditto.
(take_last_empty_consider_view):

Canonical link: <a href="https://commits.webkit.org/266207@main">https://commits.webkit.org/266207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7af5cf072a33f227a03c14b6cddf05173a0efba8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13225 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15285 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14061 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/11182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15527 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11349 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/11937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18993 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11254 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12424 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15316 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12516 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12594 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13272 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11865 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3486 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3233 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16187 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13654 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12436 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3282 "Passed tests") | 
<!--EWS-Status-Bubble-End-->