### PR TITLE
Lotsa logging in RemoteLayerTreeDrawingArea and friends.

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -1819,7 +1819,7 @@ That first argument is a log channel. These have 2 purposes:
 Here's an example invocation of `LOG_WITH_STREAM()`:
 
 ```
-LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::commitTreeState - removing unvisited node " << nodeID);
+ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::commitTreeState - removing unvisited node " << nodeID);
 ```
 
 The macro sets up a local variable named `stream` which the second argument can direct messages to. The second argument is a collection of statements - not expressions like `LOG()` and `RELEASE_LOG()`. So, you can do things like this:

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -533,7 +533,7 @@ bool Element::dispatchWheelEvent(const PlatformWheelEvent& platformEvent, Option
 
     dispatchEvent(event);
     
-    LOG_WITH_STREAM(Scrolling, stream << "Element " << *this << " dispatchWheelEvent: (cancelable " << event->cancelable() << ") defaultPrevented " << event->defaultPrevented() << " defaultHandled " << event->defaultHandled());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Element " << *this << " dispatchWheelEvent: (cancelable " << event->cancelable() << ") defaultPrevented " << event->defaultPrevented() << " defaultHandled " << event->defaultHandled());
     
     if (event->defaultPrevented())
         processing.add(EventHandling::DefaultPrevented);
@@ -1175,6 +1175,11 @@ void Element::scrollBy(const ScrollToOptions& options)
     FloatSize originalDelta(scrollToOptions.left.value(), scrollToOptions.top.value());
     scrollToOptions.left.value() += scrollLeft();
     scrollToOptions.top.value() += scrollTop();
+    ALWAYS_LOG_WITH_STREAM(stream
+        << "**Scrolling** " << "Element::scrollBy " << options.left << "," << options.top
+        << " normalized:" << originalDelta
+        << " += " << scrollLeft() << "," << scrollTop()
+        << " -> scrollTo " << scrollToOptions.left << "," << scrollToOptions.top);
     scrollTo(scrollToOptions, ScrollClamping::Clamped, ScrollSnapPointSelectionMethod::Directional, originalDelta);
 }
 
@@ -1185,7 +1190,7 @@ void Element::scrollBy(double x, double y)
 
 void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, ScrollSnapPointSelectionMethod snapPointSelectionMethod, std::optional<FloatSize> originalScrollDelta)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "Element " << *this << " scrollTo " << options.left << ", " << options.top);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Element " << *this << " scrollTo " << options.left << ", " << options.top);
 
     if (!document().settings().CSSOMViewScrollingAPIEnabled()) {
         // If the element is the root element and document is in quirks mode, terminate these steps.
@@ -1556,6 +1561,7 @@ void Element::setScrollLeft(int newLeft)
     if (document().scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(static_cast<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Element::setScrollLeft " << newLeft << " -> setScrollPosition " << position);
             frame->view()->setScrollPosition(position, options);
         }
         return;
@@ -1579,6 +1585,7 @@ void Element::setScrollTop(int newTop)
     if (document().scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(frame->view()->scrollX(), static_cast<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Element::setScrollTop " << newTop << " -> setScrollPosition " << position);
             frame->view()->setScrollPosition(position, options);
         }
         return;

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -416,6 +416,7 @@ void ImageDocument::imageClicked(int x, int y)
         int scrollX = static_cast<int>(x / scale - viewportSize.width() / 2.0f);
         int scrollY = static_cast<int>(y / scale - viewportSize.height() / 2.0f);
 
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ImageDocument::imageClicked " << x << "," << y << " -> setScrollPosition " << IntPoint(scrollX, scrollY));
         view()->setScrollPosition(IntPoint(scrollX, scrollY));
     }
 }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -161,11 +161,13 @@ void FrameLoader::HistoryController::restoreScrollPositionAndViewState()
 
         Page* page = m_frame.page();
         auto desiredScrollPosition = m_currentItem->shouldRestoreScrollPosition() ? m_currentItem->scrollPosition() : view->scrollPosition();
-        LOG(Scrolling, "HistoryController::restoreScrollPositionAndViewState scrolling to %d,%d", desiredScrollPosition.x(), desiredScrollPosition.y());
+        WTFLogAlways("**Scrolling** HistoryController::restoreScrollPositionAndViewState scrolling to %d,%d", desiredScrollPosition.x(), desiredScrollPosition.y());
         if (page && m_frame.isMainFrame() && m_currentItem->pageScaleFactor())
             page->setPageScaleFactor(m_currentItem->pageScaleFactor() * page->viewScaleFactor(), desiredScrollPosition);
-        else
+        else {
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "FrameLoader::HistoryController::restoreScrollPositionAndViewState -> setScrollPosition " << desiredScrollPosition);
             view->setScrollPosition(desiredScrollPosition);
+        }
 
         // If the scroll position doesn't have to be clamped, consider it successfully restored.
         if (m_frame.isMainFrame()) {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3058,7 +3058,7 @@ bool EventHandler::handleWheelEventInternal(const PlatformWheelEvent& event, Opt
 #endif
 
 #if PLATFORM(COCOA)
-    LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEvent " << event << " processing steps " << processingSteps);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "EventHandler::handleWheelEvent " << event << " processing steps " << processingSteps);
     auto monitor = m_frame.page()->wheelEventTestMonitor();
     if (monitor)
         monitor->receivedWheelEventWithPhases(event.phase(), event.momentumPhase());
@@ -3253,7 +3253,7 @@ bool EventHandler::scrollableAreaCanHandleEvent(const PlatformWheelEvent& wheelE
 bool EventHandler::handleWheelEventInScrollableArea(const PlatformWheelEvent& wheelEvent, ScrollableArea& scrollableArea, OptionSet<EventHandling> eventHandling)
 {
     auto gestureState = updateWheelGestureState(wheelEvent, eventHandling);
-    LOG_WITH_STREAM(Scrolling, stream << "EventHandler::handleWheelEventInScrollableArea() " << scrollableArea << " - eventHandling " << eventHandling << " -> gesture state " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "EventHandler::handleWheelEventInScrollableArea() " << scrollableArea << " - eventHandling " << eventHandling << " -> gesture state " << gestureState);
     return scrollableArea.handleWheelEventForScrolling(wheelEvent, gestureState);
 }
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1777,11 +1777,17 @@ void LocalDOMWindow::scrollBy(const ScrollToOptions& options) const
     FloatSize originalDelta(scrollToOptions.left.value(), scrollToOptions.top.value());
     scrollToOptions.left.value() += view->mapFromLayoutToCSSUnits(view->contentsScrollPosition().x());
     scrollToOptions.top.value() += view->mapFromLayoutToCSSUnits(view->contentsScrollPosition().y());
+    ALWAYS_LOG_WITH_STREAM(stream
+        << "**Scrolling** " << "LocalDOMWindow::scrollBy " << options.left << "," << options.top
+        << " normalized:" << originalDelta
+        << " += " << view->mapFromLayoutToCSSUnits(view->contentsScrollPosition().x()) << "," << view->mapFromLayoutToCSSUnits(view->contentsScrollPosition().y())
+        << " -> scrollTo " << scrollToOptions.left << "," << scrollToOptions.top);
     scrollTo(scrollToOptions, ScrollClamping::Clamped, ScrollSnapPointSelectionMethod::Directional, originalDelta);
 }
 
 void LocalDOMWindow::scrollTo(double x, double y, ScrollClamping clamping) const
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalDOMWindow::scrollTo(x,y) " << x << "," << y << " -> scrollTo(options) " << x << "," << y);
     scrollTo(ScrollToOptions(x, y), clamping);
 }
 
@@ -1801,7 +1807,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
     // This is an optimization for the common case of scrolling to (0, 0) when the scroller is already at the origin.
     // If an animated scroll is in progress, this optimization is skipped to ensure that the animated scroll is really stopped.
     if (view->scrollAnimationStatus() == ScrollAnimationStatus::NotAnimating && !scrollToOptions.left.value() && !scrollToOptions.top.value() && view->contentsScrollPosition().isZero()) {
-        LOG_WITH_STREAM(Scrolling, stream << "LocalDOMWindow::scrollTo bailing because going to 0,0");
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalDOMWindow::scrollTo bailing because going to 0,0");
         return;
     }
 
@@ -1814,6 +1820,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
     // See https://bugs.webkit.org/show_bug.cgi?id=205059
     auto animated = useSmoothScrolling(scrollToOptions.behavior.value_or(ScrollBehavior::Auto), document()->documentElement()) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
     auto scrollPositionChangeOptions = ScrollPositionChangeOptions::createProgrammaticWithOptions(clamping, animated, snapPointSelectionMethod, originalScrollDelta);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalDOMWindow::scrollTo " << options.left << "," << options.top << " normalized:" << scrollToOptions.left << "," << scrollToOptions.top << " -> setContentsScrollPosition " << layoutPos);
     view->setContentsScrollPosition(layoutPos, scrollPositionChangeOptions);
 }
 

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -978,8 +978,10 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
             view->layoutContext().layout();
 
         // Scrolling to the calculated position must be done after the layout.
