### PR TITLE
Handle SVGLength resolving in an inactive document gracefully

### DIFF
--- a/LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt
+++ b/LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: NotSupportedError: The operation is not supported.
+PASS if no assert is triggered.

--- a/LayoutTests/svg/dom/SVGLength-value-in-inactive-document.html
+++ b/LayoutTests/svg/dom/SVGLength-value-in-inactive-document.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+var svgNs = "http://www.w3.org/2000/svg";
+var element = document.createElementNS(svgNs, "feTurbulence");
+var doc = document.implementation.createDocument(svgNs, "svg");
+doc.documentElement.appendChild(element);
+element.setAttribute("y", "42em");
+element.y.baseVal.value;
+</script>
+<p>PASS if no assert is triggered.</p>

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -230,8 +230,6 @@ static inline const RenderStyle* renderStyleForLengthResolving(const SVGElement*
         currentContext = currentContext->parentNode();
     } while (currentContext);
 
-    // There must be at least a LegacyRenderSVGRoot renderer, carrying a style.
-    ASSERT_NOT_REACHED();
     return nullptr;
 }
 


### PR DESCRIPTION
#### f538153c22209151c67f41eba0ab10d7672f2e65
<pre>
Handle SVGLength resolving in an inactive document gracefully

<a href="https://bugs.webkit.org/show_bug.cgi?id=258226">https://bugs.webkit.org/show_bug.cgi?id=258226</a>
rdar://problem/112704896

Reviewed by Simon Fraser.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=196269

If the element associated with the SVGLength is in an inactive document,
there&apos;ll be no layout, so renderStyleForLengthResolving() will be able
to exit the loop without finding a RenderStyle to return.

* Source/WebCore/svg/SVGLengthContext.cpp:
(renderStyleForLengthResolving): Remove &apos;ASSERT_NOT_REACHED&apos;
* LayoutTests/svg/dom/SVGLength-value-in-inactive-document.html: Add Test Case
* LayoutTests/svg/dom/SVGLength-value-in-inactive-document-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/266250@main">https://commits.webkit.org/266250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c5dec3cca188dd3f8e0b36700d3afdb755124cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13623 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11395 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19039 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15365 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12650 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10512 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3254 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->