### PR TITLE
Generate serialization of LayerCreationProperties

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1929,6 +1929,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/MediaSourcePrivate.h
     platform/graphics/MediaSourcePrivateClient.h
     platform/graphics/MediaUsageInfo.h
+    platform/graphics/Model.h
     platform/graphics/NativeImage.h
     platform/graphics/NullGraphicsContext.h
     platform/graphics/Path.h

--- a/Source/WebCore/platform/graphics/Model.h
+++ b/Source/WebCore/platform/graphics/Model.h
@@ -44,10 +44,6 @@ public:
     Ref<SharedBuffer> data() const { return m_data; }
     const String& mimeType() const { return m_mimeType; }
     const URL& url() const { return m_url; }
-    
-    template<class Encoder> void encode(Encoder&) const;
-    template<class Decoder> static RefPtr<Model> decode(Decoder&);
-
 private:
     explicit Model(Ref<SharedBuffer>&&, String, URL);
 
@@ -55,35 +51,6 @@ private:
     String m_mimeType;
     URL m_url;
 };
-
-template<class Encoder>
-void Model::encode(Encoder& encoder) const
-{
-    encoder << m_data;
-    encoder << m_mimeType;
-    encoder << m_url;
-}
-
-template<class Decoder>
-RefPtr<Model> Model::decode(Decoder& decoder)
-{
-    std::optional<Ref<SharedBuffer>> data;
-    decoder >> data;
-    if (!data)
-        return nullptr;
-
-    std::optional<String> mimeType;
-    decoder >> mimeType;
-    if (!mimeType)
-        return nullptr;
-
-    std::optional<URL> url;
-    decoder >> url;
-    if (!url)
-        return nullptr;
-
-    return Model::create(WTFMove(*data), WTFMove(*mimeType), WTFMove(*url));
-}
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Model&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -143,3 +143,30 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     [NotSerialized] HashSet<Ref<PlatformCALayerRemote>> changedLayers;
     HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<WebKit::LayerProperties>> changedLayerProperties;
 }
+
+[Nested] struct WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData {
+};
+
+[Nested] struct WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData {
+    WebKit::PlaybackSessionContextIdentifier playerIdentifier;
+    WebCore::FloatSize initialSize;
+    WebCore::FloatSize naturalSize;
+};
+
+[Nested] struct WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData {
+    uint32_t hostingContextID;
+    float hostingDeviceScaleFactor;
+    bool preservesFlip;
+};
+
+[Nested] struct WebKit::RemoteLayerTreeTransaction::LayerCreationProperties {
+    WebCore::PlatformLayerIdentifier layerID;
+    WebCore::PlatformCALayer::LayerType type;
+    std::optional<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData> videoElementData;
+#if ENABLE(MODEL_ELEMENT)
+    std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, Ref<WebCore::Model>, WebCore::LayerHostingContextIdentifier> additionalData;
+#endif
+#if !ENABLE(MODEL_ELEMENT)
+    std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, WebCore::LayerHostingContextIdentifier> additionalData;
+#endif
+};

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5698,3 +5698,9 @@ struct WebCore::CookieStoreGetOptions {
     String name;
     String url;
 };
+
+[RefCounted] class WebCore::Model {
+    Ref<WebCore::SharedBuffer> data()
+    String mimeType()
+    URL url()
+}

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -373,9 +373,9 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
     }
 #endif
 
