### PR TITLE
window.postMessage with OffscreenCanvas is broken with isolated world message listener

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWrapper.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.cpp
@@ -49,7 +49,7 @@ JSC::JSValue cloneAcrossWorlds(JSC::JSGlobalObject& lexicalGlobalObject, const J
     if (isWorldCompatible(lexicalGlobalObject, value))
         return value;
     // FIXME: Is it best to handle errors by returning null rather than throwing an exception?
-    auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+    auto serializedValue = SerializedScriptValue::create(lexicalGlobalObject, value, SerializationForStorage::No, SerializationErrorMode::NonThrowing, SerializationContext::CloneAcrossWorlds);
     if (!serializedValue)
         return JSC::jsNull();
     // FIXME: Why is owner->globalObject() better than lexicalGlobalObject.lexicalGlobalObject() here?

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -218,6 +218,10 @@ enum SerializationTag {
 #endif
     ResizableArrayBufferTag = 54,
     ErrorInstanceTag = 55,
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    InMemoryOffscreenCanvasTag = 56,
+#endif
+    InMemoryMessagePortTag = 57,
     ErrorTag = 255
 };
 
@@ -306,7 +310,9 @@ static bool isTypeExposedToGlobalObject(JSC::JSGlobalObject& globalObject, Seria
     case ImageBitmapTag:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     case OffscreenCanvasTransferTag:
+    case InMemoryOffscreenCanvasTag:
 #endif
+    case InMemoryMessagePortTag:
 #if ENABLE(WEB_RTC)
     case RTCDataChannelTransferTag:
 #endif
@@ -800,7 +806,9 @@ public:
     static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
+            Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases,
 #endif
+            Vector<RefPtr<MessagePort>>& inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
             const Vector<Ref<RTCDataChannel>>& rtcDataChannels,
 #endif
@@ -818,7 +826,9 @@ public:
         CloneSerializer serializer(lexicalGlobalObject, messagePorts, arrayBuffers, imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             offscreenCanvases,
+            inMemoryOffscreenCanvases,
 #endif
+            inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
             rtcDataChannels,
 #endif
@@ -856,7 +866,9 @@ private:
     CloneSerializer(JSGlobalObject* lexicalGlobalObject, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
+            Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases,
 #endif
+            Vector<RefPtr<MessagePort>>& inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
             const Vector<Ref<RTCDataChannel>>& rtcDataChannels,
 #endif
@@ -875,6 +887,10 @@ private:
         , m_emptyIdentifier(Identifier::fromString(lexicalGlobalObject->vm(), emptyString()))
         , m_context(context)
         , m_sharedBuffers(sharedBuffers)
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+        , m_inMemoryOffscreenCanvases(inMemoryOffscreenCanvases)
+#endif
+        , m_inMemoryMessagePorts(inMemoryMessagePorts)
 #if ENABLE(WEBASSEMBLY)
         , m_wasmModules(wasmModules)
         , m_wasmMemoryHandles(wasmMemoryHandles)
@@ -1362,6 +1378,11 @@ private:
             write(OffscreenCanvasTransferTag);
             write(index->value);
             return;
+        } else if (m_context == SerializationContext::CloneAcrossWorlds) {
+            write(InMemoryOffscreenCanvasTag);
+            write(static_cast<uint32_t>(m_inMemoryOffscreenCanvases.size()));
+            m_inMemoryOffscreenCanvases.append(&jsCast<JSOffscreenCanvas*>(obj)->wrapped());
+            return;
         }
 
         code = SerializationReturnCode::DataCloneError;
@@ -1602,6 +1623,12 @@ private:
                     write(MessagePortReferenceTag);
                     write(index->value);
                     return true;
+                } else if (m_context == SerializationContext::CloneAcrossWorlds) {
+                    // FIXME: Only in clone accross worlds mode.
+                    write (InMemoryMessagePortTag);
+                    write(static_cast<uint32_t>(m_inMemoryMessagePorts.size()));
+                    m_inMemoryMessagePorts.append(&jsCast<JSMessagePort*>(obj)->wrapped());
+                    return true;
                 }
                 // MessagePort object could not be found in transferred message ports
                 code = SerializationReturnCode::ValidationError;
@@ -1676,10 +1703,16 @@ private:
                 WasmMemoryHandleArray dummyMemoryHandles;
 #endif
                 ArrayBufferContentsArray dummySharedBuffers;
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+                Vector<RefPtr<OffscreenCanvas>> dummyInMemoryOffscreenCanvases;
+#endif
+                Vector<RefPtr<MessagePort>> dummyInMemoryMessagePorts;
                 CloneSerializer rawKeySerializer(m_lexicalGlobalObject, dummyMessagePorts, dummyArrayBuffers, { },
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                     { },
+                    dummyInMemoryOffscreenCanvases,
 #endif
+                    dummyInMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
                     { },
 #endif
@@ -2285,6 +2318,10 @@ private:
     Identifier m_emptyIdentifier;
     SerializationContext m_context;
     ArrayBufferContentsArray& m_sharedBuffers;
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    Vector<RefPtr<OffscreenCanvas>>& m_inMemoryOffscreenCanvases;
+#endif
+    Vector<RefPtr<MessagePort>>& m_inMemoryMessagePorts;
 #if ENABLE(WEBASSEMBLY)
     WasmModuleArray& m_wasmModules;
     WasmMemoryHandleArray& m_wasmMemoryHandles;
@@ -2580,7 +2617,9 @@ public:
     static DeserializationResult deserialize(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, Vector<std::optional<ImageBitmapBacking>>&& backingStores
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
+        , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases
 #endif
+        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -2600,7 +2639,9 @@ public:
         CloneDeserializer deserializer(lexicalGlobalObject, globalObject, messagePorts, arrayBufferContentsArray, buffer, blobURLs, blobFilePaths, sharedBuffers, WTFMove(backingStores)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             , WTFMove(detachedOffscreenCanvases)
+            , inMemoryOffscreenCanvases
 #endif
+            , inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
             , WTFMove(detachedRTCDataChannels)
 #endif
@@ -2661,7 +2702,9 @@ private:
     CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, Vector<std::optional<ImageBitmapBacking>>&& backingStores, const Vector<uint8_t>& buffer
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases = { }
+        , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases = { }
 #endif
+        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts = { }
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels = { }
 #endif
@@ -2689,7 +2732,9 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , m_detachedOffscreenCanvases(WTFMove(detachedOffscreenCanvases))
         , m_offscreenCanvases(m_detachedOffscreenCanvases.size())
+        , m_inMemoryOffscreenCanvases(inMemoryOffscreenCanvases)
 #endif
+        , m_inMemoryMessagePorts(inMemoryMessagePorts)
 #if ENABLE(WEB_RTC)
         , m_detachedRTCDataChannels(WTFMove(detachedRTCDataChannels))
         , m_rtcDataChannels(m_detachedRTCDataChannels.size())
@@ -2712,7 +2757,9 @@ private:
     CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, const Vector<uint8_t>& buffer, const Vector<String>& blobURLs, const Vector<String> blobFilePaths, ArrayBufferContentsArray* sharedBuffers, Vector<std::optional<ImageBitmapBacking>>&& backingStores
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
+        , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases
 #endif
+        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -2743,7 +2790,9 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , m_detachedOffscreenCanvases(WTFMove(detachedOffscreenCanvases))
         , m_offscreenCanvases(m_detachedOffscreenCanvases.size())
+        , m_inMemoryOffscreenCanvases(inMemoryOffscreenCanvases)
 #endif
+        , m_inMemoryMessagePorts(inMemoryMessagePorts)
 #if ENABLE(WEB_RTC)
         , m_detachedRTCDataChannels(WTFMove(detachedRTCDataChannels))
         , m_rtcDataChannels(m_detachedRTCDataChannels.size())
@@ -3847,6 +3896,17 @@ private:
         auto offscreenCanvas = m_offscreenCanvases[index].get();
         return getJSValue(offscreenCanvas);
     }
+
+    JSValue readInMemoryOffscreenCanvas()
+    {
+        uint32_t index;
+        bool indexSuccessfullyRead = read(index);
+        if (!indexSuccessfullyRead || index >= m_inMemoryOffscreenCanvases.size()) {
+            fail();
+            return JSValue();
+        }
+        return getJSValue(m_inMemoryOffscreenCanvases[index].get());
+    }
 #endif
 
 #if ENABLE(WEB_RTC)
@@ -4329,6 +4389,15 @@ private:
             }
             return getJSValue(m_messagePorts[index].get());
         }
+        case InMemoryMessagePortTag: {
+            uint32_t index;
+            bool indexSuccessfullyRead = read(index);
+            if (!indexSuccessfullyRead || index >= m_inMemoryMessagePorts.size()) {
+                fail();
+                return JSValue();
+            }
+            return getJSValue(m_inMemoryMessagePorts[index].get());
+        }
 #if ENABLE(WEBASSEMBLY)
         case WasmModuleTag: {
             if (m_version >= 12) {
@@ -4517,6 +4586,8 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         case OffscreenCanvasTransferTag:
             return readOffscreenCanvas();
+        case InMemoryOffscreenCanvasTag:
+            return readInMemoryOffscreenCanvas();
 #endif
 #if ENABLE(WEB_RTC)
         case RTCDataChannelTransferTag:
@@ -4565,7 +4636,9 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<std::unique_ptr<DetachedOffscreenCanvas>> m_detachedOffscreenCanvases;
     Vector<RefPtr<OffscreenCanvas>> m_offscreenCanvases;
+    const Vector<RefPtr<OffscreenCanvas>>& m_inMemoryOffscreenCanvases;
 #endif
+    const Vector<RefPtr<MessagePort>>& m_inMemoryMessagePorts;
 #if ENABLE(WEB_RTC)
     Vector<std::unique_ptr<DetachedRTCDataChannel>> m_detachedRTCDataChannels;
     Vector<RefPtr<RTCDataChannel>> m_rtcDataChannels;
@@ -4803,7 +4876,9 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer, std::uniq
 SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer, Vector<URLKeepingBlobAlive>&& blobHandles, std::unique_ptr<ArrayBufferContentsArray> arrayBufferContentsArray, std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray, Vector<std::optional<ImageBitmapBacking>>&& backingStores
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
+        , Vector<RefPtr<OffscreenCanvas>>&& inMemoryOffscreenCanvases
 #endif
+        , Vector<RefPtr<MessagePort>>&& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -4822,7 +4897,9 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer, Vector<UR
     , m_backingStores(WTFMove(backingStores))
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     , m_detachedOffscreenCanvases(WTFMove(detachedOffscreenCanvases))
+    , m_inMemoryOffscreenCanvases(WTFMove(inMemoryOffscreenCanvases))
 #endif
+    , m_inMemoryMessagePorts(WTFMove(inMemoryMessagePorts))
 #if ENABLE(WEB_RTC)
     , m_detachedRTCDataChannels(WTFMove(detachedRTCDataChannels))
 #endif
@@ -5101,6 +5178,10 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 
     Vector<uint8_t> buffer;
     Vector<URLKeepingBlobAlive> blobHandles;
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+    Vector<RefPtr<OffscreenCanvas>> inMemoryOffscreenCanvases;
+#endif
+    Vector<RefPtr<MessagePort>> inMemoryMessagePorts;
 #if ENABLE(WEBASSEMBLY)
     WasmModuleArray wasmModules;
     WasmMemoryHandleArray wasmMemoryHandles;
@@ -5113,7 +5194,9 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     auto code = CloneSerializer::serialize(&lexicalGlobalObject, value, messagePorts, arrayBuffers, imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         offscreenCanvases,
+        inMemoryOffscreenCanvases,
 #endif
+        inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
         dataChannels,
 #endif
@@ -5161,7 +5244,9 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     return adoptRef(*new SerializedScriptValue(WTFMove(buffer), WTFMove(blobHandles), arrayBufferContentsArray.releaseReturnValue(), context == SerializationContext::WorkerPostMessage ? WTFMove(sharedBuffers) : nullptr, WTFMove(backingStores)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                 , WTFMove(detachedCanvases)
+                , WTFMove(inMemoryOffscreenCanvases)
 #endif
+                , WTFMove(inMemoryMessagePorts)
 #if ENABLE(WEB_RTC)
                 , WTFMove(detachedRTCDataChannels)
 #endif
@@ -5225,7 +5310,9 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
     DeserializationResult result = CloneDeserializer::deserialize(&lexicalGlobalObject, globalObject, messagePorts, WTFMove(m_backingStores)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , WTFMove(m_detachedOffscreenCanvases)
+        , m_inMemoryOffscreenCanvases
 #endif
+        , m_inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , WTFMove(m_detachedRTCDataChannels)
 #endif

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -56,6 +56,7 @@ namespace WebCore {
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 class DetachedOffscreenCanvas;
+class OffscreenCanvas;
 #endif
 class IDBValue;
 class MessagePort;
@@ -64,7 +65,7 @@ class FragmentedSharedBuffer;
 enum class SerializationReturnCode;
 
 enum class SerializationErrorMode { NonThrowing, Throwing };
-enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage };
+enum class SerializationContext { Default, WorkerPostMessage, WindowPostMessage, CloneAcrossWorlds };
 enum class SerializationForStorage : bool { No, Yes };
 
 using ArrayBufferContentsArray = Vector<JSC::ArrayBufferContents>;
@@ -131,7 +132,9 @@ private:
     SerializedScriptValue(Vector<unsigned char>&&, Vector<URLKeepingBlobAlive>&& blobHandles, std::unique_ptr<ArrayBufferContentsArray>, std::unique_ptr<ArrayBufferContentsArray> sharedBuffers, Vector<std::optional<ImageBitmapBacking>>&& backingStores
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& = { }
+        , Vector<RefPtr<OffscreenCanvas>>&& = { }
 #endif
+        , Vector<RefPtr<MessagePort>>&& = { }
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }
 #endif
@@ -153,7 +156,9 @@ private:
     Vector<std::optional<ImageBitmapBacking>> m_backingStores;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<std::unique_ptr<DetachedOffscreenCanvas>> m_detachedOffscreenCanvases;
+    Vector<RefPtr<OffscreenCanvas>> m_inMemoryOffscreenCanvases;
 #endif
+    Vector<RefPtr<MessagePort>> m_inMemoryMessagePorts;
 #if ENABLE(WEB_RTC)
     Vector<std::unique_ptr<DetachedRTCDataChannel>> m_detachedRTCDataChannels;
 #endif

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -74,11 +74,9 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 
     auto& eventType = didFail ? eventNames().messageerrorEvent : eventNames().messageEvent;
-    auto event = adoptRef(*new MessageEvent(eventType, WTFMove(data), origin, lastEventId, WTFMove(source), WTFMove(ports)));
+    auto event = adoptRef(*new MessageEvent(eventType, MessageEvent::JSValueTag { }, origin, lastEventId, WTFMove(source), WTFMove(ports)));
     JSC::Strong<JSC::JSObject> strongWrapper(vm, JSC::jsCast<JSC::JSObject*>(toJS(&globalObject, JSC::jsCast<JSDOMGlobalObject*>(&globalObject), event.get())));
-    // Since we've already deserialized the SerializedScriptValue, cache the result so we don't have to deserialize
-    // again the next time JSMessageEvent::data() gets called by the main world.
-    event->cachedData().set(vm, strongWrapper.get(), deserialized);
+    event->jsData().set(vm, strongWrapper.get(), deserialized);
 
     return MessageEventWithStrongData { event, WTFMove(strongWrapper) };
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		46F03C1C255B2D5A00AA51C5 /* audio-context-playing.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46F03C1B255B2D3600AA51C5 /* audio-context-playing.html */; };
 		46FA2FEE23846CA5000CCB0C /* HTTPHeaderMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46FA2FED23846C9A000CCB0C /* HTTPHeaderMap.cpp */; };
 		46FACF7423E8842300A9EBC6 /* beforeunload-slow.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FACF7323E883EE00A9EBC6 /* beforeunload-slow.html */; };
+		46FD40382A6B3E6800A1B210 /* postMessage-various-types.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */; };
 		48124A272925A0C100EED506 /* AnimationControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 48124A262925A0C100EED506 /* AnimationControl.mm */; };
 		48354DD929F08047003E566D /* animated-red-green-blue-repeat-infinite.gif in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DD129F08036003E566D /* animated-red-green-blue-repeat-infinite.gif */; };
 		48354DDB29F092D1003E566D /* img-animation-in-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 48354DDA29F092B1003E566D /* img-animation-in-anchor.html */; };
@@ -1799,6 +1800,7 @@
 				F415086D1DA040C50044BE9B /* play-audio-on-click.html in Copy Resources */,
 				0EBBCC661FFF9E0C00FA42AB /* pop-up-check.html in Copy Resources */,
 				465C23AF2640C3FE00F2FC7F /* postMessage-regularly.html in Copy Resources */,
+				46FD40382A6B3E6800A1B210 /* postMessage-various-types.html in Copy Resources */,
 				F41AB9A81EF4696B0083FA08 /* prevent-operation.html in Copy Resources */,
 				F41AB9A91EF4696B0083FA08 /* prevent-start.html in Copy Resources */,
 				F6FDDDD614241C6F004F1729 /* push-state.html in Copy Resources */,
@@ -2371,6 +2373,7 @@
 		46F03C1B255B2D3600AA51C5 /* audio-context-playing.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "audio-context-playing.html"; sourceTree = "<group>"; };
 		46FA2FED23846C9A000CCB0C /* HTTPHeaderMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HTTPHeaderMap.cpp; sourceTree = "<group>"; };
 		46FACF7323E883EE00A9EBC6 /* beforeunload-slow.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "beforeunload-slow.html"; sourceTree = "<group>"; };
+		46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "postMessage-various-types.html"; sourceTree = "<group>"; };
 		48124A262925A0C100EED506 /* AnimationControl.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = AnimationControl.mm; sourceTree = "<group>"; };
 		48354DD129F08036003E566D /* animated-red-green-blue-repeat-infinite.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; name = "animated-red-green-blue-repeat-infinite.gif"; path = "Tests/WebKitCocoa/animated-red-green-blue-repeat-infinite.gif"; sourceTree = SOURCE_ROOT; };
 		48354DDA29F092B1003E566D /* img-animation-in-anchor.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = "img-animation-in-anchor.html"; path = "Tests/WebKitCocoa/img-animation-in-anchor.html"; sourceTree = SOURCE_ROOT; };
@@ -4815,6 +4818,7 @@
 				3FCC4FE61EC4E87E0076E37C /* PictureInPictureDelegate.html */,
 				F415086C1DA040C10044BE9B /* play-audio-on-click.html */,
 				465C23AE2640C3C500F2FC7F /* postMessage-regularly.html */,
+				46FD40302A6B3E3500A1B210 /* postMessage-various-types.html */,
 				F41AB9941EF4692C0083FA08 /* prevent-operation.html */,
 				F41AB99A1EF4692C0083FA08 /* prevent-start.html */,
 				A12DDBFF1E8373C100CF6CAE /* rendered-image-excluding-overflow.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/postMessage-various-types.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/postMessage-various-types.html
@@ -1,0 +1,60 @@
+<html>
+<body>
+<iframe id="target" srcdoc="
+    <ul id='results'></ul>
+    <script>
+      window.addEventListener('message', (event) => {
+        if (event.data && event.data.obj)
+          window.webkit.messageHandlers.testHandler.postMessage(event.data.name + ': ' + event.data.obj.constructor.name);
+        else
+           window.webkit.messageHandlers.testHandler.postMessage(event.data.name + ': FAIL');
+      }, false);
+    </script>
+  "></iframe>
+  
+  <script>
+    const target = document.getElementById("target");
+    setTimeout(() => {
+      target.contentWindow.postMessage(
+        {
+          name: "Object",
+          obj: { }
+        },
+        "*",
+        []
+      );
+
+      const buf = new ArrayBuffer(8);
+      target.contentWindow.postMessage(
+        {
+          name: "ArrayBuffer",
+          obj: buf
+        },
+        "*",
+        [buf]
+      );
+
+      const canvas = new OffscreenCanvas(10, 10);
+      target.contentWindow.postMessage(
+        {
+          name: "OffscreenCanvas",
+          obj: canvas
+        },
+        "*",
+        [canvas]
+      );
+
+      const channel = new MessageChannel();
+      target.contentWindow.postMessage(
+        {
+          name: "MessagePort",
+          obj: channel.port2
+        },
+        "*",
+        [channel.port2]
+      );
+    }, 1000);
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
#### acece69bd261c37f0a66d82d4abc80bed8b09bd7
<pre>
window.postMessage with OffscreenCanvas is broken with isolated world message listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=259362">https://bugs.webkit.org/show_bug.cgi?id=259362</a>
rdar://112618195

Reviewed by Darin Adler.

When constructing a MessageEvent, we would deserialize the `data` SerializedScriptValue
and cache the resulting JSValue. When accessing MessageEvent.data from the main world,
we would return the cached JSValue and everything would work fine.
However, upon accessing MessageEvent.data from a non-main world, the cached JSValue
would not be usable and we would deserialize the original SerializedScriptValue again.

The issue is that a SerializedScriptValue is not meant to be deserialized several times.
This is because the deserialization &quot;consumes&quot; certain internal objects. For examples,
OffscreenCanvas are stored as DetachedOffscreenCanvas internally and consumed upon
deserialization to construct OffscreenCanvas objects again.

To address the issue, this patch makes several changes:
1. MessageEvent::create() now stores the deserialized JSValue inside the MessageEvent
   object instead of the SerializedScriptValue. As a result, when accessing
   MessageEvent.data from the main world, we&apos;ll just return the internal JSValue.
   When accessing MessageEvent.data from a non-main world, cachedPropertyValue() will
   detect that the internal JSValue is no compatible with this world and call
   cloneAcrossWorlds() on the internal JSValue to generate one suitable for the non-main
   world. Internally, cloneAcrossWorlds() creates a SerializedScriptValue from the JSValue
   and then deserializes that SerializedScriptValue in the target world.
2. As currently implemented, cloneAcrossWorlds() would drop transferrable objects such
   as OffscreenCanvas and MessagePort. To address the issue, we now introduce a new
   CloneAcrossWorlds SerializationContext. When in this context, SerializedScriptValue
   serialization will store OffscreenCanvas/MessagePort in the JSValue inside internal
   vectors and merely serialize indexes inside those vectors. Upon deserialization, we
   deserialize the index and lookup the OffscreenCanvas/MessagePort from the internal
   vector. Then, we call toJS() on the implementation object to get a JS wrapper for the
   target world.

* Source/WebCore/bindings/js/JSDOMWrapper.cpp:
(WebCore::cloneAcrossWorlds):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::isTypeExposedToGlobalObject):
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::dumpOffscreenCanvas):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::deserialize):
(WebCore::CloneDeserializer::CloneDeserializer):
(WebCore::CloneDeserializer::readInMemoryOffscreenCanvas):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::SerializedScriptValue::SerializedScriptValue):
(WebCore::SerializedScriptValue::create):
(WebCore::SerializedScriptValue::deserialize):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::create):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentWorld.mm:
(-[UserContentWorldMessageHandler userContentController:didReceiveScriptMessage:]):
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/postMessage-various-types.html: Added.

Canonical link: <a href="https://commits.webkit.org/266465@main">https://commits.webkit.org/266465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c12afab1f100fec600d19dfbc2cc5e41bae51930

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13918 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15655 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15882 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16359 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19586 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13048 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15929 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12531 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3372 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->