### PR TITLE
Merge isXMLSpace() into isJSONOrHTTPWhitespace()

### DIFF
--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -141,46 +141,24 @@ template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType chara
 // Infra's "ASCII whitespace" <https://infra.spec.whatwg.org/#ascii-whitespace>
 template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType character)
 {
-    // Histogram from Apple's page load test combined with some ad hoc browsing some other test suites.
-    //
-    //     82%: 216330 non-space characters, all > U+0020
-    //     11%:  30017 plain space characters, U+0020
-    //      5%:  12099 newline characters, U+000A
-    //      2%:   5346 tab characters, U+0009
-    //
-    // No other characters seen. No U+000C or U+000D, and no other control characters.
-    // Accordingly, we check for non-spaces first, then space, then newline, then tab, then the other characters.
-
-    return character <= ' ' && (character == ' ' || character == '\n' || character == '\t' || character == '\r' || character == '\f');
+    return character == ' ' || character == '\n' || character == '\t' || character == '\r' || character == '\f';
 }
 
-template<typename CharacterType> constexpr bool isJSONOrHTTPWhitespace(CharacterType character)
+template<typename CharacterType> constexpr bool isASCIIWhitespaceWithoutFF(CharacterType character)
 {
-    // This is different from isASCIIWhitespace: JSON does not accept \v as a space.
-    // ECMA-404 specifies the followings.
+    // This is different from isASCIIWhitespace: JSON/HTTP/XML do not accept \f as a whitespace.
+    // ECMA-404 specifies the following:
     // > Whitespace is any sequence of one or more of the following code points:
     // > character tabulation (U+0009), line feed (U+000A), carriage return (U+000D), and space (U+0020).
     //
-    // Also, this definition is the same to HTTP whitespace.
+    // This matches HTTP whitespace:
     // https://fetch.spec.whatwg.org/#http-whitespace-byte
-    return character <= ' ' && (character == ' ' || character == '\n' || character == '\t' || character == '\r');
+    //
+    // And XML whitespace:
+    // https://www.w3.org/TR/2008/REC-xml-20081126/#NT-S
+    return character == ' ' || character == '\n' || character == '\t' || character == '\r';
 }
 
