### PR TITLE
REGRESSION(264990@main) some occlusion regions are incorrect

### DIFF
--- a/LayoutTests/interaction-region/overlay-expected.txt
+++ b/LayoutTests/interaction-region/overlay-expected.txt
@@ -16,13 +16,14 @@
         (occlusion (0,200) width=200 height=100)
         (borderRadius 0.00)])
       )
-      (children 2
+      (children 3
         (GraphicsLayer
           (position 0.00 400.00)
           (preserves3D 1)
           (children 1
             (GraphicsLayer
               (bounds 200.00 200.00)
+              (contentsOpaque 1)
               (drawsContent 1)
               (event region
                 (rect (0,0) width=200 height=200)
@@ -30,6 +31,20 @@
               (interaction regions [
                 (occlusion (0,0) width=200 height=200)
                 (borderRadius 0.00)])
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 600.00 400.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (contentsOpaque 1)
+              (drawsContent 1)
+              (event region
+                (rect (0,0) width=200 height=200)
               )
             )
           )

--- a/LayoutTests/interaction-region/overlay.html
+++ b/LayoutTests/interaction-region/overlay.html
@@ -13,11 +13,17 @@
         pointer-events: none;
         background-color: red;
     }
-    #fixed-container {
+    .fixed-container {
         position: fixed;
+        width: 200px;
+        height: 200px;
         left: 0;
         bottom: 0;
         pointer-events: none;
+    }
+    .fixed-container.no-occlusion {
+        left: unset;
+        right: 0;
     }
     #fixed {
         position: fixed;
@@ -25,6 +31,8 @@
         top: 0;
     }
     .paints {
+        position: absolute;
+        top: 0;
         width: 200px;
         height: 200px;
         background: blue;
@@ -40,9 +48,15 @@
 <div class="overlay"></div>
 <div class="overlay" id="not-occlusion"></div>
 <div class="overlay" onclick="click()"></div>
-<div id="fixed-container">
+<div class="fixed-container">
     <div class="paints">
         <div class="child"></div>
+        <div class="child"></div>
+    </div>
+</div>
+<div class="fixed-container no-occlusion">
+    <div class="child"></div>
+    <div class="paints">
         <div class="child"></div>
     </div>
 </div>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -173,7 +173,12 @@ static bool isOverlay(const RenderElement& renderer)
 
     if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
         auto refContentBox = renderBox->absoluteContentBox();
+        auto lastRenderer = renderBox;
         for (auto& ancestor : ancestorsOfType<RenderBox>(renderer)) {
+            // We don't want to occlude any previous siblings.
+            if (ancestor.firstChildBox() != lastRenderer)
+                return false;
+            lastRenderer = &ancestor;
             if (ancestor.absoluteContentBox() != refContentBox)
                 return false;
             if (ancestor.isFixedPositioned())


### PR DESCRIPTION
#### c73297d438825df62ee3d1e97ce88fd6a76b49d9
<pre>
REGRESSION(264990@main) some occlusion regions are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=259402">https://bugs.webkit.org/show_bug.cgi?id=259402</a>
&lt;rdar://112668310&gt;

Reviewed by Tim Horton.

We already only looked at ancestors with the same absolute content box
during the `position: fixed` search. But we also need to make sure we
won&apos;t occlude siblings.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::isOverlay):
Update the overlay detection logic.

* LayoutTests/interaction-region/overlay-expected.txt:
* LayoutTests/interaction-region/overlay.html:
Add a test covering the change.

Canonical link: <a href="https://commits.webkit.org/266227@main">https://commits.webkit.org/266227@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc49d270b50835ad71fa63212e72d0397e76f9b2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/14980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12608 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15301 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15596 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19036 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15339 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12611 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10505 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11808 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3239 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->