### PR TITLE
Add implementation of IPInt memory and global instructions

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-global.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-global.js
@@ -1,0 +1,25 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (global $value (export "value") (mut i32) (i32.const 5))
+    (func (export "set")
+        (i32.const 10)
+        (global.set $value)
+    )
+    (func (export "read") (result i32)
+        (global.get $value)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { value, set, read } = instance.exports
+    assert.eq(read(), 5);
+    set();
+    assert.eq(value.value, 10);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-memory-read-sizes.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-memory-read-sizes.js
@@ -1,0 +1,98 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1 10)
+    (func (export "i32") (result i32)
+        (i32.const 0)
+        (i32.load)
+    )
+    (func (export "i32_8s") (result i32)
+        (i32.const 0)
+        (i32.load8_s)
+    )
+    (func (export "i32_8u") (result i32)
+        (i32.const 0)
+        (i32.load8_u)
+    )
+    (func (export "i32_16s") (result i32)
+        (i32.const 0)
+        (i32.load16_s)
+    )
+    (func (export "i32_16u") (result i32)
+        (i32.const 0)
+        (i32.load16_u)
+    )
+
+    (func (export "i64") (result i64)
+        (i32.const 0)
+        (i64.load)
+    )
+    (func (export "i64_8s") (result i64)
+        (i32.const 0)
+        (i64.load8_s)
+    )
+    (func (export "i64_8u") (result i64)
+        (i32.const 0)
+        (i64.load8_u)
+    )
+    (func (export "i64_16s") (result i64)
+        (i32.const 0)
+        (i64.load16_s)
+    )
+    (func (export "i64_16u") (result i64)
+        (i32.const 0)
+        (i64.load16_u)
+    )
+    (func (export "i64_32s") (result i64)
+        (i32.const 0)
+        (i64.load32_s)
+    )
+    (func (export "i64_32u") (result i64)
+        (i32.const 0)
+        (i64.load32_u)
+    )
+)
+`
+
+function writeToMemory(m, l) {
+    let arr = new Uint8Array(m.buffer);
+    for (let i = 0; i < l; ++i) {
+        arr[i] = 128 + i;
+    }
+}
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, 
+        i32, i32_8s, i32_8u, i32_16s, i32_16u, 
+        i64, i64_8s, i64_8u, i64_16s, i64_16u, i64_32s, i64_32u
+    } = instance.exports
+    writeToMemory(memory, 16);
+
+    // mem = 80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f
+
+    // 0x83828180 as 2s complement
+    assert.eq(i32(), -2088599168);
+    // 0x80 as 2s complement
+    assert.eq(i32_8s(), -128);
+    assert.eq(i32_8u(), 128);
+    // 0x8180 as 2s complement
+    assert.eq(i32_16s(), -32384);
+    assert.eq(i32_16u(), 33152);
+
+    // 0x8786858483828180 as 2s complement
+    assert.eq(i64(), -8681104427521506944n);
+    // 0x80 as 2s complement
+    assert.eq(i64_8s(), -128n);
+    assert.eq(i64_8u(), 128n);
+    // 0x8180 as 2s complement
+    assert.eq(i64_16s(), -32384n);
+    assert.eq(i64_16u(), 33152n);
+    // 0x83828180 as 2s complement
+    assert.eq(i64_32s(), -2088599168n);
+    assert.eq(i64_32u(), 2206368128n);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-memory-read.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-memory-read.js
@@ -1,0 +1,32 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1 10)
+    (data (i32.const 0x0) "\x0e\xec\x53\x88")
+    (func (export "test") (param i32) (result i32)
+        (local.get 0)
+        (i32.load8_u)
+        (return)
+    )
+)
+`
+
+function writeStringToMemory(s, m) {
+    let arr = new Uint8Array(m.buffer);
+    for (let i = 0; i < s.length; ++i) {
+        arr[i] = s.charCodeAt(i);
+    }
+}
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, test } = instance.exports
+    writeStringToMemory("shy little frog (@nimonyx)", memory);
+    assert.eq(test(0), 115);
+    assert.eq(test(10), 32);
+    assert.eq(test(17), 64);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-memory-simple.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-memory-simple.js
@@ -1,0 +1,36 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1 10)
+    (data (i32.const 0x0) "\x0e\xec\x53\x88")
+    (func (export "test")
+        (i32.const 0)
+        (i32.const 1717661556)
+        (i32.store)
+        (i32.const 4)
+        (i32.const 117)
+        (i32.store)
+    )
+)
+`
+
+function decodeString(buffer) {
+    let s = "";
+    let i = 0;
+    let arr = new Uint8Array(buffer);
+    while (arr[i] != 0) {
+        s += String.fromCharCode(arr[i++]);
+    }
+    return s;
+}
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, test } = instance.exports
+    test();
+    assert.eq(decodeString(memory.buffer), "toafu");
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-memory-write-sizes.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-memory-write-sizes.js
@@ -1,0 +1,98 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1 10)
+    (func (export "i32") (param i32 i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.store)
+    )
+    (func (export "i32_8") (param i32 i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.store8)
+    )
+    (func (export "i32_16") (param i32 i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.store16)
+    )
+
+    (func (export "i64") (param i32 i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.store)
+    )
+    (func (export "i64_8") (param i32 i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.store8)
+    )
+    (func (export "i64_16") (param i32 i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.store16)
+    )
+    (func (export "i64_32") (param i32 i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.store32)
+    )
+)
+`
+
+function decodeString(buffer) {
+    let s = "";
+    let i = 0;
+    let arr = new Uint8Array(buffer);
+    while (arr[i] != 0) {
+        s += String.fromCharCode(arr[i++]);
+    }
+    return s;
+}
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, 
+        i32, i32_8, i32_16,
+        i64, i64_8, i64_16, i64_32
+    } = instance.exports
+    let writeString = (s) => {
+        for (let i = 0; i < s.length; ++i) {
+            i32_8(i, s.charCodeAt(i));
+        }
+    };
+
+    i32(0, 1953719668);
+    assert.eq(decodeString(memory.buffer), "test");
+
+    i64(0, 8315168158489994617n);
+    assert.eq(decodeString(memory.buffer), "yeonbies");
+
+    i32(0, 2003789165);
+    assert.eq(decodeString(memory.buffer), "meowbies");
+
+    i32_16(0, 65);
+    assert.eq(decodeString(memory.buffer), "A");
+
+    i32_8(0, 26214);
+    assert.eq(decodeString(memory.buffer), "f");
+
+    i64(0, 0n);
+
+    i64_8(0, 8315168158640989549n);
+    assert.eq(decodeString(memory.buffer), "m");
+
+    i64_16(0, 8315168158640989549n);
+    assert.eq(decodeString(memory.buffer), "me");
+
+    i64_32(0, 8315168158640989549n);
+    assert.eq(decodeString(memory.buffer), "meow");
+
+    i64(0, 8315168158640989549n);
+    assert.eq(decodeString(memory.buffer), "meowbies");
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -33,36 +33,6 @@ namespace JSC {
 
 namespace Wasm {
 
-static inline int sizeOfLEB128(uint64_t value)
-{
-    // Efficiency!
-    // Start masking from high bits
-    //      6666 5555 5555 5544 4444 4444 3333 3333 3322 2222 2222 1111 1111 1100 0000 0000
-    //      3210 9876 5432 1098 7654 3210 9876 5432 1098 7654 3210 9876 5432 1098 7654 3210
-    // use: A999 9999 8888 8887 7777 7766 6666 6555 5555 4444 4443 3333 3322 2222 2111 1111
-    //      hex0 hex1 hex2 hex3 hex4 hex5 hex6 hex7 hex8 hex9 hexa hexb hexc hexd hexe hexf
-    //            0123456789abcdef
-    if (value & 0xf000000000000000)
-        return 10;
-    if (value & 0x7f00000000000000)
-        return 9;
-    if (value & 0x00fe000000000000)
-        return 8;
-    if (value & 0x0001fc0000000000)
-        return 7;
-    if (value & 0x000004f800000000)
-        return 6;
-    if (value & 0x00000007f0000000)
-        return 5;
-    if (value & 0x000000000fe00000)
-        return 4;
-    if (value & 0x00000000001fc000)
-        return 3;
-    if (value & 0x0000000000003f80)
-        return 2;
-    return 1;
-}
-
 void FunctionIPIntMetadataGenerator::addBlankSpace(uint32_t size)
 {
     m_metadata.grow(m_metadata.size() + size);
@@ -80,7 +50,7 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength(uint32_t va
     size_t size = m_metadata.size();
     m_metadata.grow(size + 8);
     WRITE_TO_METADATA(m_metadata.data() + size, value, uint32_t);
-    WRITE_TO_METADATA(m_metadata.data() + size + 4, static_cast<uint32_t>(sizeOfLEB128(length)), uint32_t);
+    WRITE_TO_METADATA(m_metadata.data() + size + 4, length, uint32_t);
 }
 
 void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type, uint64_t value, uint32_t length)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -52,6 +52,12 @@ namespace LLInt {
 #define WASM_SLOW_PATH_HIDDEN_DECL(name) \
     WASM_SLOW_PATH_DECL(name) REFERENCED_FROM_ASM WTF_INTERNAL
 
+#define WASM_IPINT_EXTERN_CPP_DECL(name, ...) \
+    extern "C" UGPRPair ipint_extern_##name(Wasm::Instance* instance, __VA_ARGS__)
+
+#define WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(name, ...) \
+    WASM_IPINT_EXTERN_CPP_DECL(name, __VA_ARGS__) REFERENCED_FROM_ASM WTF_INTERNAL
+
 #if ENABLE(WEBASSEMBLY_B3JIT)
 WASM_SLOW_PATH_HIDDEN_DECL(prologue_osr);
 WASM_SLOW_PATH_HIDDEN_DECL(loop_osr);
@@ -73,13 +79,18 @@ WASM_SLOW_PATH_HIDDEN_DECL(memory_init);
 WASM_SLOW_PATH_HIDDEN_DECL(call);
 WASM_SLOW_PATH_HIDDEN_DECL(call_indirect);
 
-extern "C" UGPRPair doWasmIPIntCall(Wasm::Instance* instance, unsigned functionIndex) REFERENCED_FROM_ASM WTF_INTERNAL;
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(callIndirect, CallFrame*, unsigned, unsigned, unsigned);
 
 WASM_SLOW_PATH_HIDDEN_DECL(call_ref);
 WASM_SLOW_PATH_HIDDEN_DECL(tail_call);
 WASM_SLOW_PATH_HIDDEN_DECL(tail_call_indirect);
 WASM_SLOW_PATH_HIDDEN_DECL(call_builtin);
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref);
+
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(get_global_64, unsigned);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(set_global_64, unsigned, uint64_t);
+
 WASM_SLOW_PATH_HIDDEN_DECL(set_global_ref_portable_binding);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait32);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_atomic_wait64);


