### PR TITLE
[iOS 17] [Mail] Tabbing from subject field to compose body dismisses the keyboard and ends editing

### DIFF
--- a/LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus-expected.txt
+++ b/LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that after relinquishing focus by pressing shift-tab and then becoming first responder in an editable web view, we'll begin an input session. This test requires WebKitTestRunner; to test manually, use the iOS Mail app.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS 1. Input view disappeared after pressing Shift-Tab
+PASS 2. Input view appeared after becoming first responder
+PASS caretRect.width > 0 is true
+PASS caretRect.height > 0 is true
+PASS 3. Input view disappeared after blurring focused element
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus.html
+++ b/LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true focusStartsInputSessionPolicy=allow ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description(`This test verifies that after relinquishing focus by pressing shift-tab and then
+        becoming first responder in an editable web view, we'll begin an input session. This test
+        requires WebKitTestRunner; to test manually, use the iOS Mail app.`);
+
+    await UIHelper.setWebViewEditable(true);
+    await UIHelper.activateElementAndWaitForInputSession(document.body);
+
+    await UIHelper.keyDown("\t", ["shiftKey"]);
+    await UIHelper.resignFirstResponder();
+    await UIHelper.waitForKeyboardToHide();
+    testPassed("1. Input view disappeared after pressing Shift-Tab");
+
+    await UIHelper.becomeFirstResponder();
+    await UIHelper.waitForKeyboardToShow();
+    testPassed("2. Input view appeared after becoming first responder");
+
+    caretRect = await UIHelper.getUICaretViewRect();
+    shouldBeTrue("caretRect.width > 0");
+    shouldBeTrue("caretRect.height > 0");
+
+    document.activeElement.blur();
+    await UIHelper.waitForKeyboardToHide();
+    testPassed("3. Input view disappeared after blurring focused element");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div><br></div>
+</body>
+</html>


### PR DESCRIPTION
#### b532c60a79794ae5c6d41f02419bbba79a3da347
<pre>
[iOS 17] [Mail] Tabbing from subject field to compose body dismisses the keyboard and ends editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259434">https://bugs.webkit.org/show_bug.cgi?id=259434</a>
rdar://109244061

Reviewed by Megan Gardner.

In Mail on iOS 17, shift-tabbing from the compose body field to the subject field and attempting to
tab back into the body field causes the keyboard to dismiss. This happens because when the user
attempts to tab back into the web view, we fail to set the focused element to the `body`, while
handling the `IsFocused` activity state change in the web process after `-becomeFirstResponder`;
more precisely, when entering `dispatchEventsOnWindowAndFocusedElement` during the activity state
change, `document-&gt;focusedElement()` is null and so we don&apos;t dispatch a focus event.

On iOS 16, this bug doesn&apos;t happen — when the selection is moved into the native subject field,
UIKit code ends up calling into `-[WKContentView clearSelection]` to clear out the previous
selection, such that when we try to tab back into the web view, we set the focused element back to
the `body` as a byproduct of the fact that we&apos;re changing the selection underneath this call stack:

```
1   WebCore::Document::setFocusedElement(…)
2   WebCore::FocusController::setFocusedElement(…)
3   WebCore::FrameSelection::setFocusedElementIfNeeded(…)
4   WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance(…)
5   WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance(…)
6   WebCore::FrameSelection::setSelection(…)
7   WebCore::FrameSelection::setSelectionFromNone(…)
8   WebCore::FrameSelection::focusedOrActiveStateChanged(…)
9   WebCore::FrameSelection::setFocused(…)
```

In contrast, on iOS 17, the call to `-[WKContentView clearSelection]` never happens; this in turn
causes the selection to remain the same after tabbing back into the web view, which means that
`willMutateSelection := false` in `FrameSelection::setSelectionWithoutUpdatingAppearance` and we
bail before we get a chance to invoke `setFocusedElementIfNeeded();`.

From examining UIKit sources, this basically worked by sheer accident on iOS 16: there&apos;s code in
`UITextSelectionView` to *collapse* the selection to the end, but ends up clearing the selection
only in WebKit views because `-[WKContentView textRangeFromPosition:toPosition:]` unconditionally
returns `nil`. In iOS 17, we now use `UITextSelectionDisplayInteraction` instead of the legacy
`UITextSelectionView`, which skips this codepath, and so the (accidental-but-necessary) process of
clearing the selection no longer happens.

Rather than try and ressurrect the iOS 16 codepath in a way that works with
`UITextSelectionDisplayInteraction`, this patch fixes the bug by instead changing
`relinquishFocusToChrome` to additionally clear the selection, such that when we subsequently
refocus the web view and set the initial selection, we&apos;ll trigger a selection change that will also
update the focused element. Note that this also brings `FocusController::relinquishFocusToChrome`
more in line with `FocusController::setFocusedElement`, which also uses the same helper to clear the
selection prior to updating the focused element.

* LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus-expected.txt: Added.
* LayoutTests/editing/selection/ios/become-first-responder-after-relinquishing-focus.html: Added.

Add a layout test to exercise the bug, by using shift-tab and `-resignFirstResponder` to dismiss the
keyboard in an editable web view, and then verifying that the keyboard shows up again after calling
`-becomeFirstResponder`.

* Source/WebCore/page/FocusController.cpp:
(WebCore::clearSelectionIfNeeded):

Move this helper function to the top of this file, so we can use it in `relinquishFocusToChrome`.
Also make some minor adjustments to handle the case where the `newFocusedFrame` is `nullptr`.

(WebCore::FocusController::relinquishFocusToChrome):

Call `clearSelectionIfNeeded` when relinquishing focus to be consistent with the regular
`setFocusedElement` codepath.

Canonical link: <a href="https://commits.webkit.org/266256@main">https://commits.webkit.org/266256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3cf1f620f647eb9249fabb2bf0f41b703efee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12687 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16147 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15368 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15693 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19074 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10550 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11887 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3258 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16286 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->