### PR TITLE
[WebGPU] Make wgslc and wgslfuzz distinct from each other

### DIFF
--- a/Source/WebGPU/Configurations/wgslfuzz.xcconfig
+++ b/Source/WebGPU/Configurations/wgslfuzz.xcconfig
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+PRIVATE_HEADERS_FOLDER_PATH = $(WGSL_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH);
+PUBLIC_HEADERS_FOLDER_PATH = $(WGSL_INSTALL_PATH_PREFIX)$(WK_LIBRARY_HEADERS_FOLDER_PATH);
+HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)$(WK_LIBRARY_HEADERS_FOLDER_PATH)" $(inherited);
+SYSTEM_HEADER_SEARCH_PATHS = $(SDK_DIR)$(WK_ALTERNATE_WEBKIT_SDK_PATH)$(WK_LIBRARY_HEADERS_FOLDER_PATH) $(inherited);
+PRODUCT_NAME = wgslfuzz;

--- a/Source/WebGPU/WGSL/wgslfuzz.cpp
+++ b/Source/WebGPU/WGSL/wgslfuzz.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "AST/ASTStringDumper.h"
+#include "WGSL.h"
+#include "WGSLShaderModule.h"
+#include <wtf/DataLog.h>
+#include <wtf/FileSystem.h>
+#include <wtf/WTFProcess.h>
+
+extern "C" {
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t);
+int LLVMFuzzerInitialize(int *argc, char ***argv);
+} // extern "C"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    WTF::initializeMainThread();
+
+    WGSL::Configuration configuration;
+    auto source = String::fromUTF8WithLatin1Fallback(data, size);
+    auto checkResult = WGSL::staticCheck(source, std::nullopt, configuration);
+    if (auto* successfulCheck = std::get_if<WGSL::SuccessfulCheck>(&checkResult)) {
+        auto& shaderModule = successfulCheck->ast;
+        WGSL::prepare(shaderModule, "main"_str, std::nullopt);
+    }
+
+    return 0;
+}

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		1C5ACAE9273A55FD0095F8D5 /* Sampler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACAE8273A55FD0095F8D5 /* Sampler.mm */; };
 		1C5ACAEB273A560D0095F8D5 /* TextureView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C5ACAEA273A560D0095F8D5 /* TextureView.mm */; };
 		1C9F7CDF29762F51006B5BE9 /* PresentationContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C9F7CDD29762F51006B5BE9 /* PresentationContext.mm */; };
+		1CA5B4F42A6F28C400E5F297 /* wgslfuzz.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CA5B4F32A6F28C400E5F297 /* wgslfuzz.cpp */; };
+		1CA5B4FF2A6F2A5800E5F297 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CA5B4FE2A6F2A5800E5F297 /* JavaScriptCore.framework */; };
+		1CA5B5002A6F2A5E00E5F297 /* libwgsl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CEBD7F22716B2CC00A5254D /* libwgsl.a */; };
 		1CBAB0922718CCA0006080BB /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		1CBD2E972977DAC900BBF52C /* PresentationContextCoreAnimation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBD2E932977DAC900BBF52C /* PresentationContextCoreAnimation.mm */; };
 		1CBD2E992977DAC900BBF52C /* PresentationContextIOSurface.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CBD2E952977DAC900BBF52C /* PresentationContextIOSurface.mm */; };
@@ -181,6 +184,13 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		1CA5B5012A6F2A5E00E5F297 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1CEBD7F12716B2CC00A5254D;
+			remoteInfo = WGSL;
+		};
 		1CEBD8272716CACC00A5254D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1CEBD7DA2716AFBA00A5254D /* Project object */;
