### PR TITLE
Support title attribute for pattern validation errors

### DIFF
--- a/LayoutTests/fast/forms/validation-messages-expected.txt
+++ b/LayoutTests/fast/forms/validation-messages-expected.txt
@@ -6,6 +6,7 @@ Required file input:
 Required email input:
 Required url input:
 Required input with pattern:
+Required input with pattern and title:
 Required input with minlength=100:
 Required range with min=5:
 Required range with max=5:
@@ -21,6 +22,7 @@ PASS message is "Select a file"
 PASS message is "Enter an email address"
 PASS message is "Enter a URL"
 PASS message is "Match the requested format"
+PASS message is "Match the requested format: UI testing is awesome"
 PASS message is "Use at least 100 characters"
 PASS message is "Value must be greater than or equal to 5"
 PASS message is "Value must be less than or equal to 5"

--- a/LayoutTests/fast/forms/validation-messages.html
+++ b/LayoutTests/fast/forms/validation-messages.html
@@ -27,6 +27,16 @@
   Required input with pattern: <input type="text" value="1" pattern="[a-z]" required><input id="input_with_pattern_submit" type="submit">
 </form>
 <form>
+  Required input with pattern and title: <input type="text" value="1" pattern="[a-z]" required title="   
+  UI
+  
+  testing
+  
+      is
+      
+          awesome    "><input id="input_with_pattern_title_submit" type="submit">
+</form>
+<form>
   Required input with minlength=100: <input type="text" minlength=100 id="field_with_minlength" required><input id="input_with_minlength_submit" type="submit">
 </form>
 <form>
@@ -52,6 +62,7 @@ var tests = [
     ['required_email_submit', 'Enter an email address'],
     ['required_url_submit', 'Enter a URL'],
     ['input_with_pattern_submit', 'Match the requested format'],
+    ['input_with_pattern_title_submit', 'Match the requested format: UI testing is awesome'],
     ['input_with_minlength_submit', 'Use at least 100 characters'],
     ['range_with_min_submit', 'Value must be greater than or equal to 5'],
     ['range_with_max_submit', 'Value must be less than or equal to 5'],

--- a/LayoutTests/platform/ios-wk2/fast/forms/validation-messages-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/forms/validation-messages-expected.txt
@@ -6,6 +6,7 @@ Required file input:
 Required email input:
 Required url input:
 Required input with pattern:
+Required input with pattern and title:
 Required input with minlength=100:
 Required range with min=5:
 Required range with max=5:
@@ -21,6 +22,7 @@ PASS message is "Select a file"
 PASS message is "Enter an email address"
 PASS message is "Enter a URL"
 PASS message is "Match the requested format"
+PASS message is "Match the requested format: UI testing is awesome"
 FAIL message should be Use at least 100 characters. Was Fill out this field.
 PASS message is "Value must be greater than or equal to 5"
 PASS message is "Value must be less than or equal to 5"

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -757,6 +757,12 @@
 /* Validation message for input form controls requiring a constrained value according to pattern */
 "Match the requested format" = "Match the requested format";
 
+/* Validation message for input form controls requiring a constrained value according to pattern followed by a website-provided description of the pattern */
+"Match the requested format: %@" = "Match the requested format: %@";
+
+/* Validation message for input form controls requiring a constrained value according to pattern followed by a website-provided description of the pattern */
+"Match the requested format: %s" = "Match the requested format: %s";
+
 /* Malware confirmation dialog */
 "Merely visiting a site is sufficient for malware to install itself and harm your computer." = "Merely visiting a site is sufficient for malware to install itself and harm your computer.";
 

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -564,8 +564,12 @@ String InputType::validationMessage() const
     if (typeMismatch())
         return typeMismatchText();
 
-    if (patternMismatch(value))
-        return validationMessagePatternMismatchText();
+    if (patternMismatch(value)) {
+        auto title = element()->attributeWithoutSynchronization(HTMLNames::titleAttr).string().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
+        if (title.isEmpty())
+            return validationMessagePatternMismatchText();
+        return validationMessagePatternMismatchText(title);
+    }
 
     if (element()->tooShort())
         return validationMessageTooShortText(value.length(), element()->minLength());

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -1195,6 +1195,18 @@ String validationMessagePatternMismatchText()
     return WEB_UI_STRING("Match the requested format", "Validation message for input form controls requiring a constrained value according to pattern");
 }
 
+String validationMessagePatternMismatchText(const String& title)
+{
+#if PLATFORM(COCOA)
+    return WEB_UI_FORMAT_CFSTRING("Match the requested format: %@", "Validation message for input form controls requiring a constrained value according to pattern followed by a website-provided description of the pattern", title.createCFString().get());
+#elif USE(GLIB)
+    return WEB_UI_FORMAT_STRING("Match the requested format: %s", "Validation message for input form controls requiring a constrained value according to pattern followed by a website-provided description of the pattern", title.utf8().data());
+#else
+    UNUSED_PARAM(title);
+    return validationMessagePatternMismatchText();
+#endif
+}
+
 #if !PLATFORM(GTK)
 String validationMessageTooShortText(int, int minLength)
 {

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -320,6 +320,7 @@ namespace WebCore {
     String validationMessageTypeMismatchForMultipleEmailText();
     String validationMessageTypeMismatchForURLText();
     String validationMessagePatternMismatchText();
+    String validationMessagePatternMismatchText(const String& title);
     String validationMessageTooShortText(int valueLength, int minLength);
     String validationMessageTooLongText(int valueLength, int maxLength);
     String validationMessageRangeUnderflowText(const String& minimum);


### PR DESCRIPTION
#### 2d36f436ba4efb45b5e3f3826637e671c9b13eaa
<pre>
Support title attribute for pattern validation errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=258301">https://bugs.webkit.org/show_bug.cgi?id=258301</a>
rdar://111394402

Reviewed by Aditya Keerthi.

The HTML Standard suggests that the title attribute can be used to
augment the message presented to the end user. As this is not trusted
UI space this seems reasonable (JavaScript has full control over this
UI) and also matches other browsers.

* LayoutTests/fast/forms/validation-messages-expected.txt:
* LayoutTests/fast/forms/validation-messages.html:
* LayoutTests/platform/ios-wk2/fast/forms/validation-messages-expected.txt:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::validationMessage const):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::validationMessagePatternMismatchText):
* Source/WebCore/platform/LocalizedStrings.h:

Canonical link: <a href="https://commits.webkit.org/266311@main">https://commits.webkit.org/266311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfdf34ef5cab4bddbeaf858bc1dfc0939eeb9ba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12854 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15955 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19242 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15577 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10759 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12060 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12718 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->