### PR TITLE
Remove unnecessary headers including other headers

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1897,14 +1897,28 @@ inline auto copyToVectorOf(const Collection& collection) -> Vector<DestinationIt
 }
 
 template<typename Collection>
-struct CopyToVectorResult {
+struct CopyOrMoveToVectorResult {
     using Type = typename std::remove_cv<typename CollectionInspector<Collection>::SourceItemType>::type;
 };
 
 template<typename Collection>
-inline auto copyToVector(const Collection& collection) -> Vector<typename CopyToVectorResult<Collection>::Type>
+inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> copyToVector(const Collection& collection)
 {
-    return copyToVectorOf<typename CopyToVectorResult<Collection>::Type>(collection);
+    return copyToVectorOf<typename CopyOrMoveToVectorResult<Collection>::Type>(collection);
+}
+
+template<typename DestinationItemType, typename Collection>
+inline auto moveToVectorOf(Collection&& collection) -> Vector<DestinationItemType>
+{
+    return WTF::map(collection, [] (auto&& v) -> DestinationItemType {
+        return WTFMove(v);
+    });
+}
+
+template<typename Collection>
+inline Vector<typename CopyOrMoveToVectorResult<Collection>::Type> moveToVector(Collection&& collection)
+{
+    return moveToVectorOf<typename CopyOrMoveToVectorResult<Collection>::Type>(collection);
 }
 
 } // namespace WTF

--- a/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp
@@ -30,6 +30,7 @@
 #include "SQLiteStorageArea.h"
 #include "StorageAreaRegistry.h"
 #include <WebCore/SecurityOriginData.h>
+#include <wtf/FileSystem.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1512,4 +1512,8 @@ const char* errorAsString(Error error)
     return "";
 }
 
+Connection::DecoderOrError::DecoderOrError(DecoderOrError&&) = default;
+
+Connection::DecoderOrError::~DecoderOrError() = default;
+
 } // namespace IPC

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include "Decoder.h"
-#include "Encoder.h"
 #include "MessageReceiveQueueMap.h"
 #include "MessageReceiver.h"
 #include "ReceiverMatcher.h"
@@ -148,6 +146,8 @@ template<typename AsyncReplyResult> struct AsyncReplyError {
     static AsyncReplyResult create() { return AsyncReplyResult { }; };
 };
 
+class Decoder;
+class Encoder;
 class MachMessage;
 class UnixMessage;
 class WorkQueueMessageReceiver;
@@ -331,6 +331,8 @@ public:
         {
             ASSERT(error != Error::NoError);
         }
+        DecoderOrError(DecoderOrError&&);
+        ~DecoderOrError();
     };
 
     static RefPtr<Connection> connection(UniqueID);

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -27,6 +27,7 @@
 #import "Connection.h"
 
 #import "DataReference.h"
+#import "Encoder.h"
 #import "IPCUtilities.h"
 #import "ImportanceAssertion.h"
 #import "Logging.h"