@@ -191,6 +201,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		1CA5B4EF2A6F28C400E5F297 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		97FA1A7D29C085740052D650 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,6 +288,10 @@
 		1C5ACAEA273A560D0095F8D5 /* TextureView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextureView.mm; sourceTree = "<group>"; };
 		1C9F7CDD29762F51006B5BE9 /* PresentationContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PresentationContext.mm; sourceTree = "<group>"; };
 		1C9F7CDE29762F51006B5BE9 /* PresentationContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PresentationContext.h; sourceTree = "<group>"; };
+		1CA5B4F12A6F28C400E5F297 /* wgslfuzz */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wgslfuzz; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CA5B4F32A6F28C400E5F297 /* wgslfuzz.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wgslfuzz.cpp; sourceTree = "<group>"; };
+		1CA5B4F92A6F28E500E5F297 /* wgslfuzz.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = wgslfuzz.xcconfig; sourceTree = "<group>"; };
+		1CA5B4FE2A6F2A5800E5F297 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/iOSSupport/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		1CA7CDB12A2B284A0094071F /* WebGPUInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUInternal.h; sourceTree = "<group>"; };
 		1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = JavaScriptCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CBD2E922977DAC900BBF52C /* PresentationContextCoreAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PresentationContextCoreAnimation.h; sourceTree = "<group>"; };
@@ -415,6 +438,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1CA5B4EE2A6F28C400E5F297 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CA5B4FF2A6F2A5800E5F297 /* JavaScriptCore.framework in Frameworks */,
+				1CA5B5002A6F2A5E00E5F297 /* libwgsl.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1CEBD7E02716AFBA00A5254D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -464,6 +496,7 @@
 				97FA1A7F29C085740052D650 /* wgslc */,
 				1CEBD7F22716B2CC00A5254D /* libwgsl.a */,
 				1CEBD7E32716AFBA00A5254D /* WebGPU.framework */,
+				1CA5B4F12A6F28C400E5F297 /* wgslfuzz */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -588,6 +621,7 @@
 				1CEBD8022716BF8200A5254D /* WGSL.cpp */,
 				1CEBD7F72716B34400A5254D /* WGSL.h */,
 				97FA1A8729C085A60052D650 /* wgslc.cpp */,
+				1CA5B4F32A6F28C400E5F297 /* wgslfuzz.cpp */,
 				9776BE7529957E12002D6D93 /* WGSLShaderModule.h */,
 			);
 			path = WGSL;
@@ -601,6 +635,7 @@
 				1CEBD7FC2716B64400A5254D /* WebGPU.xcconfig */,
 				1CEBD7FD2716B64F00A5254D /* WGSL.xcconfig */,
 				97FA1AA229C0BB700052D650 /* wgslc.xcconfig */,
+				1CA5B4F92A6F28E500E5F297 /* wgslfuzz.xcconfig */,
 			);
 			path = Configurations;
 			sourceTree = "<group>";
@@ -612,6 +647,7 @@
 				0D30F93A29F1FBE40055D9F1 /* CoreVideo.framework */,
 				1CEBD82D2716CB1600A5254D /* Foundation.framework */,
 				664C92FC286A66090008D143 /* IOSurface.framework */,
+				1CA5B4FE2A6F2A5800E5F297 /* JavaScriptCore.framework */,
 				1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */,
 				1CEBD8302716CB3800A5254D /* libicucore.tbd */,
 				1CEBD8292716CAE700A5254D /* libWTF.a */,
@@ -825,6 +861,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1CA5B4F02A6F28C400E5F297 /* wgslfuzz */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1CA5B4F82A6F28C400E5F297 /* Build configuration list for PBXNativeTarget "wgslfuzz" */;
+			buildPhases = (
+				1CA5B4ED2A6F28C400E5F297 /* Sources */,
+				1CA5B4EE2A6F28C400E5F297 /* Frameworks */,
+				1CA5B4EF2A6F28C400E5F297 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1CA5B5022A6F2A5E00E5F297 /* PBXTargetDependency */,
+			);
+			name = wgslfuzz;
+			productName = wgslfuzz;
+			productReference = 1CA5B4F12A6F28C400E5F297 /* wgslfuzz */;
+			productType = "com.apple.product-type.tool";
+		};
 		1CEBD7E22716AFBA00A5254D /* WebGPU */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1CEBD7EA2716AFBA00A5254D /* Build configuration list for PBXNativeTarget "WebGPU" */;
@@ -890,6 +944,9 @@
 				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1330;
 				TargetAttributes = {
+					1CA5B4F02A6F28C400E5F297 = {
+						CreatedOnToolsVersion = 15.0;
+					};
 					1CEBD7E22716AFBA00A5254D = {
 						CreatedOnToolsVersion = 13.3;
 					};
@@ -917,6 +974,7 @@
 				1CEBD7E22716AFBA00A5254D /* WebGPU */,
 				1CEBD7F12716B2CC00A5254D /* WGSL */,
 				97FA1A7E29C085740052D650 /* wgslc */,
+				1CA5B4F02A6F28C400E5F297 /* wgslfuzz */,
 			);
 		};
 /* End PBXProject section */
