### PR TITLE
[GStreamer][WebRTC] Basic implementation of rtpSender.setParameters()

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1788,7 +1788,6 @@ webkit.org/b/235885 webrtc/datachannel/getStats-no-prflx-remote-candidate.html [
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-statsSelector.html [ Skip ]
 
 webrtc/video-av1.html [ Skip ]
-webrtc/video-maxFramerate.html [ Failure ]
 
 # GStreamer's DTLS agent currently generates RSA certificates only. DTLS 1.2 is not supported yet (AFAIK).
 webrtc/datachannel/dtls10.html [ Failure ]

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1110,6 +1110,9 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
     }
     gst_structure_take_value(initData.get(), "encodings", &encodingsValue);
 
+    auto transactionId = createVersion4UUIDString();
+    gst_structure_set(initData.get(), "transaction-id", G_TYPE_STRING, transactionId.ascii().data(), nullptr);
+
     GRefPtr<GstWebRTCRTPTransceiver> rtcTransceiver;
     g_signal_emit_by_name(m_webrtcBin.get(), "add-transceiver", direction, caps.get(), &rtcTransceiver.outPtr());
     if (!rtcTransceiver)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -256,7 +256,7 @@ static inline RefPtr<RTCRtpSender> findExistingSender(const Vector<RefPtr<RTCRtp
 ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStreamTrack& track, FixedVector<String>&& mediaStreamIds)
 {
     GST_DEBUG_OBJECT(m_endpoint->pipeline(), "Adding new track.");
-    auto senderBackend = WTF::makeUnique<GStreamerRtpSenderBackend>(*this, nullptr, nullptr);
+    auto senderBackend = WTF::makeUnique<GStreamerRtpSenderBackend>(*this, nullptr);
     if (!m_endpoint->addTrack(*senderBackend, track, mediaStreamIds))
         return Exception { TypeError, "Unable to add track"_s };
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -46,10 +46,9 @@ static void ensureDebugCategoryIsRegistered()
     });
 }
 
-GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender, GUniquePtr<GstStructure>&& initData)
+GStreamerRtpSenderBackend::GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend& backend, GRefPtr<GstWebRTCRTPSender>&& rtcSender)
     : m_peerConnectionBackend(WeakPtr { &backend })
     , m_rtcSender(WTFMove(rtcSender))
