### PR TITLE
Set intrinsic size for inline SVG earlier

### DIFF
--- a/LayoutTests/svg/in-html/inside-inline-block-expected.html
+++ b/LayoutTests/svg/in-html/inside-inline-block-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>SVG inside inline block</title>
+<style>
+    body { margin: 0 }
+    div {
+        width: 100px;
+        background: green;
+        position: absolute;
+        top: 0;
+        left: 0
+    }
+    .cover1 {
+        top: 0;
+        left: 0;
+        height: 150px
+    }
+    .cover2 {
+        top: 50px;
+        left: 100px;
+        height: 100px
+    }
+</style>
+<div class="cover1"></div>
+<div class="cover2"></div>

--- a/LayoutTests/svg/in-html/inside-inline-block.html
+++ b/LayoutTests/svg/in-html/inside-inline-block.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>SVG inside inline block</title>
+<style>
+    body { margin: 0 }
+    span { display: inline-block }
+    div {
+        width: 100px;
+        background: green;
+        position: absolute;
+        top: 0;
+        left: 0
+    }
+    .cover1 {
+        top: 0;
+        left: 0;
+        height: 150px
+    }
+    .cover2 {
+        top: 50px;
+        left: 100px;
+        height: 100px
+    }
+    svg {
+        width: 100%;
+        height: 100%
+    }
+</style>
+<span>
+    <svg width="100">
+        <rect width="100%" height="100%" fill="red"/>
+    </svg>
+</span><span>
+    <svg width="100" height="100" style="width: 100%; height: 100%;">
+        <rect width="100%" height="100%" fill="red"/>
+    </svg>
+</span>
+<div class="cover1"></div>
+<div class="cover2"></div>

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -56,12 +56,21 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRenderSVGRoot);
 
+const int defaultWidth = 300;
+const int defaultHeight = 150;
+
 LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
     : RenderReplaced(element, WTFMove(style))
     , m_isLayoutSizeChanged(false)
     , m_needsBoundariesOrTransformUpdate(true)
     , m_hasBoxDecorations(false)
 {
+    LayoutSize intrinsicSize(calculateIntrinsicSize());
+    if (!intrinsicSize.width())
+        intrinsicSize.setWidth(defaultWidth);
+    if (!intrinsicSize.height())
+        intrinsicSize.setHeight(defaultHeight);
+    setIntrinsicSize(intrinsicSize);
 }
 
 LegacyRenderSVGRoot::~LegacyRenderSVGRoot() = default;
@@ -76,22 +85,17 @@ bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
     return computeIntrinsicAspectRatio();
 }
 
