### PR TITLE
[JSC] Remove ValueProfile from tail calls

### DIFF
--- a/JSTests/stress/arith-abs-on-various-types.js
+++ b/JSTests/stress/arith-abs-on-various-types.js
@@ -77,6 +77,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesAbs) > 3)
         throw "We should have detected abs() was polymorphic and generated a generic version.";
 }

--- a/JSTests/stress/arith-acos-on-various-types.js
+++ b/JSTests/stress/arith-acos-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesACos) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesACos) > 3)
         throw "We should have detected acos() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-acosh-on-various-types.js
+++ b/JSTests/stress/arith-acosh-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesACosh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesACosh) > 3)
         throw "We should have detected acosh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-asin-on-various-types.js
+++ b/JSTests/stress/arith-asin-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesASin) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesASin) > 3)
         throw "We should have detected asin() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-asinh-on-various-types.js
+++ b/JSTests/stress/arith-asinh-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesASinh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesASinh) > 3)
         throw "We should have detected asinh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-atan-on-various-types.js
+++ b/JSTests/stress/arith-atan-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesATan) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesATan) > 3)
         throw "We should have detected atan() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-atanh-on-various-types.js
+++ b/JSTests/stress/arith-atanh-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesATanh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesATanh) > 3)
         throw "We should have detected atanh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-cbrt-on-various-types.js
+++ b/JSTests/stress/arith-cbrt-on-various-types.js
@@ -75,7 +75,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesCbrt) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesCbrt) > 3)
         throw "We should have detected cbrt() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-ceil-on-various-types.js
+++ b/JSTests/stress/arith-ceil-on-various-types.js
@@ -90,6 +90,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesCeil) > 3)
         throw "We should have detected ceil() was polymorphic and generated a generic version.";
 }
@@ -111,6 +112,7 @@ function testAllTypesWithoutNegativeZeroCall() {
                 throw "Failed testAllTypesWithoutNegativeZeroCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesCeil) > 3)
         throw "We should have detected ceil() was polymorphic and generated a generic version.";
 }

--- a/JSTests/stress/arith-clz32-on-various-types.js
+++ b/JSTests/stress/arith-clz32-on-various-types.js
@@ -71,7 +71,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesClz32) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesClz32) > 3)
         throw "We should have detected clz32() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-cos-on-various-types.js
+++ b/JSTests/stress/arith-cos-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesCos) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesCos) > 3)
         throw "We should have detected cos() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-cosh-on-various-types.js
+++ b/JSTests/stress/arith-cosh-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesCosh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesCosh) > 3)
         throw "We should have detected cosh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-expm1-on-various-types.js
+++ b/JSTests/stress/arith-expm1-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesExpm1) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesExpm1) > 3)
         throw "We should have detected expm1() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-floor-on-various-types.js
+++ b/JSTests/stress/arith-floor-on-various-types.js
@@ -90,6 +90,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesFloor) > 3)
         throw "We should have detected floor() was polymorphic and generated a generic version.";
 }

--- a/JSTests/stress/arith-fround-on-various-types.js
+++ b/JSTests/stress/arith-fround-on-various-types.js
@@ -75,7 +75,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesFround) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesFround) > 3)
         throw "We should have detected fround() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-log-on-various-types.js
+++ b/JSTests/stress/arith-log-on-various-types.js
@@ -76,7 +76,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesLog) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesLog) > 3)
         throw "We should have detected log() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-log10-on-various-types.js
+++ b/JSTests/stress/arith-log10-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesLog10) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesLog10) > 3)
         throw "We should have detected log10() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-log2-on-various-types.js
+++ b/JSTests/stress/arith-log2-on-various-types.js
@@ -74,7 +74,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesLog2) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesLog2) > 3)
         throw "We should have detected log2() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-negate-on-various-types.js
+++ b/JSTests/stress/arith-negate-on-various-types.js
@@ -69,6 +69,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesNegate) > 3)
         throw "We should have detected negate was polymorphic and generated a generic version.";
 }

