### PR TITLE
URL pathname and search setter incorrectly strips trailing spaces

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json
@@ -2021,6 +2021,24 @@
                 "href": "sc:/space%20",
                 "pathname": "/space%20"
             }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/%20",
+                "pathname": "/%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/%00",
+                "pathname": "/%00"
+            }
         }
     ],
     "search": [
@@ -2140,6 +2158,24 @@
             "expected": {
                 "href": "sc:space  #fragment",
                 "search": ""
+            }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/?%20",
+                "search": "?%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/?%00",
+                "search": "?%00"
             }
         }
     ],
@@ -2310,6 +2346,24 @@
             "expected": {
                 "href": "sc:space  ?query",
                 "hash": ""
+            }
+        },
+        {
+            "comment": "Trailing space should be encoded",
+            "href": "http://example.net",
+            "new_value": " ",
+            "expected": {
+                "href": "http://example.net/#%20",
+                "hash": "#%20"
+            }
+        },
+        {
+            "comment": "Trailing C0 control should be encoded",
+            "href": "http://example.net",
+            "new_value": "\u0000",
+            "expected": {
+                "href": "http://example.net/#%00",
+                "hash": "#%00"
             }
         }
     ],

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt
@@ -434,10 +434,14 @@ PASS <a>: Setting <non-spec:/>.pathname = '//p'
 PASS <area>: Setting <non-spec:/>.pathname = '//p'
 PASS <a>: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path
 PASS <area>: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path
-FAIL <a>: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020 assert_equals: expected "data:/space%20" but got "data:/space"
-FAIL <area>: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020 assert_equals: expected "data:/space%20" but got "data:/space"
-FAIL <a>: Setting <sc:/nospace>.pathname = 'space ' assert_equals: expected "sc:/space%20" but got "sc:/space"
-FAIL <area>: Setting <sc:/nospace>.pathname = 'space ' assert_equals: expected "sc:/space%20" but got "sc:/space"
+PASS <a>: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020
+PASS <area>: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020
+PASS <a>: Setting <sc:/nospace>.pathname = 'space '
+PASS <area>: Setting <sc:/nospace>.pathname = 'space '
+PASS <a>: Setting <http://example.net>.pathname = ' ' Trailing space should be encoded
+PASS <area>: Setting <http://example.net>.pathname = ' ' Trailing space should be encoded
+PASS <a>: Setting <http://example.net>.pathname = '\0' Trailing C0 control should be encoded
+PASS <area>: Setting <http://example.net>.pathname = '\0' Trailing C0 control should be encoded
 PASS <a>: Setting <https://example.net#nav>.search = 'lang=fr'
 PASS <area>: Setting <https://example.net#nav>.search = 'lang=fr'
 PASS <a>: Setting <https://example.net?lang=en-US#nav>.search = 'lang=fr'
@@ -468,6 +472,10 @@ PASS <a>: Setting <data:space  ?query#fragment>.search = '' Do not drop trailing
 PASS <area>: Setting <data:space  ?query#fragment>.search = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS <a>: Setting <sc:space  ?query#fragment>.search = ''
 PASS <area>: Setting <sc:space  ?query#fragment>.search = ''
+PASS <a>: Setting <http://example.net>.search = ' ' Trailing space should be encoded
+PASS <area>: Setting <http://example.net>.search = ' ' Trailing space should be encoded
+PASS <a>: Setting <http://example.net>.search = '\0' Trailing C0 control should be encoded
+PASS <area>: Setting <http://example.net>.search = '\0' Trailing C0 control should be encoded
 PASS <a>: Setting <https://example.net>.hash = 'main'
 PASS <area>: Setting <https://example.net>.hash = 'main'
 PASS <a>: Setting <https://example.net#nav>.hash = 'main'
