### PR TITLE
Properly handle a '/' in the cookie's path when setting a cookie with the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
@@ -9,7 +9,7 @@ FAIL cookieStore.delete with domain set to a non-domain-matching suffix of the c
 FAIL cookieStore.delete with path set to the current directory assert_equals: expected null but got object "[object Object]"
 PASS cookieStore.delete with path set to subdirectory of the current directory
 FAIL cookieStore.delete with missing / at the end of path assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.delete with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.delete with path that does not start with /
 FAIL cookieStore.delete with get result assert_equals: expected null but got object "[object Object]"
 FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -16,7 +16,7 @@ FAIL cookieStore.set default domain is null and differs from current hostname as
 PASS cookieStore.set with path set to the current directory
 FAIL cookieStore.set with path set to a subdirectory of the current directory assert_equals: expected null but got object "[object Object]"
 FAIL cookieStore.set default path is / assert_equals: expected 1 but got 2
-FAIL cookieStore.set adds / to path that does not end with / assert_equals: expected "/cookie-store/" but got "/cookie-store"
-FAIL cookieStore.set with path that does not start with / assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set adds / to path that does not end with /
+PASS cookieStore.set with path that does not start with /
 FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"
 


### PR DESCRIPTION
#### d52eb029fa40b2be7f7a8275c2e5fccf962a2e7d
<pre>
Properly handle a &apos;/&apos; in the cookie&apos;s path when setting a cookie with the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259505">https://bugs.webkit.org/show_bug.cgi?id=259505</a>

Reviewed by Chris Dumez and Alex Christensen.

The spec (<a href="https://wicg.github.io/cookie-store/#set-cookie-algorithm)">https://wicg.github.io/cookie-store/#set-cookie-algorithm)</a>
dictates that in the set function, if the path is not null, then if
the path does not begin with a &apos;/&apos;, the promise should be rejected
with a TypeError. If the path does begin with a &apos;/&apos;,  but does not
end with a &apos;/&apos;, then a &apos;/&apos; should be added, and then the rest of the

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/266317@main">https://commits.webkit.org/266317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43aad0332d4b5ffc91559b94a2d105ccc7b9f811

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13563 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15514 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15925 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19216 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12662 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15551 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12114 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3292 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->