--- a/JSTests/stress/arith-round-on-various-types.js
+++ b/JSTests/stress/arith-round-on-various-types.js
@@ -90,6 +90,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesRound) > 3)
         throw "We should have detected round() was polymorphic and generated a generic version.";
 }
@@ -111,6 +112,7 @@ function testAllTypesWithoutNegativeZeroCall() {
                 throw "Failed testAllTypesWithoutNegativeZeroCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesRound) > 3)
         throw "We should have detected round() was polymorphic and generated a generic version.";
 }

--- a/JSTests/stress/arith-sin-on-various-types.js
+++ b/JSTests/stress/arith-sin-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesSin) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesSin) > 3)
         throw "We should have detected sin() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-sinh-on-various-types.js
+++ b/JSTests/stress/arith-sinh-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesSinh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesSinh) > 3)
         throw "We should have detected sinh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-sqrt-on-various-types.js
+++ b/JSTests/stress/arith-sqrt-on-various-types.js
@@ -71,7 +71,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesSqrt) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesSqrt) > 3)
         throw "We should have detected sqrt() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-tan-on-various-types.js
+++ b/JSTests/stress/arith-tan-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesTan) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesTan) > 3)
         throw "We should have detected tan() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-tanh-on-various-types.js
+++ b/JSTests/stress/arith-tanh-on-various-types.js
@@ -73,7 +73,8 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
-    if (numberOfDFGCompiles(opaqueAllTypesTanh) > 2)
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
+    if (numberOfDFGCompiles(opaqueAllTypesTanh) > 3)
         throw "We should have detected tanh() was polymorphic and generated a generic version.";
 }
 testAllTypesCall();

--- a/JSTests/stress/arith-trunc-on-various-types.js
+++ b/JSTests/stress/arith-trunc-on-various-types.js
@@ -90,6 +90,7 @@ function testAllTypesCall() {
                 throw "Failed testAllTypesCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesTrunc) > 3)
         throw "We should have detected trunc() was polymorphic and generated a generic version.";
 }
@@ -111,6 +112,7 @@ function testAllTypesWithoutNegativeZeroCall() {
                 throw "Failed testAllTypesWithoutNegativeZeroCall for input " + testCaseInput[0] + " expected " + testCaseInput[1] + " got " + output;
         }
     }
+    // Because DoubleRep has three UseKinds we could pick before getting to the generic version
     if (numberOfDFGCompiles(opaqueAllTypesTrunc) > 3)
         throw "We should have detected trunc() was polymorphic and generated a generic version.";
 }

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -97,7 +97,6 @@ op :tail_call_varargs,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        profile: ValueProfile,
     },
     tmps: {
         argCountIncludingThis: unsigned
@@ -302,7 +301,6 @@ op :tail_call,
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
         arrayProfile: ArrayProfile,
-        profile: ValueProfile,
     }
 
 op :call_direct_eval,
@@ -331,7 +329,6 @@ op :tail_call_forward_arguments,
     },
     metadata: {
         callLinkInfo: BaselineCallLinkInfo,
-        profile: ValueProfile,
     }
 
 op_group :CreateInternalFieldObjectOp,

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -523,14 +523,14 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
         LINK(OpProfileControlFlow)
 
         LINK(OpCall, callLinkInfo, profile)
-        LINK(OpTailCall, callLinkInfo, profile)
+        LINK(OpTailCall, callLinkInfo)
         LINK(OpCallDirectEval, callLinkInfo, profile)
         LINK(OpConstruct, callLinkInfo, profile)
         LINK(OpIteratorOpen, callLinkInfo)
         LINK(OpIteratorNext, callLinkInfo)
         LINK(OpCallVarargs, callLinkInfo, profile)
-        LINK(OpTailCallVarargs, callLinkInfo, profile)
-        LINK(OpTailCallForwardArguments, callLinkInfo, profile)
+        LINK(OpTailCallVarargs, callLinkInfo)
+        LINK(OpTailCallForwardArguments, callLinkInfo)
         LINK(OpConstructVarargs, callLinkInfo, profile)
 
         case op_new_array_with_species: {

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -409,6 +409,7 @@ public:
         return result;
     }
 
