### PR TITLE
Throttle `mousemove` events to one per rendering update

### DIFF
--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants-expected.txt
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants-expected.txt
@@ -1,7 +1,10 @@
-PASS
-PASS
-PASS
-PASS
-PASS
-PASS
+PASS .target styleChangeType was InlineStyleChange
+PASS .container styleChangeType was NoStyleChange
+PASS .inert styleChangeType was NoStyleChange
+PASS .target styleChangeType was InlineStyleChange
+PASS .container styleChangeType was NoStyleChange
+PASS .inert styleChangeType was NoStyleChange
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html
@@ -1,4 +1,8 @@
 <html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
 <style>
 .container {
     background-color: blue;
@@ -42,7 +46,6 @@
         </div>
     </div>
 </div>
-<pre id=log></pre>
 
 <script>
 function testStyleChangeType(selector, expectedType)
@@ -52,31 +55,35 @@ function testStyleChangeType(selector, expectedType)
     for (var i = 0; i < elements.length; ++i) {
         const type = window.internals.styleChangeType(elements[i]);
         if (type != expectedType) {
-            log.textContent += `FAIL ${selector} styleChangeType was ${type} expected ${expectedType}\n`;
+            testFailed(`${selector} styleChangeType was ${type} expected ${expectedType}`);
             pass = false;
         }
     }
     if (pass)
-        log.textContent += "PASS\n";
+        testPassed(`${selector} styleChangeType was ${expectedType}`);
 }
 
