### PR TITLE
Use the presence of hover styles as a signal for InteractionRegion consolidation

### DIFF
--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -1,16 +1,17 @@
 Nested  Nested  Nested Secondary
 Tappable! Secondary
+labels y aligned Secondary
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 600.00)
+  (bounds 800.00 613.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 600.00)
+      (bounds 800.00 613.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=600)
+        (rect (0,0) width=800 height=613)
 
       (interaction regions [
         (interaction (0,0) width=125 height=100)
@@ -28,6 +29,10 @@ Tappable! Secondary
         (interaction (200,150) width=122 height=122)
         (borderRadius 0.00),
         (interaction (253,151) width=68 height=20)
+        (borderRadius 5.00),
+        (interaction (0,500) width=240 height=100)
+        (borderRadius 0.00),
+        (interaction (172,500) width=68 height=20)
         (borderRadius 5.00)])
       )
     )

--- a/LayoutTests/interaction-region/consolidated-nested-regions.html
+++ b/LayoutTests/interaction-region/consolidated-nested-regions.html
@@ -41,6 +41,20 @@
         height: 120px;
         border: 1px blue dotted;
     }
+    .tap-and-hover {
+        position: relative;
+        cursor: pointer;
+        width: 200px;
+        height: 60px;
+        padding: 20px;
+        background: lightblue;
+    }
+    .tap-and-hover:hover {
+        background: blue;
+    }
+    .tap-and-hover span {
+        line-height: 60px;
+    }
 </style>
 <body>
 <div class="nested" style="border-radius: 12px;">
@@ -80,6 +94,12 @@
             </div>
         </div>
     </div>
+</div>
+<div class="tap-and-hover">
+    <span>labels</span>
+    <span>y</span>
+    <span>aligned</span>
+    <a href="#" class="secondary">Secondary</a>
 </div>
 
 <pre id="results"></pre>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -112,7 +112,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     }
 }
 
-static bool elementMatchesHoverRules(Element& element)
+bool elementMatchesHoverRules(Element& element)
 {
     bool foundHoverRules = false;
     bool initialValue = element.isUserActionElement() && element.document().userActionElements().isHovered(element);

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -72,6 +72,7 @@ inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 }
 
 WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject&, const Region&);
+WEBCORE_EXPORT bool elementMatchesHoverRules(Element&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const InteractionRegion&);
 


### PR DESCRIPTION
#### 969122115609f420b20ac90102f61e4e934a0af3
<pre>
Use the presence of hover styles as a signal for InteractionRegion consolidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259398">https://bugs.webkit.org/show_bug.cgi?id=259398</a>
&lt;rdar://111551476&gt;

Reviewed by Tim Horton.

Relax the consolidation rule when the ancestor has hover styles, so
that &quot;buttons&quot; with child spans get a single InteractionRegion.

* Source/WebCore/page/InteractionRegion.h:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::elementMatchesHoverRules):
Export `elementMatchesHoverRules`.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Allow consolidation if the ancestor has hover rules and the element is
centered in either axis.

* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions.html:
Add a test covering the change.

Canonical link: <a href="https://commits.webkit.org/266230@main">https://commits.webkit.org/266230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52482ec3df1c27eb08a7958ac1066a9821f2f2cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13927 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15018 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15329 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15636 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19038 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12648 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10506 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11919 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11843 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->