+    ValueProfile* tryGetValueProfileForBytecodeIndex(BytecodeIndex);
     ValueProfile& valueProfileForBytecodeIndex(BytecodeIndex);
     SpeculatedType valueProfilePredictionForBytecodeIndex(const ConcurrentJSLocker&, BytecodeIndex);
 
@@ -905,7 +906,6 @@ private:
 
     unsigned numberOfNonArgumentValueProfiles() { return totalNumberOfValueProfiles() - numberOfArgumentValueProfiles(); }
     unsigned totalNumberOfValueProfiles() { return m_unlinkedCode->numberOfValueProfiles(); }
-    ValueProfile* tryGetValueProfileForBytecodeIndex(BytecodeIndex);
 
     Seconds timeSinceCreation()
     {

--- a/Source/JavaScriptCore/bytecode/Opcode.h
+++ b/Source/JavaScriptCore/bytecode/Opcode.h
@@ -100,8 +100,6 @@ static constexpr unsigned bitWidthForMaxBytecodeStructLength = WTF::getMSBSetCon
 
 #define FOR_EACH_OPCODE_WITH_VALUE_PROFILE(macro) \
     macro(OpCallVarargs) \
-    macro(OpTailCallVarargs) \
-    macro(OpTailCallForwardArguments) \
     macro(OpConstructVarargs) \
     macro(OpGetByVal) \
     macro(OpEnumeratorGetByVal) \
@@ -119,7 +117,6 @@ static constexpr unsigned bitWidthForMaxBytecodeStructLength = WTF::getMSBSetCon
     macro(OpGetInternalField) \
     macro(OpToThis) \
     macro(OpCall) \
-    macro(OpTailCall) \
     macro(OpCallDirectEval) \
     macro(OpConstruct) \
     macro(OpGetFromScope) \

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1751,8 +1751,32 @@ MethodOfGettingAValueProfile Graph::methodOfGettingAValueProfileFor(Node* curren
                     return MethodOfGettingAValueProfile::lazyOperandValueProfile(node->origin.semantic, node->operand());
             }
 
-            if (node->hasHeapPrediction())
-                return MethodOfGettingAValueProfile::bytecodeValueProfile(node->origin.semantic);
+            if (node->hasHeapPrediction()) {
+                auto instruction = profiledBlock->instructions().at(node->origin.semantic.bytecodeIndex());
+                OpcodeID opcodeID = instruction->opcodeID();
+                switch (opcodeID) {
+                case op_tail_call:
+                case op_tail_call_varargs:
+                case op_tail_call_forward_arguments: {
+                    InlineCallFrame* inlineCallFrame = node->origin.semantic.inlineCallFrame();
+                    if (!inlineCallFrame)
+                        return { }; // TailCall in the outermost function.
+
+                    CodeOrigin* codeOrigin = inlineCallFrame->getCallerSkippingTailCalls();
+                    if (!codeOrigin)
+                        return { };
+
+                    CodeBlock* callerBlock = baselineCodeBlockFor(*codeOrigin);
+                    auto* valueProfile = callerBlock->tryGetValueProfileForBytecodeIndex(codeOrigin->bytecodeIndex());
+                    if (!valueProfile)
+                        return { };
+
+                    return MethodOfGettingAValueProfile::bytecodeValueProfile(*codeOrigin);
+                }
+                default:
+                    return MethodOfGettingAValueProfile::bytecodeValueProfile(node->origin.semantic);
+                }
+            }
 
             if (profiledBlock->hasBaselineJITProfiling()) {
                 if (profiledBlock->binaryArithProfileForBytecodeIndex(node->origin.semantic.bytecodeIndex()))

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1902,7 +1902,6 @@ public:
     bool hasHeapPrediction()
     {
         switch (op()) {
-        case ArithAbs:
         case ArithRound:
         case ArithFloor:
         case ArithCeil:

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1164,7 +1164,7 @@ if ARM64E
     global _llint_function_for_construct_arity_checkTagGateAfter
 end
 
-macro callTargetFunction(opcodeName, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, callee, callPtrTag)
+macro callTargetFunction(opcodeName, size, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, dispatch, callee, callPtrTag)
     if C_LOOP or C_LOOP_WIN
         cloopCallJSFunction callee
     elsif ARM64E
@@ -1232,7 +1232,7 @@ macro prepareForRegularCall(temp1, temp2, temp3, temp4, storeCodeBlock)
 end
 
 macro invokeForRegularCall(opcodeName, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, callee, maybeOldCFR, callPtrTag)
-    callTargetFunction(opcodeName, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, callee, callPtrTag)
+    callTargetFunction(opcodeName, size, opcodeStruct, dispatchAfterRegularCall, valueProfileName, dstVirtualRegister, dispatch, callee, callPtrTag)
 end
 
 # t5 is metadata
@@ -1343,7 +1343,7 @@ macro slowPathForCall(opcodeName, size, opcodeStruct, valueProfileName, dstVirtu
             move calleeFramePtr, sp
             prepareCall(t2, t3, t4, t1, macro(address) end)
         .dontUpdateSP:
-            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, callee, JSEntrySlowPathPtrTag)
+            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, dispatchAfterRegularCall, valueProfileName, dstVirtualRegister, dispatch, callee, JSEntrySlowPathPtrTag)
         end)
 end
 
@@ -2379,24 +2379,17 @@ end)
 # we can't use callOp because we can't pass `call` as the opcode name, since it's an instruction name
 commonCallOp(op_call, _llint_slow_path_call, OpCall, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, macro (getu, metadata)
     arrayProfileForCall(OpCall, getu)
-end)
+end, dispatchAfterRegularCall)
 