-        if (scrollPositionAfterZoomed)
+        if (scrollPositionAfterZoomed) {
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrame::setPageAndTextZoomFactors -> setScrollPosition " << scrollPositionAfterZoomed.value());
             view->setScrollPosition(scrollPositionAfterZoomed.value());
+        }
     }
 }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1788,7 +1788,7 @@ void LocalFrameView::setLayoutViewportOverrideRect(std::optional<LayoutRect> rec
     if (oldRect.height() != newRect.height())
         layoutTriggering = TriggerLayoutOrNot::Yes;
 
-    LOG_WITH_STREAM(Scrolling, stream << "\nFrameView " << this << " setLayoutViewportOverrideRect() - changing override layout viewport from " << oldRect << " to " << valueOrDefault(m_layoutViewportOverrideRect) << " layoutTriggering " << (layoutTriggering == TriggerLayoutOrNot::Yes ? "yes" : "no"));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "\nFrameView " << this << " setLayoutViewportOverrideRect() - changing override layout viewport from " << oldRect << " to " << valueOrDefault(m_layoutViewportOverrideRect) << " layoutTriggering " << (layoutTriggering == TriggerLayoutOrNot::Yes ? "yes" : "no"));
 
     if (layoutTriggering == TriggerLayoutOrNot::Yes) {
         if (oldRect != newRect)
@@ -1823,14 +1823,14 @@ void LocalFrameView::updateLayoutViewport()
 
     LayoutRect layoutViewport = layoutViewportRect();
 
-    LOG_WITH_STREAM(Scrolling, stream << "\nFrameView " << this << " updateLayoutViewport() totalContentSize " << totalContentsSize() << " unscaledDocumentRect " << (renderView() ? renderView()->unscaledDocumentRect() : IntRect()) << " header height " << headerHeight() << " footer height " << footerHeight() << " fixed behavior " << scrollBehaviorForFixedElements());
-    LOG_WITH_STREAM(Scrolling, stream << "layoutViewport: " << layoutViewport);
-    LOG_WITH_STREAM(Scrolling, stream << "visualViewport: " << visualViewportRect() << " (is override " << (bool)m_visualViewportOverrideRect << ")");
-    LOG_WITH_STREAM(Scrolling, stream << "stable origins: min: " << minStableLayoutViewportOrigin() << " max: "<< maxStableLayoutViewportOrigin());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "\nFrameView " << this << " updateLayoutViewport() totalContentSize " << totalContentsSize() << " unscaledDocumentRect " << (renderView() ? renderView()->unscaledDocumentRect() : IntRect()) << " header height " << headerHeight() << " footer height " << footerHeight() << " fixed behavior " << scrollBehaviorForFixedElements());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "layoutViewport: " << layoutViewport);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "visualViewport: " << visualViewportRect() << " (is override " << (bool)m_visualViewportOverrideRect << ")");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "stable origins: min: " << minStableLayoutViewportOrigin() << " max: "<< maxStableLayoutViewportOrigin());
     
     if (m_layoutViewportOverrideRect) {
         if (currentScrollType() == ScrollType::Programmatic) {
-            LOG_WITH_STREAM(Scrolling, stream << "computing new override layout viewport because of programmatic scrolling");
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "computing new override layout viewport because of programmatic scrolling");
             LayoutPoint newOrigin = computeLayoutViewportOrigin(visualViewportRect(), minStableLayoutViewportOrigin(), maxStableLayoutViewportOrigin(), layoutViewport, StickToDocumentBounds);
             setLayoutViewportOverrideRect(LayoutRect(newOrigin, m_layoutViewportOverrideRect.value().size()));
         }
@@ -1841,7 +1841,7 @@ void LocalFrameView::updateLayoutViewport()
     LayoutPoint newLayoutViewportOrigin = computeLayoutViewportOrigin(visualViewportRect(), minStableLayoutViewportOrigin(), maxStableLayoutViewportOrigin(), layoutViewport, scrollBehaviorForFixedElements());
     if (newLayoutViewportOrigin != m_layoutViewportOrigin) {
         setBaseLayoutViewportOrigin(newLayoutViewportOrigin);
-        LOG_WITH_STREAM(Scrolling, stream << "layoutViewport changed to " << layoutViewportRect());
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "layoutViewport changed to " << layoutViewportRect());
     }
     layoutOrVisualViewportChanged();
 }
@@ -2352,7 +2352,7 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
     if (fragmentIdentifier.isNull())
         return false;
 
-    LOG_WITH_STREAM(Scrolling, stream << *this << " scrollToFragmentInternal " << fragmentIdentifier);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << *this << " scrollToFragmentInternal " << fragmentIdentifier);
 
     ASSERT(m_frame->document());
     auto& document = *m_frame->document();
@@ -2360,7 +2360,7 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
 
     RefPtr anchorElement = document.findAnchor(fragmentIdentifier);
 
-    LOG(Scrolling, " anchorElement is %p", anchorElement.get());
+    WTFLogAlways("**Scrolling**  anchorElement is %p", anchorElement.get());
 
     // Setting to null will clear the current target.
     document.setCSSTarget(anchorElement.get());
@@ -2400,7 +2400,7 @@ bool LocalFrameView::scrollToFragmentInternal(StringView fragmentIdentifier)
 
 void LocalFrameView::maintainScrollPositionAtAnchor(ContainerNode* anchorNode)
 {
-    LOG(Scrolling, "LocalFrameView::maintainScrollPositionAtAnchor at %p", anchorNode);
+    WTFLogAlways("**Scrolling** LocalFrameView::maintainScrollPositionAtAnchor at %p", anchorNode);
 
     m_maintainScrollPositionAnchor = anchorNode;
     if (!m_maintainScrollPositionAnchor)
@@ -2443,12 +2443,13 @@ void LocalFrameView::scrollElementToRect(const Element& element, const IntRect& 
         bounds = renderer->absoluteAnchorRect();
     int centeringOffsetX = (rect.width() - bounds.width()) / 2;
     int centeringOffsetY = (rect.height() - bounds.height()) / 2;
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::scrollElementToRect " << rect << " -> setScrollPosition " << IntPoint(bounds.x() - centeringOffsetX - rect.x(), bounds.y() - centeringOffsetY - rect.y()));
     setScrollPosition(IntPoint(bounds.x() - centeringOffsetX - rect.x(), bounds.y() - centeringOffsetY - rect.y()));
 }
 
 void LocalFrameView::setScrollPosition(const ScrollPosition& scrollPosition, const ScrollPositionChangeOptions& options)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::setScrollPosition " << scrollPosition << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::setScrollPosition " << scrollPosition << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");
 
     auto oldScrollType = currentScrollType();
     setCurrentScrollType(options.type);
@@ -2703,6 +2704,7 @@ void LocalFrameView::scrollRectToVisibleInChildView(const LayoutRect& absoluteRe
 
     // FIXME: Should we use contentDocument()->scrollingElement()?
     // See https://bugs.webkit.org/show_bug.cgi?id=205059
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::scrollRectToVisibleInChildView " << absoluteRect << " -> setScrollPosition " << scrollPosition);
     setScrollPosition(scrollPosition, scrollPositionChangeOptionsForElement(*this, element, options));
 
     if (options.shouldAllowCrossOriginScrolling == ShouldAllowCrossOriginScrolling::No && !safeToPropagateScrollToParent()) 
@@ -2762,6 +2764,7 @@ void LocalFrameView::scrollRectToVisibleInTopLevelView(const LayoutRect& absolut
         // FIXME: Should we use document()->scrollingElement()?
         // See https://bugs.webkit.org/show_bug.cgi?id=205059
         ScrollOffset clampedScrollPosition = roundedIntPoint(revealRect.location()).constrainedBetween(minScrollPosition, maxScrollPosition);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::scrollRectToVisibleInTopLevelView " << absoluteRect << " -> setScrollPosition " << clampedScrollPosition);
         setScrollPosition(clampedScrollPosition, scrollPositionChangeOptionsForElement(*this, element, options));
     }
 
@@ -2885,7 +2888,7 @@ void LocalFrameView::scrollPositionChanged(const ScrollPosition& oldPosition, co
             renderView->compositor().frameViewDidScroll();
     }
 
-    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView " << this << " scrollPositionChanged from " << oldPosition << " to " << newPosition << " (scale " << frameScaleFactor() << " )");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView " << this << " scrollPositionChanged from " << oldPosition << " to " << newPosition << " (scale " << frameScaleFactor() << " )");
     updateLayoutViewport();
     viewportContentsChanged();
 
@@ -3086,7 +3089,7 @@ bool LocalFrameView::requestStopKeyboardScrollAnimation(bool immediate)
 
 bool LocalFrameView::requestScrollToPosition(const ScrollPosition& position, const ScrollPositionChangeOptions& options)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::requestScrollToPosition " << position << " options  " << options);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::requestScrollToPosition " << position << " options  " << options);
 
 #if ENABLE(ASYNC_SCROLLING)
     if (auto* tiledBacking = this->tiledBacking(); tiledBacking && options.animated == ScrollIsAnimated::No) {
@@ -3113,7 +3116,7 @@ bool LocalFrameView::requestScrollToPosition(const ScrollPosition& position, con
 void LocalFrameView::stopAsyncAnimatedScroll()
 {
 #if ENABLE(ASYNC_SCROLLING)
-    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::stopAsyncAnimatedScroll");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView::stopAsyncAnimatedScroll");
 
     if (auto scrollingCoordinator = this->scrollingCoordinator())
         return scrollingCoordinator->stopAnimatedScroll(*this);
@@ -3689,7 +3692,7 @@ void LocalFrameView::scrollToAnchor()
     if (!anchorNode)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << *this << " scrollToAnchor() " << anchorNode.get());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << *this << " scrollToAnchor() " << anchorNode.get());
 
     if (!anchorNode->renderer())
         return;
@@ -3701,7 +3704,7 @@ void LocalFrameView::scrollToAnchor()
     if (anchorNode != m_frame->document() && anchorNode->renderer())
         rect = anchorNode->renderer()->absoluteAnchorRectWithScrollMargin(&insideFixed).marginRect;
 