-window.onload = function () {
+jsTestIsAsync = true;
+
+window.onload = async () => {
     if (!window.testRunner)
         return;
-    testRunner.dumpAsText();
 
-    document.body.offsetLeft;
-    eventSender.mouseMoveTo(50,50);
+    addEventListener("mousemove", () => {
+        testStyleChangeType(".target", "InlineStyleChange");
+        testStyleChangeType(".container", "NoStyleChange");
+        testStyleChangeType(".inert", "NoStyleChange");
+    }, { "once" : true });
+    eventSender.mouseMoveTo(50, 50);
 
-    testStyleChangeType(".target", "InlineStyleChange");
-    testStyleChangeType(".container", "NoStyleChange");
-    testStyleChangeType(".inert", "NoStyleChange");
+    await UIHelper.ensurePresentationUpdate();
+    addEventListener("mousemove", () => {
+        testStyleChangeType(".target", "InlineStyleChange");
+        testStyleChangeType(".container", "NoStyleChange");
+        testStyleChangeType(".inert", "NoStyleChange");
+    }, { "once" : true });
+    eventSender.mouseMoveTo(300, 50, "mouse", false);
 
-    document.body.offsetLeft;
-    eventSender.mouseMoveTo(300,50);
-
-    testStyleChangeType(".target", "InlineStyleChange");
-    testStyleChangeType(".container", "NoStyleChange");
-    testStyleChangeType(".inert", "NoStyleChange");
+    finishJSTest();
 };
 </script>

--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings-expected.txt
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings-expected.txt
@@ -1,7 +1,10 @@
-PASS
-PASS
-PASS
-PASS
-PASS
-PASS
+PASS .target styleChangeType was InlineStyleChange
+PASS .container styleChangeType was NoStyleChange
+PASS .inert styleChangeType was NoStyleChange
+PASS .target styleChangeType was InlineStyleChange
+PASS .container styleChangeType was NoStyleChange
+PASS .inert styleChangeType was NoStyleChange
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html
+++ b/LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html
@@ -1,4 +1,8 @@
 <html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+</head>
 <style>
 .container {
     background-color: blue;
@@ -45,7 +49,6 @@
         </div>
     </div>
 </div>
-<pre id=log></pre>
 
 <script>
 function testStyleChangeType(selector, expectedType)
@@ -55,31 +58,36 @@ function testStyleChangeType(selector, expectedType)
     for (var i = 0; i < elements.length; ++i) {
         const type = window.internals.styleChangeType(elements[i]);
         if (type != expectedType) {
-            log.textContent += `FAIL ${selector} styleChangeType was ${type} expected ${expectedType}\n`;
+            testFailed(`${selector} styleChangeType was ${type} expected ${expectedType}`);
             pass = false;
         }
     }
     if (pass)
-        log.textContent += "PASS\n";
+        testPassed(`${selector} styleChangeType was ${expectedType}`);
 }
 
-window.onload = function () {
+jsTestIsAsync = true;
+
+window.onload = async () => {
     if (!window.testRunner)
         return;
-    testRunner.dumpAsText();
 
-    document.body.offsetLeft;
-    eventSender.mouseMoveTo(50,50);
+    addEventListener("mousemove", () => {
+        testStyleChangeType(".target", "InlineStyleChange");
+        testStyleChangeType(".container", "NoStyleChange");
+        testStyleChangeType(".inert", "NoStyleChange");
+    }, { "once" : true });
+    eventSender.mouseMoveTo(50, 50);
 
-    testStyleChangeType(".target", "InlineStyleChange");
-    testStyleChangeType(".container", "NoStyleChange");
-    testStyleChangeType(".inert", "NoStyleChange");
+    await UIHelper.ensurePresentationUpdate();
 
-    document.body.offsetLeft;
-    eventSender.mouseMoveTo(300,50);
+    addEventListener("mousemove", () => {
+        testStyleChangeType(".target", "InlineStyleChange");
+        testStyleChangeType(".container", "NoStyleChange");
+        testStyleChangeType(".inert", "NoStyleChange");
+    }, { "once" : true });
+    eventSender.mouseMoveTo(300, 50);
 
-    testStyleChangeType(".target", "InlineStyleChange");
-    testStyleChangeType(".container", "NoStyleChange");
-    testStyleChangeType(".inert", "NoStyleChange");
+    finishJSTest();
 };
 </script>

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -31,6 +31,7 @@
 
 #include "WebEvent.h"
 #include "WebEventModifier.h"
+#include "WebEventType.h"
 
 #include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
@@ -45,41 +46,6 @@ class Encoder;
 }
 
 namespace WebKit {
-
-enum class WebEventType : int8_t {
-    NoType = -1,
-    
-    // WebMouseEvent
-    MouseDown,
-    MouseUp,
-    MouseMove,
-    MouseForceChanged,
-    MouseForceDown,
-    MouseForceUp,
-
-    // WebWheelEvent
-    Wheel,
-
-    // WebKeyboardEvent
-    KeyDown,
-    KeyUp,
-    RawKeyDown,
-    Char,
-
-#if ENABLE(TOUCH_EVENTS)
-    // WebTouchEvent
-    TouchStart,
-    TouchMove,
-    TouchEnd,
-    TouchCancel,
-#endif
-
-#if ENABLE(MAC_GESTURE_EVENTS)
-    GestureStart,
-    GestureChange,
-    GestureEnd,
-#endif
-};
 
 class WebEvent {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/Shared/WebEventType.h
+++ b/Source/WebKit/Shared/WebEventType.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebKit {
+
+enum class WebEventType : int8_t {
+    NoType = -1,
+
+    // WebMouseEvent
+    MouseDown,
+    MouseUp,
+    MouseMove,
+    MouseForceChanged,
+    MouseForceDown,
+    MouseForceUp,
+
+    // WebWheelEvent
+    Wheel,
+
+    // WebKeyboardEvent
+    KeyDown,
+    KeyUp,
+    RawKeyDown,
+    Char,
+
+#if ENABLE(TOUCH_EVENTS)
+    // WebTouchEvent
+    TouchStart,
+    TouchMove,
+    TouchEnd,
+    TouchCancel,
+#endif
+
+#if ENABLE(MAC_GESTURE_EVENTS)
+    GestureStart,
+    GestureChange,
+    GestureEnd,
+#endif
+};
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3210,6 +3210,9 @@ void WebPageProxy::handleMouseEvent(const NativeWebMouseEvent& event)
     UNUSED_PARAM(didRemoveEvent);
     LOG_WITH_STREAM(MouseHandling, stream << "UIProcess: " << (didRemoveEvent ? "replaced" : "enqueued") << " mouse event " << event.type() << " (queue size " << internals().mouseEventQueue.size() << ")");
 
+    if (event.type() != WebEventType::MouseMove)
+        send(Messages::WebPage::FlushDeferredDidReceiveMouseEvent());
+
     if (internals().mouseEventQueue.size() == 1) // Otherwise, called from DidReceiveEvent message handler.
         processNextQueuedMouseEvent();
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2205,6 +2205,7 @@
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
 		F4CB09E5225D5A0900891487 /* WebsiteMediaSourcePolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CB09E4225D5A0300891487 /* WebsiteMediaSourcePolicy.h */; };
+		F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CBF79D2A6ADF5400C066BF /* WebEventType.h */; };
 		F4CF1E9D25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4CF1E9B25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.h */; };
 		F4D188EF29B99B4500D838D4 /* PrivateClickMeasurementEphemeralStore.h in Headers */ = {isa = PBXBuildFile; fileRef = F4D188ED29B99B4500D838D4 /* PrivateClickMeasurementEphemeralStore.h */; };
 		F4D5F51D206087A10038BBA8 /* WKTextInputListViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4D5F519206087A00038BBA8 /* WKTextInputListViewController.h */; };
