### PR TITLE
Speedometer 3: Fix signpost patch

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch
@@ -1,8 +1,8 @@
 diff --git a/resources/benchmark-runner.mjs b/resources/benchmark-runner.mjs
-index bce469d..9cebc9d 100644
+index 06596a7..5db38cf 100644
 --- a/resources/benchmark-runner.mjs
 +++ b/resources/benchmark-runner.mjs
-@@ -348,6 +348,8 @@ export class BenchmarkRunner {
+@@ -441,6 +441,8 @@ export class BenchmarkRunner {
          const syncEndLabel = `${suite.name}.${test.name}-sync-end`;
          const asyncStartLabel = `${suite.name}.${test.name}-async-start`;
          const asyncEndLabel = `${suite.name}.${test.name}-async-end`;
@@ -11,7 +11,7 @@ index bce469d..9cebc9d 100644
  
          let syncTime;
          let asyncStartTime;
-@@ -362,14 +364,17 @@ export class BenchmarkRunner {
+@@ -455,21 +457,25 @@ export class BenchmarkRunner {
                  performance.mark("warmup-end");
              }
              performance.mark(startLabel);
@@ -25,15 +25,15 @@ index bce469d..9cebc9d 100644
              syncTime = syncEndTime - syncStartTime;
  
              performance.mark(asyncStartLabel);
-+            __signpostStart(asyncName);
              asyncStartTime = performance.now();
++            __signpostStart(asyncName);
          };
          const measureAsync = () => {
-@@ -379,6 +384,7 @@ export class BenchmarkRunner {
+             // Some browsers don't immediately update the layout for paint.
+             // Force the layout here to ensure we're measuring the layout time.
+             const height = this._frame.contentDocument.body.getBoundingClientRect().height;
              const asyncEndTime = performance.now();
++            __signpostStop(asyncName);
              asyncTime = asyncEndTime - asyncStartTime;
              this._frame.contentWindow._unusedHeightValue = height; // Prevent dead code elimination.
-+            __signpostStop(asyncName);
              performance.mark(asyncEndLabel);
-             if (params.warmupBeforeSync)
-                 performance.measure("warmup", "warmup-start", "warmup-end");


### PR DESCRIPTION
#### bd0d59dc28f6be28d6279e44b78df22761cefe7d
<pre>
Speedometer 3: Fix signpost patch
<a href="https://bugs.webkit.org/show_bug.cgi?id=259414">https://bugs.webkit.org/show_bug.cgi?id=259414</a>

Reviewed by Yusuke Suzuki.

Fixed the signpost patch for Speedometer 3.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/Speedometer3.patch:

Canonical link: <a href="https://commits.webkit.org/266232@main">https://commits.webkit.org/266232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f600436d781f42e651e2b33b6b80856e68746fc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15026 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13456 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/11232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13381 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/11402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/11987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/15650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11313 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/12477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12577 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10516 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13334 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16249 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13718 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1516 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->