### PR TITLE
Allocating a new IPC::Semaphore for each RemoteImageBufferProxy::flushDrawingContextAsync adds significant overhead.

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -69,6 +69,14 @@ public:
         return m_signaled;
     }
 
+    std::optional<IPC::Semaphore> tryTakeSemaphore()
+    {
+        if (!m_signaled)
+            return std::nullopt;
+        Locker locker { m_lock };
+        return WTFMove(m_semaphore);
+    }
+
 private:
     RemoteImageBufferProxyFlushFence(IPC::Semaphore semaphore)
         : m_semaphore(WTFMove(semaphore))
@@ -76,8 +84,8 @@ private:
         tracePoint(FlushRemoteImageBufferStart, reinterpret_cast<uintptr_t>(this));
     }
     Lock m_lock;
-    bool m_signaled WTF_GUARDED_BY_LOCK(m_lock) { false };
-    IPC::Semaphore m_semaphore;
+    std::atomic<bool> m_signaled { false };
+    IPC::Semaphore WTF_GUARDED_BY_LOCK(m_lock) m_semaphore;
 };
 
 namespace {
@@ -326,9 +334,13 @@ bool RemoteImageBufferProxy::flushDrawingContextAsync()
         return m_pendingFlush;
 
     LOG_WITH_STREAM(SharedDisplayLists, stream << "RemoteImageBufferProxy " << m_renderingResourceIdentifier << " flushDrawingContextAsync");
-    IPC::Semaphore flushSemaphore;
-    m_remoteDisplayList.flushContext(flushSemaphore);
-    m_pendingFlush = RemoteImageBufferProxyFlushFence::create(WTFMove(flushSemaphore));
+    std::optional<IPC::Semaphore> flushSemaphore;
+    if (m_pendingFlush)
+        flushSemaphore = m_pendingFlush->tryTakeSemaphore();
+    if (!flushSemaphore)
+        flushSemaphore.emplace();
+    m_remoteDisplayList.flushContext(*flushSemaphore);
+    m_pendingFlush = RemoteImageBufferProxyFlushFence::create(WTFMove(*flushSemaphore));
     m_needsFlush = false;
     return true;
 }


### PR DESCRIPTION
#### 80f6e24ca1d10903db9e2c76dd6ea91249a45d9f
<pre>
Allocating a new IPC::Semaphore for each RemoteImageBufferProxy::flushDrawingContextAsync adds significant overhead.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259433">https://bugs.webkit.org/show_bug.cgi?id=259433</a>
&lt;rdar://112743547&gt;

Reviewed by Dean Jackson.

Frequently we have an existing pending flush object, where the semaphore has already been signaled.

This makes the m_signaled bool atomic, so that we can check for completed flush objects without taking
the lock and blocking. This will still be false if the existing use of the semaphore hasn&apos;t yet been signaled,
or if the waitFor call failed.

If we find a completed flush objects, then moves the semaphore across into the new one to prevent a new allocation.

* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxyFlushFence::tryTakeSemaphore):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
(WebKit::RemoteImageBufferProxyFlushFence::WTF_GUARDED_BY_LOCK): Deleted.

Canonical link: <a href="https://commits.webkit.org/266265@main">https://commits.webkit.org/266265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2da68601f9beb729e2748db656ad2d299855d3be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15685 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11430 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19068 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15394 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10545 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11957 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3264 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16279 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->