### PR TITLE
Path::transform() should not trigger creation of a platform path

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3378,6 +3378,11 @@ imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-022.svg [ Fail
 imported/w3c/web-platform-tests/svg/painting/reftests/marker-path-023.svg [ Failure ]
 svg/W3C-SVG-1.1/painting-marker-03-f.svg [ Failure ]
 
+# Path with transform failures
+imported/w3c/web-platform-tests/html/canvas/element/path-objects/2d.path.stroke.skew.html [ Failure ]
+imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.skew.html [ Failure ]
+imported/w3c/web-platform-tests/html/canvas/offscreen/path-objects/2d.path.stroke.skew.worker.html [ Failure ]
+
 imported/w3c/web-platform-tests/preload/onerror-event.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/preload/preload-time-to-fetch.https.html [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/preload/preload-type-match.html [ DumpJSConsoleLogInStdErr ]

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -352,6 +352,14 @@ void Path::transform(const AffineTransform& transform)
     if (transform.isIdentity() || isEmpty())
         return;
 
+    auto segment = asSingle();
+    if (segment && segment->transform(transform))
+        return;
+
+    auto impl = asImpl();
+    if (impl && impl->transform(transform))
+        return;
+
     ensurePlatformPathImpl().transform(transform);
 }
 

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -72,6 +72,8 @@ public:
     virtual void applySegments(const PathSegmentApplier&) const = 0;
     virtual bool applyElements(const PathElementApplier&) const = 0;
 
+    virtual bool transform(const AffineTransform&) = 0;
+
     virtual std::optional<PathSegment> singleSegment() const { return std::nullopt; }
     virtual std::optional<PathDataLine> singleDataLine() const { return std::nullopt; }
     virtual std::optional<PathArc> singleArc() const { return std::nullopt; }

--- a/Source/WebCore/platform/graphics/PathSegment.cpp
+++ b/Source/WebCore/platform/graphics/PathSegment.cpp
@@ -83,6 +83,24 @@ bool PathSegment::applyElements(const PathElementApplier& applier) const
     });
 }
 
+bool PathSegment::canTransform() const
+{
+    return WTF::switchOn(m_data, [&](auto& data) {
+        return data.canTransform;
+    });
+}
+
+bool PathSegment::transform(const AffineTransform& transform)
+{
+    return WTF::switchOn(m_data, [&](auto& data) {
+        if constexpr (std::decay_t<decltype(data)>::canTransform) {
+            data.transform(transform);
+            return true;
+        }
+        return false;
+    });
+}
+
 TextStream& operator<<(TextStream& ts, const PathSegment& segment)
 {
     return WTF::switchOn(segment.data(), [&](auto& data) -> TextStream& {

--- a/Source/WebCore/platform/graphics/PathSegment.h
+++ b/Source/WebCore/platform/graphics/PathSegment.h
@@ -70,6 +70,9 @@ public:
     bool canApplyElements() const;
     bool applyElements(const PathElementApplier&) const;
 
+    bool canTransform() const;
+    bool transform(const AffineTransform&);
+
 private:
     Data m_data;
 };

--- a/Source/WebCore/platform/graphics/PathSegmentData.cpp
+++ b/Source/WebCore/platform/graphics/PathSegmentData.cpp
@@ -56,6 +56,11 @@ void PathMoveTo::applyElements(const PathElementApplier& applier) const
     applier({ PathElement::Type::MoveToPoint, { point } });
 }
 
+void PathMoveTo::transform(const AffineTransform& transform)
+{
+    point = transform.mapPoint(point);
+}
+
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathMoveTo& data)
 {
     ts << "move to " << data.point;
@@ -86,6 +91,11 @@ void PathLineTo::addToImpl(PathImpl& impl) const
 void PathLineTo::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::AddLineToPoint, { point } });
