### PR TITLE
[IFC] Modern LineLayout should respect subtreePaintRoot

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		636353A71E98665D0009F8AF /* GeolocationGetCurrentPositionResult.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 636353A61E9861940009F8AF /* GeolocationGetCurrentPositionResult.html */; };
 		63A61B8B1FAD251100F06885 /* display-mode.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 63A61B8A1FAD204D00F06885 /* display-mode.html */; };
 		6B0A07F721FA9C2B00D57391 /* PrivateClickMeasurement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */; };
+		6B1CD58C2A6B839900752069 /* drag-image-paints-subtree.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 6B1CD58B2A6B837800752069 /* drag-image-paints-subtree.html */; };
 		6B306106218A372900F5A802 /* ClosingWebView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6B306105218A372900F5A802 /* ClosingWebView.mm */; };
 		6B4E861C2220A5520022F389 /* RegistrableDomain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */; };
 		6B9ABE122086952F00D75DE6 /* HTTPParsers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */; };
@@ -1565,6 +1566,7 @@
 				5714ECB91CA8B5B000051AC8 /* DownloadRequestOriginalURL.html in Copy Resources */,
 				5714ECBD1CA8C22A00051AC8 /* DownloadRequestOriginalURL2.html in Copy Resources */,
 				5714ECBB1CA8BFE400051AC8 /* DownloadRequestOriginalURLFrame.html in Copy Resources */,
+				6B1CD58C2A6B839900752069 /* drag-image-paints-subtree.html in Copy Resources */,
 				F4A32EC41F05F3850047C544 /* dragstart-change-selection-offscreen.html in Copy Resources */,
 				F4D5E4E81F0C5D38008C1A49 /* dragstart-clear-selection.html in Copy Resources */,
 				F46BD56924870643008282D6 /* dragstart-data.html in Copy Resources */,
@@ -2733,6 +2735,7 @@
 		63A61B8A1FAD204D00F06885 /* display-mode.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "display-mode.html"; sourceTree = "<group>"; };
 		63F668201F97C3AA0032EE51 /* ApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplicationManifest.mm; sourceTree = "<group>"; };
 		6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateClickMeasurement.cpp; sourceTree = "<group>"; };
+		6B1CD58B2A6B837800752069 /* drag-image-paints-subtree.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "drag-image-paints-subtree.html"; sourceTree = "<group>"; };
 		6B25A75125DC8D4E0070744F /* EventAttribution.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EventAttribution.mm; sourceTree = "<group>"; };
 		6B306105218A372900F5A802 /* ClosingWebView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ClosingWebView.mm; sourceTree = "<group>"; };
 		6B4E861B2220A5520022F389 /* RegistrableDomain.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegistrableDomain.cpp; sourceTree = "<group>"; };
@@ -4663,6 +4666,7 @@
 				5714ECB81CA8B58800051AC8 /* DownloadRequestOriginalURL.html */,
 				5714ECBC1CA8C21800051AC8 /* DownloadRequestOriginalURL2.html */,
 				5714ECBA1CA8BFD100051AC8 /* DownloadRequestOriginalURLFrame.html */,
+				6B1CD58B2A6B837800752069 /* drag-image-paints-subtree.html */,
 				F4A32EC31F05F3780047C544 /* dragstart-change-selection-offscreen.html */,
 				F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */,
 				F46BD5682487062D008282D6 /* dragstart-data.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm
@@ -171,6 +171,23 @@ TEST(DragAndDropTests, DragAndDropOnEmptyView)
 
     EXPECT_WK_STREQ("Simple HTML file.", [webView stringByEvaluatingJavaScript:@"document.body.innerText"]);
 }
+
+TEST(DragAndDropTests, DragImageShouldOnlyPaintSubtreeOfElement)
+{
+    auto simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400)]);
+    TestWKWebView *webView = [simulator webView];
+    [webView synchronouslyLoadTestPageNamed:@"drag-image-paints-subtree"];
+
+    [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 300)];
+    NSData *actualImageTIFF = [[[simulator draggingInfo] draggedImage] TIFFRepresentation];
+
+    [webView objectByEvaluatingJavaScript:@"document.querySelector(\"span\").remove()"];
+
+    [simulator runFrom:CGPointMake(100, 100) to:CGPointMake(100, 300)];
+    NSData *expectedImageTIFF = [[[simulator draggingInfo] draggedImage] TIFFRepresentation];
+
+    EXPECT_TRUE([actualImageTIFF isEqual:expectedImageTIFF]);
+}
 #endif // PLATFORM(MAC)
 
 TEST(DragAndDropTests, PreventingMouseDownShouldPreventDragStart)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/drag-image-paints-subtree.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/drag-image-paints-subtree.html
@@ -1,0 +1,23 @@
+<style>
+* {
+  margin: 0;
+  padding: 0;
+}
+#container {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+#children {
+  font-size: 1000%;
+  width: 1000%;
+  height: 1000%;
+  transform-origin: top left;
+  transform: scale(0.1);
+}
+span {
+  background: yellow;
+}
+</style>
+<div id="container" draggable="true"><div id="children">DRAG ME</div></div>
+<span>PASS if this line is not visible on the drag preview image</span>


### PR DESCRIPTION
#### 4cf789c0c51d58d89e113d8fe59afa8ba44b5e27
<pre>
[IFC] Modern path of RenderBlockFlow::paintInlineChildren should respect subtreePaintRoot
<a href="https://bugs.webkit.org/show_bug.cgi?id=259424">https://bugs.webkit.org/show_bug.cgi?id=259424</a>

Reviewed by NOBODY (OOPS!).

When creating snapshots of elements, subtreePaintRoot may be set and we should
only paint that renderer and its dependents.

This patch updates modern LineLayout paths to respect subtreePaintRoot, fixing
possible incorrect drag preview images when IFC is involved.

Combined changes:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::paintEllipsis):
(WebCore::LayoutIntegration::InlineContentPainter::paintDisplayBox):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DragAndDropTests.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/drag-image-paints-subtree.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7048cde29cd93e96520ec05c0b0380e16d5b2823

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15513 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16215 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12427 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19466 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15810 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13121 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10999 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12390 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->