### PR TITLE
CSS Custom Highlights support for text-shadow

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        html { 
+            font-size: 24pt;
+        }
+        #blue {
+            text-shadow: 2px 2px 2px blue;
+        }
+        #green {
+            text-shadow: 2px 2px 2px green;
+        }
+    </style>
+</head>
+<body>
+    <p><span id="blue">Testing</span> <span id="green">text-shadow</span> painting (with priority).</p>  
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        html { 
+            font-size: 24pt;
+        }
+        #blue {
+            text-shadow: 2px 2px 2px blue;
+        }
+        #green {
+            text-shadow: 2px 2px 2px green;
+        }
+    </style>
+</head>
+<body>
+    <p><span id="blue">Testing</span> <span id="green">text-shadow</span> painting (with priority).</p>  
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Highlight API Test: text-shadow 001</title>
+    <link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/">
+    <link rel="match" href="custom-highlight-painting-text-shadow-001-ref.html">
+    <meta name="assert" value="::highlight paints text-shadow correctly given insertion order priority">
+    <meta charset="utf-8">
+    <style>
+        html { 
+            font-size: 24pt;
+        }
+        ::highlight(highlight-1) {
+            text-shadow: 2px 2px 2px blue;
+        }
+        ::highlight(highlight-2) {
+            text-shadow: 2px 2px 2px green;
+        }
+    </style>
+</head>
+<body>
+    <p>Testing text-shadow painting (with priority).</p> 
+
+    <script>
+        const text = document.querySelector("p").firstChild;
+
+        const range1 = new Range();
+        range1.setStart(text, 0);
+        range1.setEnd(text, 12);
+
+        const range2 = new Range();
+        range2.setStart(text, 8);
+        range2.setEnd(text, 19);
+
+        const highlight1 = new Highlight(range1);
+        const highlight2 = new Highlight(range2);
+
+        CSS.highlights.set("highlight-1", highlight1);
+        CSS.highlights.set("highlight-2", highlight2);
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative-expected.html
@@ -4,6 +4,7 @@
     .highlighted {
       background-color: yellow;
       color: blue;
+      text-shadow: 1px 2px rgba(255, 0, 0, 0.5);
     }
 </style>
 <body><span class="highlighted">One two </span><span>three…</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="UTF-8">
-<title>CSS Highlight API Test: text-decoration</title>
+<title>CSS Highlight API Test: text-shadow</title>
 <link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/">
 <link rel="match" href="custom-highlight-painting-001-ref.html">
-<meta name="assert" value="::highlight overlay does not paint text-shadow">
+<meta name="assert" value="::highlight overlay paints text-shadow">
 <style>
   ::highlight(example-highlight) {
     background-color: yellow;

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -56,6 +56,9 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             style.textStyles.strokeColor = renderStyle->computedStrokeColor();
             style.textStyles.hasExplicitlySetFillColor = renderStyle->hasExplicitlySetColor();
 
+            if (auto* shadowData = renderStyle->textShadow())
+                style.textShadow = ShadowData::clone(shadowData);
+
             auto color = TextDecorationPainter::decorationColor(*renderStyle.get());
             auto decorationStyle = renderStyle->textDecorationStyle();
             auto decorations = renderStyle->textDecorationsInEffect();
@@ -177,6 +180,8 @@ static Vector<StyledMarkedText> coalesceAdjacentWithSameRanges(Vector<StyledMark
                 // If higher or same priority and opaque, override background color.
                 if (it->style.backgroundColor.isOpaque())
                     previousStyledMarkedText.style.backgroundColor = it->style.backgroundColor;
+                if (it->style.textShadow)
+                    previousStyledMarkedText.style.textShadow = WTFMove(it->style.textShadow);
             }
             continue;
         }


### PR DESCRIPTION
#### 18535e9c2a40a768365fb8f661adc356d70f894d
<pre>
CSS Custom Highlights support for text-shadow
<a href="https://bugs.webkit.org/show_bug.cgi?id=259422">https://bugs.webkit.org/show_bug.cgi?id=259422</a>
rdar://112719504

Reviewed by NOBODY (OOPS!).

Added support for text-shadow for custom highlights.
Before, StyledMarkedText did not collect information for text-shadow.
Edited custom-highlight-painting-text-shadow.tentative wpt to expect
text-shadow to be painted.
Added new wpt for testing text-shadow painting with custom highlights
following order of insertion priority as mentioned in spec.
<a href="https://www.w3.org/TR/css-highlight-api-1/#priorities">https://www.w3.org/TR/css-highlight-api-1/#priorities</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-text-shadow.tentative.html:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
(WebCore::coalesceAdjacentWithSameRanges):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18535e9c2a40a768365fb8f661adc356d70f894d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15409 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15760 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19115 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12556 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15446 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11932 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12579 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->