+}
+
+void PathLineTo::transform(const AffineTransform& transform)
+{
+    point = transform.mapPoint(point);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathLineTo& data)
@@ -156,6 +166,12 @@ void PathQuadCurveTo::addToImpl(PathImpl& impl) const
 void PathQuadCurveTo::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::AddQuadCurveToPoint, { controlPoint, endPoint } });
+}
+
+void PathQuadCurveTo::transform(const AffineTransform& transform)
+{
+    controlPoint = transform.mapPoint(controlPoint);
+    endPoint = transform.mapPoint(endPoint);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathQuadCurveTo& data)
@@ -263,6 +279,13 @@ void PathBezierCurveTo::addToImpl(PathImpl& impl) const
 void PathBezierCurveTo::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::AddCurveToPoint, { controlPoint1, controlPoint2, endPoint } });
+}
+
+void PathBezierCurveTo::transform(const AffineTransform& transform)
+{
+    controlPoint1 = transform.mapPoint(controlPoint1);
+    controlPoint2 = transform.mapPoint(controlPoint2);
+    endPoint = transform.mapPoint(endPoint);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathBezierCurveTo& data)
@@ -561,6 +584,12 @@ void PathDataLine::applyElements(const PathElementApplier& applier) const
     applier({ PathElement::Type::AddLineToPoint, { end } });
 }
 
+void PathDataLine::transform(const AffineTransform& transform)
+{
+    start = transform.mapPoint(start);
+    end = transform.mapPoint(end);
+}
+
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataLine& data)
 {
     ts << "move to " << data.start;
@@ -600,6 +629,13 @@ void PathDataQuadCurve::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::MoveToPoint, { start } });
     applier({ PathElement::Type::AddQuadCurveToPoint, { controlPoint, endPoint } });
+}
+
+void PathDataQuadCurve::transform(const AffineTransform& transform)
+{
+    start = transform.mapPoint(start);
+    controlPoint = transform.mapPoint(controlPoint);
+    endPoint = transform.mapPoint(endPoint);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataQuadCurve& data)
@@ -643,6 +679,14 @@ void PathDataBezierCurve::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::MoveToPoint, { start } });
     applier({ PathElement::Type::AddCurveToPoint, { controlPoint1, controlPoint2, endPoint } });
+}
+
+void PathDataBezierCurve::transform(const AffineTransform& transform)
+{
+    start = transform.mapPoint(start);
+    controlPoint1 = transform.mapPoint(controlPoint1);
+    controlPoint2 = transform.mapPoint(controlPoint2);
+    endPoint = transform.mapPoint(endPoint);
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathDataBezierCurve& data)
@@ -710,6 +754,10 @@ void PathCloseSubpath::addToImpl(PathImpl& impl) const
 void PathCloseSubpath::applyElements(const PathElementApplier& applier) const
 {
     applier({ PathElement::Type::CloseSubpath, { } });
+}
+
+void PathCloseSubpath::transform(const AffineTransform&)
+{
 }
 
 WTF::TextStream& operator<<(WTF::TextStream& ts, const PathCloseSubpath&)

--- a/Source/WebCore/platform/graphics/PathSegmentData.h
+++ b/Source/WebCore/platform/graphics/PathSegmentData.h
@@ -42,6 +42,7 @@ struct PathMoveTo {
     FloatPoint point;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathMoveTo&) const = default;
 
@@ -52,6 +53,8 @@ struct PathMoveTo {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathMoveTo&);
@@ -60,6 +63,7 @@ struct PathLineTo {
     FloatPoint point;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathLineTo&) const = default;
 
@@ -70,6 +74,8 @@ struct PathLineTo {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathLineTo&);
@@ -79,6 +85,7 @@ struct PathQuadCurveTo {
     FloatPoint endPoint;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathQuadCurveTo&) const = default;
 
@@ -89,6 +96,8 @@ struct PathQuadCurveTo {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathQuadCurveTo&);
@@ -99,6 +108,7 @@ struct PathBezierCurveTo {
     FloatPoint endPoint;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathBezierCurveTo&) const = default;
 