+commonCallOp(op_construct, _llint_slow_path_construct, OpConstruct, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, macro (getu, metadata)
+end, dispatchAfterRegularCall)
 
-macro callOp(opcodeName, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, fn)
-    commonCallOp(op_%opcodeName%, _llint_slow_path_%opcodeName%, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, fn)
-end
-
-
-callOp(tail_call, OpTailCall, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall, macro (getu, metadata)
+commonCallOp(op_tail_call, _llint_slow_path_tail_call, OpTailCall, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall, macro (getu, metadata)
     arrayProfileForCall(OpTailCall, getu)
     checkSwitchToJITForEpilogue()
     # reload metadata since checkSwitchToJITForEpilogue() might have trashed t5
     metadata(t5, t0)
-end)
-
-
-callOp(construct, OpConstruct, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, macro (getu, metadata) end)
-
+end, dispatchAfterTailCall)
 
 macro branchIfException(exceptionTarget)
     loadp CodeBlock[cfr], t3
@@ -2408,14 +2401,14 @@ end
 
 
 llintOpWithMetadata(op_call_varargs, OpCallVarargs, macro (size, get, dispatch, metadata, return)
-    doCallVarargs(op_call_varargs, size, get, OpCallVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_call_varargs, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall)
+    doCallVarargs(op_call_varargs, size, get, OpCallVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_call_varargs, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, dispatchAfterRegularCall)
 end)
 
 llintOpWithMetadata(op_tail_call_varargs, OpTailCallVarargs, macro (size, get, dispatch, metadata, return)
     checkSwitchToJITForEpilogue()
     # We lie and perform the tail call instead of preparing it since we can't
     # prepare the frame for a call opcode
-    doCallVarargs(op_tail_call_varargs, size, get, OpTailCallVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_tail_call_varargs, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall)
+    doCallVarargs(op_tail_call_varargs, size, get, OpTailCallVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_tail_call_varargs, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall, dispatchAfterTailCall)
 end)
 
 