### PR DESCRIPTION
#### f0224c3ac49698bf7a0408d646bd62283e0f645a
<pre>
Add implementation of IPInt memory and global instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=259460">https://bugs.webkit.org/show_bug.cgi?id=259460</a>
rdar://112802752

Reviewed by Justin Michaud.

Adds in implementations for (i32|i64|f32|f64).(load|store) instructions (including for smaller sizes), and global.get / global.set.

* JSTests/wasm/ipint-tests/ipint-test-global.js: Added.
* JSTests/wasm/ipint-tests/ipint-test-memory-read-sizes.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.export.string_appeared_here.1.10.func.export.string_appeared_here.result.i32.i32.const.0.i32.load.func.export.string_appeared_here.result.i32.i32.const.0.i32.load8_s.func.export.string_appeared_here.result.i32.i32.const.0.i32.load8_u.func.export.string_appeared_here.result.i32.i32.const.0.i32.load16_s.func.export.string_appeared_here.result.i32.i32.const.0.i32.load16_u.func.export.string_appeared_here.result.i64.i32.const.0.i64.load.func.export.string_appeared_here.result.i64.i32.const.0.i64.load8_s.func.export.string_appeared_here.result.i64.i32.const.0.i64.load8_u.func.export.string_appeared_here.result.i64.i32.const.0.i64.load16_s.func.export.string_appeared_here.result.i64.i32.const.0.i64.load16_u.func.export.string_appeared_here.result.i64.i32.const.0.i64.load32_s.func.export.string_appeared_here.result.i64.i32.const.0.i64.load32_u.writeToMemory):
(async test):
* JSTests/wasm/ipint-tests/ipint-test-memory-read.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.export.string_appeared_here.1.10.data.i32.const.0x0.string_appeared_here.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.load8_u.return.writeStringToMemory):
(async test):
* JSTests/wasm/ipint-tests/ipint-test-memory-simple.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.export.string_appeared_here.1.10.data.i32.const.0x0.string_appeared_here.func.export.string_appeared_here.i32.const.0.i32.const.1717661556.i32.store.i32.const.4.i32.const.117.i32.store.decodeString):
(async test):
* JSTests/wasm/ipint-tests/ipint-test-memory-write-sizes.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.export.string_appeared_here.1.10.func.export.string_appeared_here.param.i32.i32.local.0.local.1.i32.store.func.export.string_appeared_here.param.i32.i32.local.0.local.1.i32.store8.func.export.string_appeared_here.param.i32.i32.local.0.local.1.i32.store16.func.export.string_appeared_here.param.i32.i64.local.0.local.1.i64.store.func.export.string_appeared_here.param.i32.i64.local.0.local.1.i64.store8.func.export.string_appeared_here.param.i32.i64.local.0.local.1.i64.store16.func.export.string_appeared_here.param.i32.i64.local.0.local.1.i64.store32.decodeString):
(async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::sizeOfLEB128): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::getLocal):
(JSC::Wasm::IPIntGenerator::setLocal):
(JSC::Wasm::IPIntGenerator::getGlobal):
(JSC::Wasm::IPIntGenerator::setGlobal):
(JSC::Wasm::IPIntGenerator::load):
(JSC::Wasm::IPIntGenerator::store):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::doWasmIPIntCallIndirect):
(JSC::LLInt::ipintGetGlobal64B):
(JSC::LLInt::ipintSetGlobal64B):
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/266306@main">https://commits.webkit.org/266306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8426f22de14021a9bb4a206697925733672d3459

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13786 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15209 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12823 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16294 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/13868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15504 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13639 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11406 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15913 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12161 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11486 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12654 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15540 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12755 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12833 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10720 "Exiting early after 60 failures. 5732 tests run. 60 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13516 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12103 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3537 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16429 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13901 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1551 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12676 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3337 "Passed tests") | 
<!--EWS-Status-Bubble-End-->