### PR TITLE
ProcessThrottler should use smart pointers instead of raw pointers

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -76,9 +76,9 @@ bool ProcessThrottler::addActivity(Activity& activity)
     }
 
     if (activity.isForeground())
-        m_foregroundActivities.add(&activity);
+        m_foregroundActivities.add(activity);
     else
-        m_backgroundActivities.add(&activity);
+        m_backgroundActivities.add(activity);
     updateThrottleStateIfNeeded();
     return true;
 }
@@ -87,16 +87,16 @@ void ProcessThrottler::removeActivity(Activity& activity)
 {
     ASSERT(isMainRunLoop());
     if (!m_allowsActivities) {
-        ASSERT(m_foregroundActivities.isEmpty());
-        ASSERT(m_backgroundActivities.isEmpty());
+        ASSERT(m_foregroundActivities.isEmptyIgnoringNullReferences());
+        ASSERT(m_backgroundActivities.isEmptyIgnoringNullReferences());
         return;
     }
 
     bool wasRemoved;
     if (activity.isForeground())
-        wasRemoved = m_foregroundActivities.remove(&activity);
+        wasRemoved = m_foregroundActivities.remove(activity);
     else
-        wasRemoved = m_backgroundActivities.remove(&activity);
+        wasRemoved = m_backgroundActivities.remove(activity);
     ASSERT(wasRemoved);
     if (!wasRemoved)
         return;
@@ -107,11 +107,11 @@ void ProcessThrottler::removeActivity(Activity& activity)
 void ProcessThrottler::invalidateAllActivities()
 {
     ASSERT(isMainRunLoop());
-    PROCESSTHROTTLER_RELEASE_LOG("invalidateAllActivities: BEGIN (foregroundActivityCount: %u, backgroundActivityCount: %u)", m_foregroundActivities.size(), m_backgroundActivities.size());
-    while (!m_foregroundActivities.isEmpty())
-        (*m_foregroundActivities.begin())->invalidate();
-    while (!m_backgroundActivities.isEmpty())
-        (*m_backgroundActivities.begin())->invalidate();
+    PROCESSTHROTTLER_RELEASE_LOG("invalidateAllActivities: BEGIN (foregroundActivityCount: %u, backgroundActivityCount: %u)", m_foregroundActivities.computeSize(), m_backgroundActivities.computeSize());
+    while (!m_foregroundActivities.isEmptyIgnoringNullReferences())
+        m_foregroundActivities.begin()->invalidate();
+    while (!m_backgroundActivities.isEmptyIgnoringNullReferences())
+        m_backgroundActivities.begin()->invalidate();
     PROCESSTHROTTLER_RELEASE_LOG("invalidateAllActivities: END");
 }
 
@@ -126,9 +126,9 @@ void ProcessThrottler::invalidateAllActivitiesAndDropAssertion()
 
 ProcessThrottleState ProcessThrottler::expectedThrottleState()
 {
-    if (!m_foregroundActivities.isEmpty())
+    if (!m_foregroundActivities.isEmptyIgnoringNullReferences())
         return ProcessThrottleState::Foreground;
-    if (!m_backgroundActivities.isEmpty())
+    if (!m_backgroundActivities.isEmptyIgnoringNullReferences())
         return ProcessThrottleState::Background;
     return ProcessThrottleState::Suspended;
 }
@@ -184,7 +184,7 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
     if (m_assertion && m_assertion->isValid() && m_assertion->type() == newType)
         return;
 
-    PROCESSTHROTTLER_RELEASE_LOG("setThrottleState: Updating process assertion type to %u (foregroundActivities=%u, backgroundActivities=%u)", WTF::enumToUnderlyingType(newType), m_foregroundActivities.size(), m_backgroundActivities.size());
+    PROCESSTHROTTLER_RELEASE_LOG("setThrottleState: Updating process assertion type to %u (foregroundActivities=%u, backgroundActivities=%u)", WTF::enumToUnderlyingType(newType), m_foregroundActivities.computeSize(), m_backgroundActivities.computeSize());
 
     // Keep the previous assertion active until the new assertion is taken asynchronously.
     auto previousAssertion = std::exchange(m_assertion, nullptr);
@@ -359,8 +359,8 @@ void ProcessThrottler::setAllowsActivities(bool allow)
         invalidateAllActivities();
     }
 
-    ASSERT(m_foregroundActivities.isEmpty());
-    ASSERT(m_backgroundActivities.isEmpty());
+    ASSERT(m_foregroundActivities.isEmptyIgnoringNullReferences());
+    ASSERT(m_backgroundActivities.isEmptyIgnoringNullReferences());
     m_allowsActivities = allow;
 }
 