-    LOG_WITH_STREAM(Scrolling, stream << " anchor node rect " << rect);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << " anchor node rect " << rect);
 
     // Scroll nested layers and frames to reveal the anchor.
     // Align to the top and to the closest side (this matches other browsers).
@@ -3716,7 +3719,7 @@ void LocalFrameView::scrollToAnchor()
         cache->handleScrolledToAnchor(anchorNode.get());
 
     // scrollRectToVisible can call into setScrollPosition(), which resets m_maintainScrollPositionAnchor.
-    LOG_WITH_STREAM(Scrolling, stream << " restoring anchor node to " << anchorNode.get());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << " restoring anchor node to " << anchorNode.get());
     m_maintainScrollPositionAnchor = anchorNode;
     cancelScheduledScrolls();
 }
@@ -3734,7 +3737,7 @@ void LocalFrameView::scrollToTextFragmentRange()
     if (m_pendingTextFragmentIndicatorText != plainText(range))
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << *this << " scrollToTextFragmentRange() " << range);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << *this << " scrollToTextFragmentRange() " << range);
 
     if (!range.startContainer().renderer() || !range.endContainer().renderer())
         return;
@@ -4722,7 +4725,7 @@ bool LocalFrameView::wasScrolledByUser() const
 
 void LocalFrameView::setWasScrolledByUser(bool wasScrolledByUser)
 {
-    LOG(Scrolling, "LocalFrameView::setWasScrolledByUser at %d", wasScrolledByUser);
+    WTFLogAlways("**Scrolling** LocalFrameView::setWasScrolledByUser at %d", wasScrolledByUser);
 
     cancelScheduledScrolls();
     if (currentScrollType() == ScrollType::Programmatic)
@@ -6052,7 +6055,7 @@ void LocalFrameView::setViewExposedRect(std::optional<FloatRect> viewExposedRect
     if (m_viewExposedRect == viewExposedRect)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView " << this << " setViewExposedRect " << (viewExposedRect ? viewExposedRect.value() : FloatRect()));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "LocalFrameView " << this << " setViewExposedRect " << (viewExposedRect ? viewExposedRect.value() : FloatRect()));
 
     bool hasRectExistenceChanged = !m_viewExposedRect == !viewExposedRect;
     m_viewExposedRect = viewExposedRect;

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -791,7 +791,7 @@ NSArray *LocalFrame::interpretationsForCurrentRoot() const
 
 void LocalFrame::viewportOffsetChanged(ViewportOffsetChangeType changeType)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "Frame::viewportOffsetChanged - " << (changeType == IncrementalScrollOffset ? "incremental" : "completed"));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Frame::viewportOffsetChanged - " << (changeType == IncrementalScrollOffset ? "incremental" : "completed"));
 
     if (changeType == IncrementalScrollOffset) {
         if (RenderView* root = contentRenderer())
@@ -814,7 +814,7 @@ bool LocalFrame::containsTiledBackingLayers() const
 
 void LocalFrame::overflowScrollPositionChangedForNode(const IntPoint& position, Node* node, bool isUserScroll)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "Frame::overflowScrollPositionChangedForNode " << node << " position " << position);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "Frame::overflowScrollPositionChangedForNode " << node << " position " << position);
 
     RenderObject* renderer = node->renderer();
     if (!renderer || !renderer->hasLayer())

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -924,7 +924,7 @@ bool EventHandler::processWheelEventForScrolling(const PlatformWheelEvent& wheel
         LOG_WITH_STREAM(ScrollLatching, stream << "  latching state " << m_frame.page()->scrollLatchingController());
 
         if (!frameHasPlatformWidget(m_frame) && scrollableArea != view) {
-            LOG_WITH_STREAM(Scrolling, stream << "  latched to non-view scroller " << scrollableArea << " and not propagating");
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "  latched to non-view scroller " << scrollableArea << " and not propagating");
             return true;
         }
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -346,7 +346,7 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
     else
         stateNode->setRequestedScrollData({ ScrollRequestType::PositionUpdate, scrollPosition, options.type, options.clamping, options.animated });
 
-    LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::requestScrollToPosition: " << (options.animated == ScrollIsAnimated::Yes ? "isAnimated" : "isntAnimated") << " currentScrollPosition: " << scrollableArea.scrollPosition() << " scrollTo:" << (options.animated == ScrollIsAnimated::Yes ? IntPoint(scrollPosition - scrollableArea.scrollPosition()) : scrollPosition) << " requestedScrollData: " << stateNode->requestedScrollData() << "options" << options);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "AsyncScrollingCoordinator::requestScrollToPosition: " << (options.animated == ScrollIsAnimated::Yes ? "isAnimated" : "isntAnimated") << " currentScrollPosition: " << scrollableArea.scrollPosition() << " scrollTo:" << (options.animated == ScrollIsAnimated::Yes ? IntPoint(scrollPosition - scrollableArea.scrollPosition()) : scrollPosition) << " requestedScrollData: " << stateNode->requestedScrollData() << "options" << options);
 
     // FIXME: This should schedule a rendering update
     commitTreeStateIfNeeded();
@@ -449,7 +449,7 @@ void AsyncScrollingCoordinator::synchronizeStateFromScrollingTree()
 
     m_scrollingTree->traverseScrollingTree([&](ScrollingNodeID nodeID, ScrollingNodeType, std::optional<FloatPoint> scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool scrolledSinceLastCommit) {
         if (scrollPosition && scrolledSinceLastCommit) {
-            LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::synchronizeStateFromScrollingTree - node " << nodeID << " scroll position " << scrollPosition);
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "AsyncScrollingCoordinator::synchronizeStateFromScrollingTree - node " << nodeID << " scroll position " << scrollPosition);
             updateScrollPositionAfterAsyncScroll(nodeID, scrollPosition.value(), layoutViewportOrigin, ScrollingLayerPositionAction::Set, ScrollType::User);
         }
     });
@@ -462,7 +462,7 @@ void AsyncScrollingCoordinator::applyPendingScrollUpdates()
 
     auto scrollUpdates = m_scrollingTree->takePendingScrollUpdates();
     for (auto& update : scrollUpdates) {
-        LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::applyPendingScrollUpdates - node " << update.nodeID << " scroll position " << update.scrollPosition);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "AsyncScrollingCoordinator::applyPendingScrollUpdates - node " << update.nodeID << " scroll position " << update.scrollPosition);
         applyScrollPositionUpdate(WTFMove(update), ScrollType::User);
     }
 }
@@ -569,7 +569,7 @@ void AsyncScrollingCoordinator::animatedScrollDidEndForNode(ScrollingNodeID scro
     if (!frameView)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::animatedScrollDidEndForNode node " << scrollingNodeID);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "AsyncScrollingCoordinator::animatedScrollDidEndForNode node " << scrollingNodeID);
 
     m_hysterisisActivity.stop();
 
@@ -624,7 +624,7 @@ void AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll(ScrollingNo
     if (!frameViewPtr)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll node " << scrollingNodeID << " " << scrollType << " scrollPosition " << scrollPosition << " action " << scrollingLayerPositionAction);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll node " << scrollingNodeID << " " << scrollType << " scrollPosition " << scrollPosition << " action " << scrollingLayerPositionAction);
 
     auto& frameView = *frameViewPtr;
 
@@ -656,7 +656,7 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
     auto previousScrollType = frameView.currentScrollType();
     frameView.setCurrentScrollType(scrollType);
 
-    LOG_WITH_STREAM(Scrolling, stream << getCurrentProcessID() << " AsyncScrollingCoordinator " << this << " reconcileScrollingState scrollPosition " << scrollPosition << " type " << scrollType << " stability " << viewportRectStability << " " << scrollingLayerPositionAction);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << getCurrentProcessID() << " AsyncScrollingCoordinator " << this << " reconcileScrollingState scrollPosition " << scrollPosition << " type " << scrollType << " stability " << viewportRectStability << " " << scrollingLayerPositionAction);
 
     std::optional<FloatRect> layoutViewportRect;
 