+FloatSize LegacyRenderSVGRoot::calculateIntrinsicSize() const
+{
+    return FloatSize(floatValueForLength(svgSVGElement().intrinsicWidth(), 0), floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
+}
+
 void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const
 {
     ASSERT(!shouldApplySizeContainment());
 
-    // Spec: http://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
-    // SVG needs to specify how to calculate some intrinsic sizing properties to enable inclusion within other languages.
-
-    // The intrinsic aspect ratio of the viewport of SVG content is necessary for example, when including SVG from an ‘object’
-    // element in HTML styled with CSS. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but
-    // not to have an intrinsic width or height. The intrinsic aspect ratio must be calculated based upon the following rules:
-    // - The aspect ratio is calculated by dividing a width by a height.
-    // - If the ‘width’ and ‘height’ of the rootmost ‘svg’ element are both specified with unit identifiers (in, mm, cm, pt, pc,
-    //   px, em, ex) or in user units, then the aspect ratio is calculated from the ‘width’ and ‘height’ attributes after
-    //   resolving both values to user units.
-    intrinsicSize.setWidth(floatValueForLength(svgSVGElement().intrinsicWidth(), 0));
-    intrinsicSize.setHeight(floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
+    // https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
+    intrinsicSize = calculateIntrinsicSize();
 
     if (style().aspectRatioType() == AspectRatioType::Ratio) {
         intrinsicRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth(), style().aspectRatioLogicalHeight()); 
@@ -102,10 +106,6 @@ void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicS
     if (!intrinsicSize.isEmpty())
         intrinsicRatio = { intrinsicSize.width(), intrinsicSize.height() };
     else {
-        // - If either/both of the ‘width’ and ‘height’ of the rootmost ‘svg’ element are in percentage units (or omitted), the
-        //   aspect ratio is calculated from the width and height values of the ‘viewBox’ specified for the current SVG document
-        //   fragment. If the ‘viewBox’ is not correctly specified, or set to 'none', the intrinsic aspect ratio cannot be
-        //   calculated and is considered unspecified.
         FloatSize viewBoxSize = svgSVGElement().viewBox().size();
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2009 Google, Inc.  All rights reserved.
+ * Copyright (C) 2009-2016 Google, Inc.  All rights reserved.
  * Copyright (C) 2009 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -105,6 +105,8 @@ private:
     bool shouldApplyViewportClip() const;
     void updateCachedBoundaries();
     void buildLocalToBorderBoxTransform();
+
+    FloatSize calculateIntrinsicSize() const;
 
     IntSize m_containerSize;
     FloatRect m_objectBoundingBox;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -64,9 +64,18 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RenderSVGRoot);
 
+const int defaultWidth = 300;
+const int defaultHeight = 150;
+
 RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
     : RenderReplaced(element, WTFMove(style))
 {
+    LayoutSize intrinsicSize(calculateIntrinsicSize());
+    if (!intrinsicSize.width())
+        intrinsicSize.setWidth(defaultWidth);
+    if (!intrinsicSize.height())
+        intrinsicSize.setHeight(defaultHeight);
+    setIntrinsicSize(intrinsicSize);
 }
 
 RenderSVGRoot::~RenderSVGRoot() = default;
@@ -89,22 +98,17 @@ bool RenderSVGRoot::hasIntrinsicAspectRatio() const
     return computeIntrinsicAspectRatio();
 }
 
+FloatSize RenderSVGRoot::calculateIntrinsicSize() const
+{
+    return FloatSize(floatValueForLength(svgSVGElement().intrinsicWidth(), 0), floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
+}
+
 void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, FloatSize& intrinsicRatio) const
 {
     ASSERT(!shouldApplySizeContainment());
 
-    // Spec: http://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
-    // SVG needs to specify how to calculate some intrinsic sizing properties to enable inclusion within other languages.
-
-    // The intrinsic aspect ratio of the viewport of SVG content is necessary for example, when including SVG from an ‘object’
-    // element in HTML styled with CSS. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but
-    // not to have an intrinsic width or height. The intrinsic aspect ratio must be calculated based upon the following rules:
-    // - The aspect ratio is calculated by dividing a width by a height.
-    // - If the ‘width’ and ‘height’ of the rootmost ‘svg’ element are both specified with unit identifiers (in, mm, cm, pt, pc,
-    //   px, em, ex) or in user units, then the aspect ratio is calculated from the ‘width’ and ‘height’ attributes after
-    //   resolving both values to user units.
-    intrinsicSize.setWidth(floatValueForLength(svgSVGElement().intrinsicWidth(), 0));
-    intrinsicSize.setHeight(floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
+    // https://www.w3.org/TR/SVG/coords.html#IntrinsicSizing
+    intrinsicSize = calculateIntrinsicSize();
 
     if (style().aspectRatioType() == AspectRatioType::Ratio) {
         intrinsicRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth(), style().aspectRatioLogicalHeight());
@@ -115,10 +119,6 @@ void RenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicSize, F
     if (!intrinsicSize.isEmpty())
         intrinsicRatioValue = { intrinsicSize.width(), intrinsicSize.height() }; 
     else {
-        // - If either/both of the ‘width’ and ‘height’ of the rootmost ‘svg’ element are in percentage units (or omitted), the
-        //   aspect ratio is calculated from the width and height values of the ‘viewBox’ specified for the current SVG document
-        //   fragment. If the ‘viewBox’ is not correctly specified, or set to 'none', the intrinsic aspect ratio cannot be
-        //   calculated and is considered unspecified.
         FloatSize viewBoxSize = svgSVGElement().viewBox().size();
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007 Rob Buis <buis@kde.org>
- * Copyright (C) 2009 Google, Inc.  All rights reserved.
+ * Copyright (C) 2009-2016 Google, Inc.  All rights reserved.
  * Copyright (C) 2009 Apple Inc. All rights reserved.
  * Copyright (C) 2020, 2021, 2022 Igalia S.L.
  *
@@ -103,6 +103,8 @@ private:
     void updateFromStyle() final;
     bool needsHasSVGTransformFlags() const final;
     void updateLayerTransform() final;
+
+    FloatSize calculateIntrinsicSize() const;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 


### PR DESCRIPTION
#### dbdb89fe49e86b4bb7563df8544776e9f9c9f4fb
<pre>
Set intrinsic size for inline SVG earlier

<a href="https://bugs.webkit.org/show_bug.cgi?id=257614">https://bugs.webkit.org/show_bug.cgi?id=257614</a>
rdar://problem/110480382

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/545b2183e1b4ee3eb433537f9a6386b5337d6588">https://chromium.googlesource.com/chromium/src.git/+/545b2183e1b4ee3eb433537f9a6386b5337d6588</a>

RenderReplaced has a m_intrinsicSize that&apos;s updated when computing
logical widths and heights (and only if needed; specified style makes
it not being set at all).

But m_intrinsicSize can be used earlier that that, when computing
preferred widths for the container, see
RenderReplaced::computeIntrinsicLogicalWidths called from
RenderReplaced::computePreferredLogicalWidths().

This patch computes the intrinsic size in the constructor to avoid
returning the stale default size.

* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(1) Add constants for &apos;defaultWidth&apos; and &apos;defaultHeight&apos;
(2) Add &apos;intrinsicSize&apos; logic
(3) Introduce new function &apos;calculateIntrinsicSize&apos;
(LegacyRenderSVGRoot::computeIntrinsicRatioInformation): Call above function and remove unneeded comments
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h: Definition of &apos;calculateIntrinsicSize&apos;
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp: Same changes as &apos;Legacy&apos; for LBSE
* Source/WebCore/rendering/svg/RenderSVGRoot.h: Ditto
* LayoutTests/svg/in-html/inside-inline-block.html: Add Test Case
* LayoutTests/svg/in-html/inside-inline-block-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/266314@main">https://commits.webkit.org/266314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/510ccbadf1ac716cdef92fa150244f1df547a2b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15215 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15507 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15919 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19209 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15543 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10748 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12035 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->