-    if (properties.hostIdentifier) {
-        m_hostingLayers.set(*properties.hostIdentifier, properties.layerID);
-        if (auto* hostedNode = nodeForID(m_hostedLayers.get(*properties.hostIdentifier)))
+    if (auto* hostIdentifier = std::get_if<WebCore::LayerHostingContextIdentifier>(&properties.additionalData)) {
+        m_hostingLayers.set(*hostIdentifier, properties.layerID);
+        if (auto* hostedNode = nodeForID(m_hostedLayers.get(*hostIdentifier)))
             [node->layer() addSublayer:hostedNode->layer()];
     }
 
@@ -386,7 +386,7 @@ void RemoteLayerTreeHost::createLayer(const RemoteLayerTreeTransaction::LayerCre
 std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties& properties)
 {
     auto makeWithLayer = [&] (RetainPtr<CALayer>&& layer) {
-        return makeUnique<RemoteLayerTreeNode>(properties.layerID, properties.hostIdentifier, WTFMove(layer));
+        return makeUnique<RemoteLayerTreeNode>(properties.layerID, properties.hostIdentifier(), WTFMove(layer));
     };
 
     switch (properties.type) {
@@ -426,15 +426,15 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
             return RemoteLayerTreeNode::createWithPlainLayer(properties.layerID);
 
 #if HAVE(AVKIT)
-        if (properties.playerIdentifier && properties.initialSize && properties.naturalSize) {
+        if (properties.videoElementData) {
             if (auto videoManager = m_drawingArea->page().videoFullscreenManager()) {
-                m_videoLayers.add(properties.layerID, *properties.playerIdentifier);
-                return makeWithLayer(videoManager->createLayerWithID(*properties.playerIdentifier, properties.hostingContextID, *properties.initialSize, *properties.naturalSize, properties.hostingDeviceScaleFactor));
+                m_videoLayers.add(properties.layerID, properties.videoElementData->playerIdentifier);
+                return makeWithLayer(videoManager->createLayerWithID(properties.videoElementData->playerIdentifier, properties.hostingContextID(), properties.videoElementData->initialSize, properties.videoElementData->naturalSize, properties.hostingDeviceScaleFactor()));
             }
         }
 #endif
 
-        return makeWithLayer([CALayer _web_renderLayerWithContextID:properties.hostingContextID shouldPreserveFlip:properties.preservesFlip]);
+        return makeWithLayer([CALayer _web_renderLayerWithContextID:properties.hostingContextID() shouldPreserveFlip:properties.preservesFlip()]);
 
     case PlatformCALayer::LayerTypeShapeLayer:
         return makeWithLayer(adoptNS([[CAShapeLayer alloc] init]));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -47,7 +47,7 @@ using namespace WebCore;
 std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties& properties)
 {
     auto makeWithView = [&] (RetainPtr<UIView>&& view) {
-        return makeUnique<RemoteLayerTreeNode>(properties.layerID, properties.hostIdentifier, WTFMove(view));
+        return makeUnique<RemoteLayerTreeNode>(properties.layerID, properties.hostIdentifier(), WTFMove(view));
     };
 
     switch (properties.type) {
@@ -76,15 +76,15 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
             return makeWithView(adoptNS([[WKCompositingView alloc] init]));
 
 #if HAVE(AVKIT)
-        if (properties.playerIdentifier && properties.initialSize && properties.naturalSize) {
+        if (properties.videoElementData) {
             if (auto videoManager = m_drawingArea->page().videoFullscreenManager()) {
-                m_videoLayers.add(properties.layerID, *properties.playerIdentifier);
-                return makeWithView(videoManager->createViewWithID(*properties.playerIdentifier, properties.hostingContextID, *properties.initialSize, *properties.naturalSize, properties.hostingDeviceScaleFactor));
+                m_videoLayers.add(properties.layerID, properties.videoElementData->playerIdentifier);
+                return makeWithView(videoManager->createViewWithID(properties.videoElementData->playerIdentifier, properties.hostingContextID(), properties.videoElementData->initialSize, properties.videoElementData->naturalSize, properties.hostingDeviceScaleFactor()));
             }
         }
 #endif
 
-        auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page().processID() contextID:properties.hostingContextID]);
+        auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page().processID() contextID:properties.hostingContextID()]);
         return makeWithView(WTFMove(view));
     }
     case PlatformCALayer::LayerTypeShapeLayer:
@@ -99,11 +99,13 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
 #if ENABLE(MODEL_ELEMENT)
     case PlatformCALayer::LayerTypeModelLayer:
         if (m_drawingArea->page().preferences().modelElementEnabled()) {
+            if (auto* model = std::get_if<Ref<Model>>(&properties.additionalData)) {
 #if ENABLE(SEPARATED_MODEL)
-            return makeWithView(adoptNS([[WKSeparatedModelView alloc] initWithModel:*properties.model]));
+                return makeWithView(adoptNS([[WKSeparatedModelView alloc] initWithModel:*model]));
 #elif ENABLE(ARKIT_INLINE_PREVIEW_IOS)
-            return makeWithView(adoptNS([[WKModelView alloc] initWithModel:*properties.model layerID:properties.layerID page:m_drawingArea->page()]));
+                return makeWithView(adoptNS([[WKModelView alloc] initWithModel:*model layerID:properties.layerID page:m_drawingArea->page()]));
 #endif
+            }
         }
         return makeWithView(adoptNS([[WKCompositingView alloc] init]));
 #endif // ENABLE(MODEL_ELEMENT)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -111,9 +111,12 @@ uint32_t PlatformCALayerRemoteCustom::hostingContextID()
 void PlatformCALayerRemoteCustom::populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties& properties, const RemoteLayerTreeContext& context, PlatformCALayer::LayerType type)
 {
     PlatformCALayerRemote::populateCreationProperties(properties, context, type);
-    properties.hostingContextID = hostingContextID();
-    properties.hostingDeviceScaleFactor = context.deviceScaleFactor();
-    properties.preservesFlip = YES;
+    ASSERT(std::holds_alternative<RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData>(properties.additionalData));
+    properties.additionalData = RemoteLayerTreeTransaction::LayerCreationProperties::CustomData {
+        .hostingContextID = hostingContextID(),
+        .hostingDeviceScaleFactor = context.deviceScaleFactor(),
+        .preservesFlip = true
+    };
 }
 
 Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteCustom::clone(PlatformCALayerClient* owner) const

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm
@@ -44,7 +44,8 @@ PlatformCALayerRemoteHost::PlatformCALayerRemoteHost(WebCore::LayerHostingContex
 void PlatformCALayerRemoteHost::populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties& properties, const RemoteLayerTreeContext& context, WebCore::PlatformCALayer::LayerType type)
 {
     PlatformCALayerRemote::populateCreationProperties(properties, context, type);
-    properties.hostIdentifier = m_identifier;
+    ASSERT(std::holds_alternative<RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData>(properties.additionalData));
+    properties.additionalData = m_identifier;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm
@@ -65,7 +65,8 @@ Ref<WebCore::PlatformCALayer> PlatformCALayerRemoteModelHosting::clone(WebCore::
 void PlatformCALayerRemoteModelHosting::populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties& properties, const RemoteLayerTreeContext& context, PlatformCALayer::LayerType type)
 {
     PlatformCALayerRemote::populateCreationProperties(properties, context, type);
-    properties.model = m_model.ptr();
+    ASSERT(std::holds_alternative<RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData>(properties.additionalData));
+    properties.additionalData = m_model;
 }
 
 void PlatformCALayerRemoteModelHosting::dumpAdditionalProperties(TextStream& ts, OptionSet<WebCore::PlatformLayerTreeAsTextFlags> flags)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -124,10 +124,13 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
     PlatformLayerIdentifier layerID = layer.layerID();
 
     RemoteLayerTreeTransaction::LayerCreationProperties creationProperties;
-    creationProperties.playerIdentifier = videoElement.identifier();
-    creationProperties.initialSize = videoElement.videoInlineSize();
-    creationProperties.naturalSize = videoElement.naturalSize();
     layer.populateCreationProperties(creationProperties, *this, type);
+    ASSERT(!creationProperties.videoElementData);
+    creationProperties.videoElementData = RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData {
+        videoElement.identifier(),
+        videoElement.videoInlineSize(),
+        videoElement.naturalSize()
+    };
 
     m_webPage.videoFullscreenManager().setupRemoteLayerHosting(videoElement);
     m_videoLayers.add(layerID, videoElement.identifier());


### PR DESCRIPTION
#### a6be02efdc1819cbcead28681d297002283ad2bc
<pre>
Generate serialization of LayerCreationProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=259413">https://bugs.webkit.org/show_bug.cgi?id=259413</a>
rdar://112694735

Reviewed by Tim Horton.

* Source/WebCore/platform/graphics/Model.h:
(WebCore::Model::encode const): Deleted.
(WebCore::Model::decode): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::hostIdentifier const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::hostingContextID const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::preservesFlip const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::hostingDeviceScaleFactor const):
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties): Deleted.
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::encode const): Deleted.
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::createLayer):
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::populateCreationProperties):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteHost.mm:
(WebKit::PlatformCALayerRemoteHost::populateCreationProperties):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteModelHosting.mm:
(WebKit::PlatformCALayerRemoteModelHosting::populateCreationProperties):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):

Canonical link: <a href="https://commits.webkit.org/266268@main">https://commits.webkit.org/266268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f65f5f5be04823db1c1e9d1c2cb4c279307c2ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15112 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15413 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15767 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12073 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12559 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10600 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16334 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1529 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->