### PR TITLE
[iOS] Safari window sometimes flashes black when app switching or tab switching

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1532,8 +1532,6 @@ BOOL UIKeyboardIsRightToLeftInputModeActive(void);
 extern const float UITableCellDefaultFontSize;
 extern const float UITableViewCellDefaultFontSize;
 
-extern NSString *const _UIApplicationDidFinishSuspensionSnapshotNotification;
-
 extern NSString * const UIWindowDidMoveToScreenNotification;
 extern NSString * const UIWindowDidRotateNotification;
 extern NSString * const UIWindowNewScreenUserInfoKey;

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.h
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.h
@@ -40,7 +40,7 @@ namespace WebKit {
 class ApplicationStateTracker : public CanMakeWeakPtr<ApplicationStateTracker> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL didFinishSnapshottingAfterEnteringBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
+    ApplicationStateTracker(UIView *, SEL didEnterBackgroundSelector, SEL willEnterForegroundSelector, SEL willBeginSnapshotSequenceSelector, SEL didCompleteSnapshotSequenceSelector);
     ~ApplicationStateTracker();
 
     bool isInBackground() const { return m_isInBackground; }
@@ -54,7 +54,6 @@ private:
 
     WeakObjCPtr<UIView> m_view;
     SEL m_didEnterBackgroundSelector;
-    SEL m_didFinishSnapshottingAfterEnteringBackgroundSelector;
     SEL m_willEnterForegroundSelector;
     SEL m_willBeginSnapshotSequenceSelector;
     SEL m_didCompleteSnapshotSequenceSelector;
@@ -62,7 +61,6 @@ private:
     bool m_isInBackground;
 
     id m_didEnterBackgroundObserver;
-    id m_didFinishSnapshottingAfterEnteringBackgroundObserver;
     id m_willEnterForegroundObserver;
     id m_willBeginSnapshotSequenceObserver;
     id m_didCompleteSnapshotSequenceObserver;


### PR DESCRIPTION
#### 5ae7317c43cdc8799371c8f0cbde1dc5c683ae78
<pre>
[iOS] Safari window sometimes flashes black when app switching or tab switching
<a href="https://bugs.webkit.org/show_bug.cgi?id=259455">https://bugs.webkit.org/show_bug.cgi?id=259455</a>
rdar://107673739

Reviewed by Tim Horton.

WebKit relies on the _UIApplicationDidFinishSuspensionSnapshotNotification notification to do two things
in WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground(): if layers contain Mach port
contents, map in IOSurfaces for those so that we don&apos;t hold an in-use count which prevents the layers from
becoming volatile (no longer applicable now that layers hold CAIOSurfaceRefs), and storing a TransactionID
in RemoteLayerTreeDrawingAreaProxy::hideContentUntilPendingUpdate() to keep content hidden until we get
a new transaction on resume.

UIKit stopped sending that notification a few years ago (rdar://112569013) so just hook up our call to
`applicationDidFinishSnapshottingAfterEnteringBackground()` at the end of `_didCompleteSnapshotSequence`.

Also add some release logging for background snapshotting.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.h:
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::ApplicationStateTracker):
(WebKit::ApplicationStateTracker::~ApplicationStateTracker):
(WebKit::ApplicationStateTracker::applicationDidFinishSnapshottingAfterEnteringBackground): Deleted.
* Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm:
(-[WKApplicationStateTrackingView didMoveToWindow]):
(-[WKApplicationStateTrackingView _applicationDidFinishSnapshottingAfterEnteringBackground]):
(-[WKApplicationStateTrackingView _willBeginSnapshotSequence]):
(-[WKApplicationStateTrackingView _didCompleteSnapshotSequence]):

Canonical link: <a href="https://commits.webkit.org/266274@main">https://commits.webkit.org/266274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677ce9e76da2e37c7262ebd996f509935d1976dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12737 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15418 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15776 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11488 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12563 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15454 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12016 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3270 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->