@@ -851,7 +851,7 @@ Vector<ScrollingNodeID> AsyncScrollingCoordinator::childrenOfNode(ScrollingNodeI
 
 void AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions(ScrollingNodeID scrollingNodeID, const LayoutRect& viewportRect, ScrollingLayerPositionAction action)
 {
-    LOG_WITH_STREAM(Scrolling, stream << getCurrentProcessID() << " AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions for viewport rect " << viewportRect << " and node " << scrollingNodeID);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << getCurrentProcessID() << " AsyncScrollingCoordinator::reconcileViewportConstrainedLayerPositions for viewport rect " << viewportRect << " and node " << scrollingNodeID);
 
     m_scrollingStateTree->reconcileViewportConstrainedLayerPositions(scrollingNodeID, viewportRect, action);
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFixedNode.cpp
@@ -72,7 +72,7 @@ void ScrollingStateFixedNode::updateConstraints(const FixedPositionViewportConst
     if (m_constraints == constraints)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() << " updateConstraints with viewport rect " << constraints.viewportRectAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout() << " offset from top " << (constraints.layerPositionAtLastLayout().y() - constraints.viewportRectAtLastLayout().y()));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingStateFixedNode " << scrollingNodeID() << " updateConstraints with viewport rect " << constraints.viewportRectAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout() << " offset from top " << (constraints.layerPositionAtLastLayout().y() - constraints.viewportRectAtLastLayout().y()));
 
     m_constraints = constraints;
     setPropertyChanged(Property::ViewportConstraints);
@@ -84,7 +84,7 @@ void ScrollingStateFixedNode::reconcileLayerPositionForViewportRect(const Layout
     if (layer().representsGraphicsLayer()) {
         auto* graphicsLayer = static_cast<GraphicsLayer*>(layer());
 
-        LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateFixedNode " << scrollingNodeID() <<" reconcileLayerPositionForViewportRect " << action << " position of layer " << graphicsLayer->primaryLayerID() << " to " << position);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingStateFixedNode " << scrollingNodeID() <<" reconcileLayerPositionForViewportRect " << action << " position of layer " << graphicsLayer->primaryLayerID() << " to " << position);
         
         switch (action) {
         case ScrollingLayerPositionAction::Set:

--- a/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStatePositionedNode.cpp
@@ -82,7 +82,7 @@ void ScrollingStatePositionedNode::updateConstraints(const AbsolutePositionConst
     if (m_constraints == constraints)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingStatePositionedNode " << scrollingNodeID() << " updateConstraints " << constraints);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingStatePositionedNode " << scrollingNodeID() << " updateConstraints " << constraints);
 
     m_constraints = constraints;
     setPropertyChanged(Property::LayoutConstraintData);

--- a/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateStickyNode.cpp
@@ -77,7 +77,7 @@ void ScrollingStateStickyNode::updateConstraints(const StickyPositionViewportCon
     if (m_constraints == constraints)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingStateStickyNode " << scrollingNodeID() << " updateConstraints with constraining rect " << constraints.constrainingRectAtLastLayout() << " sticky offset " << constraints.stickyOffsetAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingStateStickyNode " << scrollingNodeID() << " updateConstraints with constraining rect " << constraints.constrainingRectAtLastLayout() << " sticky offset " << constraints.stickyOffsetAtLastLayout() << " layer pos at last layout " << constraints.layerPositionAtLastLayout());
 
     m_constraints = constraints;
     setPropertyChanged(Property::ViewportConstraints);

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -98,7 +98,7 @@ OptionSet<WheelEventProcessingSteps> ScrollingTree::computeWheelProcessingSteps(
         // Event regions are affected by page scale, so no need to map through scale.
         bool isSynchronousDispatchRegion = m_treeState.eventTrackingRegions.trackingTypeForPoint(EventTrackingRegions::EventType::Wheel, roundedPosition) == TrackingType::Synchronous
             || m_treeState.eventTrackingRegions.trackingTypeForPoint(EventTrackingRegions::EventType::Mousewheel, roundedPosition) == TrackingType::Synchronous;
-        LOG_WITH_STREAM(Scrolling, stream << "\nScrollingTree::computeWheelProcessingSteps: wheelEvent " << wheelEvent << " mapped to content point " << position << ", in non-fast region " << isSynchronousDispatchRegion);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "\nScrollingTree::computeWheelProcessingSteps: wheelEvent " << wheelEvent << " mapped to content point " << position << ", in non-fast region " << isSynchronousDispatchRegion);
 
         if (isSynchronousDispatchRegion)
             return { WheelEventProcessingSteps::SynchronousScrolling, WheelEventProcessingSteps::BlockingDOMEventDispatch };
@@ -108,7 +108,7 @@ OptionSet<WheelEventProcessingSteps> ScrollingTree::computeWheelProcessingSteps(
     auto eventListenerTypes = eventListenerRegionTypesForPoint(position);
     if (eventListenerTypes.contains(EventListenerRegionType::NonPassiveWheel)) {
         if (m_treeState.gestureState.value_or(WheelScrollGestureState::Blocking) == WheelScrollGestureState::NonBlocking) {
-            LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::computeWheelProcessingSteps: wheelEvent - gesture state made event non-blocking");
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::computeWheelProcessingSteps: wheelEvent - gesture state made event non-blocking");
             return { WheelEventProcessingSteps::AsyncScrolling, WheelEventProcessingSteps::NonBlockingDOMEventDispatch };
         }
 
@@ -138,14 +138,14 @@ OptionSet<WheelEventProcessingSteps> ScrollingTree::determineWheelEventProcessin
 
     m_latchingController.receivedWheelEvent(wheelEvent, processingSteps, m_allowLatching);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::determineWheelEventProcessing: " << wheelEvent << " processingSteps " << processingSteps);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::determineWheelEventProcessing: " << wheelEvent << " processingSteps " << processingSteps);
 
     return processingSteps;
 }
 
 WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEvent& wheelEvent, OptionSet<WheelEventProcessingSteps> processingSteps)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "\nScrollingTree " << this << " handleWheelEvent " << wheelEvent);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "\nScrollingTree " << this << " handleWheelEvent " << wheelEvent);
 
     Locker locker { m_treeLock };
 
@@ -192,7 +192,7 @@ WheelEventHandlingResult ScrollingTree::handleWheelEvent(const PlatformWheelEven
         }
         auto node = scrollingNodeForPoint(position);
 
-        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::handleWheelEvent found node " << (node ? node->scrollingNodeID() : 0) << " for point " << position);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::handleWheelEvent found node " << (node ? node->scrollingNodeID() : 0) << " for point " << position);
 
         return handleWheelEventWithNode(wheelEvent, processingSteps, node.get());
     }();
@@ -294,7 +294,7 @@ void ScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNode& node,
 
 void ScrollingTree::mainFrameViewportChangedViaDelegatedScrolling(const FloatPoint& scrollPosition, const FloatRect& layoutViewport, double)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::viewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::viewportChangedViaDelegatedScrolling - layoutViewport " << layoutViewport);
     
     if (!m_rootNode)
         return;
@@ -367,7 +367,7 @@ bool ScrollingTree::commitTreeState(std::unique_ptr<ScrollingStateTree>&& scroll
     propagateSynchronousScrollingReasons(commitState.synchronousScrollingNodes);
 
     for (auto nodeID : commitState.unvisitedNodes) {
-        LOG_WITH_STREAM(Scrolling, stream << "ScrollingTree::commitTreeState - removing unvisited node " << nodeID);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTree::commitTreeState - removing unvisited node " << nodeID);
 
         m_latchingController.nodeWasRemoved(nodeID);
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -108,16 +108,16 @@ FloatRect ScrollingTreeFrameScrollingNode::layoutViewportForScrollPosition(const
     LayoutRect visualViewport(LocalFrameView::visibleDocumentRect(visibleContentRect, headerHeight(), footerHeight(), totalContentsSize(), scale));
     LayoutRect layoutViewport(m_layoutViewport);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFrameScrollingNode " << scrollingNodeID() << " layoutViewportForScrollPosition: " << "(visibleContentOrigin " << visibleContentOrigin << ", visualViewportSize " << visualViewportSize << ") fixed behavior " << m_behaviorForFixed);
-    LOG_WITH_STREAM(Scrolling, stream << "  layoutViewport: " << layoutViewport);
-    LOG_WITH_STREAM(Scrolling, stream << "  visualViewport: " << visualViewport);
-    LOG_WITH_STREAM(Scrolling, stream << "  scroll positions: min: " << minLayoutViewportOrigin() << " max: "<< maxLayoutViewportOrigin());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeFrameScrollingNode " << scrollingNodeID() << " layoutViewportForScrollPosition: " << "(visibleContentOrigin " << visibleContentOrigin << ", visualViewportSize " << visualViewportSize << ") fixed behavior " << m_behaviorForFixed);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "  layoutViewport: " << layoutViewport);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "  visualViewport: " << visualViewport);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "  scroll positions: min: " << minLayoutViewportOrigin() << " max: "<< maxLayoutViewportOrigin());
 
     LayoutPoint newLocation = LocalFrameView::computeLayoutViewportOrigin(LayoutRect(visualViewport), LayoutPoint(minLayoutViewportOrigin()), LayoutPoint(maxLayoutViewportOrigin()), layoutViewport, fixedBehavior);
 
     if (layoutViewport.location() != newLocation) {
         layoutViewport.setLocation(newLocation);
-        LOG_WITH_STREAM(Scrolling, stream << " new layoutViewport " << layoutViewport);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << " new layoutViewport " << layoutViewport);
     }
 
     return layoutViewport;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -252,7 +252,7 @@ void ScrollingTreeScrollingNode::willStartAnimatedScroll()
 
 void ScrollingTreeScrollingNode::didStopAnimatedScroll()
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeScrollingNode " << scrollingNodeID() << " didStopAnimatedScroll");
     scrollingTree().scrollingTreeNodeDidStopAnimatedScroll(*this);
 }
 
@@ -301,7 +301,7 @@ void ScrollingTreeScrollingNode::requestKeyboardScroll(const RequestedKeyboardSc
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest()" << " animated " << (requestedScrollData.animated == ScrollIsAnimated::Yes) << " requestedScrollData: " << requestedScrollData);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeScrollingNode " << scrollingNodeID() << " handleScrollPositionRequest()" << " animated " << (requestedScrollData.animated == ScrollIsAnimated::Yes) << " requestedScrollData: " << requestedScrollData);
 
     stopAnimatedScroll();
 
@@ -349,7 +349,7 @@ void ScrollingTreeScrollingNode::scrollTo(const FloatPoint& position, ScrollType
 
     m_currentScrollPosition = adjustedScrollPosition(position, clamp);
     
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeScrollingNode " << scrollingNodeID() << " scrollTo " << position << " adjusted to "
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeScrollingNode " << scrollingNodeID() << " scrollTo " << position << " adjusted to "
         << m_currentScrollPosition << " (" << scrollType << ", " << clamp << ") (delta from last committed position " << (m_lastCommittedScrollPosition - m_currentScrollPosition) << ")"
         << " rubberbanding " << scrollingTree().isRubberBandInProgressForNode(scrollingNodeID()));
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.cpp
@@ -57,7 +57,7 @@ void ThreadedScrollingCoordinator::commitTreeStateIfNeeded()
 {
     willCommitTree();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::commitTreeState, has changes " << scrollingStateTree()->hasChangedProperties());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingCoordinator::commitTreeState, has changes " << scrollingStateTree()->hasChangedProperties());
 
     if (!scrollingStateTree()->hasChangedProperties())
         return;
@@ -77,7 +77,7 @@ WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScroll
     if (scrollingTree()->willWheelEventStartSwipeGesture(wheelEvent))
         return WheelEventHandlingResult::unhandled();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - sending event to scrolling thread, node " << targetNodeID << " gestureState " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - sending event to scrolling thread, node " << targetNodeID << " gestureState " << gestureState);
 
     auto deferrer = WheelEventTestMonitorCompletionDeferrer { m_page->wheelEventTestMonitor().get(), reinterpret_cast<WheelEventTestMonitor::ScrollableAreaIdentifier>(targetNodeID), WheelEventTestMonitor::PostMainThreadWheelEventHandling };
 
