### PR TITLE
Sync 'naturalWidth' and 'naturalHeight' with Spec and change from 'int' to 'unsigned'

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -596,20 +596,20 @@ float HTMLImageElement::effectiveImageDevicePixelRatio() const
     return m_imageDevicePixelRatio;
 }
 
-int HTMLImageElement::naturalWidth() const
+unsigned HTMLImageElement::naturalWidth() const
 {
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).width();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).width().toUnsigned();
 }
 
-int HTMLImageElement::naturalHeight() const
+unsigned HTMLImageElement::naturalHeight() const
 {
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).height();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(renderer(), effectiveImageDevicePixelRatio()).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -64,8 +64,8 @@ public:
     WEBCORE_EXPORT unsigned width();
     WEBCORE_EXPORT unsigned height();
 
-    WEBCORE_EXPORT int naturalWidth() const;
-    WEBCORE_EXPORT int naturalHeight() const;
+    WEBCORE_EXPORT unsigned naturalWidth() const;
+    WEBCORE_EXPORT unsigned naturalHeight() const;
     const URL& currentURL() const { return m_currentURL; }
     const AtomString& currentSrc() const { return m_currentSrc; }
 

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -36,8 +36,8 @@
     [CEReactions=NotNeeded, Reflect] attribute boolean isMap;
     [CEReactions=NotNeeded] attribute unsigned long width;
     [CEReactions=NotNeeded] attribute unsigned long height;
-    readonly attribute long naturalHeight;
-    readonly attribute long naturalWidth;
+    readonly attribute unsigned long naturalHeight;
+    readonly attribute unsigned long naturalWidth;
     readonly attribute boolean complete;
     readonly attribute USVString currentSrc;
     [CEReactions=NotNeeded, EnabledBySetting=ReferrerPolicyAttributeEnabled, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;


### PR DESCRIPTION
#### e7d267d296c7cf9ae1250e2b0ba55b541a5965f5
<pre>
Sync &apos;naturalWidth&apos; and &apos;naturalHeight&apos; with Spec and change from &apos;int&apos; to &apos;unsigned&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=253364">https://bugs.webkit.org/show_bug.cgi?id=253364</a>
rdar://problem/106580337

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web-Spec [1] by changing &apos;naturalWidth&apos;
and &apos;naturalHeight&apos; from &apos;int&apos; to &apos;unsigned&apos;.

[1] <a href="https://html.spec.whatwg.org/#the-img-element">https://html.spec.whatwg.org/#the-img-element</a>

* Source/WebCore/html/HTMLImageElement.cpp:
(HTMLImageElement::naturalWidth): Change to &apos;unsigned&apos; and return to have &apos;toUnsigned&apos;
(HTMLImageElement::naturalHeight): Ditto
* Source/WebCore/html/HTMLImageElement.h: Update definition to &apos;unsigned&apos; from &apos;int&apos; for &apos;naturalWidth&apos; and &apos;naturalHeight&apos;
* Source/WebCore/html/HTMLImageElement.idl: Update &apos;naturalWidth&apos; and &apos;naturalHeight&apos; to have &apos;unsigned&apos;

Canonical link: <a href="https://commits.webkit.org/266302@main">https://commits.webkit.org/266302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/157b455093304a77cc5f6814246cad8c753cac9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15195 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15489 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15899 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19191 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15524 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10704 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12089 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->