### PR TITLE
[JSC] Add dumpAndClearSamplingProfilerSamples function

### DIFF
--- a/JSTests/stress/sampling-profiler-anonymous-function.js
+++ b/JSTests/stress/sampling-profiler-anonymous-function.js
@@ -18,5 +18,5 @@ if (platformSupportsSamplingProfiler()) {
         });
     }
 
-    runTest(baz, ["(anonymous function)", "foo", "baz"]);
+    runTest(baz, ["", "foo", "baz"]);
 }

--- a/JSTests/stress/sampling-profiler-stack-trace-with-double-quote-in-function-name.js
+++ b/JSTests/stress/sampling-profiler-stack-trace-with-double-quote-in-function-name.js
@@ -11,7 +11,7 @@ if (platformSupportsSamplingProfiler()) {
         for (let i = 0; i < 1000; ++i) {
             foo();
             let stacktraces = samplingProfilerStackTraces();
-            for (let stackTrace of stacktraces) { }
+            for (let stackTrace of stacktraces.traces) { }
         }
     }
 

--- a/JSTests/stress/sampling-profiler/samplingProfiler.js
+++ b/JSTests/stress/sampling-profiler/samplingProfiler.js
@@ -25,10 +25,10 @@ function makeNode(name) {
 
 function updateCallingContextTree(root) {
     let stacktraces = samplingProfilerStackTraces();
-    for (let stackTrace of stacktraces) {
+    for (let stackTrace of stacktraces.traces) {
         let node = root;
-        for (let i = stackTrace.length; i--; ) {
-            let functionName = stackTrace[i];
+        for (let i = stackTrace.frames.length; i--; ) {
+            let functionName = stackTrace.frames[i].name;
             node = node.makeChildIfNeeded(functionName);
         }
     }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2976,8 +2976,9 @@ JSC_DEFINE_HOST_FUNCTION(functionSamplingProfilerStackTraces, (JSGlobalObject* g
     if (!vm.samplingProfiler())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Sampling profiler was never started"_s)));
 
-    String jsonString = vm.samplingProfiler()->stackTracesAsJSON();
-    EncodedJSValue result = JSValue::encode(JSONParse(globalObject, jsonString));
+    auto json = vm.samplingProfiler()->stackTracesAsJSON();
+    auto jsonString = json->toJSONString();
+    EncodedJSValue result = JSValue::encode(JSONParse(globalObject, WTFMove(jsonString)));
     scope.releaseAssertNoException();
     return result;
 }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -149,7 +149,6 @@ public:
         // These are function-level data.
         String nameFromCallee(VM&);
         String displayName(VM&);
-        String displayNameForJSONTests(VM&); // Used for JSC stress tests because they want the "(anonymous function)" string for anonymous functions and they want "(eval)" for eval'd code.
         int functionStartLine();
         unsigned functionStartColumn();
         SourceID sourceID();
@@ -187,7 +186,7 @@ public:
     JS_EXPORT_PRIVATE void start();
     void startWithLock() WTF_REQUIRES_LOCK(m_lock);
     Vector<StackTrace> releaseStackTraces() WTF_REQUIRES_LOCK(m_lock);
-    JS_EXPORT_PRIVATE String stackTracesAsJSON();
+    JS_EXPORT_PRIVATE Ref<JSON::Value> stackTracesAsJSON();
     JS_EXPORT_PRIVATE void noticeCurrentThreadAsJSCExecutionThread();
     void noticeCurrentThreadAsJSCExecutionThreadWithLock() WTF_REQUIRES_LOCK(m_lock);
     void processUnverifiedStackTraces() WTF_REQUIRES_LOCK(m_lock);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -577,6 +577,34 @@ SamplingProfiler& VM::ensureSamplingProfiler(Ref<Stopwatch>&& stopwatch)
     }
     return *m_samplingProfiler;
 }
+
+void VM::enableSamplingProfiler()
+{
+    SamplingProfiler* profiler = samplingProfiler();
+    if (!profiler)
+        profiler = &ensureSamplingProfiler(Stopwatch::create());
+    profiler->start();
+}
+
+void VM::disableSamplingProfiler()
+{
+    SamplingProfiler* profiler = samplingProfiler();
+    if (!profiler)
+        profiler = &ensureSamplingProfiler(Stopwatch::create());
+    {
+        Locker locker { profiler->getLock() };
+        profiler->pause();
+    }
+}
+
+RefPtr<JSON::Value> VM::takeSamplingProfilerSamplesAsJSON()
+{
+    SamplingProfiler* profiler = samplingProfiler();
+    if (!profiler)
+        return nullptr;
+    return profiler->stackTracesAsJSON();
+}
+
 #endif // ENABLE(SAMPLING_PROFILER)
 
 static StringImpl::StaticStringImpl terminationErrorString { "JavaScript execution terminated." };

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -333,6 +333,10 @@ public:
 #if ENABLE(SAMPLING_PROFILER)
     SamplingProfiler* samplingProfiler() { return m_samplingProfiler.get(); }
     JS_EXPORT_PRIVATE SamplingProfiler& ensureSamplingProfiler(Ref<Stopwatch>&&);
+
+    JS_EXPORT_PRIVATE void enableSamplingProfiler();
+    JS_EXPORT_PRIVATE void disableSamplingProfiler();
+    JS_EXPORT_PRIVATE RefPtr<JSON::Value> takeSamplingProfilerSamplesAsJSON();
 #endif
 
     FuzzerAgent* fuzzerAgent() const { return m_fuzzerAgent.get(); }

--- a/Tools/Scripts/display-sampling-profiler-output
+++ b/Tools/Scripts/display-sampling-profiler-output
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'rubygems'
+
+require 'readline'
+
+begin
+    require 'json'
+    require 'highline'
+rescue LoadError
+    $stderr.puts "Error: some required gems are not installed!"
+    $stderr.puts
+    $stderr.puts "Try running:"
+    $stderr.puts
+    $stderr.puts "sudo gem install json"
+    $stderr.puts "sudo gem install highline"
+    exit 1
+end
+
+$samplingProfilerTopFunctionsCount = 12
+$samplingProfilerTopBytecodesCount = 40
+$json = JSON::parse(IO::read(ARGV[0]))
+
+def reportTopFunctions database
+  totalSamples = 0
+  functionCounts = Hash.new(0)
+  database["traces"].each do |stackTrace|
+    next if stackTrace["frames"].empty?
+    frame = stackTrace["frames"][0]
+    hash, category, offset = frame["location"].split(":")
+    description = "#{frame["name"]}#{hash}:#{frame["sourceID"]}"
+    functionCounts[description] += 1
+    totalSamples += 1
+  end
+
+  def takeMax functionCounts
+    maxFrameDescription = nil
+    maxFrameCount = 0
+    functionCounts.each do |key, value|
+      if value > maxFrameCount
+        maxFrameCount = value
+        maxFrameDescription = key
+      end
+    end
+
+    if maxFrameDescription
+      functionCounts.delete(maxFrameDescription)
+    end
+    return maxFrameDescription, maxFrameCount
+  end
+
+  timingInterval = database["interval"] * 1000.0 * 1000.0
+  puts "Sampling rate: #{timingInterval} microseconds. Total samples: #{totalSamples}"
+  puts "Top functions as <numSamples  'functionName#hash:sourceID'>"
+  $samplingProfilerTopFunctionsCount.times do
+    key, value = takeMax(functionCounts)
+    break unless key
+    printf("%6u   '%s'\n", value, key)
+  end
+end
+
+$tiers = {
+  :llint => "LLInt",
+  :baseline => "Baseline",
+  :dfg => "DFG",
+  :ftl => "FTL",
+  :ipint => "IPInt",
+  :wasmllint => "WasmLLInt",
+  :bbq => "BBQ",
+  :omg => "OMG",
+  :wasm => "Wasm",
+  :host => "Host",
+  :regexp => "RegExp",
+  :cpp => "C/C++",
+  :unknownFrame => "Unknown Frame",
+  :unknownExecutable => "Unknown Executable",
+}
+
+def reportTopBytecodes database
+  totalSamples = 0
+  bytecodeCounts = Hash.new(0)
+  tierCounts = Hash.new(0)
+
+  database["traces"].each do |stackTrace|
+    next if stackTrace["frames"].empty?
+    frame = stackTrace["frames"][0]
+    description = "#{frame["name"]}#{frame["location"]}"
+    bytecodeCounts[description] += 1
+    tierCounts[frame["category"]] += 1
+    totalSamples += 1
+  end
+
+  def takeMax bytecodeCounts
+    maxFrameDescription = nil
+    maxFrameCount = 0
+    bytecodeCounts.each do |key, value|
+      if value > maxFrameCount
+        maxFrameCount = value
+        maxFrameDescription = key
+      end
+    end
+
+    if maxFrameDescription
+      bytecodeCounts.delete(maxFrameDescription)
+    end
+    return maxFrameDescription, maxFrameCount
+  end
+
+  timingInterval = database["interval"] * 1000.0 * 1000.0
+  puts "Sampling rate: #{timingInterval} microseconds. Total samples: #{totalSamples}"
+  puts ""
+  puts "Tier breakdown:"
+  puts "-----------------------------------"
+
+  $tiers.each do |key, value|
+    printf("%s %s  (%0.06f%%)\n", (value + ':').ljust(20, ' '), tierCounts[value].to_s.rjust(10, ' '), tierCounts[value] * 100.0 / totalSamples.to_f)
+  end
+
+  puts ""
+  puts "Hottest bytecodes as <numSamples   'functionName#hash:JITType:bytecodeIndex'>"
+
+  $samplingProfilerTopBytecodesCount.times do
+    key, value = takeMax(bytecodeCounts)
+    break unless key
+    printf("%6u   '%s'\n", value, key)
+  end
+end
+
+reportTopFunctions($json)
+puts ""
+reportTopBytecodes($json)


### PR DESCRIPTION
#### cc1dd7f1939dc03e9cf8e606067e3b5e90a78ee9
<pre>
[JSC] Add dumpAndClearSamplingProfilerSamples function
<a href="https://bugs.webkit.org/show_bug.cgi?id=259411">https://bugs.webkit.org/show_bug.cgi?id=259411</a>
rdar://112686960

Reviewed by Justin Michaud.

This patch adds dumpAndClearSamplingProfilerSamples behind a flag, which dumps sampling profiler data into temp file.
This allows us to automated sampling data collection for benchmarks by calling this function at the right timing.
We also significantly expand the JSON data generation of SamplingProfiler to reconstruct enough information from this output.

We also attach display-sampling-profiler-output script as the same to display-profiler-output. Which can feed the above JSON
and dump sampling profiler output.

* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::enableSamplingProfiler):
(JSC::VM::disableSamplingProfiler):
(JSC::VM::takeSamplingProfilerSamplesAsJSONString):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/266270@main">https://commits.webkit.org/266270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be8ed3e0bd39d066f61866e5622f2d676b539709

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15120 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13723 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15780 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12078 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12566 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15458 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12669 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12748 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13428 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12019 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3519 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16342 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13812 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1530 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12590 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3316 "Passed tests") | 
<!--EWS-Status-Bubble-End-->