@@ -90,7 +90,7 @@ WheelEventHandlingResult ThreadedScrollingCoordinator::handleWheelEventForScroll
 
 void ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread(const PlatformWheelEvent& wheelEvent, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingCoordinator::wheelEventWasProcessedByMainThread " << gestureState);
 
     RefPtr<ThreadedScrollingTree> threadedScrollingTree = downcast<ThreadedScrollingTree>(scrollingTree());
     threadedScrollingTree->wheelEventWasProcessedByMainThread(wheelEvent, gestureState);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -67,7 +67,7 @@ bool ThreadedScrollingTree::handleWheelEventAfterMainThread(const PlatformWheelE
 {
     ASSERT(ScrollingThread::isCurrentThread());
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::handleWheelEventAfterMainThread " << wheelEvent << " node " << targetNodeID << " gestureState " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingTree::handleWheelEventAfterMainThread " << wheelEvent << " node " << targetNodeID << " gestureState " << gestureState);
 
     Locker locker { m_treeLock };
 
@@ -86,7 +86,7 @@ bool ThreadedScrollingTree::handleWheelEventAfterMainThread(const PlatformWheelE
 
 void ThreadedScrollingTree::wheelEventWasProcessedByMainThread(const PlatformWheelEvent& wheelEvent, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::wheelEventWasProcessedByMainThread - gestureState " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingTree::wheelEventWasProcessedByMainThread - gestureState " << gestureState);
 
     ASSERT(isMainThread());
     
@@ -131,7 +131,7 @@ void ThreadedScrollingTree::waitForEventToBeProcessedByMainThread(const Platform
         setGestureState(WheelScrollGestureState::NonBlocking);
     }
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::waitForBeganEventFromMainThread done - timed out " << !receivedEvent << " gesture state is " << gestureState());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingTree::waitForBeganEventFromMainThread done - timed out " << !receivedEvent << " gesture state is " << gestureState());
 }
 
 void ThreadedScrollingTree::invalidate()
@@ -261,7 +261,7 @@ void ThreadedScrollingTree::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNod
         return;
     }
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::scrollingTreeNodeDidScroll " << node.scrollingNodeID() << " to " << scrollPosition << " triggering main thread rendering update");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingTree::scrollingTreeNodeDidScroll " << node.scrollingNodeID() << " to " << scrollPosition << " triggering main thread rendering update");
 
     addPendingScrollUpdate(WTFMove(scrollUpdate));
 
@@ -277,7 +277,7 @@ void ThreadedScrollingTree::scrollingTreeNodeScrollUpdated(ScrollingTreeScrollin
     if (!m_scrollingCoordinator)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ThreadedScrollingTree::scrollingTreeNodeScrollUpdated " << node.scrollingNodeID() << " update type " << scrollUpdateType);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ThreadedScrollingTree::scrollingTreeNodeScrollUpdated " << node.scrollingNodeID() << " update type " << scrollUpdateType);
 
     auto scrollUpdate = ScrollUpdate { node.scrollingNodeID(), { }, { }, scrollUpdateType };
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -68,7 +68,7 @@ void ScrollingTreeFixedNodeCocoa::applyLayerPositions()
 {
     auto layerPosition = computeLayerPosition();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreePositionedNodeCocoa.mm
@@ -63,7 +63,7 @@ void ScrollingTreePositionedNodeCocoa::applyLayerPositions()
     auto delta = scrollDeltaSinceLastCommit();
     auto layerPosition = m_constraints.layerPositionAtLastLayout() - delta;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
 
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm
@@ -63,7 +63,7 @@ void ScrollingTreeStickyNodeCocoa::applyLayerPositions()
 {
     auto layerPosition = computeLayerPosition();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeCocoa " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeStickyNodeCocoa " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
 #if ENABLE(SCROLLING_THREAD)
     if (ScrollingThread::isCurrentThread()) {

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -146,7 +146,7 @@ void ScrollingTreeFrameScrollingNodeMac::willDoProgrammaticScroll(const FloatPoi
 
 void ScrollingTreeFrameScrollingNodeMac::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFrameScrollingNodeMac " << scrollingNodeID() << " currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons() << " is animating: " << scrollingTree().isScrollAnimationInProgressForNode(scrollingNodeID()));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeFrameScrollingNodeMac " << scrollingNodeID() << " currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons() << " is animating: " << scrollingTree().isScrollAnimationInProgressForNode(scrollingNodeID()));
 
     delegate().currentScrollPositionChanged();
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeMac.mm
@@ -137,10 +137,10 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
     Vector<LayerAndPoint, 16> layersAtPoint;
     collectDescendantLayersAtPoint(layersAtPoint, rootContentsLayer.get(), pointInContentsLayer, layerEventRegionContainsPoint);
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found " << layersAtPoint.size() << " layers");
 #if !LOG_DISABLED
     for (auto [layer, point] : WTF::makeReversedRange(layersAtPoint))
-        LOG_WITH_STREAM(Scrolling, stream << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << " layer " << [layer description] << " scrolling node " << scrollingNodeIDForLayer(layer));
 #endif
 
     if (layersAtPoint.size()) {
@@ -159,7 +159,7 @@ RefPtr<ScrollingTreeNode> ScrollingTreeMac::scrollingNodeForPoint(FloatPoint poi
         }
     }
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found no scrollable layers; using root node");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeMac " << this << " scrollingNodeForPoint " << point << " found no scrollable layers; using root node");
     return rootScrollingNode;
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -131,7 +131,7 @@ bool ScrollingTreeScrollingNodeDelegateMac::handleWheelEvent(const PlatformWheel
 void ScrollingTreeScrollingNodeDelegateMac::willDoProgrammaticScroll(const FloatPoint& targetPosition)
 {
     if (scrollPositionIsNotRubberbandingEdge(targetPosition)) {
-        LOG(Scrolling, "ScrollingTreeScrollingNodeDelegateMac::willDoProgrammaticScroll() - scrolling away from rubberbanding edge so stopping rubberbanding");
+        WTFLogAlways("**Scrolling** ScrollingTreeScrollingNodeDelegateMac::willDoProgrammaticScroll() - scrolling away from rubberbanding edge so stopping rubberbanding");
         m_scrollController.stopRubberBanding();
     }
 }

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFixedNodeNicosia.cpp
@@ -68,7 +68,7 @@ void ScrollingTreeFixedNodeNicosia::applyLayerPositions()
 {
     auto layerPosition = computeLayerPosition();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeFixedNode " << scrollingNodeID() << " relatedNodeScrollPositionDidChange: viewportRectAtLastLayout " << m_constraints.viewportRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
     ASSERT(m_layer);
     m_layer->accessPending(

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeFrameScrollingNodeNicosia.cpp
@@ -109,7 +109,7 @@ WheelEventHandlingResult ScrollingTreeFrameScrollingNodeNicosia::handleWheelEven
 
 void ScrollingTreeFrameScrollingNodeNicosia::currentScrollPositionChanged(ScrollType scrollType, ScrollingLayerPositionAction action)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeFrameScrollingNodeNicosia::currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeFrameScrollingNodeNicosia::currentScrollPositionChanged to " << currentScrollPosition() << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition() << " sync: " << hasSynchronousScrollingReasons());
 
     ScrollingTreeFrameScrollingNode::currentScrollPositionChanged(scrollType, hasSynchronousScrollingReasons() ? ScrollingLayerPositionAction::Set : action);
 }

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeOverflowScrollProxyNodeNicosia.cpp
@@ -62,7 +62,7 @@ void ScrollingTreeOverflowScrollProxyNodeNicosia::applyLayerPositions()
 {
     FloatPoint scrollOffset = computeLayerPosition();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeOverflowScrollProxyNodeNicosia " << scrollingNodeID() << " applyLayerPositions: setting bounds origin to " << scrollOffset);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeOverflowScrollProxyNodeNicosia " << scrollingNodeID() << " applyLayerPositions: setting bounds origin to " << scrollOffset);
     m_layer->accessPending(
         [&scrollOffset](Nicosia::CompositionLayer::LayerState& state)
         {

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreePositionedNodeNicosia.cpp
@@ -68,7 +68,7 @@ void ScrollingTreePositionedNodeNicosia::applyLayerPositions()
     FloatSize delta = scrollDeltaSinceLastCommit();
     FloatPoint layerPosition = m_constraints.layerPositionAtLastLayout() + delta;
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreePositionedNode " << scrollingNodeID() << " applyLayerPositions: overflow delta " << delta << " moving layer to " << layerPosition);
 
     layerPosition -= m_constraints.alignmentOffset();
 

--- a/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
+++ b/Source/WebCore/page/scrolling/nicosia/ScrollingTreeStickyNodeNicosia.cpp
@@ -69,7 +69,7 @@ void ScrollingTreeStickyNodeNicosia::applyLayerPositions()
 {
     auto layerPosition = computeLayerPosition();
 
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollingTreeStickyNodeNicosia " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollingTreeStickyNodeNicosia " << scrollingNodeID() << " constrainingRectAtLastLayout " << m_constraints.constrainingRectAtLastLayout() << " last layer pos " << m_constraints.layerPositionAtLastLayout() << " layerPosition " << layerPosition);
 
     layerPosition -= m_constraints.alignmentOffset();
 

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -214,6 +214,7 @@ void ScrollView::setContentsScrollPosition(const IntPoint& position, const Scrol
     if (platformWidget())
         setActualScrollPosition(position);
 #endif
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollView::setContentsScrollPosition -> setScrollPosition " << position);
     setScrollPosition(position, options);
 }
 
@@ -443,7 +444,7 @@ ScrollPosition ScrollView::documentScrollPositionRelativeToScrollableAreaOrigin(
 
 void ScrollView::setScrollOffset(const ScrollOffset& offset)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "\nScrollView::setScrollOffset " << offset << " clamping " << scrollClamping());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "\nScrollView::setScrollOffset " << offset << " clamping " << scrollClamping());
 
     auto constrainedOffset = offset;
     if (scrollClamping() == ScrollClamping::Clamped)
@@ -486,7 +487,7 @@ void ScrollView::handleDeferredScrollUpdateAfterContentSizeChange()
 
 void ScrollView::scrollTo(const ScrollPosition& newPosition)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollView::scrollTo " << newPosition << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollView::scrollTo " << newPosition << " min: " << minimumScrollPosition() << " max: " << maximumScrollPosition());
 
     IntSize scrollDelta = newPosition - m_scrollPosition;
     if (scrollDelta.isZero())
@@ -528,7 +529,7 @@ void ScrollView::completeUpdatesAfterScrollTo(const IntSize& scrollDelta)
 
 void ScrollView::setScrollPosition(const ScrollPosition& scrollPosition, const ScrollPositionChangeOptions& options)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollView::setScrollPosition " << scrollPosition);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollView::setScrollPosition " << scrollPosition);
 
     if (prohibitsScrolling())
         return;
@@ -545,7 +546,7 @@ void ScrollView::setScrollPosition(const ScrollPosition& scrollPosition, const S
 
     ScrollPosition newScrollPosition = (!delegatesScrollingToNativeView() && options.clamping == ScrollClamping::Clamped) ? adjustScrollPositionWithinRange(scrollPosition) : scrollPosition;
     if ((!delegatesScrollingToNativeView() || currentScrollType() == ScrollType::User) && newScrollPosition == this->scrollPosition()) {
-        LOG_WITH_STREAM(Scrolling, stream << "ScrollView::setScrollPosition " << scrollPosition << " return for no change");
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollView::setScrollPosition " << scrollPosition << " return for no change");
         return;
     }
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -167,13 +167,13 @@ void ScrollableArea::endKeyboardScroll(bool immediate)
 
 void ScrollableArea::scrollToPositionWithoutAnimation(const FloatPoint& position, ScrollClamping clamping)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithoutAnimation " << position);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollableArea " << this << " scrollToPositionWithoutAnimation " << position);
     scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
 }
 
 void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, const ScrollPositionChangeOptions& options)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToPositionWithAnimation " << position);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollableArea " << this << " scrollToPositionWithAnimation " << position);
 
     bool startedAnimation = requestScrollToPosition(roundedIntPoint(position), { ScrollType::Programmatic, options.clamping, ScrollIsAnimated::Yes, options.snapPointSelectionMethod, options.originalScrollDelta });
     if (!startedAnimation)
