### PR TITLE
Fix some security tests after 266167@main

### DIFF
--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -93,13 +93,12 @@ static RetainPtr<TestWebsiteDataStoreDelegate>& globalWebsiteDataStoreDelegateCl
     return globalWebsiteDataStoreDelegateClient;
 }
 
-void initializeWebViewConfiguration(const char* libraryPath, WKStringRef injectedBundlePath, WKContextRef context, WKContextConfigurationRef contextConfiguration, WKPreferences *preferences)
+void initializeWebViewConfiguration(const char* libraryPath, WKStringRef injectedBundlePath, WKContextRef context, WKContextConfigurationRef contextConfiguration)
 {
     globalWebViewConfiguration() = [&] {
         auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
         [configuration setProcessPool:(__bridge WKProcessPool *)context];
-        [configuration setPreferences:preferences];
         [configuration setWebsiteDataStore:(__bridge WKWebsiteDataStore *)TestController::defaultWebsiteDataStore()];
         [configuration _setAllowUniversalAccessFromFileURLs:YES];
         [configuration _setAllowTopNavigationToDataURLs:YES];
@@ -282,7 +281,8 @@ void TestController::finishCreatingPlatformWebView(PlatformWebView* view, const 
 
 WKContextRef TestController::platformAdjustContext(WKContextRef context, WKContextConfigurationRef contextConfiguration)
 {
-    initializeWebViewConfiguration(libraryPathForTesting(), injectedBundlePath(), context, contextConfiguration, (__bridge WKPreferences *)m_preferences.get());
+    initializeWebViewConfiguration(libraryPathForTesting(), injectedBundlePath(), context, contextConfiguration);
+    m_preferences = (__bridge WKPreferencesRef)[globalWebViewConfiguration() preferences];
     return (__bridge WKContextRef)[globalWebViewConfiguration() processPool];
 }
 


### PR DESCRIPTION
#### f504bf12a3e6c82ff1a90de0e3e8b465e0efb5e2
<pre>
Fix some security tests after 266167@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=259417">https://bugs.webkit.org/show_bug.cgi?id=259417</a>

Unreviewed.

266167@main changed Cocoa&apos;s WebKitTestRunner&apos;s preferences management
from copying from the newly allocated WKWebViewConfiguration to copying
from the long-living WKPreferencesRef to the newly allocated WKWebViewConfiguration.
This made it so that state set in previous test runs was being carried forward
to future test runs done with the same WebKitTestRunner instance.
This just reverses the copying back to how it was before 266167@main.
I verified this fixes the tests Fujii noticed in <a href="https://bugs.webkit.org/show_bug.cgi?id=259324">https://bugs.webkit.org/show_bug.cgi?id=259324</a>

* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::initializeWebViewConfiguration):
(WTR::TestController::platformAdjustContext):

Canonical link: <a href="https://commits.webkit.org/266231@main">https://commits.webkit.org/266231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd2028ee52787b654d8b6d7a03aa5a649bdabd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13288 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15025 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15336 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15645 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11986 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12153 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10515 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16248 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->