### PR TITLE
Use a new type PathCloseSubpath instead of std::monostate to represent a close command in PathSegment

### DIFF
--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -39,75 +39,44 @@ PathSegment::PathSegment(Data&& data)
 
 FloatPoint PathSegment::calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const
 {
-    return WTF::switchOn(m_data,
-        [&](auto& data) {
-            return data.calculateEndPoint(currentPoint, lastMoveToPoint);
-        },
-        [&](std::monostate) {
-            return lastMoveToPoint;
-        }
-    );
+    return WTF::switchOn(m_data, [&](auto& data) {
+        return data.calculateEndPoint(currentPoint, lastMoveToPoint);
+    });
 }
 
 void PathSegment::extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
-    WTF::switchOn(m_data,
-        [&](auto& data) {
-            data.extendFastBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
-        },
-        [&](std::monostate) {
-            boundingRect.extend(lastMoveToPoint);
-        }
-    );
+    WTF::switchOn(m_data, [&](auto& data) {
+        data.extendFastBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
+    });
 }
 
 void PathSegment::extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
 {
-    WTF::switchOn(m_data,
-        [&](auto& data) {
-            data.extendBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
-        },
-        [&](std::monostate) {
-            boundingRect.extend(lastMoveToPoint);
-        }
-    );
+    WTF::switchOn(m_data, [&](auto& data) {
+        data.extendBoundingRect(currentPoint, lastMoveToPoint, boundingRect);
+    });
 }
 
 void PathSegment::addToImpl(PathImpl& impl) const
 {
-    WTF::switchOn(m_data,
-        [&](auto& data) {
-            data.addToImpl(impl);
-        },
-        [&](std::monostate) {
-            impl.closeSubpath();
-        }
-    );
+    WTF::switchOn(m_data, [&](auto& data) {
+        data.addToImpl(impl);
+    });
 }
 
 void PathSegment::applyElements(const PathElementApplier& applier) const
 {
-    WTF::switchOn(m_data,
-        [&](auto& data) {
-            data.applyElements(applier);
-        },
-        [&](std::monostate) {
-            applier({ PathElement::Type::CloseSubpath, { } });
-        }
-    );
+    WTF::switchOn(m_data, [&](auto& data) {
+        data.applyElements(applier);
+    });
 }
 
 TextStream& operator<<(TextStream& ts, const PathSegment& segment)
 {
-    return WTF::switchOn(segment.data(),
-        [&](auto& data) -> TextStream& {
-            return ts << data;
-        },
-        [&](std::monostate) -> TextStream& {
-            ts << "close subpath";
-            return ts;
-        }
-    );
+    return WTF::switchOn(segment.data(), [&](auto& data) -> TextStream& {
+        return ts << data;
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -51,7 +51,7 @@ public:
         PathDataBezierCurve,
         PathDataArc,
 
-        std::monostate
+        PathCloseSubpath
     >;
 
     WEBCORE_EXPORT PathSegment(Data&&);
@@ -59,7 +59,7 @@ public:
     bool operator==(const PathSegment&) const = default;
 
     const Data& data() const { return m_data; }
-    bool isCloseSubPath() const { return std::holds_alternative<std::monostate>(m_data); }
+    bool isCloseSubPath() const { return std::holds_alternative<PathCloseSubpath>(m_data); }
 
     FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
     void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -687,4 +687,35 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataArc& data)
     return ts;
 }
 
+FloatPoint PathCloseSubpath::calculateEndPoint(const FloatPoint&, FloatPoint& lastMoveToPoint) const
+{
+    return lastMoveToPoint;
+}
+
+void PathCloseSubpath::extendFastBoundingRect(const FloatPoint&, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
+{
+    boundingRect.extend(lastMoveToPoint);
+}
+
+void PathCloseSubpath::extendBoundingRect(const FloatPoint&, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const
+{
+    boundingRect.extend(lastMoveToPoint);
+}
+
+void PathCloseSubpath::addToImpl(PathImpl& impl) const
+{
+    impl.closeSubpath();
+}
+
+void PathCloseSubpath::applyElements(const PathElementApplier& applier) const
+{
+    applier({ PathElement::Type::CloseSubpath, { } });
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, const PathCloseSubpath&)
+{
+    ts << "close subpath";
+    return ts;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -292,4 +292,18 @@ struct PathDataArc {
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&);
 
+struct PathCloseSubpath {
+    bool operator==(const PathCloseSubpath&) const = default;
+
+    FloatPoint calculateEndPoint(const FloatPoint& currentPoint, FloatPoint& lastMoveToPoint) const;
+
+    void extendFastBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+    void extendBoundingRect(const FloatPoint& currentPoint, const FloatPoint& lastMoveToPoint, FloatRect& boundingRect) const;
+
+    void addToImpl(PathImpl&) const;
+    void applyElements(const PathElementApplier&) const;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathCloseSubpath&);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -179,7 +179,7 @@ void PathStream::addRoundedRect(const FloatRoundedRect& roundedRect, PathRounded
 
 void PathStream::closeSubpath()
 {
-    segments().append(std::monostate());
+    segments().append(PathCloseSubpath { });
 }
 
 const Vector<PathSegment>& PathStream::segments() const

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -341,7 +341,7 @@ void PathCairo::applySegments(const PathSegmentApplier& applier) const
             break;
 
         case PathElement::Type::CloseSubpath:
-            applier({ std::monostate() });
+            applier({ PathCloseSubpath { } });
             break;
         }
     });

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -252,7 +252,7 @@ static void pathSegmentApplierCallback(void* info, const CGPathElement* element)
         break;
 
     case kCGPathElementCloseSubpath:
-        applier({ std::monostate() });
+        applier({ PathCloseSubpath { } });
         break;
     }
 }

