### PR TITLE
Disable builtInNotification endpoints when builtInNotificationsEnabled is set to false

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6316,6 +6316,8 @@ imported/w3c/web-platform-tests/css/css-text/text-spacing/tentative/parsing [ Sk
 # This test is checking that WebContent is terminated when performing an invalid IPC operation
 ipc/restrictedendpoints/no-test-only-ipc-expected-crash.html [ Crash ]
 ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html [ Crash ]
+[ Debug ] ipc/restrictedendpoints/deny-access-webPush.html [ Crash ]
+[ Release ] ipc/restrictedendpoints/deny-access-webPush.html [ Skip ]
 
 # Early hints require network callbacks that are only present in macOS 12 / iOS 15 or greater.
 http/wpt/loading/early-hints [ Skip ]

--- a/LayoutTests/ipc/restrictedendpoints/deny-access-webPush.html
+++ b/LayoutTests/ipc/restrictedendpoints/deny-access-webPush.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true BuiltInNotificationsEnabled=false ] -->
+<title>Test that we can only call into WebPush endpoints in Network Process if BuiltInNotificationsEnabled is set</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<script>
+
+if (window.IPC) {
+    buf = new Uint8Array();
+    IPC.sendMessage('Networking',IPC.webPageProxyID,IPC.messages.NotificationManagerMessageHandler_PageWasNotifiedOfNotificationPermission.name,[]);
+}
+</script>
+</body>

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -332,6 +332,9 @@ void NetworkProcess::initializeNetworkProcess(NetworkProcessCreationParameters&&
 
     setPrivateClickMeasurementEnabled(parameters.enablePrivateClickMeasurement);
     m_ftpEnabled = parameters.ftpEnabled;
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    m_builtInNotificationsEnabled = parameters.builtInNotificationsEnabled;
+#endif
 
     for (auto [processIdentifier, domain] : parameters.allowedFirstPartiesForCookies) {
         if (auto* connection = webProcessConnection(processIdentifier))

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -390,6 +390,7 @@ public:
 #endif
 
     bool ftpEnabled() const { return m_ftpEnabled; }
+    bool builtInNotificationsEnabled() const { return m_builtInNotificationsEnabled; }
 
 #if ENABLE(SERVICE_WORKER)
     void getPendingPushMessages(PAL::SessionID, CompletionHandler<void(const Vector<WebPushMessage>&)>&&);
@@ -573,6 +574,7 @@ private:
 
     bool m_privateClickMeasurementEnabled { true };
     bool m_ftpEnabled { false };
+    bool m_builtInNotificationsEnabled { false };
     bool m_isSuspended { false };
     bool m_didSyncCookiesForClose { false };
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -76,6 +76,9 @@ struct NetworkProcessCreationParameters {
 
     bool enablePrivateClickMeasurement { true };
     bool ftpEnabled { false };
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    bool builtInNotificationsEnabled { false };
+#endif
 
     Vector<WebsiteDataStoreParameters> websiteDataStoreParameters;
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -54,6 +54,9 @@ struct WebKit::NetworkProcessCreationParameters {
 
     bool enablePrivateClickMeasurement
     bool ftpEnabled
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    bool builtInNotificationsEnabled
+#endif
 
     Vector<WebKit::WebsiteDataStoreParameters> websiteDataStoreParameters
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -192,10 +192,6 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
         parameters.serviceWorkerProcessTerminationDelayEnabled
     };
 #endif
-
-#if ENABLE(BUILT_IN_NOTIFICATIONS)
-    m_networkProcess->addMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), m_sessionID.toUInt64(), m_notificationManager);
-#endif
 }
 
 NetworkSession::~NetworkSession()
@@ -205,10 +201,6 @@ NetworkSession::~NetworkSession()
 #endif
     for (auto& loader : std::exchange(m_keptAliveLoads, { }))
         loader->abort();
-
-#if ENABLE(BUILT_IN_NOTIFICATIONS)
-    m_networkProcess->removeMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), m_sessionID.toUInt64());
-#endif
 }
 
 #if ENABLE(TRACKING_PREVENTION)

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -48,7 +48,6 @@ public:
     virtual void didDestroyNotification(const WTF::UUID& notificationID) = 0;
     virtual void pageWasNotifiedOfNotificationPermission() = 0;
 
-private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 };

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -98,6 +98,10 @@
 #include "LegacyCustomProtocolManagerClient.h"
 #endif
 
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+#include <WebCore/DeprecatedGlobalSettings.h>
+#endif
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, connection())
 
 namespace WebKit {
@@ -225,6 +229,10 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 
 #if !PLATFORM(COCOA)
     parameters.enablePrivateClickMeasurement = false;
+#endif
+
+#if ENABLE(BUILT_IN_NOTIFICATIONS)
+    parameters.builtInNotificationsEnabled = DeprecatedGlobalSettings::builtInNotificationsEnabled();
 #endif
 
     parameters.allowedFirstPartiesForCookies = WebProcessProxy::allowedFirstPartiesForCookies();


### PR DESCRIPTION
#### e68eac0ee93ab3d5f87e6bad5e063c86508511da
<pre>
Disable builtInNotification endpoints when builtInNotificationsEnabled is set to false
<a href="https://bugs.webkit.org/show_bug.cgi?id=259443">https://bugs.webkit.org/show_bug.cgi?id=259443</a>
rdar://112769420

Reviewed by Alex Christensen.

When builtInNotificationsEnabled is set to false, we don&apos;t need to expose the
endpoints associated with the feature. This change syncs the feature state to the
network process and checks the endpoints is only reached when it&apos;s enabled.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/restrictedendpoints/deny-access-webPush.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::didReceiveMessage):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::m_shouldAcceptInsecureCertificatesForWebSockets):
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):

Canonical link: <a href="https://commits.webkit.org/266312@main">https://commits.webkit.org/266312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c7ee94053b4d8a37e55bd2a79f6ea924a79ea97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13422 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15456 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14241 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15857 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19160 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15493 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10672 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/11980 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->