@@ -7237,6 +7238,7 @@
 		F4BA33F125757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = WKImageAnalysisGestureRecognizer.mm; path = ios/WKImageAnalysisGestureRecognizer.mm; sourceTree = "<group>"; };
 		F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlaybackSessionContextIdentifier.h; sourceTree = "<group>"; };
 		F4CB09E4225D5A0300891487 /* WebsiteMediaSourcePolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebsiteMediaSourcePolicy.h; sourceTree = "<group>"; };
+		F4CBF79D2A6ADF5400C066BF /* WebEventType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebEventType.h; sourceTree = "<group>"; };
 		F4CF1E9B25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GestureRecognizerConsistencyEnforcer.h; path = ios/GestureRecognizerConsistencyEnforcer.h; sourceTree = "<group>"; };
 		F4CF1E9C25E40DCC000F9D73 /* GestureRecognizerConsistencyEnforcer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = GestureRecognizerConsistencyEnforcer.mm; path = ios/GestureRecognizerConsistencyEnforcer.mm; sourceTree = "<group>"; };
 		F4D188ED29B99B4500D838D4 /* PrivateClickMeasurementEphemeralStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateClickMeasurementEphemeralStore.h; sourceTree = "<group>"; };
@@ -8113,6 +8115,7 @@
 				BC032DB110F4380F0058C15A /* WebEventConversion.h */,
 				33D059A42A1EEEDC009AFE71 /* WebEventModifier.cpp */,
 				86DD518F28EF28E800DF2A58 /* WebEventModifier.h */,
+				F4CBF79D2A6ADF5400C066BF /* WebEventType.h */,
 				1C0234BF28A00DCF00AC1E5B /* WebExtensionContextIdentifier.h */,
 				1C0234BE28A00DCF00AC1E5B /* WebExtensionContextParameters.h */,
 				1CBEE26128F334D6006D1A02 /* WebExtensionContextParameters.serialization.in */,
@@ -14875,6 +14878,7 @@
 				BC032DBB10F4380F0058C15A /* WebEventConversion.h in Headers */,
 				BC111B5D112F629800337BAB /* WebEventFactory.h in Headers */,
 				86DD519028EF28E800DF2A58 /* WebEventModifier.h in Headers */,