@@ -473,18 +473,18 @@ void ProcessThrottlerTimedActivity::updateTimer()
 template <typename T>
 static void logActivityNames(WTF::TextStream& ts, ASCIILiteral description, const T& activities, bool& didLog)
 {
-    if (!activities.size())
+    if (activities.isEmptyIgnoringNullReferences())
         return;
 
     ts << (didLog ? ", "_s : ""_s) << description << ": "_s;
     didLog = true;
 
     bool isFirstItem = true;
-    for (const auto* activity : activities) {
-        if (activity && !activity->isQuietActivity()) {
+    for (const auto& activity : activities) {
+        if (!activity.isQuietActivity()) {
             if (!isFirstItem)
                 ts << ", "_s;
-            ts << activity->name();
+            ts << activity.name();
             isFirstItem = false;
         }
     }

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -57,7 +57,7 @@ enum class IsSuspensionImminent : bool { No, Yes };
 enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
 
-class ProcessThrottlerActivity {
+class ProcessThrottlerActivity : public CanMakeWeakPtr<ProcessThrottlerActivity> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerActivity);
 public:
@@ -80,7 +80,7 @@ private:
 
     void invalidate();
 
-    ProcessThrottler* m_throttler { nullptr };
+    WeakPtr<ProcessThrottler> m_throttler;
     ASCIILiteral m_name;
     ProcessThrottlerActivityType m_type;
 };
@@ -90,18 +90,18 @@ class ProcessThrottlerTimedActivity {
     WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;
     using ActivityVariant = std::variant<std::nullptr_t, UniqueRef<Activity>>;
-    public:
-        explicit ProcessThrottlerTimedActivity(Seconds timeout, ActivityVariant&& = nullptr);
-        ProcessThrottlerTimedActivity& operator=(ActivityVariant&&);
-        const ActivityVariant& activity() const { return m_activity; }
+public:
+    explicit ProcessThrottlerTimedActivity(Seconds timeout, ActivityVariant&& = nullptr);
+    ProcessThrottlerTimedActivity& operator=(ActivityVariant&&);
+    const ActivityVariant& activity() const { return m_activity; }
 
-    private:
-        void activityTimedOut();
-        void updateTimer();
+private:
+    void activityTimedOut();
+    void updateTimer();
 
-        RunLoop::Timer m_timer;
-        Seconds m_timeout;
-        ActivityVariant m_activity;
+    RunLoop::Timer m_timer;
+    Seconds m_timeout;
+    ActivityVariant m_activity;
 };
 
 class ProcessThrottler : public CanMakeWeakPtr<ProcessThrottler> {
@@ -130,7 +130,7 @@ public:
 
     void didConnectToProcess(ProcessID);
     void didDisconnectFromProcess();
-    bool shouldBeRunnable() const { return m_foregroundActivities.size() || m_backgroundActivities.size(); }
+    bool shouldBeRunnable() const { return !m_foregroundActivities.isEmptyIgnoringNullReferences() || !m_backgroundActivities.isEmptyIgnoringNullReferences(); }
     void setAllowsActivities(bool);
     void setShouldDropNearSuspendedAssertionAfterDelay(bool);
     void setShouldTakeNearSuspendedAssertion(bool);
@@ -175,8 +175,8 @@ private:
     RunLoop::Timer m_prepareToSuspendTimeoutTimer;
     RunLoop::Timer m_dropNearSuspendedAssertionTimer;
     RunLoop::Timer m_prepareToDropLastAssertionTimeoutTimer;
-    HashSet<Activity*> m_foregroundActivities;
-    HashSet<Activity*> m_backgroundActivities;
+    WeakHashSet<Activity> m_foregroundActivities;
+    WeakHashSet<Activity> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
     PageAllowedToRunInTheBackgroundCounter m_pageAllowedToRunInTheBackgroundCounter;
@@ -186,7 +186,7 @@ private:
     bool m_allowsActivities { true };
 };
 
-#define PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d, throttler=%p] ProcessThrottler::Activity::" msg, this, m_throttler->m_processID, m_throttler, ##__VA_ARGS__)
+#define PROCESSTHROTTLER_ACTIVITY_RELEASE_LOG(msg, ...) RELEASE_LOG(ProcessSuspension, "%p - [PID=%d, throttler=%p] ProcessThrottler::Activity::" msg, this, m_throttler->m_processID, m_throttler.get(), ##__VA_ARGS__)
 
 inline ProcessThrottlerActivity::ProcessThrottlerActivity(ProcessThrottler& throttler, ASCIILiteral name, ProcessThrottlerActivityType type)
     : m_throttler(&throttler)


### PR DESCRIPTION
#### 0d88eebace38331e70dc2c4a08a38b5ca3f28fb5
<pre>
ProcessThrottler should use smart pointers instead of raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259500">https://bugs.webkit.org/show_bug.cgi?id=259500</a>

Reviewed by Chris Dumez.

Deploy smart pointers around ProcessThrottler.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::addActivity):
(WebKit::ProcessThrottler::removeActivity):
(WebKit::ProcessThrottler::invalidateAllActivities):
(WebKit::ProcessThrottler::expectedThrottleState):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::setAllowsActivities):
(WebKit::logActivityNames):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottlerTimedActivity::activity const):
(WebKit::ProcessThrottler::shouldBeRunnable const):

Canonical link: <a href="https://commits.webkit.org/266496@main">https://commits.webkit.org/266496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64a641b52c0c196ea1c41ec10d7416bf79964cfd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15208 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12822 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15503 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14287 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11574 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19204 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12650 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15538 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10741 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12102 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16428 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1645 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->