@@ -953,6 +1011,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1CA5B4ED2A6F28C400E5F297 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CA5B4F42A6F28C400E5F297 /* wgslfuzz.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1CEBD7DF2716AFBA00A5254D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1031,6 +1097,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1CA5B5022A6F2A5E00E5F297 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1CEBD7F12716B2CC00A5254D /* WGSL */;
+			targetProxy = 1CA5B5012A6F2A5E00E5F297 /* PBXContainerItemProxy */;
+		};
 		1CEBD8282716CACC00A5254D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 1CEBD7F12716B2CC00A5254D /* WGSL */;
@@ -1039,6 +1110,27 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1CA5B4F52A6F28C400E5F297 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CA5B4F92A6F28E500E5F297 /* wgslfuzz.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		1CA5B4F62A6F28C400E5F297 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CA5B4F92A6F28E500E5F297 /* wgslfuzz.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		1CA5B4F72A6F28C400E5F297 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1CA5B4F92A6F28E500E5F297 /* wgslfuzz.xcconfig */;
+			buildSettings = {
+			};
+			name = Production;
+		};
 		1CEBD7E82716AFBA00A5254D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1CEBD7FB2716B5B400A5254D /* DebugRelease.xcconfig */;
@@ -1126,6 +1218,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1CA5B4F82A6F28C400E5F297 /* Build configuration list for PBXNativeTarget "wgslfuzz" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CA5B4F52A6F28C400E5F297 /* Debug */,
+				1CA5B4F62A6F28C400E5F297 /* Release */,
+				1CA5B4F72A6F28C400E5F297 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
 		1CEBD7DD2716AFBA00A5254D /* Build configuration list for PBXProject "WebGPU" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme
+++ b/Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1CA5B4F02A6F28C400E5F297"
+               BuildableName = "wgslfuzz"
+               BlueprintName = "wgslfuzz"
+               ReferencedContainer = "container:WebGPU.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1CA5B4F02A6F28C400E5F297"
+            BuildableName = "wgslfuzz"
+            BlueprintName = "wgslfuzz"
+            ReferencedContainer = "container:WebGPU.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1CA5B4F02A6F28C400E5F297"
+            BuildableName = "wgslfuzz"
+            BlueprintName = "wgslfuzz"
+            ReferencedContainer = "container:WebGPU.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>


### PR DESCRIPTION
#### e812d681255b5530d4bdc7272899b17dbf023342
<pre>
[WebGPU] Make wgslc and wgslfuzz distinct from each other
<a href="https://bugs.webkit.org/show_bug.cgi?id=259454">https://bugs.webkit.org/show_bug.cgi?id=259454</a>
rdar://112798797

Reviewed by Mike Wyrzykowski.

It would be useful to make the compiler and the fuzzer different executables
for local development, so when the fuzzer finds a problem, you can feed that
into the compiler to debug it.

The way this works is:
% set-webkit-configuration --debug --asan --libFuzzer
% cd Source/WebGPU
% make SCHEME=wgslfuzz
% make SCHEME=wgslc
% ASAN_OPTIONS=whatever DYLD_FRAMEWORK_PATH=/path/to/Products/Debug DYLD_LIBRARY_PATH=/path/to/Products/Debug /path/to/Products/Debug/wgslfuzz
% ASAN_OPTIONS=whatever DYLD_FRAMEWORK_PATH=/path/to/Products/Debug DYLD_LIBRARY_PATH=/path/to/Products/Debug /path/to/Products/Debug/wgslc

* Source/WebGPU/Configurations/wgslfuzz.xcconfig: Added.
* Source/WebGPU/WGSL/wgslc.cpp:
(main):
(LLVMFuzzerTestOneInput): Deleted.
* Source/WebGPU/WGSL/wgslfuzz.cpp: Added.
(LLVMFuzzerTestOneInput):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU.xcodeproj/xcshareddata/xcschemes/wgslfuzz.xcscheme: Added.

Canonical link: <a href="https://commits.webkit.org/266269@main">https://commits.webkit.org/266269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34bc0e3782090033ec3623a55e94f5a51a7fd52a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12736 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15415 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13545 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15773 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11486 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15453 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12743 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10602 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12015 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3266 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->