### PR TITLE
Only special-case document element outermost `svg` embedded via a frame

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>An &lt;svg> wrapped in a &lt;foreignObject> in an &lt;object></title>
+<link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#embedded-ForeignObjectElement"/>
+<link rel="match" href="../../struct/reftests/reference/green-100x100.html">
+<object data="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+  <foreignObject width='100' height='100'>
+    <div xmlns='http://www.w3.org/1999/xhtml' style='display: flex'>
+      <div>
+        <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+          <rect width='100' height='100' fill='green'/>
+        </svg>
+      </div>
+    </div>
+  </foreignObject>
+</svg>"></object>

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2023 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -128,7 +128,7 @@ bool LegacyRenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
 {
     // If our frame has an owner renderer, we're embedded through eg. object/embed/iframe,
     // but we only negotiate if we're in an SVG document.
-    if (!frame().ownerRenderer())
+    if (!frame().ownerRenderer() || !isDocumentElementRenderer())
         return false;
     return frame().document()->isSVGDocument();
 }

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2023 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  * Copyright (C) 2020, 2021, 2022 Igalia S.L.
  *
@@ -141,7 +141,7 @@ bool RenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
 {
     // If our frame has an owner renderer, we're embedded through eg. object/embed/iframe,
     // but we only negotiate if we're in an SVG document inside object/embed, not iframe.
-    if (!frame().ownerRenderer() || !frame().ownerRenderer()->isEmbeddedObject())
+    if (!frame().ownerRenderer() || !frame().ownerRenderer()->isEmbeddedObject() || !isDocumentElementRenderer())
         return false;
     return frame().document()->isSVGDocument();
 }


### PR DESCRIPTION
#### 4d88a0a85b71cfcf3ddba9e1fbfd7eeb6aeff4ec
<pre>
Only special-case document element outermost `svg` embedded via a frame

<a href="https://bugs.webkit.org/show_bug.cgi?id=259313">https://bugs.webkit.org/show_bug.cgi?id=259313</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/4681730">https://chromium-review.googlesource.com/c/chromium/src/+/4681730</a>

In Legacy &amp; LBSE *RenderSVGRoot::IsEmbeddedThroughFrameContainingSVGDocument(), it
wasn&apos;t considered whether the `svg` was the document element or not, and
thus the special layout rules would be applied for all outermost `svg`
elements. This lead to incorrect layout results being calculated in some
of these cases.

Return false from said function if the *RenderSVGRoot is not associated
with the document element.

* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(LegacyRenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument): As above
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(RenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument): As above
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object.html: Add Test Case (manually)
* LayoutTests/imported/w3c/web-platform-tests/svg/extensibility/foreignObject/foreign-object-containing-svg-in-svg-in-object-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/266251@main">https://commits.webkit.org/266251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a4f0d74f75d0fa37eead1fbf9f23470a296196

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15332 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15642 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19041 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15367 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12652 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10510 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11923 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3255 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->