+				F4CBF79E2A6ADF7E00C066BF /* WebEventType.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -813,6 +813,11 @@ void WKBundlePageCallAfterTasksAndTimers(WKBundlePageRef pageRef, WKBundlePageTe
     });
 }
 
+void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page)
+{
+    WebKit::toImpl(page)->flushDeferredDidReceiveMouseEvent();
+}
+
 void WKBundlePagePostMessage(WKBundlePageRef pageRef, WKStringRef messageNameRef, WKTypeRef messageBodyRef)
 {
     WebKit::toImpl(pageRef)->postMessage(WebKit::toWTFString(messageNameRef), WebKit::toImpl(messageBodyRef));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h
@@ -136,6 +136,8 @@ WK_EXPORT void WKBundlePagePostSynchronousMessageForTesting(WKBundlePageRef page
 // Same as WKBundlePagePostMessage() but the message cannot become synchronous, even if the connection is in fully synchronous mode.
 WK_EXPORT void WKBundlePagePostMessageIgnoringFullySynchronousMode(WKBundlePageRef page, WKStringRef messageName, WKTypeRef messageBody);
 
+WK_EXPORT void WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(WKBundlePageRef page);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1698,6 +1698,8 @@ void WebPage::close()
     if (m_isClosed)
         return;
 
+    flushDeferredDidReceiveMouseEvent();
+
     WEBPAGE_RELEASE_LOG(Loading, "close:");
 
     WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
@@ -1818,6 +1820,8 @@ void WebPage::sendClose()
 
 void WebPage::suspendForProcessSwap()
 {
+    flushDeferredDidReceiveMouseEvent();
+
     auto failedToSuspend = [this, protectedThis = Ref { *this }] {
         send(Messages::WebPageProxy::DidFailToSuspendAfterProcessSwap());
     };
@@ -3423,9 +3427,45 @@ void WebPage::mouseEvent(const WebMouseEvent& mouseEvent, std::optional<Vector<S
         handled = handleMouseEvent(mouseEvent, this);
     }
 
-    send(Messages::WebPageProxy::DidReceiveEvent(mouseEvent.type(), handled));
-
     revokeSandboxExtensions(mouseEventSandboxExtensions);
+
+    bool shouldDeferDidReceiveEvent = [&] {
+        if (!m_drawingArea)
+            return false;
+
+        if (mouseEvent.type() != WebEventType::MouseMove)
+            return false;
+
+        if (mouseEvent.button() != WebMouseEventButton::NoButton)
+            return false;
+
+        if (mouseEvent.force())
+            return false;
+
+        return true;
+    }();
+
+    flushDeferredDidReceiveMouseEvent();
+
+    if (shouldDeferDidReceiveEvent) {
+        // For mousemove events where the user is only hovering (not clicking and dragging),
+        // we defer sending the DidReceiveEvent() IPC message until the end of the rendering
+        // update to throttle the rate of these events to the rendering update frequency.
+        // This logic works in tandem with the mouse event queue in the UI process, which
+        // coalesces mousemove events until the DidReceiveEvent() message is received after
+        // the rendering update.
+        m_deferredDidReceiveMouseEvent = { { mouseEvent.type(), handled } };
+        m_drawingArea->scheduleRenderingUpdate();
+        return;
+    }
+
+    send(Messages::WebPageProxy::DidReceiveEvent(mouseEvent.type(), handled));
+}
+
+void WebPage::flushDeferredDidReceiveMouseEvent()
+{
+    if (auto info = std::exchange(m_deferredDidReceiveMouseEvent, std::nullopt))
+        send(Messages::WebPageProxy::DidReceiveEvent(info->type, info->handled));
 }
 
 void WebPage::performHitTestForMouseEvent(const WebMouseEvent& event, CompletionHandler<void(WebHitTestResultData&&, OptionSet<WebEventModifier>, UserData&&)>&& completionHandler)
@@ -4812,6 +4852,7 @@ void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> fl
     if (m_remoteRenderingBackendProxy)
         m_remoteRenderingBackendProxy->finalizeRenderingUpdate();
 #endif
+    flushDeferredDidReceiveMouseEvent();
 }
 
 void WebPage::willStartRenderingUpdateDisplay()
@@ -7266,6 +7307,8 @@ void WebPage::didCommitLoad(WebFrame* frame)
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     m_elementsToExcludeFromRemoveBackground.clear();
 #endif
+
+    flushDeferredDidReceiveMouseEvent();
 }
 
 void WebPage::didFinishDocumentLoad(WebFrame& frame)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -59,6 +59,7 @@
 #include "UserContentControllerIdentifier.h"
 #include "UserData.h"
 #include "WebBackForwardListProxy.h"
+#include "WebEventType.h"
 #include "WebPageProxyIdentifier.h"
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WebUndoStepID.h"
@@ -347,15 +348,16 @@ class WebUserContentController;
 class WebWheelEvent;
 class RemoteLayerTreeTransaction;
 
+enum class DragControllerAction : uint8_t;
 enum class FindOptions : uint16_t;
 enum class FindDecorationStyle : uint8_t;
-enum class DragControllerAction : uint8_t;
 enum class NavigatingToAppBoundDomain : bool;
-enum class TextRecognitionUpdateResult : uint8_t;
 enum class SyntheticEditingCommandType : uint8_t;
+enum class TextRecognitionUpdateResult : uint8_t;
 
 struct BackForwardListItemState;
 struct DataDetectionResult;
+struct DeferredDidReceiveMouseEvent;
 struct DocumentEditingContext;
 struct DocumentEditingContextRequest;
 struct EditorState;
@@ -1626,6 +1628,8 @@ public:
     void setInteractionRegionsEnabled(bool);
 #endif
 
+    void flushDeferredDidReceiveMouseEvent();
+
     void generateTestReport(String&& message, String&& group);
 
     bool isUsingUISideCompositing() const;
@@ -2374,6 +2378,12 @@ private:
     bool m_hasWheelEventHandlers { false };
 
     unsigned m_cachedPageCount { 0 };
+
+    struct DeferredDidReceiveMouseEvent {
+        WebEventType type { WebEventType::NoType };
+        bool handled { false };
+    };
+    std::optional<DeferredDidReceiveMouseEvent> m_deferredDidReceiveMouseEvent;
 
     HashSet<WebCore::ResourceLoaderIdentifier> m_trackedNetworkResourceRequestIdentifiers;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -574,6 +574,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidEndMagnificationGesture()
 #endif
 
+    FlushDeferredDidReceiveMouseEvent()
+
     PerformHitTestForMouseEvent(WebKit::WebMouseEvent event) -> (struct WebKit::WebHitTestResultData hitTestResult, OptionSet<WebKit::WebEventModifier> modifiers, WebKit::UserData messageBody)
 
     EffectiveAppearanceDidChange(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1243,6 +1243,7 @@
 		F4E0A2B42122402B00AF7C7F /* image-and-file-upload.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E0A2B321223F2D00AF7C7F /* image-and-file-upload.html */; };
 		F4E0A2B82122847400AF7C7F /* TestFilePromiseReceiver.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A2B72122847400AF7C7F /* TestFilePromiseReceiver.mm */; };
 		F4E3D80820F70BB9007B58C5 /* significant-text-milestone-article.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E3D80720F708E4007B58C5 /* significant-text-milestone-article.html */; };