@@ -185,7 +185,7 @@ void ScrollableArea::scrollToPositionWithAnimation(const FloatPoint& position, c
 
 void ScrollableArea::scrollToOffsetWithoutAnimation(const FloatPoint& offset, ScrollClamping clamping)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea " << this << " scrollToOffsetWithoutAnimation " << offset);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollableArea " << this << " scrollToOffsetWithoutAnimation " << offset);
 
     auto position = scrollPositionFromOffset(offset, toFloatSize(scrollOrigin()));
     scrollAnimator().scrollToPositionWithoutAnimation(position, clamping);
@@ -246,7 +246,7 @@ bool ScrollableArea::handleWheelEventForScrolling(const PlatformWheelEvent& whee
 
     bool handledEvent = scrollAnimator().handleWheelEvent(wheelEvent);
     
-    LOG_WITH_STREAM(Scrolling, stream << "ScrollableArea (" << *this << ") handleWheelEvent - handled " << handledEvent);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "ScrollableArea (" << *this << ") handleWheelEvent - handled " << handledEvent);
     return handledEvent;
 }
 

--- a/Source/WebCore/platform/graphics/ca/TileController.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileController.cpp
@@ -575,7 +575,7 @@ IntSize TileController::computeTileSize()
     } else if (m_scrollability == Scrollability::VerticallyScrollable)
         tileSize.setWidth(std::min(std::max<int>(ceilf(boundsWithoutMargin().width() * tileGrid().scale()), kDefaultTileSize), maxTileSize.width()));
 
