### PR TITLE
REGRESSION (iOS 17 Beta): The call is not unmuted automatically after the use of Siri in the middle of the WebRTC call, sometimes incoming audio is lost

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -120,11 +120,13 @@ void RemoteAudioSessionProxy::configurationChanged()
 
 void RemoteAudioSessionProxy::beginInterruption()
 {
+    m_isInterrupted = true;
     connection().send(Messages::RemoteAudioSession::BeginInterruptionRemote(), { });
 }
 
 void RemoteAudioSessionProxy::endInterruption(AudioSession::MayResume mayResume)
 {
+    m_isInterrupted = false;
     connection().send(Messages::RemoteAudioSession::EndInterruptionRemote(mayResume), { });
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -57,6 +57,7 @@ public:
     WebCore::RouteSharingPolicy routeSharingPolicy() const { return m_routeSharingPolicy; }
     size_t preferredBufferSize() const { return m_preferredBufferSize; }
     bool isActive() const { return m_active; }
+    bool isInterrupted() const { return m_isInterrupted; }
 
     void configurationChanged();
     void beginInterruption();
@@ -93,6 +94,7 @@ private:
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     size_t m_preferredBufferSize { 0 };
     bool m_active { false };
+    bool m_isInterrupted { false };
     bool m_isPlayingToBluetoothOverrideChanged { false };
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -143,7 +143,7 @@ bool RemoteAudioSessionProxyManager::tryToSetActiveForProcess(RemoteAudioSession
 
     size_t activeProxyCount { 0 };
     for (auto& otherProxy : m_proxies) {
-        if (otherProxy.isActive())
+        if (otherProxy.isActive() && !otherProxy.isInterrupted())
             ++activeProxyCount;
     }
 


### PR DESCRIPTION
#### 727f9c1406c6504a7fc77fe79671e91f02f3ba2e
<pre>
REGRESSION (iOS 17 Beta): The call is not unmuted automatically after the use of Siri in the middle of the WebRTC call, sometimes incoming audio is lost
<a href="https://bugs.webkit.org/show_bug.cgi?id=259368">https://bugs.webkit.org/show_bug.cgi?id=259368</a>
rdar://112636992

Reviewed by Eric Carlson.

WebProcess might want to try active its audio session when being interrupted.
In case GPUProcess tells it succeeded activating, it will uninterrupt and restart capturing microphone.

RemoteAudioSessionProxyManager::tryToSetActiveForProcess may return true to activation even though the underlying shared session was not properly activated.
This happens in case there is one RemoteAudioSessionProxy which is active but interrupted.
In that case, RemoteAudioSessionProxyManager::tryToSetActiveForProcess would think everything is fine.

To prevent this, RemoteAudioSessionProxy is now tracking whether it is interrupted or not.
If it is active but interrupted, RemoteAudioSessionProxyManager will not consider it is actually active and will try to activate the underlying audio session.
If activation succeeds, uninterruption will follow.
If activation fails, uninterruption will be further delayed.

Manually tested.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
(WebKit::RemoteAudioSessionProxy::isInterrupted const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess):

Canonical link: <a href="https://commits.webkit.org/266293@main">https://commits.webkit.org/266293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/966ea7e4a1208ec44289ebcd775e120bdb6de657

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13793 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15451 "127 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14237 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15852 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11525 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19156 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10667 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12050 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3277 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12622 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->