--- a/Source/WebKit/Platform/IPC/unix/UnixMessage.h
+++ b/Source/WebKit/Platform/IPC/unix/UnixMessage.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "Attachment.h"
+#include "Encoder.h"
 #include <wtf/Vector.h>
 
 namespace IPC {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -33,16 +33,13 @@
 #include "RemoteLayerBackingStore.h"
 #include "TransactionID.h"
 #include <WebCore/Color.h>
-#include <WebCore/FilterOperations.h>
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/MediaPlayerEnums.h>
-#include <WebCore/Model.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/ScrollTypes.h>
-#include <WebCore/TransformationMatrix.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/text/StringHash.h>
@@ -56,11 +53,6 @@
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/AcceleratedEffectValues.h>
 #endif
-
-namespace IPC {
-class Decoder;
-class Encoder;
-}
 
 namespace WebKit {
 
@@ -93,18 +85,24 @@ public:
             WebCore::FloatSize initialSize;
             WebCore::FloatSize naturalSize;
         };
-
-        WebCore::PlatformLayerIdentifier layerID;
-        WebCore::PlatformCALayer::LayerType type { WebCore::PlatformCALayer::LayerTypeLayer };
-        std::optional<VideoElementData> videoElementData;
-        std::variant<
+        using AdditionalData = std::variant<
             NoAdditionalData, // PlatformCALayerRemote and PlatformCALayerRemoteTiledBacking
             CustomData, // PlatformCALayerRemoteCustom
 #if ENABLE(MODEL_ELEMENT)
             Ref<WebCore::Model>, // PlatformCALayerRemoteModelHosting
 #endif
             WebCore::LayerHostingContextIdentifier // PlatformCALayerRemoteHost
-        > additionalData;
+        >;
+
+        WebCore::PlatformLayerIdentifier layerID;
+        WebCore::PlatformCALayer::LayerType type { WebCore::PlatformCALayer::LayerTypeLayer };
+        std::optional<VideoElementData> videoElementData;
+        AdditionalData additionalData;
+
+        LayerCreationProperties();
+        LayerCreationProperties(WebCore::PlatformLayerIdentifier, WebCore::PlatformCALayer::LayerType, std::optional<VideoElementData>&&, AdditionalData&&);
+        LayerCreationProperties(LayerCreationProperties&&);
+        LayerCreationProperties& operator=(LayerCreationProperties&&);
 
         std::optional<WebCore::LayerHostingContextIdentifier> hostIdentifier() const;
         uint32_t hostingContextID() const;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -796,6 +796,18 @@ ChangedLayers& ChangedLayers::operator=(ChangedLayers&&) = default;
 ChangedLayers::ChangedLayers(LayerPropertiesMap&& changedLayerProperties)
     : changedLayerProperties(WTFMove(changedLayerProperties)) { }
 
+RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties() = default;
+
+RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties(LayerCreationProperties&&) = default;
+
+auto RemoteLayerTreeTransaction::LayerCreationProperties::operator=(LayerCreationProperties&&) -> LayerCreationProperties& = default;
+
+RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties(WebCore::PlatformLayerIdentifier layerID, WebCore::PlatformCALayer::LayerType type, std::optional<RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData>&& videoElementData, RemoteLayerTreeTransaction::LayerCreationProperties::AdditionalData&& additionalData)
+    : layerID(layerID)
+    , type(type)
+    , videoElementData(WTFMove(videoElementData))
+    , additionalData(WTFMove(additionalData)) { }
+
 std::optional<WebCore::LayerHostingContextIdentifier> RemoteLayerTreeTransaction::LayerCreationProperties::hostIdentifier() const
 {
     if (auto* identifier = std::get_if<WebCore::LayerHostingContextIdentifier>(&additionalData))

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AuxiliaryProcessProxy.h"
 
+#include "AuxiliaryProcessCreationParameters.h"
 #include "AuxiliaryProcessMessages.h"
 #include "Logging.h"
 #include "OverrideLanguages.h"
@@ -476,7 +477,7 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
     return parameters;
 }
 
-std::optional<SandboxExtension::Handle> AuxiliaryProcessProxy::createMobileGestaltSandboxExtensionIfNeeded() const
+std::optional<SandboxExtensionHandle> AuxiliaryProcessProxy::createMobileGestaltSandboxExtensionIfNeeded() const
 {
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     if (_MGCacheValid())

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -25,13 +25,11 @@
 
 #pragma once
 
-#include "AuxiliaryProcessCreationParameters.h"
 #include "Connection.h"
 #include "MessageReceiverMap.h"
 #include "ProcessLauncher.h"
 #include "ProcessThrottler.h"
 #include "ResponsivenessTimer.h"
-#include "SandboxExtension.h"
 #include <WebCore/ProcessIdentifier.h>
 #include <memory>
 #include <wtf/ProcessID.h>
@@ -39,10 +37,17 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/UniqueRef.h>
 
+namespace WebCore {
+class SharedBuffer;
+}
+
 namespace WebKit {
 
 class ProcessThrottler;
 class ProcessAssertion;
+class SandboxExtensionHandle;
+
+struct AuxiliaryProcessCreationParameters;
 
 class AuxiliaryProcessProxy : public ThreadSafeRefCounted<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>, public ResponsivenessTimer::Client, private ProcessLauncher::Client, public IPC::Connection::Client {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcessProxy);
@@ -161,7 +166,7 @@ public:
 
     bool operator==(const AuxiliaryProcessProxy& other) const { return (this == &other); }
 
-    std::optional<SandboxExtension::Handle> createMobileGestaltSandboxExtensionIfNeeded() const;
+    std::optional<SandboxExtensionHandle> createMobileGestaltSandboxExtensionIfNeeded() const;
 
 #if USE(RUNNINGBOARD)
     void wakeUpTemporarilyForIPC();

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "AuxiliaryProcessProxy.h"
 
+#import <WebCore/SharedBuffer.h>
 #import <WebCore/WebMAudioUtilitiesCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -29,7 +29,6 @@
 
 #include "AuxiliaryProcessProxy.h"
 #include "ProcessLauncher.h"
-#include "ProcessTerminationReason.h"
 #include "ProcessThrottler.h"
 #include "ProcessThrottlerClient.h"
 #include "ShareableBitmap.h"
@@ -58,8 +57,12 @@ class SecurityOriginData;
 
 namespace WebKit {
 
+enum class ProcessTerminationReason : uint8_t;
+
+class SandboxExtensionHandle;
 class WebProcessProxy;
 class WebsiteDataStore;
+
 struct GPUProcessConnectionParameters;
 struct GPUProcessCreationParameters;
 
@@ -123,7 +126,7 @@ public:
 
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     bool hasSentGPUToolsSandboxExtensions() const { return m_hasSentGPUToolsSandboxExtensions; }
-    static Vector<SandboxExtension::Handle> createGPUToolsSandboxExtensionHandlesIfNeeded();
+    static Vector<SandboxExtensionHandle> createGPUToolsSandboxExtensionHandlesIfNeeded();
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5862,10 +5862,10 @@ void WebPageProxy::createRemoteSubframesInOtherProcesses(WebFrameProxy& newFrame
     });
 }
 
-void WebPageProxy::broadcastFrameRemovalToOtherProcesses(WebCore::ProcessIdentifier processID, WebCore::FrameIdentifier frameID)
+void WebPageProxy::broadcastFrameRemovalToOtherProcesses(IPC::Connection& connection, WebCore::FrameIdentifier frameID)
 {
     forEachWebContentProcess([&](auto& webProcess) {
-        if (webProcess.coreProcessIdentifier() == processID)
+        if (!webProcess.hasConnection() || webProcess.connection() == &connection)
             return;
         webProcess.send(Messages::WebPage::FrameWasRemovedInAnotherProcess(frameID), webPageID());
     });

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -28,7 +28,6 @@
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
-#include <WebCore/ProcessIdentifier.h>
 #include <WebCore/SleepDisablerIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/ProcessID.h>
@@ -2174,7 +2173,7 @@ public:
     HashMap<WebCore::RegistrableDomain, WeakPtr<RemotePageProxy>> takeRemotePageMap();
 
     void createRemoteSubframesInOtherProcesses(WebFrameProxy&);
-    void broadcastFrameRemovalToOtherProcesses(WebCore::ProcessIdentifier, WebCore::FrameIdentifier);
+    void broadcastFrameRemovalToOtherProcesses(IPC::Connection&, WebCore::FrameIdentifier);
 
     void addOpenedPage(WebPageProxy&);
     bool hasOpenedPage() const;

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -632,5 +632,5 @@ messages -> WebPageProxy {
     RequestCookieConsent() -> (enum:uint8_t WebCore::CookieConsentDecisionResult result)
 
     DidApplyLinkDecorationFiltering(URL originalURL, URL adjustedURL)
-    BroadcastFrameRemovalToOtherProcesses(WebCore::ProcessIdentifier processID, WebCore::FrameIdentifier frameID)
+    BroadcastFrameRemovalToOtherProcesses(WebCore::FrameIdentifier frameID)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -177,7 +177,7 @@ void WebFrameLoaderClient::broadcastFrameRemovalToOtherProcesses()
         ASSERT_NOT_REACHED();
         return;
     }
-    webPage->send(Messages::WebPageProxy::BroadcastFrameRemovalToOtherProcesses(Process::identifier(), m_frame->frameID()));
+    webPage->send(Messages::WebPageProxy::BroadcastFrameRemovalToOtherProcesses(m_frame->frameID()));
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -195,10 +195,8 @@ void RemoteLayerTreeContext::buildTransaction(RemoteLayerTreeTransaction& transa
     if (paintedAnyBackingStore)
         m_nextRenderingUpdateRequiresSynchronousImageDecoding = false;
 
-    transaction.setCreatedLayers(copyToVector(m_createdLayers.values()));
+    transaction.setCreatedLayers(moveToVector(std::exchange(m_createdLayers, { }).values()));
     transaction.setDestroyedLayerIDs(WTFMove(m_destroyedLayers));
-    
-    m_createdLayers.clear();
 }
 
 void RemoteLayerTreeContext::layerPropertyChangedWhileBuildingTransaction(PlatformCALayerRemote& layer)


### PR DESCRIPTION
#### 96d6de2528b6ff3f706a6eb9aa41e99023a9b44b
<pre>
Remove unnecessary headers including other headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259499">https://bugs.webkit.org/show_bug.cgi?id=259499</a>
rdar://112862626

Reviewed by Tim Horton.

The WebPageProxy::broadcastFrameRemovalToOtherProcesses message was the only reason ProcessIdentifier.h
was included from the widely-included WebPageProxy.h.  Use the sender&apos;s connection instead of the sender&apos;s ProcessID.

DecoderOrError and LayerCreationProperties required a few includes just for the implicit constructors and destructors.
Make them explicit instead of including an unnecessary header.

Doing this exposed an unnecessary copy in RemoteLayerTreeContext::buildTransaction.  Add some Vector support
to make it a move instead of a copy.

* Source/WTF/wtf/Vector.h:
(WTF::copyToVector):
(WTF::moveToVectorOf):
(WTF::moveToVector):
* Source/WebKit/NetworkProcess/storage/LocalStorageManager.cpp:
* Source/WebKit/Platform/IPC/Connection.cpp:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
* Source/WebKit/Platform/IPC/unix/UnixMessage.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::createMobileGestaltSandboxExtensionIfNeeded const):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::broadcastFrameRemovalToOtherProcesses):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::broadcastFrameRemovalToOtherProcesses):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::buildTransaction):

Canonical link: <a href="https://commits.webkit.org/266333@main">https://commits.webkit.org/266333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11cdeb4b12fff007f7d38d79415a5691ca6ecd53

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15287 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12889 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15571 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15991 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19283 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11550 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15620 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12831 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10797 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13594 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12179 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3550 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16507 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13979 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1565 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12754 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3351 "Passed tests") | 
<!--EWS-Status-Bubble-End-->