-/*
-    Statistics from a run of Apple's page load test for callers of isUnicodeCompatibleASCIIWhitespace:
-
-    character          count
-    ---------          -----
-    non-spaces         689383
-    20  space          294720
-    0A  \n             89059
-    09  \t             28320
-    0D  \r             0
-    0C  \f             0
-    0B  \v             0
-
-    As these are compatible with those for isASCIIWhitespace we let that do most of the work.
-*/
 template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType character)
 {
     return isASCIIWhitespace(character) || character == '\v';
@@ -288,7 +266,7 @@ using WTF::isASCIIOctalDigit;
 using WTF::isASCIIPrintable;
 using WTF::isTabOrSpace;
 using WTF::isASCIIWhitespace;
-using WTF::isJSONOrHTTPWhitespace;
+using WTF::isASCIIWhitespaceWithoutFF;
 using WTF::isUnicodeCompatibleASCIIWhitespace;
 using WTF::isASCIIUpper;
 using WTF::isNotASCIIWhitespace;

--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -207,7 +207,7 @@ bool parseStringToken(const CodeUnit* start, const CodeUnit* end, const CodeUnit
 template<typename CodeUnit>
 Token parseToken(const CodeUnit* start, const CodeUnit* end, const CodeUnit** tokenStart, const CodeUnit** tokenEnd)
 {
-    while (start < end && isJSONOrHTTPWhitespace(*start))
+    while (start < end && isASCIIWhitespaceWithoutFF(*start))
         ++start;
 
     if (start == end)
@@ -524,7 +524,7 @@ RefPtr<Value> Value::parseJSON(StringView json)
         if (!begin)
             return false;
         for (const auto* it = begin; it < end; it++) {
-            if (!isJSONOrHTTPWhitespace(*it))
+            if (!isASCIIWhitespaceWithoutFF(*it))
                 return true;
         }
         return false;

--- a/Source/WTF/wtf/text/StringToIntegerConversion.h
+++ b/Source/WTF/wtf/text/StringToIntegerConversion.h
@@ -34,7 +34,7 @@ namespace WTF {
 // The parseIntegerAllowingTrailingJunk function template is like parseInteger, but allows any characters after the integer.
 
 // FIXME: Should we add a version that does not allow "+"?
-// FIXME: Should we add a version that allows other definitions of spaces, like isASCIIWhitespace or isJSONOrHTTPWhitespace?
+// FIXME: Should we add a version that allows other definitions of spaces, like isASCIIWhitespace or isASCIIWhitespaceWithoutFF?
 // FIXME: Should we add a version that does not allow leading and trailing spaces?
 
 template<typename IntegralType> std::optional<IntegralType> parseInteger(StringView, uint8_t base = 10);

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -174,7 +174,7 @@ static inline bool hasResponseVaryStarHeaderValue(const FetchResponse& response)
     auto varyValue = response.headers().internalHeaders().get(WebCore::HTTPHeaderName::Vary);
     bool hasStar = false;
     varyValue.split(',', [&](StringView view) {
-        if (!hasStar && view.trim(isJSONOrHTTPWhitespace<UChar>) == "*"_s)
+        if (!hasStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
             hasStar = true;
     });
     return hasStar;

--- a/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheEngine.cpp
@@ -97,7 +97,7 @@ bool queryCacheMatch(const ResourceRequest& request, const ResourceRequest& cach
     varyValue.split(',', [&](StringView view) {
         if (isVarying)
             return;
-        auto nameView = view.trim(isJSONOrHTTPWhitespace<UChar>);
+        auto nameView = view.trim(isASCIIWhitespaceWithoutFF<UChar>);
         if (nameView == "*"_s) {
             isVarying = true;
             return;

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -95,7 +95,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
             size_t valueBegin = position;
             while (position < input.length() && input[position] != ';')
                 position++;
-            parameterValue = input.substring(valueBegin, position - valueBegin).trim(isJSONOrHTTPWhitespace<UChar>);
+            parameterValue = input.substring(valueBegin, position - valueBegin).trim(isASCIIWhitespaceWithoutFF<UChar>);
         }
 
         if (parameterName.length()
@@ -110,7 +110,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
 // https://mimesniff.spec.whatwg.org/#parsing-a-mime-type
 static std::optional<MimeType> parseMIMEType(const String& contentType)
 {
-    String input = contentType.trim(isJSONOrHTTPWhitespace<UChar>);
+    String input = contentType.trim(isASCIIWhitespaceWithoutFF<UChar>);
     size_t slashIndex = input.find('/');
     if (slashIndex == notFound)
         return std::nullopt;
@@ -120,7 +120,7 @@ static std::optional<MimeType> parseMIMEType(const String& contentType)
         return std::nullopt;
     
     size_t semicolonIndex = input.find(';', slashIndex);
-    String subtype = input.substring(slashIndex + 1, semicolonIndex - slashIndex - 1).trim(isJSONOrHTTPWhitespace<UChar>);
+    String subtype = input.substring(slashIndex + 1, semicolonIndex - slashIndex - 1).trim(isASCIIWhitespaceWithoutFF<UChar>);
     if (!subtype.length() || !isValidHTTPToken(subtype))
         return std::nullopt;
 
@@ -175,7 +175,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             size_t contentTypeBegin = header.find(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
                 size_t contentTypeEnd = header.find("\r\n"_s, contentTypeBegin);
-                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isJSONOrHTTPWhitespace<UChar>).toString();
+                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isASCIIWhitespaceWithoutFF<UChar>).toString();
             }
 
             form.append(name, File::create(context, Blob::create(context, Vector { bodyBegin, bodyLength }, Blob::normalizedContentType(contentType)).get(), filename).get(), filename);

--- a/Source/WebCore/Modules/fetch/FetchHeaders.cpp
+++ b/Source/WebCore/Modules/fetch/FetchHeaders.cpp
@@ -43,7 +43,7 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
 {
     if (!isValidHTTPToken(name))
         return Exception { TypeError, makeString("Invalid header name: '", name, "'") };
-    ASSERT(value.isEmpty() || (!isJSONOrHTTPWhitespace(value[0]) && !isJSONOrHTTPWhitespace(value[value.length() - 1])));
+    ASSERT(value.isEmpty() || (!isASCIIWhitespaceWithoutFF(value[0]) && !isASCIIWhitespaceWithoutFF(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
         return Exception { TypeError, makeString("Header '", name, "' has invalid value: '", value, "'") };
     if (guard == FetchHeaders::Guard::Immutable)
@@ -72,7 +72,7 @@ static ExceptionOr<void> appendSetCookie(const String& value, Vector<String>& se
 
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, Vector<String>& setCookieValues, FetchHeaders::Guard guard)
 {
-    String normalizedValue = value.trim(isJSONOrHTTPWhitespace<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
     if (equalIgnoringASCIICase(name, "set-cookie"_s))
         return appendSetCookie(normalizedValue, setCookieValues, guard);
 
@@ -95,7 +95,7 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapConstIterator::KeyValue& header, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
     ASSERT(!equalIgnoringASCIICase(header.key, "set-cookie"_s));
-    String normalizedValue = header.value.trim(isJSONOrHTTPWhitespace<UChar>);
+    String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<UChar>);
     auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -239,7 +239,7 @@ ExceptionOr<bool> FetchHeaders::has(const String& name) const
 
 ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 {
-    String normalizedValue = value.trim(isJSONOrHTTPWhitespace<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
     auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
@@ -262,7 +262,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 void FetchHeaders::filterAndFill(const HTTPHeaderMap& headers, Guard guard)
 {
     for (auto& header : headers) {
-        String normalizedValue = header.value.trim(isJSONOrHTTPWhitespace<UChar>);
+        String normalizedValue = header.value.trim(isASCIIWhitespaceWithoutFF<UChar>);
         auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
         if (canWriteResult.hasException())
             continue;

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -183,7 +183,7 @@ MathMLElement::Length MathMLPresentationElement::parseMathMLLength(const String&
 
     // We first skip whitespace from both ends of the string.
     StringView stringView = string;
-    StringView trimmedLength = stringView.trim(isJSONOrHTTPWhitespace<UChar>);
+    StringView trimmedLength = stringView.trim(isASCIIWhitespaceWithoutFF<UChar>);
 
     if (trimmedLength.isEmpty())
         return Length();

--- a/Source/WebCore/mathml/MathMLTokenElement.cpp
+++ b/Source/WebCore/mathml/MathMLTokenElement.cpp
@@ -82,7 +82,7 @@ bool MathMLTokenElement::childShouldCreateRenderer(const Node& child) const
 
 std::optional<UChar32> MathMLTokenElement::convertToSingleCodePoint(StringView string)
 {
-    auto codePoints = string.trim(isJSONOrHTTPWhitespace<UChar>).codePoints();
+    auto codePoints = string.trim(isASCIIWhitespaceWithoutFF<UChar>).codePoints();
     auto iterator = codePoints.begin();
     if (iterator == codePoints.end())
         return std::nullopt;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -449,7 +449,7 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
     // A meta tag delievered CSP could contain invalid HTTP header values depending on how it was formatted in the document.
     // We want to store the CSP as a valid HTTP header for e.g. blob URL inheritance.
     if (policyFrom == ContentSecurityPolicy::PolicyFrom::HTTPEquivMeta) {
-        m_header = policy.trim(isJSONOrHTTPWhitespace<UChar>).removeCharacters([](auto c) {
+        m_header = policy.trim(isASCIIWhitespaceWithoutFF<UChar>).removeCharacters([](auto c) {
             return c == 0x00 || c == '\r' || c == '\n';
         });
     } else

--- a/Source/WebCore/platform/ReferrerPolicy.cpp
+++ b/Source/WebCore/platform/ReferrerPolicy.cpp
@@ -74,7 +74,7 @@ std::optional<ReferrerPolicy> parseReferrerPolicy(StringView policyString, Refer
         // Implementing https://www.w3.org/TR/2017/CR-referrer-policy-20170126/#parse-referrer-policy-from-header.
         std::optional<ReferrerPolicy> result;
         for (auto tokenView : policyString.split(',')) {
-            auto token = parseReferrerPolicyToken(tokenView.trim(isJSONOrHTTPWhitespace<UChar>), ShouldParseLegacyKeywords::No);
+            auto token = parseReferrerPolicyToken(tokenView.trim(isASCIIWhitespaceWithoutFF<UChar>), ShouldParseLegacyKeywords::No);
             if (token && token.value() != ReferrerPolicy::EmptyString)
                 result = token.value();
         }

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -110,13 +110,13 @@ public:
         // formatTypeStart might be at the begining of "base64" or "charset=...".
         size_t formatTypeStart = mediaTypeEnd + 1;
         auto formatType = header.substring(formatTypeStart, header.length() - formatTypeStart);
-        formatType = formatType.trim(isJSONOrHTTPWhitespace<UChar>);
+        formatType = formatType.trim(isASCIIWhitespaceWithoutFF<UChar>);
 
         isBase64 = equalLettersIgnoringASCIICase(formatType, "base64"_s);
 
         // If header does not end with "base64", mediaType should be the whole header.
         auto mediaType = (isBase64 ? header.left(mediaTypeEnd) : header).toString();
-        mediaType = mediaType.trim(isJSONOrHTTPWhitespace<UChar>);
+        mediaType = mediaType.trim(isASCIIWhitespaceWithoutFF<UChar>);
         if (mediaType.startsWith(';'))
             mediaType = makeString("text/plain"_s, mediaType);
 

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -536,7 +536,7 @@ XSSProtectionDisposition parseXSSProtectionHeader(const String& header, String& 
 ContentTypeOptionsDisposition parseContentTypeOptionsHeader(StringView header)
 {
     StringView leftToken = header.left(header.find(','));
-    if (equalLettersIgnoringASCIICase(leftToken.trim(isJSONOrHTTPWhitespace<UChar>), "nosniff"_s))
+    if (equalLettersIgnoringASCIICase(leftToken.trim(isASCIIWhitespaceWithoutFF<UChar>), "nosniff"_s))
         return ContentTypeOptionsDisposition::Nosniff;
     return ContentTypeOptionsDisposition::None;
 }
@@ -595,7 +595,7 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
         return result;
 
     for (auto value : StringView(headerValue).split(',')) {
-        auto trimmedValue = value.trim(isJSONOrHTTPWhitespace<UChar>);
+        auto trimmedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
         if (trimmedValue == "\"cache\""_s)
             result.add(ClearSiteDataValue::Cache);
         else if (trimmedValue == "\"cookies\""_s)
@@ -625,7 +625,7 @@ bool parseRange(StringView range, RangeAllowWhitespace allowWhitespace, long lon
     if (!startsWithLettersIgnoringASCIICase(range, "bytes"_s))
         return false;
 
-    auto byteRange = range.substring(bytesLength).trim(isJSONOrHTTPWhitespace<UChar>);
+    auto byteRange = range.substring(bytesLength).trim(isASCIIWhitespaceWithoutFF<UChar>);
 
     if (!byteRange.startsWith('='))
         return false;
@@ -991,7 +991,7 @@ bool isSafeMethod(const String& method)
 
 CrossOriginResourcePolicy parseCrossOriginResourcePolicyHeader(StringView header)
 {
-    auto trimmedHeader = header.trim(isJSONOrHTTPWhitespace<UChar>);
+    auto trimmedHeader = header.trim(isASCIIWhitespaceWithoutFF<UChar>);
 
     if (trimmedHeader.isEmpty())
         return CrossOriginResourcePolicy::None;

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -131,7 +131,7 @@ bool addToAccessControlAllowList(const String& string, unsigned start, unsigned 
         return true;
 
     // Skip white space from start.
-    while (start <= end && isJSONOrHTTPWhitespace((*stringImpl)[start]))
+    while (start <= end && isASCIIWhitespaceWithoutFF((*stringImpl)[start]))
         ++start;
 
     // only white space
@@ -139,7 +139,7 @@ bool addToAccessControlAllowList(const String& string, unsigned start, unsigned 
         return true;
 
     // Skip white space from end.
-    while (end && isJSONOrHTTPWhitespace((*stringImpl)[end]))
+    while (end && isASCIIWhitespaceWithoutFF((*stringImpl)[end]))
         --end;
 
     auto token = string.substring(start, end - start + 1);

--- a/Source/WebCore/platform/network/ParsedContentType.cpp
+++ b/Source/WebCore/platform/network/ParsedContentType.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 static void skipSpaces(StringView input, unsigned& startIndex)
 {
-    while (startIndex < input.length() && isJSONOrHTTPWhitespace(input[startIndex]))
+    while (startIndex < input.length() && isASCIIWhitespaceWithoutFF(input[startIndex]))
         ++startIndex;
 }
 
@@ -78,7 +78,7 @@ static StringView parseToken(StringView input, unsigned& startIndex, CharacterMe
             while (input[tokenEnd - 1] == ' ')
                 --tokenEnd;
         } else {
-            while (isJSONOrHTTPWhitespace(input[tokenEnd - 1]))
+            while (isASCIIWhitespaceWithoutFF(input[tokenEnd - 1]))
                 --tokenEnd;
         }
     }
@@ -329,7 +329,7 @@ bool ParsedContentType::parseContentType(Mode mode)
 
 std::optional<ParsedContentType> ParsedContentType::create(const String& contentType, Mode mode)
 {
-    ParsedContentType parsedContentType(mode == Mode::Rfc2045 ? contentType : contentType.trim(isJSONOrHTTPWhitespace<UChar>));
+    ParsedContentType parsedContentType(mode == Mode::Rfc2045 ? contentType : contentType.trim(isASCIIWhitespaceWithoutFF<UChar>));
     if (!parsedContentType.parseContentType(mode))
         return std::nullopt;
     return { WTFMove(parsedContentType) };
@@ -369,7 +369,7 @@ void ParsedContentType::setContentType(String&& contentRange, Mode mode)
 {
     m_mimeType = WTFMove(contentRange);
     if (mode == Mode::MimeSniff)
-        m_mimeType = StringView(m_mimeType).trim(isJSONOrHTTPWhitespace<UChar>).convertToASCIILowercase();
+        m_mimeType = StringView(m_mimeType).trim(isASCIIWhitespaceWithoutFF<UChar>).convertToASCIILowercase();
     else
         m_mimeType = m_mimeType.trim(deprecatedIsSpaceOrNewline);
 }

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -870,7 +870,7 @@ bool ResourceResponseBase::equalForWebKitLegacyChallengeComparison(const Resourc
 bool ResourceResponseBase::containsInvalidHTTPHeaders() const
 {
     for (auto& header : httpHeaderFields()) {
-        if (!isValidHTTPHeaderValue(header.value.trim(isJSONOrHTTPWhitespace<UChar>)))
+        if (!isValidHTTPHeaderValue(header.value.trim(isASCIIWhitespaceWithoutFF<UChar>)))
             return true;
     }
     return false;

--- a/Source/WebCore/platform/network/TimingAllowOrigin.cpp
+++ b/Source/WebCore/platform/network/TimingAllowOrigin.cpp
@@ -42,7 +42,7 @@ bool passesTimingAllowOriginCheck(const ResourceResponse& response, const Securi
     const auto& timingAllowOriginString = response.httpHeaderField(HTTPHeaderName::TimingAllowOrigin);
     const auto& securityOrigin = initiatorSecurityOrigin.toString();
     for (auto originWithSpace : StringView(timingAllowOriginString).split(',')) {
-        auto origin = originWithSpace.trim(isJSONOrHTTPWhitespace<UChar>);
+        auto origin = originWithSpace.trim(isASCIIWhitespaceWithoutFF<UChar>);
         if (origin == "*"_s || origin == securityOrigin)
             return true;
     }

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -796,7 +796,7 @@ ExceptionOr<void> XMLHttpRequest::setRequestHeader(const String& name, const Str
     if (readyState() != OPENED || m_sendFlag)
         return Exception { InvalidStateError };
 
-    String normalizedValue = value.trim(isJSONOrHTTPWhitespace<UChar>);
+    String normalizedValue = value.trim(isASCIIWhitespaceWithoutFF<UChar>);
     if (!isValidHTTPToken(name) || !isValidHTTPHeaderValue(normalizedValue))
         return Exception { SyntaxError };
 

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -568,10 +568,10 @@ Value FunNormalizeSpace::evaluate() const
     // https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space
     if (!argumentCount()) {
         String s = Value(Expression::evaluationContext().node.get()).toString();
-        return s.simplifyWhiteSpace(isXMLSpace);
+        return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<UChar>);
     }
     String s = argument(0).evaluate().toString();
-    return s.simplifyWhiteSpace(isXMLSpace);
+    return s.simplifyWhiteSpace(isASCIIWhitespaceWithoutFF<UChar>);
 }
 
 Value FunTranslate::evaluate() const

--- a/Source/WebCore/xml/XPathParser.cpp
+++ b/Source/WebCore/xml/XPathParser.cpp
@@ -33,7 +33,6 @@
 #include "XPathNSResolver.h"
 #include "XPathPath.h"
 #include "XPathStep.h"
-#include "XPathUtil.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/StdLibExtras.h>
@@ -135,7 +134,7 @@ bool Parser::isBinaryOperatorContext() const
 // See https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-ExprWhitespace .
 void Parser::skipWS()
 {
-    while (m_nextPos < m_data.length() && isXMLSpace(m_data[m_nextPos]))
+    while (m_nextPos < m_data.length() && isASCIIWhitespaceWithoutFF(m_data[m_nextPos]))
         ++m_nextPos;
 }
 

--- a/Source/WebCore/xml/XPathUtil.cpp
+++ b/Source/WebCore/xml/XPathUtil.cpp
@@ -74,10 +74,5 @@ bool isValidContextNode(Node& node)
     return false;
 }
 
-bool isXMLSpace(UChar character)
-{
-    return character == ' ' || character == '\t' || character == '\r' || character == '\n';
-}
-
 }
 }

--- a/Source/WebCore/xml/XPathUtil.h
+++ b/Source/WebCore/xml/XPathUtil.h
@@ -45,9 +45,6 @@ namespace WebCore {
         /* @return whether the given node is a valid context node */
         bool isValidContextNode(Node&);
 
-        // https://www.w3.org/TR/REC-xml/#NT-S
-        bool isXMLSpace(UChar character);
-
     } // namespace XPath
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp
@@ -89,7 +89,7 @@ static inline void updateVaryInformation(RecordInformation& recordInformation, c
     }
 
     varyValue.split(',', [&](StringView view) {
-        if (!recordInformation.hasVaryStar && view.trim(isJSONOrHTTPWhitespace<UChar>) == "*"_s)
+        if (!recordInformation.hasVaryStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
             recordInformation.hasVaryStar = true;
         recordInformation.varyHeaders.add(view.toString(), request.httpHeaderField(view));
     });

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -68,7 +68,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, const WebCore::Resou
         protocols.reset(static_cast<char**>(g_new0(char*, protocolList.size() + 1)));
         unsigned i = 0;
         for (auto& subprotocol : protocolList)
-            protocols.get()[i++] = g_strdup(subprotocol.trim(isJSONOrHTTPWhitespace<UChar>).utf8().data());
+            protocols.get()[i++] = g_strdup(subprotocol.trim(isASCIIWhitespaceWithoutFF<UChar>).utf8().data());
     }
 
 #if USE(SOUP2)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -42,7 +42,7 @@ struct CacheStorageRecordInformation {
         }
 
         varyValue.split(',', [&](StringView view) {
-            if (!hasVaryStar && view.trim(isJSONOrHTTPWhitespace<UChar>) == "*"_s)
+            if (!hasVaryStar && view.trim(isASCIIWhitespaceWithoutFF<UChar>) == "*"_s)
                 hasVaryStar = true;
             varyHeaders.add(view.toString(), request.httpHeaderField(view));
         });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8920,7 +8920,7 @@ bool WebPage::shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&
     if (response.url().protocolIsFile())
         return false;
 
-    if (auto components = response.httpHeaderField(HTTPHeaderName::ContentDisposition).split(';'); !components.isEmpty() && equalIgnoringASCIICase(components[0].trim(isJSONOrHTTPWhitespace<UChar>), "attachment"_s))
+    if (auto components = response.httpHeaderField(HTTPHeaderName::ContentDisposition).split(';'); !components.isEmpty() && equalIgnoringASCIICase(components[0].trim(isASCIIWhitespaceWithoutFF<UChar>), "attachment"_s))
         return false;
 
     return true;


### PR DESCRIPTION
#### f70bfc73d58cb05654edbe416adde6bb63804c79
<pre>
Merge isXMLSpace() into isJSONOrHTTPWhitespace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255872">https://bugs.webkit.org/show_bug.cgi?id=255872</a>
rdar://108738795

Reviewed by Darin Adler.

It turns out that JSON, HTTP, and XML all use the same whitespace
definition, so let&apos;s make them share it. Also correct an existing
comment for that function as \v is not part of isASCIIWhitespace(), but
\f is.

Furthermore, remove the &quot;optimization&quot; from these whitespace functions
per a comment from Chris Dumez at
<a href="https://github.com/WebKit/WebKit/pull/13080#discussion_r1174653845">https://github.com/WebKit/WebKit/pull/13080#discussion_r1174653845</a>:

&gt; Just verified out of curiosity and llvm does generate the same code
&gt; with -O2 (tried both arm64 and x86_64):
&gt;
&gt; isXMLSpace1(char):                       // @isXMLSpace1(char)
&gt;         mov     x8, #9728                       // =0x2600
&gt;         and     w9, w0, #0xff
&gt;         movk    x8, #1, lsl #32
&gt;         cmp     w9, #33
&gt;         cset    w9, lo
&gt;         lsr     x8, x8, x0
&gt;         and     w0, w9, w8
&gt;         ret
&gt; isXMLSpace2(char):                       // @isXMLSpace2(char)
&gt;         mov     x8, #9728                       // =0x2600
&gt;         and     w9, w0, #0xff
&gt;         movk    x8, #1, lsl #32
&gt;         cmp     w9, #33
&gt;         cset    w9, lo
&gt;         lsr     x8, x8, x0
&gt;         and     w0, w9, w8
&gt;         ret
&gt;
&gt; Ahmad-S792 Let&apos;s simplify the code then.

* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCIIWhitespace):
(WTF::isJSONOrHTTPOrXMLWhitespace):
(WTF::isJSONOrHTTPWhitespace): Deleted.
* Source/WTF/wtf/JSONValues.cpp:
(WTF::JSONImpl::Value::parseJSON):
* Source/WTF/wtf/text/StringToIntegerConversion.h:
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::hasResponseVaryStarHeaderValue):
* Source/WebCore/Modules/cache/DOMCacheEngine.cpp:
(WebCore::DOMCacheEngine::queryCacheMatch):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::parseParameters):
(WebCore::parseMIMEType):
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/fetch/FetchHeaders.cpp:
(WebCore::canWriteHeader):
(WebCore::appendToHeaderMap):
(WebCore::FetchHeaders::set):
(WebCore::FetchHeaders::filterAndFill):
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::parseMathMLLength):
* Source/WebCore/mathml/MathMLTokenElement.cpp:
(WebCore::MathMLTokenElement::convertToSingleCodePoint):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parse):
* Source/WebCore/platform/ReferrerPolicy.cpp:
(WebCore::parseReferrerPolicy):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::DecodeTask::process):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseContentTypeOptionsHeader):
(WebCore::parseClearSiteDataHeader):
(WebCore::parseRange):
(WebCore::parseCrossOriginResourcePolicyHeader):
* Source/WebCore/platform/network/HTTPParsers.h:
(WebCore::addToAccessControlAllowList):
* Source/WebCore/platform/network/ParsedContentType.cpp:
(WebCore::skipSpaces):
(WebCore::parseToken):
(WebCore::ParsedContentType::create):
(WebCore::ParsedContentType::setContentType):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::containsInvalidHTTPHeaders const):
* Source/WebCore/platform/network/TimingAllowOrigin.cpp:
(WebCore::passesTimingAllowOriginCheck):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::setRequestHeader):
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::FunNormalizeSpace::evaluate const):
* Source/WebCore/xml/XPathParser.cpp:
(WebCore::XPath::Parser::skipWS):
* Source/WebCore/xml/XPathUtil.cpp:
(WebCore::XPath::isXMLSpace): Deleted.
* Source/WebCore/xml/XPathUtil.h:
* Source/WebKit/NetworkProcess/cache/CacheStorageEngineCache.cpp:
(WebKit::CacheStorage::updateVaryInformation):
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecordInformation::updateVaryHeaders):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::shouldSkipDecidePolicyForResponse const):

Canonical link: <a href="https://commits.webkit.org/266253@main">https://commits.webkit.org/266253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b1cbb43900becdcc62c5bddaaba8369ffcb3c52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15396 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15727 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12050 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11378 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15432 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12642 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12721 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13399 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11991 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3512 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3253 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16314 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13783 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12562 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3309 "Passed tests") | 
<!--EWS-Status-Bubble-End-->