### PR TITLE
Avoid creating a new CSSParserContext each time a color is assigned to fillStyle/strokeStyle on a canvas context

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "ActiveDOMObject.h"
+#include "CSSParserContext.h"
 #include "CanvasBase.h"
 #include "Document.h"
 #include "FloatRect.h"
@@ -142,6 +143,8 @@ public:
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
 
+    CSSParserContext& cssParserContext();
+
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
 
@@ -186,6 +189,7 @@ private:
 
     std::unique_ptr<CanvasRenderingContext> m_context;
     mutable RefPtr<Image> m_copiedImage; // FIXME: This is temporary for platforms that have to copy the image buffer to render (and for CSSCanvasValue).
+    std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     std::optional<bool> m_usesDisplayListDrawing;
     
@@ -199,6 +203,13 @@ private:
 #endif
     bool m_isSnapshotting { false };
 };
+
+inline CSSParserContext& HTMLCanvasElement::cssParserContext()
+{
+    if (!m_cssParserContext)
+        m_cssParserContext = WTF::makeUnique<CSSParserContext>(document());
+    return *m_cssParserContext;
+}
 
 WebCoreOpaqueRoot root(HTMLCanvasElement*);
 

--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -60,7 +60,7 @@ Color parseColor(const String& colorString, CanvasBase& canvasBase)
 
     Color color;
     if (is<HTMLCanvasElement>(canvasBase))
-        color = CSSParser::parseColor(colorString, CSSParserContext { downcast<HTMLCanvasElement>(canvasBase).document() });
+        color = CSSParser::parseColor(colorString, downcast<HTMLCanvasElement>(canvasBase).cssParserContext());
     else
         color = CSSParser::parseColorWithoutContext(colorString);
 


### PR DESCRIPTION
#### 5ec234192a2eebd476418c0dea4a3fc20604b92c
<pre>
Avoid creating a new CSSParserContext each time a color is assigned to fillStyle/strokeStyle on a canvas context
<a href="https://bugs.webkit.org/show_bug.cgi?id=259431">https://bugs.webkit.org/show_bug.cgi?id=259431</a>
rdar://112439220

Reviewed by Tim Nguyen.

Creating the CSSParserContext is slightly expensive, since it fetches all of the relevant document Settings.

* Source/WebCore/html/HTMLCanvasElement.h:
(WebCore::HTMLCanvasElement::cssParserContext):
* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::parseColor):

Canonical link: <a href="https://commits.webkit.org/266238@main">https://commits.webkit.org/266238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffd66388c538ad722591969415fdf583d3e9f6f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15358 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15682 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19066 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12683 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10542 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11954 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16276 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1519 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->