### PR TITLE
Handle focusability for plugin elements which has browsing context

### DIFF
--- a/LayoutTests/fast/dom/focus-navigation-in-plugin-expected.txt
+++ b/LayoutTests/fast/dom/focus-navigation-in-plugin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Focus should navigate to <object>/<embed>
+

--- a/LayoutTests/fast/dom/focus-navigation-in-plugin.html
+++ b/LayoutTests/fast/dom/focus-navigation-in-plugin.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<input id="outer-before">
+<object data="resources/plugin-focus-subframe.html" type="text/html" id="obj"></object>
+<embed src="resources/plugin-focus-subframe.html" type="text/html" id="emb"></embed>
+<input id="outer-after">
+<script>
+function PressTab() {
+    eventSender.keyDown('\t');
+}
+function PressShiftTab() {
+    eventSender.keyDown('\t', ['shiftKey']);
+}
+function testFocusNavigation() {
+    test(() => {
+      var before = document.querySelector('#outer-before');
+      var after = document.querySelector('#outer-after');
+      before.focus();
+      // 'plugin-focus-subframe.html' has 2 focus areas.
+      var expected = ['outer-before', 'obj', 'obj', 'emb', 'emb', 'outer-after'];
+      var i;
+      for (i = 0; i < 5; ++i) {
+          assert_equals(document.activeElement.id, expected[i]);
+          PressTab();
+      }
+      assert_equals(document.activeElement, after, '#after');
+      expected.reverse();
+      for (i = 0; i < 5; ++i) {
+          assert_equals(document.activeElement.id, expected[i]);
+          PressShiftTab();
+      }
+      assert_equals(document.activeElement, before, '#before');
+    }, "Focus should navigate to <object>/<embed>");
+}
+if (window.testRunner) {
+    window.addEventListener('load', testFocusNavigation, false);
+}
+</script>

--- a/LayoutTests/fast/dom/resources/plugin-focus-subframe.html
+++ b/LayoutTests/fast/dom/resources/plugin-focus-subframe.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+  <input placeholder="subframe-before">
+  <input placeholder="subframe-after">
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -917,6 +917,7 @@ editing/selection/shrink-selection-after-shift-pagedown.html [ Skip ]
 editing/spelling/spelling-changed-text.html
 editing/undo/undo-deleteWord.html [ Skip ]
 fast/dom/access-key-iframe.html [ Skip ]
+fast/dom/focus-navigation-in-plugin.html [ Skip ]
 fast/dom/fragment-activation-focuses-target.html [ Skip ]
 fast/dom/hidden-iframe-no-focus.html [ Skip ]
 fast/dom/horizontal-scrollbar-in-rtl.html [ Skip ]

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
- * Copyright (C) 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -71,9 +71,9 @@ protected:
     HTMLFrameOwnerElement(const QualifiedName& tagName, Document&, ConstructionType = CreateHTMLFrameOwnerElement);
     void setSandboxFlags(SandboxFlags);
     bool isProhibitedSelfReference(const URL&) const;
+    bool isKeyboardFocusable(KeyboardEvent*) const override;
 
 private:
-    bool isKeyboardFocusable(KeyboardEvent*) const override;
     bool isFrameOwnerElement() const final { return true; }
 
     WeakPtr<Frame> m_contentFrame;

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -3,6 +3,7 @@
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Stefan Schimanski (1Stein@gmx.de)
  * Copyright (C) 2004-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -201,8 +202,10 @@ void HTMLPlugInElement::defaultEventHandler(Event& event)
     HTMLFrameOwnerElement::defaultEventHandler(event);
 }
 
-bool HTMLPlugInElement::isKeyboardFocusable(KeyboardEvent*) const
+bool HTMLPlugInElement::isKeyboardFocusable(KeyboardEvent* event) const
 {
+    if (HTMLFrameOwnerElement::isKeyboardFocusable(event))
+        return true;
     return false;
 }
 


### PR DESCRIPTION
#### 61a5480546df3e43c1b258c65d12e9396b1b5f0b
<pre>
Handle focusability for plugin elements which has browsing context

<a href="https://bugs.webkit.org/show_bug.cgi?id=259420">https://bugs.webkit.org/show_bug.cgi?id=259420</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/a2c82afad86cf4f85f91df76f858434b15fe6b13">https://chromium.googlesource.com/chromium/src.git/+/a2c82afad86cf4f85f91df76f858434b15fe6b13</a>

If `object` or `embed` has HTML/SVG contents,
focus navigation within documents under these
elements should work. This has been working fine
for `iframe`&apos;s.

The FocusController code checks for FrameOwnerElement,
which is parent of `iframe`, `object`, and `embed` if
it is isKeyboardFocusable() and has contentFrame().

HTMLPluginElement::isKeyboardFocsuable() didn&apos;t handle
the cases with HTML/SVG contents, only considered plugins.

* Source/WebCore/html/HTMLPlugInElement.cpp:
(HTMLPlugInElement::isKeyboardFocusable): As above for focusability
* Source/WebCore/html/HTMLFrameOwnerElement.h: Move &apos;isKeyboardFocusable&apos; from private to protected
* LayoutTests/fast/dom/focus-navigation-in-plugin.html: Add Test Case
* LayoutTests/fast/dom/resources/plugin-focus-subframe.html: Add Test Case resource
* LayoutTests/fast/dom/focus-navigation-in-plugin-expected.txt: Add Test Case Expectation
* LayoutTests/platform/ios/TestExpectations: Added test to skip on iOS since it does not support &apos;keyDown&apos;

Canonical link: <a href="https://commits.webkit.org/266286@main">https://commits.webkit.org/266286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8336fb1593d85db83a86c69975fe05176eb17dcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15129 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15429 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19134 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15465 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11951 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3276 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->