### PR TITLE
[GLib] In new API, update to base data directories in TestWebsiteData configuration test.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -183,9 +183,12 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
     test->runJavaScriptAndWaitUntilFinished("window.localStorage.myproperty = 42;", nullptr);
-    GUniquePtr<char> localStorageDirectory(g_build_filename(Test::dataDirectory(), "localstorage", nullptr));
 #if !ENABLE(2022_GLIB_API)
+    GUniquePtr<char> localStorageDirectory(g_build_filename(Test::dataDirectory(), "localstorage", nullptr));
     g_assert_cmpstr(localStorageDirectory.get(), ==, webkit_website_data_manager_get_local_storage_directory(test->m_manager));
+#endif
+#if ENABLE(2022_GLIB_API)
+    GUniquePtr<char> localStorageDirectory(g_build_filename(Test::dataDirectory(), "storage", nullptr));
 #endif
     test->assertFileIsCreated(localStorageDirectory.get());
     g_assert_true(g_file_test(localStorageDirectory.get(), G_FILE_TEST_IS_DIR));
@@ -194,9 +197,12 @@ static void testWebsiteDataConfiguration(WebsiteDataTest* test, gconstpointer)
     test->loadURI(kServer->getURIForPath("/empty").data());
     test->waitUntilLoadFinished();
     test->runJavaScriptAndWaitUntilFinished("window.indexedDB.open('TestDatabase');", nullptr);
-    GUniquePtr<char> indexedDBDirectory(g_build_filename(Test::dataDirectory(), "databases", "indexeddb", nullptr));
 #if !ENABLE(2022_GLIB_API)
+    GUniquePtr<char> indexedDBDirectory(g_build_filename(Test::dataDirectory(), "databases", "indexeddb", nullptr));
     g_assert_cmpstr(indexedDBDirectory.get(), ==, webkit_website_data_manager_get_indexeddb_directory(test->m_manager));
+#endif
+#if ENABLE(2022_GLIB_API)
+    GUniquePtr<char> indexedDBDirectory(g_build_filename(Test::dataDirectory(), "storage", nullptr));
 #endif
     test->assertFileIsCreated(indexedDBDirectory.get());
     g_assert_true(g_file_test(indexedDBDirectory.get(), G_FILE_TEST_IS_DIR));

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -132,9 +132,6 @@
             "/webkit/WebKitWebsiteData/cache": {
                 "expected": {"gtk": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/254002"}}
             },
-            "/webkit/WebKitWebsiteData/configuration": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}}
-            },
             "/webkit/WebKitWebsiteData/ephemeral": {
                 "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}}
             },


### PR DESCRIPTION
#### 85e47cd2bdd527cd70684647f9bfd50c32dac7d6
<pre>
[GLib] In new API, update to base data directories in TestWebsiteData configuration test.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259427">https://bugs.webkit.org/show_bug.cgi?id=259427</a>

Reviewed by Michael Catanzaro.

In 260375@main, we use UnifiedOriginStorageLevel::Basic in the new
GLib API, which means that WebsiteDataStore::defaultLocalStorageDirectory
and WebsiteDataStore::defaultIndexedDBDatabaseDirectory are no longer
respected. Updating the dirs fixes the tests in the new API for WPE and
GTK; this essentially uses WebsiteDataStore:defaultGeneralStorageDirectory.

Some other helpful commit messages I found along the way were 253824@main,
259132@main and 260511@main; noting those here for historical purposes.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebsiteDataConfiguration): Update to base directories per new API.
* Tools/TestWebKitAPI/glib/TestExpectations.json: remove failing WPE
test expectation that was added in a &quot;meta gardening&quot; bug ticket.

Canonical link: <a href="https://commits.webkit.org/266245@main">https://commits.webkit.org/266245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/138e03df88892c1a21ab3df5be412574628aa731

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15382 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15712 "Built successfully") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11451 "An unexpected error occured. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12037 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15417 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10566 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11978 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3248 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->