### PR TITLE
REGRESSION: fast/history/visited-link-caret-color.html is a consistent image failure

### DIFF
--- a/LayoutTests/fast/history/visited-link-caret-color-expected.html
+++ b/LayoutTests/fast/history/visited-link-caret-color-expected.html
@@ -5,12 +5,14 @@
 #test-container {
     height: 50px;
     width: 50px;
-    overflow: hidden;
 }
 
 #mock-caret {
-    height: inherit;
-    width: inherit;
+    width: 50px;
+    height: 100px;
+    position: absolute;
+    top: 100px;
+    left: 8px;
     background-color: green;
 }
 </style>

--- a/LayoutTests/fast/history/visited-link-caret-color.html
+++ b/LayoutTests/fast/history/visited-link-caret-color.html
@@ -3,8 +3,8 @@
 <head>
 <style>
 #test-container {
-    height: 50px;
-    width: 50px;
+    height: 150px;
+    width: 100px;
     overflow: hidden;
     outline: none;
 }
@@ -15,6 +15,7 @@ a {
     width: inherit;
     transform-origin: left top;
     transform: scale(50, 50);
+    clip-path: inset(1px 99px 0px 0px);
     font-size: 10px; /* Needed for the caret to render in Firefox. */
 }
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1918,7 +1918,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
         return elementStyle.colorByApplyingColorFilter(systemAccentColor);
     }
 
-    return elementStyle.colorByApplyingColorFilter(elementStyle.colorResolvingCurrentColor(elementStyle.caretColor()));
+    return elementStyle.visitedDependentColorWithColorFilter(CSSPropertyCaretColor);
 #else
     RefPtr parentElement = node ? node->parentElement() : nullptr;
     auto* parentStyle = parentElement && parentElement->renderer() ? &parentElement->renderer()->style() : nullptr;


### PR DESCRIPTION
#### eb3e8157099daef872b6b01d9c35d33d1e99ff49
<pre>
REGRESSION: fast/history/visited-link-caret-color.html is a consistent image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=259469">https://bugs.webkit.org/show_bug.cgi?id=259469</a>
rdar://111077813

Reviewed by Megan Gardner and Aditya Keerthi.

When the caret doesn&apos;t need to use the system accent color, it should just get the color the normal
way, which already both accounts for the visited-ness and any color filter.

* LayoutTests/fast/history/visited-link-caret-color-expected.html:
* LayoutTests/fast/history/visited-link-caret-color.html:
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):

Canonical link: <a href="https://commits.webkit.org/266295@main">https://commits.webkit.org/266295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2cacd849ef8ca4950a59daacb0eedc2576cbc57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15440 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15833 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19146 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15477 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10671 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3278 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->