@@ -2423,12 +2416,12 @@ llintOpWithMetadata(op_tail_call_forward_arguments, OpTailCallForwardArguments, 
     checkSwitchToJITForEpilogue()
     # We lie and perform the tail call instead of preparing it since we can't
     # prepare the frame for a call opcode
-    doCallVarargs(op_tail_call_forward_arguments, size, get, OpTailCallForwardArguments, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_forward_arguments, _llint_slow_path_tail_call_forward_arguments, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall)
+    doCallVarargs(op_tail_call_forward_arguments, size, get, OpTailCallForwardArguments, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_forward_arguments, _llint_slow_path_tail_call_forward_arguments, prepareForTailCall, invokeForTailCall, prepareForPolymorphicTailCall, prepareForSlowTailCall, dispatchAfterTailCall)
 end)
 
 
 llintOpWithMetadata(op_construct_varargs, OpConstructVarargs, macro (size, get, dispatch, metadata, return)
-    doCallVarargs(op_construct_varargs, size, get, OpConstructVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_construct_varargs, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall)
+    doCallVarargs(op_construct_varargs, size, get, OpConstructVarargs, m_profile, m_dst, dispatch, metadata, _llint_slow_path_size_frame_for_varargs, _llint_slow_path_construct_varargs, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, dispatchAfterRegularCall)
 end)
 
 
@@ -2494,7 +2487,7 @@ _llint_op_call_direct_eval_wide32:
 
 
 commonOp(llint_generic_return_point, macro () end, macro (size)
-    dispatchAfterCall(size, OpCallDirectEval, m_profile, m_dst, macro ()
+    dispatchAfterRegularCall(size, OpCallDirectEval, m_profile, m_dst, macro ()
         dispatchOp(size, op_call_direct_eval)
     end)
 end)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -93,7 +93,7 @@ end
 
 
 # After calling, calling bytecode is claiming input registers are not used.
-macro dispatchAfterCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
+macro dispatchAfterRegularCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadi ArgumentCountIncludingThis + TagOffset[cfr], PC
     if C_LOOP or C_LOOP_WIN
         # On non C_LOOP builds, CSR restore takes care of this.
@@ -106,7 +106,20 @@ macro dispatchAfterCall(size, opcodeStruct, valueProfileName, dstVirtualRegister
     metadata(size, opcodeStruct, t2, t3)
     valueProfile(opcodeStruct, valueProfileName, t2, r1, r0)
     dispatch()
+end
 
+macro dispatchAfterTailCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
+    loadi ArgumentCountIncludingThis + TagOffset[cfr], PC
+    if C_LOOP or C_LOOP_WIN
+        # On non C_LOOP builds, CSR restore takes care of this.
+        loadp CodeBlock[cfr], PB
+        loadp CodeBlock::m_instructionsRawPointer[PB], PB
+    end
+    get(size, opcodeStruct, dstVirtualRegister, t3)
+    storei r1, TagOffset[cfr, t3, 8]
+    storei r0, PayloadOffset[cfr, t3, 8]
+    metadata(size, opcodeStruct, t2, t3)
+    dispatch()
 end
 
 macro cCall2(function)
@@ -2282,7 +2295,7 @@ macro arrayProfileForCall(opcodeStruct, getu)
 end
 
 # t5 holds metadata.
-macro callHelper(opcodeName, slowPath, opcodeStruct, valueProfileName, dstVirtualRegister, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCountIncludingThis)
+macro callHelper(opcodeName, slowPath, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCountIncludingThis)
     getCallee(t3)
 
     loadConstantOrVariable(size, t3, t1, t0)
@@ -2330,10 +2343,10 @@ macro callHelper(opcodeName, slowPath, opcodeStruct, valueProfileName, dstVirtua
     loadp CodeBlock[cfr], t3
     loadp CodeBlock::m_globalObject[t3], t3
     prepareSlowCall()
-    callTargetFunction(%opcodeName%_slow, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
+    callTargetFunction(%opcodeName%_slow, size, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
 end
         
-macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, prologue)
+macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, prologue, dispatchAfterCall)
     llintOpWithMetadata(opcodeName, opcodeStruct, macro (size, get, dispatch, metadata, return)
         metadata(t5, t0)
 
@@ -2354,11 +2367,11 @@ macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, 
         end
         
         # t5 holds metadata
-        callHelper(opcodeName, slowPath, opcodeStruct, m_profile, m_dst, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCount)
+        callHelper(opcodeName, slowPath, opcodeStruct, dispatchAfterCall, m_profile, m_dst, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCount)
     end)
 end
 
-macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, metadata, frameSlowPath, slowPath, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall)
+macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, metadata, frameSlowPath, slowPath, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, dispatchAfterCall)
     callSlowPath(frameSlowPath)
     branchIfException(_llint_throw_from_slow_path_trampoline)
     # calleeFrame in r1
@@ -2412,7 +2425,7 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
             loadp CodeBlock[cfr], t3
             loadp CodeBlock::m_globalObject[t3], t3
             prepareSlowCall()
-            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
+            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
         .dontUpdateSP:
             jmp _llint_throw_from_slow_path_trampoline
         end)