@@ -109,6 +119,8 @@ struct PathBezierCurveTo {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathBezierCurveTo&);
@@ -119,6 +131,7 @@ struct PathArcTo {
     float radius;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathArcTo&) const = default;
 
@@ -140,6 +153,7 @@ struct PathArc {
     RotationDirection direction;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathArc&) const = default;
 
@@ -163,6 +177,7 @@ struct PathEllipse {
     RotationDirection direction;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathEllipse&) const = default;
 
@@ -180,6 +195,7 @@ struct PathEllipseInRect {
     FloatRect rect;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathEllipseInRect&) const = default;
 
@@ -197,6 +213,7 @@ struct PathRect {
     FloatRect rect;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathRect&) const = default;
 
@@ -220,6 +237,7 @@ struct PathRoundedRect {
     Strategy strategy;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathRoundedRect&) const = default;
 
@@ -238,6 +256,7 @@ struct PathDataLine {
     FloatPoint end;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathDataLine&) const = default;
 
@@ -248,6 +267,8 @@ struct PathDataLine {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataLine&);
@@ -258,6 +279,7 @@ struct PathDataQuadCurve {
     FloatPoint endPoint;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathDataQuadCurve&) const = default;
 
@@ -268,6 +290,8 @@ struct PathDataQuadCurve {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataQuadCurve&);
@@ -279,6 +303,7 @@ struct PathDataBezierCurve {
     FloatPoint endPoint;
 
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathDataBezierCurve&) const = default;
 
@@ -289,6 +314,8 @@ struct PathDataBezierCurve {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataBezierCurve&);
@@ -300,6 +327,7 @@ struct PathDataArc {
     float radius;
 
     static constexpr bool canApplyElements = false;
+    static constexpr bool canTransform = false;
 
     bool operator==(const PathDataArc&) const = default;
 
@@ -315,6 +343,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathDataArc&)
 
 struct PathCloseSubpath {
     static constexpr bool canApplyElements = true;
+    static constexpr bool canTransform = true;
 
     bool operator==(const PathCloseSubpath&) const = default;
 
@@ -325,6 +354,8 @@ struct PathCloseSubpath {
 
     void addToImpl(PathImpl&) const;
     void applyElements(const PathElementApplier&) const;
+
+    void transform(const AffineTransform&);
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const PathCloseSubpath&);

--- a/Source/WebCore/platform/graphics/PathStream.cpp
+++ b/Source/WebCore/platform/graphics/PathStream.cpp
@@ -206,6 +206,19 @@ bool PathStream::applyElements(const PathElementApplier& applier) const
     return true;
 }
 
+bool PathStream::transform(const AffineTransform& transform)
+{
+    for (auto& segment : m_segmentsData->segments) {
+        if (!segment.canTransform())
+            return false;
+    }
+
+    for (auto& segment : m_segmentsData.access().segments)
+        segment.transform(transform);
+
+    return true;
+}
+
 std::optional<PathSegment> PathStream::singleSegment() const
 {
     if (m_segmentsData->segments.size() != 1)

--- a/Source/WebCore/platform/graphics/PathStream.h
+++ b/Source/WebCore/platform/graphics/PathStream.h
@@ -70,6 +70,8 @@ public:
     void applySegments(const PathSegmentApplier&) const final;
     bool applyElements(const PathElementApplier&) const final;
 
+    bool transform(const AffineTransform&) final;
+
     FloatRect fastBoundingRect() const final;
     FloatRect boundingRect() const final;
 

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -403,13 +403,16 @@ FloatPoint PathCairo::currentPoint() const
     return FloatPoint(x, y);
 }
 