@@ -510,6 +518,10 @@ PASS <a>: Setting <data:space  ?query#fragment>.hash = '' Do not drop trailing s
 PASS <area>: Setting <data:space  ?query#fragment>.hash = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS <a>: Setting <sc:space  ?query#fragment>.hash = ''
 PASS <area>: Setting <sc:space  ?query#fragment>.hash = ''
+PASS <a>: Setting <http://example.net>.hash = ' ' Trailing space should be encoded
+PASS <area>: Setting <http://example.net>.hash = ' ' Trailing space should be encoded
+PASS <a>: Setting <http://example.net>.hash = '\0' Trailing C0 control should be encoded
+PASS <area>: Setting <http://example.net>.hash = '\0' Trailing C0 control should be encoded
 PASS <a>: Setting <file:///var/log/system.log>.href = 'http://0300.168.0xF0'
 PASS <area>: Setting <file:///var/log/system.log>.href = 'http://0300.168.0xF0'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -186,8 +186,10 @@ PASS URL: Setting <non-spec:/>.pathname = '/.//p' Serialize /. in path
 PASS URL: Setting <non-spec:/>.pathname = '/..//p'
 PASS URL: Setting <non-spec:/>.pathname = '//p'
 PASS URL: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path
-FAIL URL: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020 assert_equals: expected "data:/space%20" but got "data:/space"
-FAIL URL: Setting <sc:/nospace>.pathname = 'space ' assert_equals: expected "sc:/space%20" but got "sc:/space"
+PASS URL: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020
+PASS URL: Setting <sc:/nospace>.pathname = 'space '
+PASS URL: Setting <http://example.net>.pathname = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.pathname = '\0' Trailing C0 control should be encoded
 PASS URL: Setting <https://example.net#nav>.search = 'lang=fr'
 PASS URL: Setting <https://example.net?lang=en-US#nav>.search = 'lang=fr'
 PASS URL: Setting <https://example.net?lang=en-US#nav>.search = '?lang=fr'
@@ -203,6 +205,8 @@ PASS URL: Setting <data:space ?query>.search = '' Drop trailing spaces from trai
 PASS URL: Setting <sc:space ?query>.search = ''
 PASS URL: Setting <data:space  ?query#fragment>.search = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS URL: Setting <sc:space  ?query#fragment>.search = ''
+PASS URL: Setting <http://example.net>.search = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.search = '\0' Trailing C0 control should be encoded
 PASS URL: Setting <https://example.net>.hash = 'main'
 PASS URL: Setting <https://example.net#nav>.hash = 'main'
 PASS URL: Setting <https://example.net?lang=en-US>.hash = '##nav'
@@ -223,4 +227,6 @@ PASS URL: Setting <data:space                                                   
 PASS URL: Setting <sc:space    #fragment>.hash = ''
 PASS URL: Setting <data:space  ?query#fragment>.hash = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS URL: Setting <sc:space  ?query#fragment>.hash = ''
+PASS URL: Setting <http://example.net>.hash = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.hash = '\0' Trailing C0 control should be encoded
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt
@@ -186,8 +186,10 @@ PASS URL: Setting <non-spec:/>.pathname = '/.//p' Serialize /. in path
 PASS URL: Setting <non-spec:/>.pathname = '/..//p'
 PASS URL: Setting <non-spec:/>.pathname = '//p'
 PASS URL: Setting <non-spec:/.//>.pathname = 'p' Drop /. from path
-FAIL URL: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020 assert_equals: expected "data:/space%20" but got "data:/space"
-FAIL URL: Setting <sc:/nospace>.pathname = 'space ' assert_equals: expected "sc:/space%20" but got "sc:/space"
+PASS URL: Setting <data:/nospace>.pathname = 'space ' Non-special URLs with non-opaque paths percent-encode U+0020
+PASS URL: Setting <sc:/nospace>.pathname = 'space '
+PASS URL: Setting <http://example.net>.pathname = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.pathname = '\0' Trailing C0 control should be encoded
 PASS URL: Setting <https://example.net#nav>.search = 'lang=fr'
 PASS URL: Setting <https://example.net?lang=en-US#nav>.search = 'lang=fr'
 PASS URL: Setting <https://example.net?lang=en-US#nav>.search = '?lang=fr'