@@ -3079,7 +3092,7 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
     end
 
     metadata(t5, t0)
-    callHelper(op_iterator_open, _llint_slow_path_iterator_open_call, OpIteratorOpen, m_iteratorProfile, m_iterator, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetByIdCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
+    callHelper(op_iterator_open, _llint_slow_path_iterator_open_call, OpIteratorOpen, dispatchAfterRegularCall, m_iteratorProfile, m_iterator, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetByIdCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
 
 .getByIdStart:
     macro storeNextAndDispatch(valueTag, valuePayload)
@@ -3141,7 +3154,7 @@ llintOpWithMetadata(op_iterator_next, OpIteratorNext, macro (size, get, dispatch
 
     # Use m_value slot as a tmp since we are going to write to it later.
     metadata(t5, t0)
-    callHelper(op_iterator_next, _llint_slow_path_iterator_next_call, OpIteratorNext, m_nextResultProfile, m_value, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetDoneCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
+    callHelper(op_iterator_next, _llint_slow_path_iterator_next_call, OpIteratorNext, dispatchAfterRegularCall, m_nextResultProfile, m_value, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetDoneCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
 
 .getDoneStart:
     macro storeDoneAndJmpToGetValue(doneValueTag, doneValuePayload)

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -96,7 +96,7 @@ macro valueProfile(opcodeStruct, profileName, metadata, value)
 end
 
 # After calling, calling bytecode is claiming input registers are not used.
-macro dispatchAfterCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
+macro dispatchAfterRegularCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
     loadPC()
     if C_LOOP or C_LOOP_WIN
         # On non C_LOOP builds, CSR restore takes care of this.
@@ -107,6 +107,19 @@ macro dispatchAfterCall(size, opcodeStruct, valueProfileName, dstVirtualRegister
     storeq r0, [cfr, t1, 8]
     metadata(size, opcodeStruct, t2, t1)
     valueProfile(opcodeStruct, valueProfileName, t2, r0)
+    dispatch()
+end
+
+macro dispatchAfterTailCall(size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch)
+    loadPC()
+    if C_LOOP or C_LOOP_WIN
+        # On non C_LOOP builds, CSR restore takes care of this.
+        loadp CodeBlock[cfr], PB
+        loadp CodeBlock::m_instructionsRawPointer[PB], PB
+    end
+    get(size, opcodeStruct, dstVirtualRegister, t1)
+    storeq r0, [cfr, t1, 8]
+    metadata(size, opcodeStruct, t2, t1)
     dispatch()
 end
 
@@ -2507,7 +2520,7 @@ macro arrayProfileForCall(opcodeStruct, getu)
 end
 
 # t5 holds metadata.
-macro callHelper(opcodeName, slowPath, opcodeStruct, valueProfileName, dstVirtualRegister, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCountIncludingThis)
+macro callHelper(opcodeName, slowPath, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCountIncludingThis)
     getCallee(t1)
 
     loadConstantOrVariable(size, t1, t0)
@@ -2553,10 +2566,10 @@ macro callHelper(opcodeName, slowPath, opcodeStruct, valueProfileName, dstVirtua
     loadp CodeBlock[cfr], t3
     loadp CodeBlock::m_globalObject[t3], t3
     prepareSlowCall()
-    callTargetFunction(%opcodeName%_slow, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
+    callTargetFunction(%opcodeName%_slow, size, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
 end
 
-macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, prologue)
+macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, prologue, dispatchAfterCall)
     llintOpWithMetadata(opcodeName, opcodeStruct, macro (size, get, dispatch, metadata, return)
         metadata(t5, t0)
 
@@ -2577,11 +2590,11 @@ macro commonCallOp(opcodeName, slowPath, opcodeStruct, prepareCall, invokeCall, 
         end
 
         # t5 holds metadata
-        callHelper(opcodeName, slowPath, opcodeStruct, m_profile, m_dst, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCount)
+        callHelper(opcodeName, slowPath, opcodeStruct, dispatchAfterCall, m_profile, m_dst, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, size, dispatch, metadata, getCallee, getArgumentStart, getArgumentCount)
     end)
 end
 
-macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, metadata, frameSlowPath, slowPath, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall)
+macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, metadata, frameSlowPath, slowPath, prepareCall, invokeCall, preparePolymorphic, prepareSlowCall, dispatchAfterCall)
     callSlowPath(frameSlowPath)
     branchIfException(_llint_throw_from_slow_path_trampoline)
     # calleeFrame in r1
@@ -2634,7 +2647,7 @@ macro doCallVarargs(opcodeName, size, get, opcodeStruct, valueProfileName, dstVi
             loadp CodeBlock[cfr], t3
             loadp CodeBlock::m_globalObject[t3], t3
             prepareSlowCall()
-            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
+            callTargetFunction(%opcodeName%_slow, size, opcodeStruct, dispatchAfterCall, valueProfileName, dstVirtualRegister, dispatch, t5, JSEntryPtrTag)
         .dontUpdateSP:
             jmp _llint_throw_from_slow_path_trampoline
         end)
@@ -3271,7 +3284,7 @@ llintOpWithMetadata(op_iterator_open, OpIteratorOpen, macro (size, get, dispatch
     loadi JSCell::m_structureID[t0], t3
     storei t3, OpIteratorOpen::Metadata::m_arrayProfile.m_lastSeenStructureID[t5]
     .done:
-    callHelper(op_iterator_open, _llint_slow_path_iterator_open_call, OpIteratorOpen, m_iteratorProfile, m_iterator, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetByIdCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
+    callHelper(op_iterator_open, _llint_slow_path_iterator_open_call, OpIteratorOpen, dispatchAfterRegularCall, m_iteratorProfile, m_iterator, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetByIdCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
 
 .getByIdStart:
     macro storeNextAndDispatch(value)
@@ -3329,7 +3342,7 @@ llintOpWithMetadata(op_iterator_next, OpIteratorNext, macro (size, get, dispatch
 
     # Use m_value slot as a tmp since we are going to write to it later.
     metadata(t5, t0)
-    callHelper(op_iterator_next, _llint_slow_path_iterator_next_call, OpIteratorNext, m_nextResultProfile, m_value, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetDoneCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
+    callHelper(op_iterator_next, _llint_slow_path_iterator_next_call, OpIteratorNext, dispatchAfterRegularCall, m_nextResultProfile, m_value, prepareForRegularCall, invokeForRegularCall, prepareForPolymorphicRegularCall, prepareForSlowRegularCall, size, gotoGetDoneCheckpoint, metadata, getCallee, getArgumentIncludingThisStart, getArgumentIncludingThisCount)
 
 .getDoneStart:
     macro storeDoneAndJmpToGetValue(doneValue)


### PR DESCRIPTION
#### 92d9b98e0b6c8c155478fe2b6bcb326403b4dbba
<pre>
[JSC] Remove ValueProfile from tail calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=259471">https://bugs.webkit.org/show_bug.cgi?id=259471</a>
rdar://112820068

Reviewed by Keith Miller.

This patch removes ValueProfile from tail calls since they are never used effectively (because of tail calls!).

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
* Source/JavaScriptCore/bytecode/Opcode.h:
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::compileOpCall):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/266328@main">https://commits.webkit.org/266328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7b103a59e132645233ddddfb3cc8300a62dc43f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13563 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15300 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13955 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13730 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/11483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/11661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/12238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/16004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/12736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/12844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/12924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13607 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/12192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/16520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13992 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1561 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/12767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->