-    LOG_WITH_STREAM(Scrolling, stream << "TileController::tileSize newSize=" << tileSize);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "TileController::tileSize newSize=" << tileSize);
 
     m_tileSizeLocked = true;
     return tileSize;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1196,7 +1196,7 @@ void RenderLayer::updateLayerPositionsAfterOverflowScroll()
 void RenderLayer::updateLayerPositionsAfterDocumentScroll()
 {
     ASSERT(isRenderViewLayer());
-    LOG(Scrolling, "RenderLayer::updateLayerPositionsAfterDocumentScroll");
+    WTFLogAlways("**Scrolling** RenderLayer::updateLayerPositionsAfterDocumentScroll");
 
     willUpdateLayerPositions();
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -860,7 +860,7 @@ static std::optional<ScrollingNodeID> frameHostingNodeForFrame(LocalFrame& frame
 
     auto& widgetRenderer = downcast<RenderWidget>(*frameRenderer);
     if (!widgetRenderer.hasLayer() || !widgetRenderer.layer()->isComposited()) {
-        LOG(Scrolling, "frameHostingNodeForFrame: frame renderer has no layer or is not composited.");
+        WTFLogAlways("**Scrolling** frameHostingNodeForFrame: frame renderer has no layer or is not composited.");
         return { };
     }
 
@@ -3690,7 +3690,7 @@ static void collectStationaryLayerRelatedOverflowNodes(const RenderLayer& layer,
         if (scrollingNodeID)
             scrollingNodes.append(scrollingNodeID);
         else
-            LOG(Scrolling, "Layer %p doesn't have scrolling node ID yet", &overflowLayer);
+            WTFLogAlways("**Scrolling** Layer %p doesn't have scrolling node ID yet", &overflowLayer);
     };
 
     // Collect all the composited scrollers which affect the position of this layer relative to its compositing ancestor (which might be inside the scroller or the scroller itself).
@@ -5227,7 +5227,7 @@ void RenderLayerCompositor::updateSynchronousScrollingNodes()
             continue;
 
         if (auto enclosingScrollingNodeID = asyncScrollableContainerNodeID(renderer)) {
-            LOG_WITH_STREAM(Scrolling, stream << "RenderLayerCompositor::updateSynchronousScrollingNodes - node " << enclosingScrollingNodeID << " slow-scrolling because of fixed backgrounds");
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RenderLayerCompositor::updateSynchronousScrollingNodes - node " << enclosingScrollingNodeID << " slow-scrolling because of fixed backgrounds");
             ASSERT(enclosingScrollingNodeID != rootScrollingNodeID);
 
             scrollingCoordinator->setSynchronousScrollingReasons(enclosingScrollingNodeID, { SynchronousScrollingReason::HasSlowRepaintObjects });
@@ -5242,7 +5242,7 @@ void RenderLayerCompositor::updateSynchronousScrollingNodes()
             // tree instead.)
             rootHasSlowRepaintObjects = true;
         } else if (!layer->behavesAsFixed()) {
-            LOG_WITH_STREAM(Scrolling, stream << "RenderLayerCompositor::updateSynchronousScrollingNodes - root node slow-scrolling because of fixed backgrounds");
+            ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RenderLayerCompositor::updateSynchronousScrollingNodes - root node slow-scrolling because of fixed backgrounds");
             rootHasSlowRepaintObjects = true;
         }
     }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -256,7 +256,7 @@ ScrollOffset RenderLayerScrollableArea::clampScrollOffset(const ScrollOffset& sc
 bool RenderLayerScrollableArea::requestScrollToPosition(const ScrollPosition& position, const ScrollPositionChangeOptions& options)
 {
 #if ENABLE(ASYNC_SCROLLING)
-    LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea::requestScrollToPosition " << position << " options  " << options);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RenderLayerScrollableArea::requestScrollToPosition " << position << " options  " << options);
 
     if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
         return scrollingCoordinator->requestScrollToPosition(*this, position, options);
@@ -286,7 +286,7 @@ bool RenderLayerScrollableArea::requestStopKeyboardScrollAnimation(bool immediat
 void RenderLayerScrollableArea::stopAsyncAnimatedScroll()
 {
 #if ENABLE(ASYNC_SCROLLING)
-    LOG_WITH_STREAM(Scrolling, stream << m_layer << " stopAsyncAnimatedScroll");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << m_layer << " stopAsyncAnimatedScroll");
 
     if (auto* scrollingCoordinator = m_layer.page().scrollingCoordinator())
         return scrollingCoordinator->stopAnimatedScroll(*this);
@@ -324,7 +324,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     if (!box)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea [" << scrollingNodeID() << "] scrollTo " << position << " from " << m_scrollPosition << " (is user scroll " << (currentScrollType() == ScrollType::User) << ")");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RenderLayerScrollableArea [" << scrollingNodeID() << "] scrollTo " << position << " from " << m_scrollPosition << " (is user scroll " << (currentScrollType() == ScrollType::User) << ")");
 
     ScrollPosition newPosition = position;
     if (!box->isHTMLMarquee()) {
@@ -1349,7 +1349,7 @@ void RenderLayerScrollableArea::updateScrollInfoAfterLayout()
 
     updateScrollbarsAfterLayout();
 
-    LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea [" << scrollingNodeID() << "] updateScrollInfoAfterLayout - new scroll width " << m_scrollWidth << " scroll height " << m_scrollHeight
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RenderLayerScrollableArea [" << scrollingNodeID() << "] updateScrollInfoAfterLayout - new scroll width " << m_scrollWidth << " scroll height " << m_scrollHeight
         << " rubber banding " << isRubberBandInProgress() << " user scrolling " << isUserScrollInProgress() << " scroll position updated from " << originalScrollPosition << " to " << scrollPosition());
 
     if (originalScrollPosition != scrollPosition())

--- a/Source/WebCore/rendering/SelectionRangeData.cpp
+++ b/Source/WebCore/rendering/SelectionRangeData.cpp
@@ -181,7 +181,7 @@ IntRect SelectionRangeData::collectBounds(ClipToVisibleContent clipToVisibleCont
             
             auto* block = start->containingBlock();
             while (block && !is<RenderView>(*block)) {
-                LOG_WITH_STREAM(Scrolling, stream << " added block " << *block);
+                ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << " added block " << *block);
                 std::unique_ptr<RenderSelectionInfo>& blockInfo = renderers.add(block, nullptr).iterator->value;
                 if (blockInfo)
                     break;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.h
@@ -47,6 +47,8 @@ public:
     bool clearScrollLatching() const { return m_clearScrollLatching; }
     void setClearScrollLatching(bool clearLatching) { m_clearScrollLatching = clearLatching; }
 
+    bool hasChanges() const { return m_scrollingStateTree && m_scrollingStateTree->hasChangedProperties(); }
+
 #if !defined(NDEBUG) || !LOG_DISABLED
     String description() const;
     void dump() const;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -201,6 +201,7 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
     [_contentView setFrame:bounds];
     [_scrollView addSubview:_contentView.get()];
     [_scrollView addSubview:[_contentView unscaledView]];
+    [self layer].name = @"WKWebViewIOS";
 }
 
 - (void)_registerForNotifications
@@ -1325,6 +1326,13 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
         if (WTF::areEssentiallyEqual<float>(scrollPosition.y(), 0) && scrollViewContentOffset.y < 0)
             contentOffsetInScrollViewCoordinates.y = scrollViewContentOffset.y;
 
+        ALWAYS_LOG_WITH_STREAM(stream
+            << "mattwoodrow> _scrollToContentScrollPosition(pos=" << scrollPosition << ", origin=" << scrollOrigin << ", animated=" << int(animated)
+            << ") -> contentOffset=" << contentOffset
+            << " zoomScale=" << zoomScale
+            << " scaledOffset=" << scaledOffset
+            << " scrollViewContentOffset=(" << scrollViewContentOffset.x << "," << scrollViewContentOffset.y
+            << ") contentOffsetInScrollViewCoordinates=(" << contentOffsetInScrollViewCoordinates.x << "," << contentOffsetInScrollViewCoordinates.y << ")");
         [_scrollView setContentOffset:contentOffsetInScrollViewCoordinates animated:animated];
     } else if (!_perProcessState.didDeferUpdateVisibleContentRectsForAnyReason) {
         // If we haven't changed anything, and are not deferring updates, there would not be any VisibleContentRect update sent to the content.
@@ -1417,6 +1425,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     LOG_WITH_STREAM(VisibleRects, stream << "_scrollToRect: scrolling to " << [_scrollView contentOffset] + scrollViewOffsetDelta);
 
+    WTFLogAlways("mattwoodrow> _scrollToRect %f", ([_scrollView contentOffset] + scrollViewOffsetDelta).y());
     [_scrollView setContentOffset:([_scrollView contentOffset] + scrollViewOffsetDelta) animated:YES];
     return YES;
 }
@@ -2563,6 +2572,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
             if (!CGPointEqualToPoint(activePoint, currentPoint)) {
                 RetainPtr<WKScrollView> strongScrollView = _scrollView;
                 RunLoop::main().dispatch([strongScrollView, activePoint] {
+                    WTFLogAlways("mattwoodrow> _updateVisibleContentRects async %f", activePoint.y);
                     [strongScrollView setContentOffset:activePoint animated:NO];
                 });
             }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -80,6 +80,8 @@ protected:
 
     bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
 
+    const char* messageStateDescription();
+
 private:
 
     void sizeDidChange() final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -187,7 +187,7 @@ void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll(ScrollingNodeID
     auto scrollUpdate = ScrollUpdate { scrolledNodeID, newScrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, scrollingLayerPositionAction };
     m_scrollingTree->addPendingScrollUpdate(WTFMove(scrollUpdate));
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll " << scrolledNodeID << " to " << newScrollPosition << " waitingForDidScrollReply " << m_waitingForDidScrollReply);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidScroll " << scrolledNodeID << " to " << newScrollPosition << " waitingForDidScrollReply " << m_waitingForDidScrollReply);
 
     if (WebKit::RemoteLayerTreeScrollingPerformanceData* scrollPerfData = m_webPageProxy.scrollingPerformanceData())
         scrollPerfData->didScroll(m_scrollingTree->layoutViewport());
@@ -210,7 +210,7 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll()
         const auto& update = scrollUpdates[i];
         bool isLastUpdate = i == scrollUpdates.size() - 1;
 
-        LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll - node " << update.nodeID << " scroll position " << update.scrollPosition << " isLastUpdate " << isLastUpdate);
+        ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll - node " << update.nodeID << " scroll position " << update.scrollPosition << " isLastUpdate " << isLastUpdate);
         m_webPageProxy.sendWithAsyncReply(Messages::RemoteScrollingCoordinator::ScrollPositionChangedForNode(update.nodeID, update.scrollPosition, update.layoutViewportOrigin, update.updateLayerPositionAction == ScrollingLayerPositionAction::Sync), [weakThis = WeakPtr { *this }, isLastUpdate] {
             if (!weakThis)
                 return;
@@ -224,7 +224,7 @@ void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeDidScroll()
 
 void RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollReply()
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollReply - has pending updates " << (m_scrollingTree && m_scrollingTree->hasPendingScrollUpdates()));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollReply - has pending updates " << (m_scrollingTree && m_scrollingTree->hasPendingScrollUpdates()));
     m_waitingForDidScrollReply = false;
 
     if (!m_scrollingTree || !m_scrollingTree->hasPendingScrollUpdates())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -354,6 +354,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::repositionScrollingLayers()
     if ([scrollView() _isAnimatingScroll])
         return;
 
+    WTFLogAlways("mattwoodrow> repositionScrollingLayers %f", scrollingNode().currentScrollOffset().y());
     [scrollView() setContentOffset:scrollingNode().currentScrollOffset()];
     END_BLOCK_OBJC_EXCEPTIONS
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -174,6 +174,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::layoutBannerLayers(const RemoteLayerTre
 
 void RemoteLayerTreeDrawingAreaProxyMac::didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction& transaction, const RemoteScrollingCoordinatorTransaction&)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "RemoteLayerTreeDrawingAreaProxy[pgid=" << m_webPageProxy.webPageID() << " state=" << messageStateDescription() << "]::didCommitLayerTree(transaction's ID=" << transaction.transactionID() << ")");
     m_pageScalingLayerID = transaction.pageScalingLayerID();
 
     if (m_transientZoomScale)
@@ -274,7 +275,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, Float
     IntSize scaledTotalContentsSize = roundedIntSize(m_webPageProxy.scrollingCoordinatorProxy()->totalContentsSize());
     scaledTotalContentsSize.scale(scale / m_webPageProxy.scrollingCoordinatorProxy()->mainFrameScaleFactor());
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<m_webPageProxy.scrollingCoordinatorProxy()->scrollOrigin() << "headerHeight :" << m_webPageProxy.scrollingCoordinatorProxy()->headerHeight() << " footerHeight : " << m_webPageProxy.scrollingCoordinatorProxy()->footerHeight());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<m_webPageProxy.scrollingCoordinatorProxy()->scrollOrigin() << "headerHeight :" << m_webPageProxy.scrollingCoordinatorProxy()->headerHeight() << " footerHeight : " << m_webPageProxy.scrollingCoordinatorProxy()->footerHeight());
     
     // Scaling may have exposed the overhang area, so we need to constrain the final
     // layer position exactly like scrolling will once it's committed, to ensure that