-void PathCairo::transform(const AffineTransform& transform)
+bool PathCairo::transform(const AffineTransform& transform)
 {
+    if (m_elementsStream && !m_elementsStream->transform(transform))
+        m_elementsStream = nullptr;
+
     cairo_matrix_t matrix = toCairoMatrix(transform);
     cairo_matrix_invert(&matrix);
     cairo_transform(platformPath(), &matrix);
 
-    m_elementsStream = nullptr;
+    return true;
 }
 
 bool PathCairo::contains(const FloatPoint &point, WindRule rule) const

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -54,7 +54,7 @@ public:
 
     bool applyElements(const PathElementApplier&) const final;
 
-    void transform(const AffineTransform&);
+    bool transform(const AffineTransform&) final;
 
     bool contains(const FloatPoint&, WindRule) const;
     bool strokeContains(const FloatPoint&, const Function<void(GraphicsContext&)>& strokeStyleApplier) const;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -306,10 +306,11 @@ FloatPoint PathCG::currentPoint() const
     return CGPathGetCurrentPoint(platformPath());
 }
 
-void PathCG::transform(const AffineTransform& transform)
+bool PathCG::transform(const AffineTransform& transform)
 {
     CGAffineTransform transformCG = transform;
     m_platformPath = adoptCF(CGPathCreateMutableCopyByTransformingPath(platformPath(), &transformCG));
+    return true;
 }
 
 static void copyClosingSubpathsApplierFunction(void* info, const CGPathElement* element)

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -51,7 +51,7 @@ public:
 
     bool applyElements(const PathElementApplier&) const final;
 
-    void transform(const AffineTransform&);
+    bool transform(const AffineTransform&) final;
 
     bool contains(const FloatPoint&, WindRule) const;
     bool strokeContains(const FloatPoint&, const Function<void(GraphicsContext&)>& strokeStyleApplier) const;


### PR DESCRIPTION
#### bc527208a62ff94103079beae9e5e582134d9b49
<pre>
Path::transform() should not trigger creation of a platform path
<a href="https://bugs.webkit.org/show_bug.cgi?id=258759">https://bugs.webkit.org/show_bug.cgi?id=258759</a>
rdar://problem/111934640

Reviewed by Simon Fraser.

Many paths consist only of Move/Line/Quadratic/Cubic/Close segments, which are
all simple to apply an AffineTransform to. Transform single segment and PathStream
based paths in place when Path::transform() is called, to avoid the overhead of
generating a CGPath. If other segment types are in the path, continue to convert
to a platform path first.

Some WPT (path + transform) tests fail on GTK ports because the tests are fragile
to floating point calculations. The tests rotate the context by 90 degree and scale
it by 283 then they stroke a line to cover the whole canvas by the stroke color.
If we scale by 282, the last row in the canvas will not be stroked even without
this patch. On GKT port and with this patch, the last row is stroked but it is
anti-aliased with the background.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::transform):
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/PathSegment.cpp:
(WebCore::PathSegment::canTransform const):
(WebCore::PathSegment::transform):
* Source/WebCore/platform/graphics/PathSegment.h:
* Source/WebCore/platform/graphics/PathSegmentData.cpp:
(WebCore::PathMoveTo::transform):
(WebCore::PathLineTo::transform):
(WebCore::PathQuadCurveTo::transform):
(WebCore::PathBezierCurveTo::transform):
(WebCore::PathDataLine::transform):
(WebCore::PathDataQuadCurve::transform):
(WebCore::PathDataBezierCurve::transform):
(WebCore::PathCloseSubpath::transform):
* Source/WebCore/platform/graphics/PathSegmentData.h:
* Source/WebCore/platform/graphics/PathStream.cpp:
(WebCore::PathStream::transform):
* Source/WebCore/platform/graphics/PathStream.h:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::transform):
* Source/WebCore/platform/graphics/cairo/PathCairo.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::PathCG::transform):
* Source/WebCore/platform/graphics/cg/PathCG.h:

Canonical link: <a href="https://commits.webkit.org/266672@main">https://commits.webkit.org/266672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb57a27f7e88aba00284e90b958ae58531a7b5c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16155 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14802 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15135 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12241 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16877 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12420 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13003 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13497 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16381 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13717 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13004 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->