+		F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E5CCC12A6C79770051934C /* MouseEventTests.mm */; };
 		F4E7A66327222CA900E74D36 /* canvas-image-data.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4E7A66227222BB100E74D36 /* canvas-image-data.html */; };
 		F4EC8094260D30540010311D /* simple-image-overlay.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4EC8093260D2E620010311D /* simple-image-overlay.html */; };
 		F4F137921D9B683E002BEC57 /* large-video-test-now-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4F137911D9B6832002BEC57 /* large-video-test-now-playing.html */; };
@@ -3562,6 +3563,7 @@
 		F4E0A2B62122847400AF7C7F /* TestFilePromiseReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestFilePromiseReceiver.h; sourceTree = "<group>"; };
 		F4E0A2B72122847400AF7C7F /* TestFilePromiseReceiver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestFilePromiseReceiver.mm; sourceTree = "<group>"; };
 		F4E3D80720F708E4007B58C5 /* significant-text-milestone-article.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "significant-text-milestone-article.html"; sourceTree = "<group>"; };
+		F4E5CCC12A6C79770051934C /* MouseEventTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MouseEventTests.mm; sourceTree = "<group>"; };
 		F4E7A66227222BB100E74D36 /* canvas-image-data.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "canvas-image-data.html"; sourceTree = "<group>"; };
 		F4EB4E8F2328AC3000574DAB /* NSItemProviderAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NSItemProviderAdditions.h; path = cocoa/NSItemProviderAdditions.h; sourceTree = SOURCE_ROOT; };
 		F4EB4E902328AC3000574DAB /* NSItemProviderAdditions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = NSItemProviderAdditions.mm; path = cocoa/NSItemProviderAdditions.mm; sourceTree = SOURCE_ROOT; };
@@ -5501,6 +5503,7 @@
 				517E7DFB15110EA600D0B008 /* MemoryCachePruneWithinResourceLoadDelegate.mm */,
 				5C0BF88C1DD5957400B00328 /* MemoryPressureHandler.mm */,
 				7A99D9931AD4A29D00373141 /* MenuTypesForMouseEvents.mm */,