@@ -203,6 +205,8 @@ PASS URL: Setting <data:space ?query>.search = '' Drop trailing spaces from trai
 PASS URL: Setting <sc:space ?query>.search = ''
 PASS URL: Setting <data:space  ?query#fragment>.search = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS URL: Setting <sc:space  ?query#fragment>.search = ''
+PASS URL: Setting <http://example.net>.search = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.search = '\0' Trailing C0 control should be encoded
 PASS URL: Setting <https://example.net>.hash = 'main'
 PASS URL: Setting <https://example.net#nav>.hash = 'main'
 PASS URL: Setting <https://example.net?lang=en-US>.hash = '##nav'
@@ -223,4 +227,6 @@ PASS URL: Setting <data:space                                                   
 PASS URL: Setting <sc:space    #fragment>.hash = ''
 PASS URL: Setting <data:space  ?query#fragment>.hash = '' Do not drop trailing spaces from non-trailing opaque paths
 PASS URL: Setting <sc:space  ?query#fragment>.hash = ''
+PASS URL: Setting <http://example.net>.hash = ' ' Trailing space should be encoded
+PASS URL: Setting <http://example.net>.hash = '\0' Trailing C0 control should be encoded
 

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -585,6 +585,11 @@ void URL::parse(String&& string)
     *this = URLParser(WTFMove(string)).result();
 }
 
+void URL::parseAllowingC0AtEnd(String&& string)
+{
+    *this = URLParser(WTFMove(string), { }, URLTextEncodingSentinelAllowingC0AtEnd).result();
+}
+
 void URL::remove(unsigned start, unsigned length)
 {
     if (!length)
@@ -653,7 +658,15 @@ void URL::setFragmentIdentifier(StringView identifier)
     if (!m_isValid)
         return;
 
-    *this = URLParser(makeString(StringView(m_string).left(m_queryEnd), '#', identifier), { }, URLTextEncodingSentinelAllowingC0AtEndOfHash).result();
+    parseAllowingC0AtEnd(makeString(StringView(m_string).left(m_queryEnd), '#', identifier));
+}
+
+void URL::maybeTrimTrailingSpacesFromOpaquePath()
+{
+    if (!m_isValid || !hasOpaquePath() || hasFragmentIdentifier() || hasQuery())
+        return;
+
+    parse(makeString(StringView(m_string).left(m_pathEnd)));
 }
 
 void URL::removeFragmentIdentifier()
@@ -662,6 +675,8 @@ void URL::removeFragmentIdentifier()
         return;
 
     m_string = m_string.left(m_queryEnd);
+
+    maybeTrimTrailingSpacesFromOpaquePath();
 }
 
 void URL::removeQueryAndFragmentIdentifier()
@@ -671,6 +686,8 @@ void URL::removeQueryAndFragmentIdentifier()
 
     m_string = m_string.left(m_pathEnd);
     m_queryEnd = m_pathEnd;
+
+    maybeTrimTrailingSpacesFromOpaquePath();
 }
 
 void URL::setQuery(StringView newQuery)
@@ -681,12 +698,15 @@ void URL::setQuery(StringView newQuery)
     if (!m_isValid)
         return;
 
