### PR TITLE
Regression(266170@main) Crash under CachedRawResource::switchClientsToRevalidatedResource()

### DIFF
--- a/LayoutTests/http/tests/workers/memory-cache-crash2-expected.txt
+++ b/LayoutTests/http/tests/workers/memory-cache-crash2-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/http/tests/workers/memory-cache-crash2.html
+++ b/LayoutTests/http/tests/workers/memory-cache-crash2.html
@@ -1,0 +1,20 @@
+<p>This test passes if it doesn't crash.</p>
+<script>
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+  }
+
+  onload = async () => {
+    document.createElement('audio').src = 'data:';
+    for (let i = 0; i < 5; i++) {
+      new Worker('');
+      await navigator.storage.persist();
+    }
+    new FontFace('a', 'url()');
+    setTimeout(() => {
+      if (window.testRunner)
+        testRunner.notifyDone();
+    }, 50);
+  };
+</script>

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -755,17 +755,6 @@ void CachedResource::setResourceToRevalidate(CachedResource* resource)
     m_resourceToRevalidate = resource;
 }
 
-void CachedResource::replaceResourceToRevalidate(CachedResource& resource)
-{
-    ASSERT(m_resourceToRevalidate);
-
-    m_resourceToRevalidate->m_proxyResource = nullptr;
-    m_resourceToRevalidate->deleteIfPossible();
-    m_resourceToRevalidate = &resource;
-    ASSERT(!resource.m_proxyResource);
-    resource.m_proxyResource = this;
-}
-
 void CachedResource::clearResourceToRevalidate() 
 {
     ASSERT(m_resourceToRevalidate);

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -282,7 +282,6 @@ public:
 
     // HTTP revalidation support methods for CachedResourceLoader.
     void setResourceToRevalidate(CachedResource*);
-    void replaceResourceToRevalidate(CachedResource&);
     virtual void switchClientsToRevalidatedResource();
     void clearResourceToRevalidate();
     void updateResponseAfterRevalidation(const ResourceResponse& validatingResponse);

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -146,9 +146,9 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
     ASSERT(response.source() == ResourceResponse::Source::MemoryCacheAfterValidation);
     ASSERT(revalidatingResource.resourceToRevalidate());
     CachedResourceHandle protectedRevalidatingResource { revalidatingResource };
-    auto* resource = revalidatingResource.resourceToRevalidate();
-    ASSERT(!resource->inCache());
-    ASSERT(resource->isLoaded());
+    auto& resource = *revalidatingResource.resourceToRevalidate();
+    ASSERT(!resource.inCache());
+    ASSERT(resource.isLoaded());
 
     // Calling remove() can potentially delete revalidatingResource, which we use
     // below. This mustn't be the case since revalidation means it is loaded
@@ -157,27 +157,28 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
 
     remove(revalidatingResource);
 
-    auto& resources = ensureSessionResourceMap(resource->sessionID());
-    std::pair key { resource->url(), resource->cachePartition() };
-
-    auto addResult = resources.add(key, resource);
-    if (addResult.isNewEntry) {
-        resource->setInCache(true);
-        resource->updateResponseAfterRevalidation(response);
-        insertInLRUList(*resource);
-        long long delta = resource->size();
-        if (resource->decodedSize() && resource->hasClients())
-            insertInLiveDecodedResourcesList(*resource);
-        if (delta)
-            adjustSize(resource->hasClients(), delta);
-    } else {
-        // The resource was re-inserted in the cache during its revalidation.
-        // Ignore the revalidated resource and switch clients to the one that
-        // is already in the cache.
-        resource = addResult.iterator->value.get();
-        ASSERT(resource);
-        revalidatingResource.replaceResourceToRevalidate(*resource);
+    // A resource with the same URL may have been added back in the cache during revalidation.
+    // In this case, we remove the cached resource and replace it with our freshly revalidated
+    // one.
+    std::pair key { resource.url(), resource.cachePartition() };
+    if (auto* existingResources = sessionResourceMap(resource.sessionID())) {
+        if (auto existingResource = existingResources->get(key))
+            remove(*existingResource);
     }
+
+    // Don't move the call to ensureSessionResourceMap() in this function as the calls to
+    // remove() above could invalidate the reference returned by ensureSessionResourceMap().
+    auto& resources = ensureSessionResourceMap(resource.sessionID());
+    ASSERT(!resources.contains(key));
+    resources.add(key, &resource);
+    resource.setInCache(true);
+    resource.updateResponseAfterRevalidation(response);
+    insertInLRUList(resource);
+    long long delta = resource.size();
+    if (resource.decodedSize() && resource.hasClients())
+        insertInLiveDecodedResourcesList(resource);
+    if (delta)
+        adjustSize(resource.hasClients(), delta);
 
     revalidatingResource.switchClientsToRevalidatedResource();
     ASSERT(!revalidatingResource.m_deleted);


### PR DESCRIPTION
#### 6b5f40310886172cd02969c7cd5b49d7c1e21096
<pre>
Regression(266170@main) Crash under CachedRawResource::switchClientsToRevalidatedResource()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259401">https://bugs.webkit.org/show_bug.cgi?id=259401</a>
rdar://112663008

Reviewed by Brent Fulgham.

In 266170@main, I updated MemoryCache::revalidationSucceeded() to deal with the fact
that there may already be a resource in the MemoryCache with the same URL when the
resource revalidation finishes. I dealt with this by assuming that the resource
already in the cache was good enough and I ignored the revalidated resource, and then
transferred the clients of the revalidation resource to the resource that is already
in the cache.

However, it turns out that this isn&apos;t safe to do because the resource already in the
cache may have a different type (even though it has the same URL). In the included
test, for example, the same URL is loaded both as a RawResource and a FontResource.
This would lead to crashes later on in switchClientsToRevalidatedResource().

To address the issue, I am reverting 266170@main and dealing with the original issue
in a simpler way. Upon successful revalidation, if there is already a resource in the
memory cache with the same URL, we now remove it from the cache before proceeding.

This is much safer and matches what would happen if you tried to load URL1 as a
RawResource and then load URL2 as a FontResource. Our MemoryCache logic would remove
the existing RawResource in the cache and create a new CachedResource of FontResource
type.

* LayoutTests/http/tests/workers/memory-cache-crash2.html: Added.
* LayoutTests/http/tests/workers/memory-cache-crash2-expected.txt: Added.
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::replaceResourceToRevalidate): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::revalidationSucceeded):

Canonical link: <a href="https://commits.webkit.org/266216@main">https://commits.webkit.org/266216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b11cad2299433b3d7a31647eabb591821f827457

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12606 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13310 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15294 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15550 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11948 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19001 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12609 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11812 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3235 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->