### PR TITLE
Update inverted-colors UA styles to match spec

### DIFF
--- a/LayoutTests/fast/media/mq-inverted-colors-ua-styles-expected.txt
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-styles-expected.txt
@@ -1,0 +1,13 @@
+inverted-colors ua style test
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(document.querySelector('img')).filter is 'invert(1)'
+PASS getComputedStyle(document.querySelector('picture')).filter is 'invert(1)'
+PASS getComputedStyle(document.querySelector('picture>img')).filter is 'none'
+PASS getComputedStyle(document.querySelector('video')).filter is 'invert(1)'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/media/mq-inverted-colors-ua-styles-img-expected.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-styles-img-expected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<img src="resources/apple_logo_big.jpg">
+
+<script>
+  if (window.internals) {
+    window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "on";
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-inverted-colors-ua-styles-img.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-styles-img.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<picture>
+  <img src="resources/apple_logo_big.jpg">
+</picture>
+<script>
+  if (window.internals) {
+    window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "on";
+  }
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/media/mq-inverted-colors-ua-styles.html
+++ b/LayoutTests/fast/media/mq-inverted-colors-ua-styles.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+
+<img>
+<picture>
+  <img>
+</picture>
+<video></video>
+
+<script>
+  if (window.testRunner && window.internals) {
+    window.testRunner.dumpAsText();
+    window.internals.settings.forcedColorsAreInvertedAccessibilityValue = "on";
+    description("inverted-colors ua style test");
+    shouldEvaluateTo("getComputedStyle(document.querySelector('img')).filter", "'invert(1)'");
+    shouldEvaluateTo("getComputedStyle(document.querySelector('picture')).filter", "'invert(1)'");
+    shouldEvaluateTo("getComputedStyle(document.querySelector('picture>img')).filter", "'none'");
+    shouldEvaluateTo("getComputedStyle(document.querySelector('video')).filter", "'invert(1)'");
+  }
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1426,9 +1426,10 @@ applet, embed, object, img {
     }
 }
 
-/* Default support for "Smart Invert" where all content color except media is inverted. */ 
+/* Default support for "Smart Invert" where all content color except media is inverted. */
+/* https://drafts.csswg.org/mediaqueries-5/#inverted */
 @media (inverted-colors) {
-    img, picture, video { filter: invert(100%); } /* Images and videos double-inverted. */
+    img:not(picture>img), picture, video { filter: invert(100%); } /* Images and videos double-inverted. */
 }
 
 /* https://drafts.csswg.org/css-text-decor-4/#text-decoration-skipping */


### PR DESCRIPTION
#### 87011db312c8a25aa85d0b991cc4fd19870c789d
<pre>
Update inverted-colors UA styles to match spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=259416">https://bugs.webkit.org/show_bug.cgi?id=259416</a>

Reviewed by Tim Nguyen.

Updated the style for the inverted-colors media query in html.css
the new styles are taken directly from the spec.

Spec: <a href="https://drafts.csswg.org/mediaqueries-5/#inverted">https://drafts.csswg.org/mediaqueries-5/#inverted</a>

* LayoutTests/fast/media/mq-inverted-colors-ua-styles-expected.txt: Added.
* LayoutTests/fast/media/mq-inverted-colors-ua-styles-img-expected.html: Added.
* LayoutTests/fast/media/mq-inverted-colors-ua-styles-img.html: Added.
* LayoutTests/fast/media/mq-inverted-colors-ua-styles.html: Added.
* Source/WebCore/css/html.css:
(@media (inverted-colors) img:not(picture&gt;img), picture, video):
(@media (inverted-colors) img, picture, video): Deleted.

Canonical link: <a href="https://commits.webkit.org/266234@main">https://commits.webkit.org/266234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41ecfcc01f168bd3bbba38820714de3f26f45831

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12654 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15655 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19048 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15374 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10520 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11854 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->