### PR TITLE
Rename isBlobURLContainsNullOrigin to isBlobURLContainingNullOrigin

### DIFF
--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -68,7 +68,7 @@ static HashCountedSet<String>& blobURLReferencesMap()
     return map;
 }
 
-static inline bool isBlobURLContainsNullOrigin(const URL& url)
+static inline bool isBlobURLContainingNullOrigin(const URL& url)
 {
     ASSERT(url.protocolIsBlob());
     unsigned startIndex = url.pathStart();
@@ -85,7 +85,7 @@ static inline bool isInternalBlobURL(const URL& url)
 // If the blob URL contains null origin, as in the context with unique security origin or file URL, save the mapping between url and origin so that the origin can be retrived when doing security origin check.
 static void addToOriginMapIfNecessary(const URL& url, RefPtr<SecurityOrigin>&& origin)
 {
-    if (!origin || !isBlobURLContainsNullOrigin(url))
+    if (!origin || !isBlobURLContainingNullOrigin(url))
         return;
 
     auto urlWithoutFragment = url.stringWithoutFragmentIdentifier();
@@ -125,7 +125,7 @@ void ThreadableBlobRegistry::registerInternalBlobURL(const URL& url, Vector<Blob
 static void unregisterBlobURLOriginIfNecessaryOnMainThread(const URL& url)
 {
     ASSERT(isMainThread());
-    if (!isBlobURLContainsNullOrigin(url))
+    if (!isBlobURLContainingNullOrigin(url))
         return;
 
     auto urlWithoutFragment = url.stringWithoutFragmentIdentifier();
@@ -209,7 +209,7 @@ void ThreadableBlobRegistry::unregisterBlobURL(const URLKeepingBlobAlive& url)
 void ThreadableBlobRegistry::registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>&)
 {
     ensureOnMainThread([url = url.isolatedCopy()] {
-        if (isBlobURLContainsNullOrigin(url))
+        if (isBlobURLContainingNullOrigin(url))
             blobURLReferencesMap().add(url.stringWithoutFragmentIdentifier());
 
         blobRegistry().registerBlobURLHandle(url);
@@ -237,7 +237,7 @@ RefPtr<SecurityOrigin> ThreadableBlobRegistry::getCachedOrigin(const URL& url)
     if (cachedOrigin)
         return cachedOrigin;
 
-    if (!isBlobURLContainsNullOrigin(url))
+    if (!isBlobURLContainingNullOrigin(url))
         return nullptr;
 
     // If we do not have a cached origin for null blob URLs, we use an opaque origin.


### PR DESCRIPTION
#### 2b1106bf431a9c62941d89bf6c119c85161c2cee
<pre>
Rename isBlobURLContainsNullOrigin to isBlobURLContainingNullOrigin
<a href="https://bugs.webkit.org/show_bug.cgi?id=259426">https://bugs.webkit.org/show_bug.cgi?id=259426</a>
rdar://112731483

Reviewed by Tim Nguyen.

* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::isBlobURLContainingNullOrigin):
(WebCore::addToOriginMapIfNecessary):
(WebCore::unregisterBlobURLOriginIfNecessaryOnMainThread):
(WebCore::ThreadableBlobRegistry::registerBlobURLHandle):
(WebCore::ThreadableBlobRegistry::getCachedOrigin):
(WebCore::isBlobURLContainsNullOrigin): Deleted.

Canonical link: <a href="https://commits.webkit.org/266258@main">https://commits.webkit.org/266258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d631c2cf2390d552b37d11dec0d098d7feb7099

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15729 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19100 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12216 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12722 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11992 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->