+				F4E5CCC12A6C79770051934C /* MouseEventTests.mm */,
 				83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */,
 				F43C3823278133190099ABCE /* NSResponderTests.mm */,
 				A57A34EF16AF677200C2501F /* PageVisibilityStateWithWindowChanges.mm */,
@@ -6477,6 +6480,7 @@
 				A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */,
 				1CF087D825ED7F73004148CB /* MobileAssetSandboxCheck.mm in Sources */,
 				7C83E0B61D0A64B300FEBCF3 /* ModalAlertsSPI.cpp in Sources */,
+				F4E5CCC92A6C79770051934C /* MouseEventTests.mm in Sources */,
 				7CCE7F011A411AE600447C4C /* MouseMoveAfterCrash.cpp in Sources */,
 				F4010B8024DA24AC00A876E2 /* NavigationSwipeTests.mm in Sources */,
 				9B19CDA01F06DFE3000548DD /* NetworkProcessCrashWithPendingConnection.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(MAC)
+
+#import "PlatformUtilities.h"
+#import "TestNavigationDelegate.h"
+#import "TestURLSchemeHandler.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+
+namespace TestWebKitAPI {
+
+TEST(MouseEventTests, CoalesceMouseMoveEvents)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<html>"
+        "<head>"
+        "<style>"
+        "body, html { margin: 0; width: 100%; height: 100%; }"
+        "</style>"
+        "</head>"
+        "<body>"
+        "<script>"
+        "let allMouseEvents = [];"
+        "function pushMouseEvent(event) {"
+        "    allMouseEvents.push({"
+        "        x: event.clientX,"
+        "        y: event.clientY,"
+        "        type: event.type"
+        "    });"
+        "}"
+        "addEventListener('mousemove', pushMouseEvent);"
+        "addEventListener('mousedown', pushMouseEvent);"
+        "addEventListener('mouseup', pushMouseEvent);"
+        "</script>"
+        "</body>"
+        "</html>"];
+
+    [webView mouseEnterAtPoint:NSMakePoint(100, 300)];
+    for (unsigned i = 1; i <= 200; ++i) {
+        [webView mouseMoveToPoint:NSMakePoint(100 + i, 300) withFlags:0];
+        Util::runFor(100_us);
+    }
+    [webView mouseDownAtPoint:NSMakePoint(300, 300) simulatePressure:NO];
+    [webView mouseUpAtPoint:NSMakePoint(300, 300)];
+    [webView waitForPendingMouseEvents];
+
+    NSArray<NSDictionary *> *mouseEvents = [webView objectByEvaluatingJavaScript:@"allMouseEvents"];
+    auto checkEventAtIndex = [&](NSString *type, NSPoint location, NSUInteger index) {
+        auto info = mouseEvents[index];
+        EXPECT_WK_STREQ(type, dynamic_objc_cast<NSString>(info[@"type"]));
+        EXPECT_EQ([info[@"x"] floatValue], location.x);
+        EXPECT_EQ([info[@"y"] floatValue], location.y);
+    };
+
+    auto numberOfMouseEvents = mouseEvents.count;
+    EXPECT_GE(numberOfMouseEvents, 4U);
+    EXPECT_LT(numberOfMouseEvents, 200U);
+
+    checkEventAtIndex(@"mousemove", NSMakePoint(101, 300), 0);
+    checkEventAtIndex(@"mousemove", NSMakePoint(300, 300), numberOfMouseEvents - 3);
+    checkEventAtIndex(@"mousedown", NSMakePoint(300, 300), numberOfMouseEvents - 2);
+    checkEventAtIndex(@"mouseup", NSMakePoint(300, 300), numberOfMouseEvents - 1);
+}
+
+TEST(MouseEventTests, ProcessSwapWithDeferredMouseMoveEventCompletion)
+{
+    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    [processPoolConfiguration setProcessSwapsOnNavigation:YES];
+    [processPoolConfiguration setUsesWebProcessCache:YES];
+    [processPoolConfiguration setPrewarmsProcessesAutomatically:YES];
+    [processPoolConfiguration setProcessSwapsOnNavigationWithinSameNonHTTPFamilyProtocol:YES];
+
+    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setProcessPool:processPool.get()];
+
+    auto handler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        auto host = task.request.URL.host;
+        if ([host isEqualToString:@"www.apple.com"])
+            return respond(task, "<body>Hello world</body>");
+
+        if ([host isEqualToString:@"webkit.org"]) {
+            return respond(task, makeString("<body style='width: 100%; height: 100%;'>"_s,
+                "<script>"_s,
+                "    document.body.addEventListener('mousemove', () => {"_s,
+                "        location.href = 'pson://www.apple.com/index.html';"_s,
+                "    });"_s,
+                "</script>"_s,
+                "</body>"_s).utf8().data());
+        }
+    }];
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
+
+    auto navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://webkit.org/index.html"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView mouseEnterAtPoint:NSMakePoint(400, 300)];
+
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        [webView mouseMoveToPoint:NSMakePoint(401, 301) withFlags:0];
+        [webView mouseMoveToPoint:NSMakePoint(402, 302) withFlags:0];
+        [navigationDelegate waitForDidFinishNavigation];
+
+        [webView goBack];
+        [navigationDelegate waitForDidFinishNavigation];
+    }
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -239,6 +239,11 @@ void EventSendingController::mouseMoveTo(int x, int y, JSStringRef pointerType)
         setValue(body, "PointerType", pointerType);
     m_position = WKPointMake(x, y);
     postSynchronousPageMessage("EventSender", body);
+
+    WKBundlePageFlushDeferredDidReceiveMouseEventForTesting(InjectedBundle::singleton().pageRef());
+    auto waitForDidReceiveEventBody = adoptWK(WKMutableDictionaryCreate());
+    setValue(waitForDidReceiveEventBody, "SubMessage", "WaitForDeferredMouseEvents");
+    postSynchronousPageMessage("EventSender", waitForDidReceiveEventBody);
 }
 
 void EventSendingController::mouseForceClick()

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1964,6 +1964,9 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
             return completionHandler(nullptr);
         }
 
+        if (WKStringIsEqualToUTF8CString(subMessageName, "WaitForDeferredMouseEvents"))
+            return completionHandler(nullptr);
+
 #if PLATFORM(MAC)
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseForceClick")) {
             m_eventSenderProxy->mouseForceClick();


### PR DESCRIPTION
#### a10c4813fe62020d18ca2073c2e687a9f86279af
<pre>
Throttle `mousemove` events to one per rendering update
<a href="https://bugs.webkit.org/show_bug.cgi?id=259408">https://bugs.webkit.org/show_bug.cgi?id=259408</a>
rdar://110921187

Reviewed by Tim Horton and Simon Fraser.

Throttle the mousemove event dispatch rate to a maximum of 1 per rendering update, if the user isn&apos;t
clicking or dragging. See below for more details.

Test:   MouseEventTests.CoalesceMouseMoveEvents
        MouseEventTests.ProcessSwapWithDeferredMouseMoveEventCompletion

* LayoutTests/fast/selectors/style-invalidation-hover-change-descendants-expected.txt:
* LayoutTests/fast/selectors/style-invalidation-hover-change-descendants.html:
* LayoutTests/fast/selectors/style-invalidation-hover-change-siblings-expected.txt:
* LayoutTests/fast/selectors/style-invalidation-hover-change-siblings.html:

Adjust a couple of layout tests that need to run checks for style invalidation state immediately
after handling the mousemove event, without waiting for any further IPC messages to be dispatched.
Ensure this by moving the test logic into one-shot `mousemove` event listeners; we also take the
opportunity to modernize the test a bit by using `js-test.js` and `testPassed` / `testFailed`.

* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebEventType.h: Copied from Source/WebKit/Shared/WebEvent.h.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleMouseEvent):

See comments under `WebPage::mouseEvent`.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageFlushDeferredDidReceiveMouseEventForTesting):

Add a testing-only SPI hook to flush the `DidReceiveEvent` message corresponding to any `mousemove`
events that have already been handled in the web process. WebKitTestRunner uses this to ensure that
`window.eventSender` API to simulate mouse events behaves the same way as it currently does.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
(WebKit::WebPage::suspendForProcessSwap):

Flush any deferred `mousemove` IPC responses here when suspending right before a process swap, so
that we won&apos;t end up trying to send a `DidReceiveEvent` message back to the UI process when the
`WebPageProxy`&apos;s `mouseEventQueue` has already been emptied, due to process swapping.

(WebKit::WebPage::mouseEvent):

When handling a `mousemove` event, rather than invoke the IPC completion handler immediately, we
instead defer the call to `WebPageProxy::DidReceiveEvent` until the end of the current rendering
update. This means that existing UI-side logic for coalescing `mousemove` events when the web
process is still handling mouse events will coalesce mousemove events until the end of the rendering
update, after which the web process will be done with current mousemove.

If a non-`mousemove` event enters the mouse event queue), we&apos;ll also tell the web process to
dispatch the deferred mousemove completion handler early so that we can process the incoming click
right away.

(WebKit::WebPage::flushDeferredDidReceiveMouseEvent):
(WebKit::WebPage::finalizeRenderingUpdate):

Clear out `m_deferredDidReceiveMouseEvent` if it was set, and dispatch the `DidReceiveEvent` message
back to the UI process for this deferred event.

(WebKit::WebPage::didCommitLoad):

Similarly, flush any deferred `DidReceiveEvent` response when committing a load.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm: Added.

Add an API test to exercise `mousemove` event coalescing (both this new completion deferral, as well
as the preexisting mechanism for coalescing events in the UI process). This test simulates moving a
mouse cursor over (300, 300) in the window, clicking, and then verifies that:

1.  There are at least 4 mouse events observed: a `mousemove` for the starting location, another
    `mousemove` for the final destination, and `mousedown` and `mouseup` events for the click.

2.  There are no more than 200 events in total (in other words, some `mousemove` events were
    coalesced).

Also, add an API test to verify that we don&apos;t hit a `MESSAGE_CHECK` due to sending a deferred
`mousemove` event completion message during a process swap.

* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::mouseMoveTo):

Use the above testing hook. We also wait for one extra web &lt;-&gt; UI process round trip here in order
to ensure that the UI process has received the message from the web process indicating that we&apos;ve
handled the `mousemove` event.

* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/266341@main">https://commits.webkit.org/266341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9d2db39c3946e680d613a842828603e12f1eb16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15510 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13647 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14297 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15921 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19212 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15547 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10743 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12032 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->