--- a/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
@@ -122,6 +122,10 @@ header: <WebCore/PathSegmentData.h>
 };
 
 header: <WebCore/PathSegment.h>
+[AdditionalEncoder=StreamConnectionEncoder, CustomHeader] struct WebCore::PathCloseSubpath {
+};
+
+header: <WebCore/PathSegment.h>
 [AdditionalEncoder=StreamConnectionEncoder, CustomHeader] class WebCore::PathSegment {
     WebCore::PathSegment::Data data();
 };


### PR DESCRIPTION
#### fe314ea4b982abb2cf203a909be9c5fc180cbcb0
<pre>
Use a new type PathCloseSubpath instead of std::monostate to represent a close command in PathSegment
<a href="https://bugs.webkit.org/show_bug.cgi?id=259430">https://bugs.webkit.org/show_bug.cgi?id=259430</a>
rdar://problem/112741404

Reviewed by Simon Fraser.

Adding an empty struct lets us treat this command like all the others,
and not special case it in the WTF::switchOn calls in PathSegment.cpp.

* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::calculateEndPoint const):
(WebCore::PathSegment::extendFastBoundingRect const):
(WebCore::PathSegment::extendBoundingRect const):
(WebCore::PathSegment::addToImpl const):
(WebCore::PathSegment::applyElements const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PathSegment.h:
(WebCore::PathSegment::isCloseSubPath const):
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathCloseSubpath::calculateEndPoint const):
(WebCore::PathCloseSubpath::extendFastBoundingRect const):
(WebCore::PathCloseSubpath::extendBoundingRect const):
(WebCore::PathCloseSubpath::addToImpl const):
(WebCore::PathCloseSubpath::applyElements const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::closeSubpath):
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::pathSegmentApplierCallback):
* Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in:

Canonical link: <a href="https://commits.webkit.org/266264@main">https://commits.webkit.org/266264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11510edc909c2839c0250eb75983bc100eb59bf3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15359 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15683 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12015 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19065 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15391 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10543 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11955 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->