### PR TITLE
Add --profiling-interval to run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ _log = logging.getLogger(__name__)
 class BenchmarkRunner(object):
     name = 'benchmark_runner'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, browser_args=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, profiling_interval=None, browser_args=None):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
         if 'options' not in self._plan:
             self._plan['options'] = {}
@@ -49,6 +49,7 @@ class BenchmarkRunner(object):
         if self._profile_output_dir:
             os.makedirs(self._profile_output_dir, exist_ok=True)
             _log.info('Collecting profiles to {}'.format(self._profile_output_dir))
+        self._profiling_interval = profiling_interval
         self._output_file = output_file
         self._scale_unit = scale_unit
         self._show_iteration_values = show_iteration_values

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -56,7 +56,7 @@ class BrowserDriver(object):
         yield
 
     @contextmanager
-    def profile(self, output_path, profile_filename, timeout=300):
+    def profile(self, output_path, profile_filename, profiling_interval, timeout=300):
         _log.error('The --profile option was specified, but an empty context was called. This run will not be profiled.')
         yield
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -60,6 +60,7 @@ def config_argument_parser():
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
     parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
     parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
+    parser.add_argument('--profiling-interval', default=None, help="Specify the profiling sampling rate.")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--browser-path', help='Specify the path to a non-default copy of the target browser as a path to the .app.')
@@ -100,6 +101,7 @@ def run_benchmark_plan(args, plan):
                                     args.show_iteration_values, args.device_id, args.diagnose_dir,
                                     args.diagnose_dir if args.generate_pgo_profiles else None,
                                     args.diagnose_dir if args.profile else None,
+                                    args.profiling_interval,
                                     args.browser_args)
     runner.execute()
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -23,10 +23,10 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, browser_args=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, profiling_interval=None, browser_args=None):
         self._http_server_driver = HTTPServerDriverFactory.create(platform)
         self._http_server_driver.set_device_id(device_id)
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, browser_args)
+        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, profiling_interval, browser_args)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 
@@ -65,7 +65,7 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
             if '?' not in url:
                 url = url.replace('&', '?', 1)
             if enable_profiling:
-                context = self._browser_driver.profile(self._profile_output_dir, profile_filename)
+                context = self._browser_driver.profile(self._profile_output_dir, profile_filename, self._profiling_interval)
             else:
                 context = NullContext()
             with context:


### PR DESCRIPTION
#### 64ebe5ffcf06e4b81e34e00f8644f2d28fa92086
<pre>
Add --profiling-interval to run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=259470">https://bugs.webkit.org/show_bug.cgi?id=259470</a>

Reviewed by Cameron McCormack.

Added an option to specify the profiling interval such as 1ms and 100us.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.profile):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/266283@main">https://commits.webkit.org/266283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8de0d315b6d3978608f164b69aefb1ecfb5e6f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15839 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13500 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12099 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15482 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12773 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16368 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1537 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->