### PR TITLE
Add emulation for inverted-colors to web inspector

### DIFF
--- a/LayoutTests/inspector/page/overrideUserPreference-expected.txt
+++ b/LayoutTests/inspector/page/overrideUserPreference-expected.txt
@@ -41,3 +41,16 @@ Removing PrefersColorScheme override
 PASS: (prefers-color-scheme: dark) media query does not match.
 PASS: --test-prefers-color-scheme: light
 
+-- Running test case: Page.overrideUserPreference.InvertedColors
+PASS: (inverted-colors: inverted) media query does not match.
+PASS: --test-inverted-colors: none
+Overriding InvertedColors value to Inverted
+PASS: (inverted-colors: inverted) media query matches.
+PASS: --test-inverted-colors: inverted
+Overriding InvertedColors value to None
+PASS: (inverted-colors: inverted) media query does not match.
+PASS: --test-inverted-colors: none
+Removing InvertedColors override
+PASS: (inverted-colors: inverted) media query does not match.
+PASS: --test-inverted-colors: none
+

--- a/LayoutTests/inspector/page/overrideUserPreference.html
+++ b/LayoutTests/inspector/page/overrideUserPreference.html
@@ -136,6 +136,41 @@ function test()
         },
     });
 
+    suite.addTestCase({
+        name: "Page.overrideUserPreference.InvertedColors",
+        description: "",
+        async test() {
+            let cssPropertyName = "--test-inverted-colors";
+            let mediaQuery = "(inverted-colors: inverted)";
+            let testCases = [
+                {
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.InvertedColors,
+                    preferenceValue: InspectorBackend.Enum.Page.UserPreferenceValue.Inverted,
+                    expectedValue: "inverted",
+                    expectedMatchMedia: true,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.InvertedColors,
+                    preferenceValue: InspectorBackend.Enum.Page.UserPreferenceValue.None,
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+                {
+                    preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.InvertedColors,
+                    preferenceValue: null,
+                    expectedValue: "none",
+                    expectedMatchMedia: false,
+                },
+                ];
+
+            await testOverridePreference({cssPropertyName, mediaQuery, testCases});
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 

--- a/Source/JavaScriptCore/inspector/protocol/Page.json
+++ b/Source/JavaScriptCore/inspector/protocol/Page.json
@@ -35,13 +35,13 @@
         {
             "id": "UserPreferenceName",
             "type": "string",
-            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme"],
+            "enum": ["PrefersReducedMotion", "PrefersContrast", "PrefersColorScheme", "InvertedColors"],
             "description": "User preference name."
         },
         {
             "id": "UserPreferenceValue",
             "type": "string",
-            "enum": ["NoPreference", "Reduce", "More", "Light", "Dark"],
+            "enum": ["NoPreference", "Reduce", "More", "Light", "Dark", "Inverted", "None"],
             "description": "User preference value."
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -161,6 +161,7 @@ private:
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersColorScheme(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
+    void overrideInvertedColors(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
 
     Ref<Inspector::Protocol::Page::Frame> buildObjectForFrame(LocalFrame*);
     Ref<Inspector::Protocol::Page::FrameResourceTree> buildObjectForFrameTree(LocalFrame*);

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -843,6 +843,8 @@ localizedStrings["Historical @ Font Details Sidebar Property Value"] = "Historic
 localizedStrings["Historical Forms @ Font Details Sidebar Property Value"] = "Historical Forms";
 localizedStrings["Host"] = "Host";
 localizedStrings["ICO"] = "ICO";
+/* Label for input to override the preference for inverted colors. */
+localizedStrings["Invert colors @ User Preferences Overrides"] = "Invert colors";
 localizedStrings["IP"] = "IP";
 localizedStrings["IP Address"] = "IP Address";
 localizedStrings["ITML Context"] = "ITML Context";

--- a/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js
@@ -86,7 +86,7 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
             });
         }
 
-        if (InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedMotion || InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersContrast) {
+        if (InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersReducedMotion || InspectorBackend.Enum.Page?.UserPreferenceName?.PrefersContrast || InspectorBackend.Enum.Page?.UserPreference?.Inverted) {
             let accessibilityHeader = contentElement.appendChild(document.createElement("h1"));
             accessibilityHeader.textContent = WI.UIString("Accessibility", "Accessibility @ User Preferences Overrides", "Header for section with accessibility user preferences.");
         }
@@ -110,6 +110,17 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
                 label: WI.UIString("Increase contrast", "Increase contrast @ User Preferences Overrides", "Label for input to override the preference for high contrast."),
                 preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.PrefersContrast,
                 preferenceValues: [InspectorBackend.Enum.Page.UserPreferenceValue.More, InspectorBackend.Enum.Page.UserPreferenceValue.NoPreference],
+                defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
+            });
+
+        // COMPATIBILITY (macOS 13.0, iOS 16.0): `InvertedColors` value for `Page.UserPreferenceName` did not exist yet.
+        if (InspectorBackend.Enum.Page?.UserPreferenceName?.InvertedColors)
+            this._createSelectElement({
+                contentElement,
+                id: "override-inverted-colors",
+                label: WI.UIString("Inverte colors", "Invert colors @ User Preferences Overrides", "Label for input to override the preference for inverted colors."),
+                preferenceName: InspectorBackend.Enum.Page.UserPreferenceName.InvertedColors,
+                preferenceValues: [InspectorBackend.Enum.Page.UserPreferenceValue.Inverted, InspectorBackend.Enum.Page.UserPreferenceValue.None],
                 defaultValue: WI.CSSManager.UserPreferenceDefaultValue,
             });
 
@@ -164,8 +175,10 @@ WI.OverrideUserPreferencesPopover = class OverrideUserPreferencesPopover extends
             return WI.UIString("System (%s)", "System @ User Preferences Overrides", "Label for a preference that matches the default system value. The system value is shown in parentheses.").format(this._userPreferenceValueLabel(systemValue));
         case InspectorBackend.Enum.Page.UserPreferenceValue?.Reduce:
         case InspectorBackend.Enum.Page.UserPreferenceValue?.More:
+        case InspectorBackend.Enum.Page.UserPreferenceValue?.Inverted:
             return WI.UIString("On", "On @ User Preferences Overrides", "Label for a preference that is turned on.");
         case InspectorBackend.Enum.Page.UserPreferenceValue?.NoPreference:
+        case InspectorBackend.Enum.Page.UserPreferenceValue?.None:
             return WI.UIString("Off", "Off @ User Preferences Overrides", "Label for a preference that is turned off.");
         case InspectorBackend.Enum.Page.UserPreferenceValue?.Light:
         case WI.CSSManager.Appearance.Light:


### PR DESCRIPTION
#### 08cc52f35ac1687ef6213fc46c29912c71d5c9b8
<pre>
Add emulation for inverted-colors to web inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=259418">https://bugs.webkit.org/show_bug.cgi?id=259418</a>

Reviewed by NOBODY (OOPS!).

Web inspector now allows overriding the inverted-colors media query.

* LayoutTests/inspector/page/overrideUserPreference-expected.txt:
* LayoutTests/inspector/page/overrideUserPreference.html:
* Source/JavaScriptCore/inspector/protocol/Page.json:
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::disable):
(WebCore::InspectorPageAgent::overrideUserPreference):
(WebCore::InspectorPageAgent::overrideInvertedColors):
(WebCore::InspectorPageAgent::defaultUserPreferencesDidChange):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Views/OverrideUserPreferencesPopover.js:
(WI.OverrideUserPreferencesPopover.prototype.createContentElement):
(WI.OverrideUserPreferencesPopover.prototype._userPreferenceValueLabel):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08cc52f35ac1687ef6213fc46c29912c71d5c9b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15652 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11403 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11989 "4 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19046 "131 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11315 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12478 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12156 "1 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15372 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12579 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12658 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10518 "1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13336 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11929 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11853 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3504 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16251 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13720 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12500 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3301 "Passed tests") | 
<!--EWS-Status-Bubble-End-->