### PR TITLE
Dont build default.metallib when building ANGLE

### DIFF
--- a/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
+++ b/Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj
@@ -788,7 +788,6 @@
 		FFC84CA12A4D1CE60063D8E0 /* mtl_buffer_manager.mm in Sources */ = {isa = PBXBuildFile; fileRef = FFC84C9D2A4D1CE50063D8E0 /* mtl_buffer_manager.mm */; };
 		FFC84CA22A4D1CE60063D8E0 /* mtl_pipeline_cache.mm in Sources */ = {isa = PBXBuildFile; fileRef = FFC84C9E2A4D1CE50063D8E0 /* mtl_pipeline_cache.mm */; };
 		FFC84CA52A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.h in Headers */ = {isa = PBXBuildFile; fileRef = FFC84CA32A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.h */; };
-		FFC84CA62A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.metal in Sources */ = {isa = PBXBuildFile; fileRef = FFC84CA42A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.metal */; };
 		FFC84CA72A4D1F830063D8E0 /* mtl_internal_shaders_src_autogen.metal in Sources */ = {isa = PBXBuildFile; fileRef = FFC84CA42A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.metal */; };
 		FFD0022727449647002BE3BC /* DeviceMtl.mm in Sources */ = {isa = PBXBuildFile; fileRef = FFD0022627449647002BE3BC /* DeviceMtl.mm */; };
 		FFD00234274497C4002BE3BC /* UnfoldShortCircuitAST.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD0022A274497C4002BE3BC /* UnfoldShortCircuitAST.h */; };
@@ -3956,7 +3955,6 @@
 				FF4BB3642769467600994EBF /* mtl_context_device.mm in Sources */,
 				DF83E3872639FEB8000825EF /* mtl_format_table_autogen.mm in Sources */,
 				DF83E3712639FEB8000825EF /* mtl_format_utils.mm in Sources */,
-				FFC84CA62A4D1F330063D8E0 /* mtl_internal_shaders_src_autogen.metal in Sources */,
 				7BDC8C7D2993A4E000C2BDDF /* mtl_library_cache.mm in Sources */,
 				3A0EBFB92980B6C1002C72BC /* mtl_msl_utils.mm in Sources */,
 				DF83E37A2639FEB8000825EF /* mtl_occlusion_query_pool.mm in Sources */,


### PR DESCRIPTION
#### b258292b150603e1104099b6c41a3a30ab7fb5fc
<pre>
Dont build default.metallib when building ANGLE
<a href="https://bugs.webkit.org/show_bug.cgi?id=259509">https://bugs.webkit.org/show_bug.cgi?id=259509</a>
&lt;rdar://112819533&gt;
Reviewed by Alex Christensen.

The autogenerated metal file was accidently included as a
build target in ANGLE&apos;s default shared library. It&apos;s previously
been compiled in a seperate project that builds to
&quot;ANGLEMetalLib.metallib&quot;. After the last ANGLE roll,
it was building to both &quot;default.metallib&quot; and &apos;ANGLEMetalLib.metallib&apos;

This change restores the previous behavior for this library.

* Source/ThirdParty/ANGLE/ANGLE.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/266307@main">https://commits.webkit.org/266307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0db1b47fd64e0730505c90bf228e6b42badf2dd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15220 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13866 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15513 "128 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15924 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12168 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15550 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10734 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16440 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1552 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->