-    parse(makeString(
+    parseAllowingC0AtEnd(makeString(
         StringView(m_string).left(m_pathEnd),
         (!newQuery.startsWith('?') && !newQuery.isNull()) ? "?"_s : ""_s,
         newQuery,
         StringView(m_string).substring(m_queryEnd)
     ));
+
+    if (newQuery.isNull())
+        maybeTrimTrailingSpacesFromOpaquePath();
 }
 
 static String escapePathWithoutCopying(StringView path)
@@ -702,7 +722,7 @@ void URL::setPath(StringView path)
     if (!m_isValid)
         return;
 
-    parse(makeString(
+    parseAllowingC0AtEnd(makeString(
         StringView(m_string).left(pathStart()),
         path.startsWith('/') || (path.startsWith('\\') && (hasSpecialScheme() || protocolIsFile())) || (!hasSpecialScheme() && path.isEmpty() && m_schemeEnd + 1U < pathStart()) ? ""_s : "/"_s,
         !hasSpecialScheme() && host().isEmpty() && path.startsWith("//"_s) && path.length() > 2 ? "/."_s : ""_s,

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -212,6 +212,9 @@ private:
     unsigned credentialsEnd() const;
     void remove(unsigned start, unsigned length);
     void parse(String&&);
+    void parseAllowingC0AtEnd(String&&);
+
+    void maybeTrimTrailingSpacesFromOpaquePath();
 
     friend WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
 

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -1126,7 +1126,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
     Vector<UChar> queryBuffer;
 
     unsigned endIndex = length;
-    if (UNLIKELY(nonUTF8QueryEncoding == URLTextEncodingSentinelAllowingC0AtEndOfHash))
+    if (UNLIKELY(nonUTF8QueryEncoding == URLTextEncodingSentinelAllowingC0AtEnd))
         nonUTF8QueryEncoding = nullptr;
     else {
         while (UNLIKELY(endIndex && isC0ControlOrSpace(input[endIndex - 1]))) {

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -51,7 +51,7 @@ public:
     // For host names bigger than this, we won't do IDN encoding, which is almost certainly OK.
     constexpr static size_t hostnameBufferLength = 2048;
 
-#define URLTextEncodingSentinelAllowingC0AtEndOfHash reinterpret_cast<const URLTextEncoding*>(-1)
+#define URLTextEncodingSentinelAllowingC0AtEnd reinterpret_cast<const URLTextEncoding*>(-1)
 
     WTF_EXPORT_PRIVATE static bool allValuesEqual(const URL&, const URL&);
     WTF_EXPORT_PRIVATE static bool internalValuesConsistent(const URL&);


### PR DESCRIPTION
#### cc626f31c37433b6ed8bb007f1ad67a6f8697639
<pre>
URL pathname and search setter incorrectly strips trailing spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=259080">https://bugs.webkit.org/show_bug.cgi?id=259080</a>
rdar://112433299

Reviewed by Alex Christensen.

Potentially (maybe) trim opaque paths after a query or fragment has
been removed. This ensures that re-parsing roundtrips, even when URL
component setters are used.

Additionally, preserve trailing C0 for the path and query setters using
a new shared function.

* LayoutTests/imported/w3c/web-platform-tests/url/resources/setters_tests.json:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters-a-area.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.worker_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any_exclude=(file_javascript_mailto)-expected.txt:

This is now synchronized up to the latest commit for the url directory:
01b31f8bbcf570218465a08e8dde4442ae8c3565.

* Source/WTF/wtf/URL.cpp:
(WTF::URL::parseAllowingC0AtEnd):
(WTF::URL::setFragmentIdentifier):
(WTF::URL::potentiallyStripTrailingSpacesFromOpaquePath):
(WTF::URL::removeFragmentIdentifier):
(WTF::URL::removeQueryAndFragmentIdentifier):
(WTF::URL::setQuery):
(WTF::URL::setPath):
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::parse):
* Source/WTF/wtf/URLParser.h:

Canonical link: <a href="https://commits.webkit.org/266252@main">https://commits.webkit.org/266252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28db188aa58dd56d0e54b34207e282594a4eb4aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13352 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/13666 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/13998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/15089 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/16173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/13692 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/15089 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/13519 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/16173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/13998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/16173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/13998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/15725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11376 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/16173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/13998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/15725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/12640 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12719 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/13692 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/13397 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/11989 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/13998 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/13397 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3252 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/16312 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/13781 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12560 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/13781 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->