### PR TITLE
Use WeakHashMap for m_videoElements in VideoFullscreenManager

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -38,6 +38,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakHashMap.h>
 
 namespace IPC {
 class Connection;
@@ -195,7 +196,7 @@ protected:
 
     WeakPtr<WebPage> m_page;
     Ref<PlaybackSessionManager> m_playbackSessionManager;
-    HashMap<WebCore::HTMLVideoElement*, PlaybackSessionContextIdentifier> m_videoElements;
+    WeakHashMap<WebCore::HTMLVideoElement, PlaybackSessionContextIdentifier, WebCore::WeakPtrImplWithEventTargetData> m_videoElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -214,7 +214,7 @@ void VideoFullscreenManager::removeContext(PlaybackSessionContextIdentifier cont
     model->setVideoElement(nullptr);
     model->removeClient(*interface);
     interface->invalidate();
-    m_videoElements.remove(videoElement.get());
+    m_videoElements.remove(*videoElement);
     m_contextMap.remove(contextId);
 }
 
@@ -283,7 +283,7 @@ bool VideoFullscreenManager::supportsVideoFullscreenStandby() const
 void VideoFullscreenManager::setupRemoteLayerHosting(HTMLVideoElement& videoElement)
 {
     auto contextId = m_playbackSessionManager->contextIdForMediaElement(videoElement);
-    auto addResult = m_videoElements.add(&videoElement, contextId);
+    auto addResult = m_videoElements.add(videoElement, contextId);
     if (addResult.isNewEntry)
         m_playbackSessionManager->sendLogIdentifierForMediaElement(videoElement);
     ASSERT(addResult.iterator->value == contextId);
@@ -328,7 +328,7 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
     INFO_LOG(LOGIDENTIFIER);
 
     auto contextId = m_playbackSessionManager->contextIdForMediaElement(videoElement);
-    auto addResult = m_videoElements.add(&videoElement, contextId);
+    auto addResult = m_videoElements.add(videoElement, contextId);
     if (addResult.isNewEntry)
         m_playbackSessionManager->sendLogIdentifierForMediaElement(videoElement);
     ASSERT(addResult.iterator->value == contextId);
@@ -410,9 +410,9 @@ void VideoFullscreenManager::exitVideoFullscreenForVideoElement(HTMLVideoElement
 {
     INFO_LOG(LOGIDENTIFIER);
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(&videoElement));
+    ASSERT(m_videoElements.contains(videoElement));
 
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     auto& interface = ensureInterface(contextId);
     if (interface.animationState() != VideoFullscreenInterfaceContext::AnimationType::None) {
         completionHandler(false);
@@ -440,12 +440,12 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
     INFO_LOG(LOGIDENTIFIER);
 
     ASSERT(m_page);
-    ASSERT(m_videoElements.contains(&videoElement));
+    ASSERT(m_videoElements.contains(videoElement));
 
     if (m_videoElementInPictureInPicture == &videoElement)
         m_videoElementInPictureInPicture = nullptr;
 
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     if (!contextId.isValid()) {
         // We have somehow managed to be asked to exit video fullscreen
         // for a video element which was either never in fullscreen or
@@ -743,7 +743,7 @@ void VideoFullscreenManager::updateTextTrackRepresentationForVideoElement(WebCor
 {
     if (!m_page)
         return;
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationUpdate(contextId, WTFMove(textTrack)));
 }
 
@@ -751,7 +751,7 @@ void VideoFullscreenManager::setTextTrackRepresentationContentScaleForVideoEleme
 {
     if (!m_page)
         return;
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationSetContentsScale(contextId, scale));
 
 }
@@ -760,7 +760,7 @@ void VideoFullscreenManager::setTextTrackRepresentationIsHiddenForVideoElement(W
 {
     if (!m_page)
         return;
-    auto contextId = m_videoElements.get(&videoElement);
+    auto contextId = m_videoElements.get(videoElement);
     m_page->send(Messages::VideoFullscreenManagerProxy::TextTrackRepresentationSetHidden(contextId, hidden));
 
 }


### PR DESCRIPTION
#### bb1cedbd987226aa5c5115d690ef5576808fbc0e
<pre>
Use WeakHashMap for m_videoElements in VideoFullscreenManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=259498">https://bugs.webkit.org/show_bug.cgi?id=259498</a>

Reviewed by Eric Carlson.

Use WeakHasMap instead of HashMap of raw pointers.

* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::removeContext):
(WebKit::VideoFullscreenManager::setupRemoteLayerHosting):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoFullscreenManager::updateTextTrackRepresentationForVideoElement):
(WebKit::VideoFullscreenManager::setTextTrackRepresentationContentScaleForVideoElement):
(WebKit::VideoFullscreenManager::setTextTrackRepresentationIsHiddenForVideoElement):

Canonical link: <a href="https://commits.webkit.org/266304@main">https://commits.webkit.org/266304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ac0bdc2821d84e72be03682af622b27d8515eba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12817 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15499 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13633 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14284 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15907 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11571 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12324 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15535 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12827 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12097 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16423 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1549 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->