@@ -283,7 +284,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom(double scale, Float
     constrainedOrigin.moveBy(-visibleContentRect.location());
     constrainedOrigin = -constrainedOrigin;
     
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom - constrainedOrigin: " << constrainedOrigin << " origin: " << origin << " scale: " << scale);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteLayerTreeDrawingAreaProxyMac::commitTransientZoom - constrainedOrigin: " << constrainedOrigin << " origin: " << origin << " scale: " << scale);
     
     auto transientZoomScale = std::exchange(m_transientZoomScale, { });
     auto transientZoomOrigin = std::exchange(m_transientZoomOrigin, { });

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -239,7 +239,7 @@ void RemoteLayerTreeEventDispatcher::continueWheelEventHandling(WheelEventHandli
     if (!m_scrollingCoordinator)
         return;
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::continueWheelEventHandling - result " << handlingResult);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteLayerTreeEventDispatcher::continueWheelEventHandling - result " << handlingResult);
 
     auto event = m_wheelEventsBeingProcessed.takeFirst();
     m_scrollingCoordinator->continueWheelEventHandling(event, handlingResult);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -154,7 +154,7 @@ void RemoteScrollingTreeMac::startPendingScrollAnimations()
 
     auto nodesWithPendingScrollAnimations = std::exchange(m_nodesWithPendingScrollAnimations, { });
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::startPendingScrollAnimations() - " << nodesWithPendingScrollAnimations.size() << " nodes with pending animations");
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingTreeMac::startPendingScrollAnimations() - " << nodesWithPendingScrollAnimations.size() << " nodes with pending animations");
 
     for (auto& [nodeID, data] : nodesWithPendingScrollAnimations) {
         RefPtr targetNode = dynamicDowncast<ScrollingTreeScrollingNode>(nodeForID(nodeID));
@@ -309,12 +309,12 @@ void RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion(const Platfor
         setGestureState(WheelScrollGestureState::NonBlocking);
     }
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion took " << (MonotonicTime::now() - startTime).milliseconds() << "ms - timed out " << !receivedEvent << " gesture state is " << gestureState());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion took " << (MonotonicTime::now() - startTime).milliseconds() << "ms - timed out " << !receivedEvent << " gesture state is " << gestureState());
 }
 
 void RemoteScrollingTreeMac::receivedEventAfterDefaultHandling(const WebCore::PlatformWheelEvent& wheelEvent, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::receivedEventAfterDefaultHandling - " << wheelEvent << " gestureState " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingTreeMac::receivedEventAfterDefaultHandling - " << wheelEvent << " gestureState " << gestureState);
 
     ASSERT(isMainRunLoop());
 
@@ -334,7 +334,7 @@ void RemoteScrollingTreeMac::receivedEventAfterDefaultHandling(const WebCore::Pl
 
 WheelEventHandlingResult RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling - targetNodeID " << targetNodeID << " gestureState " << gestureState);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling - targetNodeID " << targetNodeID << " gestureState " << gestureState);
 
     ASSERT(ScrollingThread::isCurrentThread());
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2341,6 +2341,7 @@ void WebPageProxy::setViewNeedsDisplay(const Region& region)
 
 void WebPageProxy::requestScroll(const FloatPoint& scrollPosition, const IntPoint& scrollOrigin, ScrollIsAnimated animated)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "mattwoodrow> WebPageProxy[pgid=" << webPageID() << "]::requestScroll(pos=" << scrollPosition << ", origin=" << scrollOrigin << ", animated=" << int(animated) << ")");
     pageClient().requestScroll(scrollPosition, scrollOrigin, animated);
 }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -114,6 +114,7 @@ void PageClientImpl::setViewNeedsDisplay(const Region&)
 
 void PageClientImpl::requestScroll(const FloatPoint& scrollPosition, const IntPoint& scrollOrigin, ScrollIsAnimated animated)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "mattwoodrow> PageClientImpl/iOS::requestScroll(pos=" << scrollPosition << ", origin=" << scrollOrigin << ", animated=" << int(animated) << ")");
     [webView() _scrollToContentScrollPosition:scrollPosition scrollOrigin:scrollOrigin animated:animated == ScrollIsAnimated::Yes];
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -233,6 +233,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     [self setUserInteractionEnabled:YES];
 
     self.layer.hitTestsAsOpaque = YES;
+    self.layer.name = @"WKContentView";
 
 #if HAVE(UI_FOCUS_EFFECT)
     if ([self respondsToSelector:@selector(setFocusEffect:)])

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -172,6 +172,8 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
     self.directionalLockEnabled = YES;
     self.automaticallyAdjustsScrollIndicatorInsets = YES;
 
+    self.layer.name = @"WKScrollView";
+
 // FIXME: Likely we can remove this special case for watchOS and tvOS.
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
     _contentInsetAdjustmentBehaviorWasExternallyOverridden = (self.contentInsetAdjustmentBehavior != UIScrollViewContentInsetAdjustmentAutomatic);
@@ -528,7 +530,7 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
     if (UNLIKELY(!canHandlePinch)) {
         static BOOL shouldLogFault = YES;
         if (shouldLogFault) {
-            RELEASE_LOG_FAULT(Scrolling, "UIScrollView no longer responds to -handlePinch:.");
+            WTFLogAlways("**Scrolling** UIScrollView no longer responds to -handlePinch:.");
             shouldLogFault = NO;
         }
         return;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -113,7 +113,7 @@ void RemoteScrollingCoordinator::buildTransaction(RemoteScrollingCoordinatorTran
 // Notification from the UI process that we scrolled.
 void RemoteScrollingCoordinator::scrollPositionChangedForNode(ScrollingNodeID nodeID, const FloatPoint& scrollPosition, std::optional<FloatPoint> layoutViewportOrigin, bool syncLayerPosition, CompletionHandler<void()>&& completionHandler)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition << " layoutViewportOrigin " << layoutViewportOrigin);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingCoordinator::scrollingTreeNodeDidScroll " << nodeID << " to " << scrollPosition << " layoutViewportOrigin " << layoutViewportOrigin);
 
     auto scrollUpdate = ScrollUpdate { nodeID, scrollPosition, layoutViewportOrigin, ScrollUpdateType::PositionUpdate, syncLayerPosition ? ScrollingLayerPositionAction::Sync : ScrollingLayerPositionAction::Set };
     applyScrollUpdate(WTFMove(scrollUpdate));
@@ -178,7 +178,7 @@ void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(Web
 
 WheelEventHandlingResult RemoteScrollingCoordinator::handleWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - node " << targetNodeID << " gestureState " << gestureState << " will start swipe " << (m_currentWheelEventWillStartSwipe && *m_currentWheelEventWillStartSwipe));
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "RemoteScrollingCoordinator::handleWheelEventForScrolling " << wheelEvent << " - node " << targetNodeID << " gestureState " << gestureState << " will start swipe " << (m_currentWheelEventWillStartSwipe && *m_currentWheelEventWillStartSwipe));
 
     if (m_currentWheelEventWillStartSwipe && *m_currentWheelEventWillStartSwipe)
         return WheelEventHandlingResult::unhandled();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8797,6 +8797,7 @@ void WebPage::scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::
     auto* frameView = localMainFrameView();
     if (!frameView)
         return;
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "WebPage::scrollToRect " << targetRect << " -> setScrollPosition " << IntPoint(targetRect.minXMinYCorner()));
     frameView->setScrollPosition(IntPoint(targetRect.minXMinYCorner()));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -739,7 +739,7 @@ void TiledCoreAnimationDrawingArea::commitTransientZoom(double scale, FloatPoint
     IntSize scaledTotalContentsSize = frameView.totalContentsSize();
     scaledTotalContentsSize.scale(scale / m_webPage.totalScaleFactor());
 
-    LOG_WITH_STREAM(Scrolling, stream << "TiledCoreAnimationDrawingArea::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<frameView.scrollOrigin() << "headerHeight :" << frameView.headerHeight() << " footerHeight : " << frameView.footerHeight());
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "TiledCoreAnimationDrawingArea::commitTransientZoom constrainScrollPositionForOverhang - constrainedOrigin: " << constrainedOrigin << " visibleContentRect: " << visibleContentRect << " scaledTotalContentsSize: " << scaledTotalContentsSize << "scrollOrigin :"<<frameView.scrollOrigin() << "headerHeight :" << frameView.headerHeight() << " footerHeight : " << frameView.footerHeight());
 
     // Scaling may have exposed the overhang area, so we need to constrain the final
     // layer position exactly like scrolling will once it's committed, to ensure that
@@ -748,7 +748,7 @@ void TiledCoreAnimationDrawingArea::commitTransientZoom(double scale, FloatPoint
     constrainedOrigin.moveBy(-visibleContentRect.location());
     constrainedOrigin = -constrainedOrigin;
 
-    LOG_WITH_STREAM(Scrolling, stream << "TiledCoreAnimationDrawingArea::commitTransientZoom m_transientZoomScale" << m_transientZoomScale << " scale: " << scale << " m_transientZoomOrigin " << m_transientZoomOrigin << " constrainedOrigin " << constrainedOrigin);
+    ALWAYS_LOG_WITH_STREAM(stream << "**Scrolling** " << "TiledCoreAnimationDrawingArea::commitTransientZoom m_transientZoomScale" << m_transientZoomScale << " scale: " << scale << " m_transientZoomOrigin " << m_transientZoomOrigin << " constrainedOrigin " << constrainedOrigin);
     if (m_transientZoomScale == scale && roundedIntPoint(m_transientZoomOrigin) == roundedIntPoint(constrainedOrigin)) {
         // We're already at the right scale and position, so we don't need to animate.
         applyTransientZoomToPage(scale, origin);


### PR DESCRIPTION
#### 393ff91b06bdfaecdb031e04aac797275cd91aae
<pre>
Lotsa logging in RemoteLayerTreeDrawingArea and friends.
Potential fix: Add a CATransaction begin&amp;commit if there is a non-empty scrolling transaction.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/393ff91b06bdfaecdb031e04aac797275cd91aae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16339 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13784 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17070 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20172 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16565 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11822 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/14491 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->