-    , m_initData(WTFMove(initData))
 {
     ensureDebugCategoryIsRegistered();
     GST_DEBUG_OBJECT(m_rtcSender.get(), "constructed without associated source");
@@ -162,17 +161,94 @@ bool GStreamerRtpSenderBackend::replaceTrack(RTCRtpSender& sender, MediaStreamTr
 
 RTCRtpSendParameters GStreamerRtpSenderBackend::getParameters() const
 {
-    return toRTCRtpSendParameters(m_initData.get());
+    switchOn(m_source, [&](const Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
+        m_currentParameters = source->parameters();
+    }, [&](const Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
+        m_currentParameters = source->parameters();
+    }, [](const std::nullptr_t&) {
+    });
+
+    GST_DEBUG_OBJECT(m_rtcSender.get(), "Current parameters: %" GST_PTR_FORMAT, m_currentParameters.get());
+    if (!m_currentParameters)
+        return toRTCRtpSendParameters(m_initData.get());
+
+    return toRTCRtpSendParameters(m_currentParameters.get());
 }
 
-void GStreamerRtpSenderBackend::setParameters(const RTCRtpSendParameters&, DOMPromiseDeferred<void>&& promise)
+static bool validateModifiedParameters(const RTCRtpSendParameters& newParameters, const RTCRtpSendParameters& oldParameters)
 {
-    if (!m_rtcSender) {
+    if (oldParameters.transactionId != newParameters.transactionId)
+        return false;
+
+    if (oldParameters.encodings.size() != newParameters.encodings.size())
+        return false;
+
+    for (size_t i = 0; i < oldParameters.encodings.size(); ++i) {
+        if (oldParameters.encodings[i].rid != newParameters.encodings[i].rid)
+            return false;
+    }
+
+    if (oldParameters.headerExtensions.size() != newParameters.headerExtensions.size())
+        return false;
+
+    for (size_t i = 0; i < oldParameters.headerExtensions.size(); ++i) {
+        const auto& oldExtension = oldParameters.headerExtensions[i];
+        const auto& newExtension = newParameters.headerExtensions[i];
+        if (oldExtension.uri != newExtension.uri || oldExtension.id != newExtension.id)
+            return false;
+    }
+
+    if (oldParameters.rtcp.cname != newParameters.rtcp.cname)
+        return false;
+
+    if (!!oldParameters.rtcp.reducedSize != !!newParameters.rtcp.reducedSize)
+        return false;
+
+    if (oldParameters.rtcp.reducedSize && *oldParameters.rtcp.reducedSize != *newParameters.rtcp.reducedSize)
+        return false;
+
+    if (oldParameters.codecs.size() != newParameters.codecs.size())
+        return false;
+
+    for (size_t i = 0; i < oldParameters.codecs.size(); ++i) {
+        const auto& oldCodec = oldParameters.codecs[i];
+        const auto& newCodec = newParameters.codecs[i];
+        if (oldCodec.payloadType != newCodec.payloadType
+            || oldCodec.mimeType != newCodec.mimeType
+            || oldCodec.clockRate != newCodec.clockRate
+            || oldCodec.channels != newCodec.channels
+            || oldCodec.sdpFmtpLine != newCodec.sdpFmtpLine)
+            return false;
+    }
+
+    return true;
+}
+
+void GStreamerRtpSenderBackend::setParameters(const RTCRtpSendParameters& parameters, DOMPromiseDeferred<void>&& promise)
+{
+    if (!hasSource()) {
         promise.reject(NotSupportedError);
         return;
     }
 
-    notImplemented();
+    if (!m_currentParameters) {
+        promise.reject(Exception { InvalidStateError, "getParameters must be called before setParameters"_s });
+        return;
+    }
+
+    if (!validateModifiedParameters(parameters, toRTCRtpSendParameters(m_currentParameters.get()))) {
+        promise.reject(InvalidModificationError, "parameters are not valid"_s);
+        return;
+    }
+
+    auto newParameters(fromRTCSendParameters(parameters));
+    switchOn(m_source, [&](Ref<RealtimeOutgoingAudioSourceGStreamer>& source) {
+        source->setParameters(WTFMove(newParameters));
+    }, [&](Ref<RealtimeOutgoingVideoSourceGStreamer>& source) {
+        source->setParameters(WTFMove(newParameters));
+    }, [](const std::nullptr_t&) {
+    });
+
     promise.resolve();
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -34,7 +34,7 @@ class GStreamerPeerConnectionBackend;
 class GStreamerRtpSenderBackend final : public RTCRtpSenderBackend {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend&, GRefPtr<GstWebRTCRTPSender>&&, GUniquePtr<GstStructure>&& initData);
+    GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend&, GRefPtr<GstWebRTCRTPSender>&&);
     using Source = std::variant<std::nullptr_t, Ref<RealtimeOutgoingAudioSourceGStreamer>, Ref<RealtimeOutgoingVideoSourceGStreamer>>;
     GStreamerRtpSenderBackend(GStreamerPeerConnectionBackend&, GRefPtr<GstWebRTCRTPSender>&&, Source&&, GUniquePtr<GstStructure>&& initData);
 
@@ -86,6 +86,7 @@ private:
     GRefPtr<GstWebRTCRTPSender> m_rtcSender;
     Source m_source;
     GUniquePtr<GstStructure> m_initData;
+    mutable GUniquePtr<GstStructure> m_currentParameters;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -263,6 +263,7 @@ RefPtr<RTCError> toRTCError(GError*);
 
 GUniquePtr<GstStructure> fromRTCEncodingParameters(const RTCRtpEncodingParameters&);
 RTCRtpSendParameters toRTCRtpSendParameters(const GstStructure*);
+GUniquePtr<GstStructure> fromRTCSendParameters(const RTCRtpSendParameters&);
 
 std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&&, const PeerConnectionBackend::CertificateInformation&);
 

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -585,7 +585,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
     Encoders::registerEncoder(X264, "x264enc", "h264parse", "video/x-h264",
         "video/x-h264,alignment=au,stream-format=byte-stream",
         [](WebKitVideoEncoder* self) {
-            g_object_set(self->priv->encoder.get(), "key-int-max", 15, "threads", NUMBER_OF_THREADS, nullptr);
+            g_object_set(self->priv->encoder.get(), "key-int-max", 15, "threads", NUMBER_OF_THREADS, "b-adapt", FALSE, "vbv-buf-capacity", 120, nullptr);
             g_object_set(self->priv->parser.get(), "config-interval", 1, nullptr);
 
             const auto* structure = gst_caps_get_structure(self->priv->encodedCaps.get(), 0);
@@ -673,6 +673,8 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
         });
 
     auto setVpxEncoderInputFormat = [](auto* self) {
+        g_object_set(self->priv->encoder.get(), "buffer-initial-size", 100, "buffer-optimal-size", 120, "buffer-size" , 150, "max-intra-bitrate", 250, nullptr);
+        gst_util_set_object_arg(G_OBJECT(self->priv->encoder.get()), "error-resilient", "default");
         auto inputCaps = adoptGRef(gst_caps_new_any());
         const auto* structure = gst_caps_get_structure(self->priv->encodedCaps.get(), 0);
         if (const char* profileString = gst_structure_get_string(structure, "profile")) {

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -193,6 +193,11 @@ void RealtimeOutgoingAudioSourceGStreamer::linkOutgoingSource()
     g_object_set(m_inputSelector.get(), "active-pad", sinkPad.get(), nullptr);
 }
 
+void RealtimeOutgoingAudioSourceGStreamer::setParameters(GUniquePtr<GstStructure>&& parameters)
+{
+    m_parameters = WTFMove(parameters);
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h
@@ -30,6 +30,7 @@ public:
     static Ref<RealtimeOutgoingAudioSourceGStreamer> create(const RefPtr<UniqueSSRCGenerator>& ssrcGenerator, const String& mediaStreamId, MediaStreamTrack& track) { return adoptRef(*new RealtimeOutgoingAudioSourceGStreamer(ssrcGenerator, mediaStreamId, track)); }
 
     bool setPayloadType(const GRefPtr<GstCaps>&) final;
+    void setParameters(GUniquePtr<GstStructure>&&) final;
 
 protected:
     explicit RealtimeOutgoingAudioSourceGStreamer(const RefPtr<UniqueSSRCGenerator>&, const String& mediaStreamId, MediaStreamTrack&);

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h
@@ -55,6 +55,10 @@ public:
     virtual bool setPayloadType(const GRefPtr<GstCaps>&) { return false; }
     virtual void teardown() { }
 
+    GUniquePtr<GstStructure> parameters();
+    virtual void fillEncodingParameters(const GUniquePtr<GstStructure>&) { }
+    virtual void setParameters(GUniquePtr<GstStructure>&&) { }
+
 protected:
     explicit RealtimeOutgoingMediaSourceGStreamer(const RefPtr<UniqueSSRCGenerator>&, const String& mediaStreamId, MediaStreamTrack&);
 
@@ -86,6 +90,7 @@ protected:
     GRefPtr<GstWebRTCRTPSender> m_sender;
     GRefPtr<GstPad> m_webrtcSinkPad;
     RefPtr<UniqueSSRCGenerator> m_ssrcGenerator;
+    GUniquePtr<GstStructure> m_parameters;
 
 private:
     void sourceMutedChanged();

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -59,6 +59,14 @@ RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer(const
     m_videoFlip = makeGStreamerElement("videoflip", nullptr);
     gst_util_set_object_arg(G_OBJECT(m_videoFlip.get()), "method", "automatic");
 
+    // Variable framerate for canvas capture tracks requires further investigation, so disable it for now.
+    if (!track.isCanvas()) {
+        m_videoRate = makeGStreamerElement("videorate", nullptr);
+        g_object_set(m_videoRate.get(), "skip-to-first", TRUE, nullptr);
+        m_frameRateCapsFilter = makeGStreamerElement("capsfilter", nullptr);
+        gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoRate.get(), m_frameRateCapsFilter.get(), nullptr);
+    }
+
     m_encoder = gst_element_factory_make("webkitvideoencoder", nullptr);
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_videoFlip.get(), m_videoConvert.get(), m_encoder.get(), nullptr);
 }
@@ -158,7 +166,20 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     auto encoderSinkPad = adoptGRef(gst_element_get_static_pad(m_encoder.get(), "sink"));
     if (!gst_pad_is_linked(encoderSinkPad.get())) {
-        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_videoFlip.get(), m_videoConvert.get(), m_preEncoderQueue.get(), m_encoder.get(), nullptr)) {
+        if (!gst_element_link_many(m_outgoingSource.get(), m_inputSelector.get(), m_videoFlip.get(), nullptr)) {
+            GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to videoflip");
+            return false;
+        }
+
+        GstElement* tail = m_videoFlip.get();
+        if (m_videoRate) {
+            if (!gst_element_link_many(m_videoFlip.get(), m_videoRate.get(), m_frameRateCapsFilter.get(), nullptr)) {
+                GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to videorate");
+                return false;
+            }
+            tail = m_frameRateCapsFilter.get();
+        }
+        if (!gst_element_link_many(tail, m_videoConvert.get(), m_preEncoderQueue.get(), m_encoder.get(), nullptr)) {
             GST_ERROR_OBJECT(m_bin.get(), "Unable to link outgoing source to encoder");
             return false;
         }
@@ -282,6 +303,78 @@ void RealtimeOutgoingVideoSourceGStreamer::flush()
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Requesting key-frame");
     gst_element_send_event(m_outgoingSource.get(), gst_video_event_new_downstream_force_key_unit(GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, FALSE, 1));
+}
+
+void RealtimeOutgoingVideoSourceGStreamer::setParameters(GUniquePtr<GstStructure>&& parameters)
+{
+    m_parameters = WTFMove(parameters);
+    GST_DEBUG_OBJECT(m_bin.get(), "New encoding parameters: %" GST_PTR_FORMAT, m_parameters.get());
+
+    auto* encodingsValue = gst_structure_get_value(m_parameters.get(), "encodings");
+    RELEASE_ASSERT(GST_VALUE_HOLDS_LIST(encodingsValue));
+    if (UNLIKELY(!gst_value_list_get_size(encodingsValue))) {
+        GST_WARNING_OBJECT(m_bin.get(), "Encodings list is empty, cancelling configuration");
+        return;
+    }
+
+    auto* firstEncoding = gst_value_list_get_value(encodingsValue, 0);
+    RELEASE_ASSERT(GST_VALUE_HOLDS_STRUCTURE(firstEncoding));
+    auto* structure = gst_value_get_structure(firstEncoding);
+
+    if (gst_structure_has_field(structure, "max-framerate")) {
+        if (!m_videoRate)
+            GST_WARNING_OBJECT(m_bin.get(), "Unable to configure max-framerate");
+        else {
+            unsigned long maxFrameRate;
+            gst_structure_get(structure, "max-framerate", G_TYPE_ULONG, &maxFrameRate, nullptr);
+
+            // Some decoder(s), like FFMpeg don't handle 1 FPS framerate, so set a minimum more likely to be accepted.
+            if (maxFrameRate < 2)
+                maxFrameRate = 2;
+
+            int numerator, denominator;
+            gst_util_double_to_fraction(static_cast<double>(maxFrameRate), &numerator, &denominator);
+
+            auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr));
+            g_object_set(m_frameRateCapsFilter.get(), "caps", caps.get(), nullptr);
+        }
+    }
+
+    if (UNLIKELY(!m_encoder) || !gst_structure_has_field(structure, "max-bitrate"))
+        return;
+
+    unsigned long maxBitrate;
+    gst_structure_get(structure, "max-bitrate", G_TYPE_ULONG, &maxBitrate, nullptr);
+
+    // maxBitrate is expessed in bits/s but the encoder property is in Kbit/s.
+    g_object_set(m_encoder.get(), "bitrate", static_cast<unsigned>(maxBitrate / 1024), nullptr);
+}
+
+void RealtimeOutgoingVideoSourceGStreamer::fillEncodingParameters(const GUniquePtr<GstStructure>& encodingParameters)
+{
+    if (m_videoRate) {
+        GRefPtr<GstCaps> caps;
+        g_object_get(m_frameRateCapsFilter.get(), "caps", &caps.outPtr(), nullptr);
+        double maxFrameRate = 30.0;
+        if (!gst_caps_is_any(caps.get())) {
+            if (auto* structure = gst_caps_get_structure(caps.get(), 0)) {
+                int numerator, denominator;
+                if (gst_structure_get_fraction(structure, "framerate", &numerator, &denominator))
+                    gst_util_fraction_to_double(numerator, denominator, &maxFrameRate);
+            }
+        }
+
+        gst_structure_set(encodingParameters.get(), "max-framerate", G_TYPE_DOUBLE, maxFrameRate, nullptr);
+    }
+
+    unsigned long maxBitrate = 2048 * 1024;
+    if (m_encoder) {
+        uint32_t bitrate;
+        g_object_get(m_encoder.get(), "bitrate", &bitrate, nullptr);
+        maxBitrate = bitrate * 1024;
+    }
+
+    gst_structure_set(encodingParameters.get(), "max-bitrate", G_TYPE_ULONG, maxBitrate, nullptr);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h
@@ -36,6 +36,9 @@ public:
     void teardown() final;
     void flush() final;
 
+    void setParameters(GUniquePtr<GstStructure>&&) final;
+    void fillEncodingParameters(const GUniquePtr<GstStructure>&) final;
+
     const GstStructure* stats() const { return m_stats.get(); }
 
 protected:
@@ -61,6 +64,9 @@ private:
     GRefPtr<GstElement> m_fallbackSource;
     GRefPtr<GstElement> m_videoConvert;
     GRefPtr<GstElement> m_videoFlip;
+    GRefPtr<GstElement> m_videoRate;
+    GRefPtr<GstElement> m_frameRateCapsFilter;
+
     GUniquePtr<GstStructure> m_stats;
 
     unsigned long m_statsPadProbeId { 0 };


### PR DESCRIPTION
#### 72651b6797aa8038b4b356e00a1a33935f51191b
<pre>
[GStreamer][WebRTC] Basic implementation of rtpSender.setParameters()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259445">https://bugs.webkit.org/show_bug.cgi?id=259445</a>

Reviewed by Xabier Rodriguez-Calvar.

This allows JS to set the video maxFrameRate and maxBitrate on the outgoing video tracks. It is not
yet supported for Canvas capture tracks.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::GStreamerPeerConnectionBackend::addTrack):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::GStreamerRtpSenderBackend):
(WebCore::m_rtcSender):
(WebCore::GStreamerRtpSenderBackend::getParameters const):
(WebCore::validateModifiedParameters):
(WebCore::GStreamerRtpSenderBackend::setParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCRtpSendParameters):
(WebCore::fromRTCSendParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingVideoSourceGStreamer.cpp:
(WebCore::RealtimeIncomingVideoSourceGStreamer::settings):
(WebCore::RealtimeIncomingVideoSourceGStreamer::settingsDidChange):
(WebCore::RealtimeIncomingVideoSourceGStreamer::dispatchSample):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setParameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::parameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.h:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::fillEncodingParameters):
(WebCore::RealtimeOutgoingMediaSourceGStreamer::setParameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::RealtimeOutgoingVideoSourceGStreamer):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setParameters):
(WebCore::RealtimeOutgoingVideoSourceGStreamer::fillEncodingParameters):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/266354@main">https://commits.webkit.org/266354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a1ecf255565c590e82a6222554e6287bf36642

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15457 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15859 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19162 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12284 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10674 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12055 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3314 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12627 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->