### PR TITLE
Implement table instructions, f64 arithmetic, and type conversions

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-error-check-call-null.js
+++ b/JSTests/wasm/ipint-tests/ipint-error-check-call-null.js
@@ -1,0 +1,27 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $i2i (func (param i32) (result i32)))
+    (table $table (export "table") 3 funcref)
+    (func (export "call") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 0)
+        (call_indirect $table (type $i2i))
+    )
+    (func $inc (export "inc") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 1)
+        (i32.add)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { table, read, write_null, write_inc, call, inc } = instance.exports
+    assert.eq(call(5), 6);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-error-check-call-sig.js
+++ b/JSTests/wasm/ipint-tests/ipint-error-check-call-sig.js
@@ -1,0 +1,34 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $p2i (func (param i32) (result i32 i32)))
+    (table $table (export "table") 3 funcref)
+    (func (export "write_inc")
+        (i32.const 0)
+        (ref.func $inc)
+        (table.set $table)
+    )
+    (func (export "call") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 0)
+        (call_indirect $table (type $p2i))
+        (drop)
+    )
+    (func $inc (export "inc") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 1)
+        (i32.add)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { table, read, write_null, write_inc, call, inc } = instance.exports
+    write_inc();
+    assert.eq(call(5), 6);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-error-check-mem-outofbounds.js
+++ b/JSTests/wasm/ipint-tests/ipint-error-check-mem-outofbounds.js
@@ -1,0 +1,22 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory (export "memory") 1 1)
+    (data (i32.const 0x0) "jinx is a good cat")
+    (func (export "test") (param i32) (result i32)
+        (local.get 0)
+        (i32.load8_u)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, test } = instance.exports
+    test(65536);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-error-check-trunc-outofbounds.js
+++ b/JSTests/wasm/ipint-tests/ipint-error-check-trunc-outofbounds.js
@@ -1,0 +1,19 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param f32) (result i32)
+        (local.get 0)
+        (i32.trunc_f32_s)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { memory, test } = instance.exports
+    test(4294967296)
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-f64-ops.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-f64-ops.js
@@ -3,90 +3,151 @@ import * as assert from "../assert.js"
 
 let wat = `
 (module
-    (func (export "clz") (param i32) (result i32)
+    (func (export "abs") (param f64) (result f64)
         (local.get 0)
-        (i32.clz)
+        (f64.abs)
         (return)
     )
-    (func (export "ctz") (param i32) (result i32)
+
+    (func (export "neg") (param f64) (result f64)
         (local.get 0)
-        (i32.ctz)
+        (f64.neg)
         (return)
     )
-    (func (export "add") (param i32 i32) (result i32)
+
+    (func (export "ceil") (param f64) (result f64)
+        (local.get 0)
+        (f64.ceil)
+        (return)
+    )
+
+    (func (export "floor") (param f64) (result f64)
+        (local.get 0)
+        (f64.floor)
+        (return)
+    )
+
+    (func (export "trunc") (param f64) (result f64)
+        (local.get 0)
+        (f64.trunc)
+        (return)
+    )
+
+    (func (export "nearest") (param f64) (result f64)
+        (local.get 0)
+        (f64.nearest)
+        (return)
+    )
+
+    (func (export "sqrt") (param f64) (result f64)
+        (local.get 0)
+        (f64.sqrt)
+        (return)
+    )
+
+    (func (export "add") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.add)
+        (f64.add)
         (return)
     )
-    (func (export "sub") (param i32 i32) (result i32)
+
+    (func (export "sub") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.sub)
+        (f64.sub)
         (return)
     )
-    (func (export "mul") (param i32 i32) (result i32)
+
+    (func (export "mul") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.mul)
+        (f64.mul)
         (return)
     )
-    (func (export "divs") (param i32 i32) (result i32)
+
+    (func (export "div") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.div_s)
+        (f64.div)
         (return)
     )
-    (func (export "divu") (param i32 i32) (result i32)
+
+    (func (export "min") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.div_u)
+        (f64.min)
         (return)
     )
-    (func (export "and") (param i32 i32) (result i32)
+
+    (func (export "max") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.and)
+        (f64.max)
         (return)
     )
-    (func (export "or") (param i32 i32) (result i32)
+
+    (func (export "copysign") (param f64 f64) (result f64)
         (local.get 0)
         (local.get 1)
-        (i32.or)
-        (return)
-    )
-    (func (export "xor") (param i32 i32) (result i32)
-        (local.get 0)
-        (local.get 1)
-        (i32.xor)
+        (f64.copysign)
         (return)
     )
 )
 `
 
+function close(a, b) {
+    return Math.abs(a - b) < 0.001;
+}
+
+let assertClose = (x, y) => assert.truthy(close(x, y))
+
 async function test() {
     const instance = await instantiate(wat, {});
-    const { clz, ctz, add, sub, mul, divs, divu, and, or, xor } = instance.exports
-    assert.eq(clz(1), 31)
-    assert.eq(clz(8), 28)
-    assert.eq(ctz(1), 0)
-    assert.eq(ctz(8), 3)
-    assert.eq(add(1, 2), 3)
-    assert.eq(add(3, 4), 7)
-    assert.eq(sub(3, 2), 1)
-    assert.eq(sub(1, 5), -4)
-    assert.eq(mul(3, 2), 6)
-    assert.eq(mul(1, 5), 5)
-    assert.eq(divs(3, 2), 1)
-    assert.eq(divs(-10, 5), -2)
-    assert.eq(divu(3, 2), 1)
-    assert.eq(divu(1, 5), 0)
-    assert.eq(and(3, 2), 2)
-    assert.eq(and(3, 5), 1)
-    assert.eq(or(3, 2), 3)
-    assert.eq(or(3, 5), 7)
-    assert.eq(xor(3, 2), 1)
-    assert.eq(xor(3, 5), 6)
+    const { abs, neg, ceil, floor, trunc, nearest, sqrt, add, sub, mul, div, min, max, copysign }= instance.exports
+    assertClose(abs(1.5), 1.5)
+    assertClose(abs(-1.5), 1.5)
+
+    assertClose(neg(1.5), -1.5)
+    assertClose(neg(-1.5), 1.5)
+
+    assertClose(ceil(2.25), 3)
+    assertClose(ceil(-3.75), -3)
+
+    assertClose(floor(2.25), 2)
+    assertClose(floor(-3.75), -4)
+
+    assertClose(trunc(2.75), 2)
+    assertClose(trunc(-2.75), -2)
+
+    assertClose(nearest(2.75), 3)
+    assertClose(nearest(-2.75), -3)
+
+    assertClose(sqrt(4), 2)
+    assertClose(sqrt(2), 1.414)
+
+    assertClose(add(1, 2), 3)
+    assertClose(add(3.5, 4.25), 7.75)
+
+    assertClose(sub(1, 2), -1)
+    assertClose(sub(7.27, 2.81), 4.46)
+
+    assertClose(mul(2, 4), 8)
+    assertClose(mul(2.5, 1.25), 3.125)
+
+    assertClose(div(1, 2), 0.5)
+    assertClose(div(22, 7), 3.143)
+
+    assertClose(min(1, 2), 1)
+    assertClose(min(3.5, 4.25), 3.5)
+
+    assertClose(max(1, 2), 2)
+    assertClose(max(3.5, 4.25), 4.25)
+
+    assertClose(copysign(1, 2), 1)
+    assertClose(copysign(-3.5, 4.25), 3.5)
+    assertClose(copysign(1.25, -1.6), -1.25)
+    assertClose(copysign(-2.56, -1.28), -2.56)
 }
 
 assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-table-read.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-table-read.js
@@ -1,0 +1,49 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (type $i2i (func (param i32) (result i32)))
+    (table $table (export "table") 3 funcref)
+    (func (export "read") (result i32)
+        (i32.const 0)
+        (table.get $table)
+        (ref.is_null)
+    )
+    (func (export "write_null")
+        (i32.const 0)
+        (ref.null func)
+        (table.set $table)
+    )
+    (func (export "write_inc")
+        (i32.const 0)
+        (ref.func $inc)
+        (table.set $table)
+    )
+    (func (export "call") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 0)
+        (call_indirect $table (type $i2i))
+    )
+    (func $inc (export "inc") (param i32) (result i32)
+        (local.get 0)
+        (i32.const 1)
+        (i32.add)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { table, read, write_null, write_inc, call, inc } = instance.exports
+    assert.eq(read(), 1);
+    table.set(0, inc);
+    assert.eq(read(), 0);
+    write_null();
+    assert.eq(read(), 1);
+    write_inc();
+    assert.eq(read(), 0);
+    assert.eq(call(5), 6);
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-type-conversion.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-type-conversion.js
@@ -1,0 +1,255 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "i32_wrap_i64") (param i64) (result i32)
+        (local.get 0)
+        (i32.wrap_i64)
+    )
+
+    (func (export "i32_trunc_f32_s") (param f32) (result i32)
+        (local.get 0)
+        (i32.trunc_f32_s)
+    )
+    (func (export "i32_trunc_f32_u") (param f32) (result i32)
+        (local.get 0)
+        (i32.trunc_f32_u)
+    )
+    (func (export "i32_trunc_f64_s") (param f64) (result i32)
+        (local.get 0)
+        (i32.trunc_f64_s)
+    )
+    (func (export "i32_trunc_f64_u") (param f64) (result i32)
+        (local.get 0)
+        (i32.trunc_f64_u)
+    )
+
+    (func (export "i64_extend_i32_s") (param i32) (result i64)
+        (local.get 0)
+        (i64.extend_i32_s)
+    )
+    (func (export "i64_extend_i32_u") (param i32) (result i64)
+        (local.get 0)
+        (i64.extend_i32_u)
+    )
+
+    (func (export "i64_trunc_f32_s") (param f32) (result i64)
+        (local.get 0)
+        (i64.trunc_f32_s)
+    )
+    (func (export "i64_trunc_f32_u") (param f32) (result i64)
+        (local.get 0)
+        (i64.trunc_f32_u)
+    )
+    (func (export "i64_trunc_f64_s") (param f64) (result i64)
+        (local.get 0)
+        (i64.trunc_f64_s)
+    )
+    (func (export "i64_trunc_f64_u") (param f64) (result i64)
+        (local.get 0)
+        (i64.trunc_f64_u)
+    )
+
+    (func (export "f32_convert_i32_s") (param i32) (result f32)
+        (local.get 0)
+        (f32.convert_i32_s)
+    )
+    (func (export "f32_convert_i32_u") (param i32) (result f32)
+        (local.get 0)
+        (f32.convert_i32_u)
+    )
+    (func (export "f32_convert_i64_s") (param i64) (result f32)
+        (local.get 0)
+        (f32.convert_i64_s)
+    )
+    (func (export "f32_convert_i64_u") (param i64) (result f32)
+        (local.get 0)
+        (f32.convert_i64_u)
+    )
+
+    (func (export "f32_demote_f64") (param f64) (result f32)
+        (local.get 0)
+        (f32.demote_f64)
+    )
+
+    (func (export "f64_convert_i32_s") (param i32) (result f64)
+        (local.get 0)
+        (f64.convert_i32_s)
+    )
+    (func (export "f64_convert_i32_u") (param i32) (result f64)
+        (local.get 0)
+        (f64.convert_i32_u)
+    )
+    (func (export "f64_convert_i64_s") (param i64) (result f64)
+        (local.get 0)
+        (f64.convert_i64_s)
+    )
+    (func (export "f64_convert_i64_u") (param i64) (result f64)
+        (local.get 0)
+        (f64.convert_i64_u)
+    )
+
+    (func (export "f64_promote_f32") (param f32) (result f64)
+        (local.get 0)
+        (f64.promote_f32)
+    )
+
+    (func (export "i32_reinterpret_f32") (param f32) (result i32)
+        (local.get 0)
+        (i32.reinterpret_f32)
+    )
+    (func (export "i64_reinterpret_f64") (param f64) (result i64)
+        (local.get 0)
+        (i64.reinterpret_f64)
+    )
+    (func (export "f32_reinterpret_i32") (param i32) (result f32)
+        (local.get 0)
+        (f32.reinterpret_i32)
+    )
+    (func (export "f64_reinterpret_i64") (param i64) (result f64)
+        (local.get 0)
+        (f64.reinterpret_i64)
+    )
+
+    (func (export "i32_extend8_s") (param i32) (result i32)
+        (local.get 0)
+        (i32.extend8_s)
+    )
+    (func (export "i32_extend16_s") (param i32) (result i32)
+        (local.get 0)
+        (i32.extend16_s)
+    )
+
+    (func (export "i64_extend8_s") (param i64) (result i64)
+        (local.get 0)
+        (i64.extend8_s)
+    )
+    (func (export "i64_extend16_s") (param i64) (result i64)
+        (local.get 0)
+        (i64.extend16_s)
+    )
+    (func (export "i64_extend32_s") (param i64) (result i64)
+        (local.get 0)
+        (i64.extend32_s)
+    )
+)
+`
+
+function close(a, b) {
+    return Math.abs(a - b) < 0.001;
+}
+
+let assertClose = (x, y) => assert.truthy(close(x, y))
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const {
+        i32_wrap_i64,
+        i32_trunc_f32_s, i32_trunc_f32_u, i32_trunc_f64_s, i32_trunc_f64_u,
+        i64_extend_i32_s, i64_extend_i32_u,
+        i64_trunc_f32_s, i64_trunc_f32_u, i64_trunc_f64_s, i64_trunc_f64_u,
+        f32_convert_i32_s, f32_convert_i32_u, f32_convert_i64_s, f32_convert_i64_u,
+        f32_demote_f64,
+        f64_convert_i32_s, f64_convert_i32_u, f64_convert_i64_s, f64_convert_i64_u,
+        f64_promote_f32,
+        i32_reinterpret_f32, i64_reinterpret_f64, f32_reinterpret_i32, f64_reinterpret_i64,
+        i32_extend8_s,
+        i32_extend16_s,
+        i64_extend8_s,
+        i64_extend16_s,
+        i64_extend32_s,
+    } = instance.exports;
+
+    assert.eq(i32_wrap_i64(5n), 5);
+    assert.eq(i32_wrap_i64(-16n), -16);
+
+    assert.eq(i32_trunc_f32_s(1.65), 1);
+    assert.eq(i32_trunc_f32_s(-2.5), -2);
+
+    assert.eq(i32_trunc_f32_u(1.65), 1);
+    assert.eq(i32_trunc_f32_u(2.5), 2);
+
+    assert.eq(i32_trunc_f64_s(1.65), 1);
+    assert.eq(i32_trunc_f64_s(-2.25), -2);
+
+    assert.eq(i32_trunc_f64_u(1.65), 1);
+    assert.eq(i32_trunc_f64_u(2.5), 2);
+
+    assert.eq(i64_extend_i32_s(16), 16n);
+    assert.eq(i64_extend_i32_s(-16), -16n);
+
+    assert.eq(i64_extend_i32_u(16), 16n);
+    assert.eq(i64_extend_i32_u(2147483647), 2147483647n);
+
+    assert.eq(i64_trunc_f32_s(1.65), 1n);
+    assert.eq(i64_trunc_f32_s(-2.5), -2n);
+
+    assert.eq(i64_trunc_f32_u(1.65), 1n);
+    assert.eq(i64_trunc_f32_u(2.5), 2n);
+
+    assert.eq(i64_trunc_f64_s(1.65), 1n);
+    assert.eq(i64_trunc_f64_s(-2.25), -2n);
+
+    assert.eq(i64_trunc_f64_u(1.65), 1n);
+    assert.eq(i64_trunc_f64_u(2.5), 2n);
+
+    assertClose(f32_convert_i32_s(16), 16);
+    assertClose(f32_convert_i32_s(-2), -2);
+
+    assertClose(f32_convert_i32_u(5), 5);
+    assertClose(f32_convert_i32_u(16), 16);
+
+    assertClose(f32_convert_i64_s(16n), 16);
+    assertClose(f32_convert_i64_s(-2n), -2);
+
+    assertClose(f32_convert_i64_u(5n), 5);
+    assertClose(f32_convert_i64_u(16n), 16);
+
+    assertClose(f32_demote_f64(0.5), 0.5);
+    assertClose(f32_demote_f64(-0.25), -0.25);
+
+    assertClose(f64_convert_i32_s(16), 16);
+    assertClose(f64_convert_i32_s(-2), -2);
+
+    assertClose(f64_convert_i32_u(5), 5);
+    assertClose(f64_convert_i32_u(16), 16);
+
+    assertClose(f64_convert_i64_s(16n), 16);
+    assertClose(f64_convert_i64_s(-2n), -2);
+
+    assertClose(f64_convert_i64_u(5n), 5);
+    assertClose(f64_convert_i64_u(16n), 16);
+
+    assertClose(f64_promote_f32(0.5), 0.5);
+    assertClose(f64_promote_f32(-0.25), -0.25);
+
+    assert.eq(i32_reinterpret_f32(0.25), 0x3e800000);
+    assert.eq(i32_reinterpret_f32(0.125), 0x3e000000);
+
+    assert.eq(i64_reinterpret_f64(0.25), 0x3fd0000000000000n);
+    assert.eq(i64_reinterpret_f64(0.125), 0x3fc0000000000000n);
+
+    assertClose(f32_reinterpret_i32(0x3e800000), 0.25);
+    assertClose(f32_reinterpret_i32(0x3e000000), 0.125);
+
+    assertClose(f64_reinterpret_i64(0x3fd0000000000000n), 0.25);
+    assertClose(f64_reinterpret_i64(0x3fc0000000000000n), 0.125);
+
+    assert.eq(i32_extend8_s(16), 16);
+    assert.eq(i32_extend8_s(255), -1);
+
+    assert.eq(i32_extend16_s(16), 16);
+    assert.eq(i32_extend16_s(32768), -32768);
+
+    assert.eq(i64_extend8_s(16n), 16n);
+    assert.eq(i64_extend8_s(255n), -1n);
+
+    assert.eq(i64_extend16_s(16n), 16n);
+    assert.eq(i64_extend16_s(32768n), -32768n);
+
+    assert.eq(i64_extend32_s(16n), 16n);
+    assert.eq(i64_extend32_s(4294967295n), -1n);
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -49,7 +49,7 @@ do { \
 
 void initialize()
 {
-#if CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS))
+#if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
     FOR_EACH_IPINT_OPCODE(VALIDATE_IPINT_OPCODE);
 #else
     RELEASE_ASSERT("IPInt only supports ARM64 and X86_64 (for now).");

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -28,7 +28,7 @@
 extern "C" void ipint_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
-    extern "C" void ipint_ ## name ## _validate();
+    extern "C" void ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL;
 
 #define FOR_EACH_IPINT_OPCODE(m) \
     m(0x00, unreachable) \
@@ -217,7 +217,7 @@ extern "C" void ipint_entry();
     m(0xfc, fc_block) \
     m(0xfd, simd)
 
-#if CPU(ARM64) || CPU(X86_64)
+#if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
 FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 #endif
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2780,6 +2780,7 @@ macro wasmScope()
     # Wrap the script in a macro since it overwrites some of the LLInt macros,
     # but we don't want to interfere with the LLInt opcodes
     include WebAssembly
+    include InPlaceInterpreter
 end
 
 global _wasmLLIntPCRangeStart
@@ -2821,8 +2822,6 @@ _wasm_trampoline_wasm_tail_call_indirect_wide32:
 end # WEBASSEMBLY and not X86_64_WIN
 
 include? LowLevelInterpreterAdditions
-
-include InPlaceInterpreter
 
 global _llintPCRangeEnd
 _llintPCRangeEnd:

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "GCLogging.h"
+#include "JSExportMacros.h"
 #include <wtf/MathExtras.h>
 
 #if OS(DARWIN)

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -166,6 +166,7 @@ WasmToJSCallee::WasmToJSCallee()
 
 IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index, std::pair<const Name*, RefPtr<NameSection>>&& name)
     : Callee(Wasm::CompilationMode::IPIntMode, index, WTFMove(name))
+    , m_signatures(WTFMove(generator.m_signatures))
     , m_bytecode(generator.m_bytecode + generator.m_bytecodeOffset)
     , m_bytecodeLength(generator.m_bytecodeLength - generator.m_bytecodeOffset)
     , m_metadataVector(WTFMove(generator.m_metadata))

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -333,6 +333,11 @@ public:
     const uint8_t* getBytecode() const { return m_bytecode; }
     const uint8_t* getMetadata() const { return m_metadata; }
 
+    const TypeDefinition& signature(unsigned index) const
+    {
+        return *m_signatures[index];
+    }
+
     using OutOfLineJumpTargets = HashMap<WasmInstructionStream::Offset, int>;
 
 private:
@@ -347,6 +352,7 @@ private:
     RefPtr<OSREntryCallee> m_osrEntryCallees[numberOfMemoryModes];
 #endif
     CodePtr<WasmEntryPtrTag> m_entrypoint;
+    FixedVector<const TypeDefinition*> m_signatures;
 public:
     // I couldn't figure out how to stop LLIntOffsetsExtractor.cpp from yelling at me.
     // So just making these public.

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp
@@ -33,6 +33,13 @@ namespace JSC {
 
 namespace Wasm {
 
+unsigned FunctionIPIntMetadataGenerator::addSignature(const TypeDefinition& signature)
+{
+    unsigned index = m_signatures.size();
+    m_signatures.append(&signature);
+    return index;
+}
+
 void FunctionIPIntMetadataGenerator::addBlankSpace(uint32_t size)
 {
     m_metadata.grow(m_metadata.size() + size);
@@ -73,6 +80,11 @@ void FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType(Type type
         m_metadata.grow(size + 16);
         WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint64_t>(value), uint64_t);
         WRITE_TO_METADATA(m_metadata.data() + size + 8, static_cast<uint64_t>(length), uint64_t);
+    }  else if (type.isFuncref()) {
+        size_t size = m_metadata.size();
+        m_metadata.grow(size + 8);
+        WRITE_TO_METADATA(m_metadata.data() + size, static_cast<uint32_t>(value), uint32_t);
+        WRITE_TO_METADATA(m_metadata.data() + size + 4, static_cast<uint32_t>(length), uint32_t);
     } else if (!type.isF32() && !type.isF64())
         ASSERT_NOT_IMPLEMENTED_YET();
 }

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -80,6 +80,8 @@ public:
     const uint8_t* getBytecode() const { return m_bytecode; }
     const uint8_t* getMetadata() const { return m_metadata.data(); }
 
+    unsigned addSignature(const TypeDefinition&);
+
 private:
 
     void addBlankSpace(uint32_t size);
@@ -102,6 +104,8 @@ private:
     unsigned m_numArgumentsOnStack { 0 };
     unsigned m_nonArgLocalOffset { 0 };
     Vector<uint32_t> m_argumentLocations { };
+
+    Vector<const TypeDefinition*> m_signatures;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -424,6 +424,17 @@ WASM_SLOW_PATH_DECL(ref_func)
     WASM_RETURN(Wasm::refFunc(instance, instruction.m_functionIndex));
 }
 
+WASM_IPINT_EXTERN_CPP_DECL(ref_func, unsigned index)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    WASM_RETURN_TWO(bitwise_cast<void*>(Wasm::refFunc(instance, index)), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(index);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARM64 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(array_new)
 {
     auto instruction = pc->as<WasmArrayNew>();
@@ -548,6 +559,21 @@ WASM_SLOW_PATH_DECL(table_get)
     WASM_RETURN(result);
 }
 
+WASM_IPINT_EXTERN_CPP_DECL(table_get, unsigned tableIndex, unsigned index)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    EncodedJSValue result = Wasm::tableGet(instance, tableIndex, index);
+    if (!result)
+        WASM_RETURN_TWO(0, bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(bitwise_cast<void*>(result), 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(index);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supported on ARMv8 and X86_64 (for now)");
+#endif
+}
+
 WASM_SLOW_PATH_DECL(table_set)
 {
     auto instruction = pc->as<WasmTableSet>();
@@ -556,6 +582,21 @@ WASM_SLOW_PATH_DECL(table_set)
     if (!Wasm::tableSet(instance, instruction.m_tableIndex, index, value))
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsTableAccess);
     WASM_END();
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value)
+{
+#if CPU(ARM64) || CPU(X86_64)
+    if (!Wasm::tableSet(instance, tableIndex, index, value))
+        WASM_RETURN_TWO(0, bitwise_cast<void*>(static_cast<uint64_t>(Wasm::ExceptionType::OutOfBoundsTableAccess)));
+    WASM_RETURN_TWO(0, 0);
+#else
+    UNUSED_PARAM(instance);
+    UNUSED_PARAM(tableIndex);
+    UNUSED_PARAM(index);
+    UNUSED_PARAM(value);
+    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now)");
+#endif
 }
 
 WASM_SLOW_PATH_DECL(table_init)
@@ -646,9 +687,25 @@ inline UGPRPair doWasmCallIndirect(CallFrame* callFrame, Wasm::Instance* instanc
     WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
 }
 
-WASM_IPINT_EXTERN_CPP_DECL(callIndirect, CallFrame* callFrame, unsigned functionIndex, unsigned tableIndex, unsigned typeIndex)
+WASM_IPINT_EXTERN_CPP_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry)
 {
-    return doWasmCallIndirect(callFrame, instance, functionIndex, tableIndex, typeIndex);
+    unsigned tableIndex = metadataEntry[0];
+    unsigned typeIndex = metadataEntry[1];
+    Wasm::FuncRefTable* table = instance->table(tableIndex)->asFuncrefTable();
+
+    if (functionIndex >= table->length())
+        WASM_THROW(Wasm::ExceptionType::OutOfBoundsCallIndirect);
+
+    const Wasm::FuncRefTable::Function& function = table->function(functionIndex);
+
+    if (function.m_function.typeIndex == Wasm::TypeDefinition::invalidIndex)
+        WASM_THROW(Wasm::ExceptionType::NullTableEntry);
+
+    const auto& callSignature = static_cast<Wasm::IPIntCallee*>(callFrame->callee().asWasmCallee())->signature(typeIndex);
+    if (callSignature.index() != function.m_function.typeIndex)
+        WASM_THROW(Wasm::ExceptionType::BadSignature);
+
+    WASM_CALL_RETURN(function.m_instance, function.m_function.entrypointLoadLocation->taggedPtr(), WasmEntryPtrTag);
 }
 
 WASM_SLOW_PATH_DECL(call_indirect)

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.h
@@ -69,8 +69,11 @@ WASM_SLOW_PATH_HIDDEN_DECL(trace);
 WASM_SLOW_PATH_HIDDEN_DECL(out_of_line_jump_target);
 
 WASM_SLOW_PATH_HIDDEN_DECL(ref_func);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(ref_func, unsigned index);
 WASM_SLOW_PATH_HIDDEN_DECL(table_get);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_get, unsigned, unsigned);
 WASM_SLOW_PATH_HIDDEN_DECL(table_set);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(table_set, unsigned tableIndex, unsigned index, EncodedJSValue value);
 WASM_SLOW_PATH_HIDDEN_DECL(table_init);
 WASM_SLOW_PATH_HIDDEN_DECL(table_fill);
 WASM_SLOW_PATH_HIDDEN_DECL(table_grow);
@@ -78,9 +81,9 @@ WASM_SLOW_PATH_HIDDEN_DECL(grow_memory);
 WASM_SLOW_PATH_HIDDEN_DECL(memory_init);
 WASM_SLOW_PATH_HIDDEN_DECL(call);
 WASM_SLOW_PATH_HIDDEN_DECL(call_indirect);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call_indirect, CallFrame* callFrame, unsigned functionIndex, unsigned* metadataEntry);
 
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(call, unsigned);
-WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(callIndirect, CallFrame*, unsigned, unsigned, unsigned);
 
 WASM_SLOW_PATH_HIDDEN_DECL(call_ref);
 WASM_SLOW_PATH_HIDDEN_DECL(tail_call);


### PR DESCRIPTION
#### 8e237a17b93c448615544a93160b779c8220f68d
<pre>
Implement table instructions, f64 arithmetic, and type conversions
<a href="https://bugs.webkit.org/show_bug.cgi?id=259510">https://bugs.webkit.org/show_bug.cgi?id=259510</a>
rdar://112869717

Reviewed by Yusuke Suzuki.

Added implementations for table.get, table.set, ref.null, ref.is_null, call_indirect, f64 arithmetic operations, and type conversions; this includes exception handling. Additionally, fix build errors for cloop build.

* JSTests/wasm/ipint-tests/ipint-test-f64-ops.js:
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.abs.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.neg.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.ceil.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.floor.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.trunc.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.nearest.return.func.export.string_appeared_here.param.f64.result.f64.local.0.f64.sqrt.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.add.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.sub.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.mul.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.div.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.min.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.max.return.func.export.string_appeared_here.param.f64.f64.result.f64.local.0.local.1.f64.copysign.return.close):
(y.async test):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.clz.return.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.ctz.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.add.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.sub.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.mul.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.div_s.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.div_u.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.and.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.or.return.func.export.string_appeared_here.param.i32.i32.result.i32.local.0.local.1.i32.xor.return.async test): Deleted.
* JSTests/wasm/ipint-tests/ipint-test-table-read.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.i2i.func.param.i32.result.i32.table.table.export.string_appeared_here.3.funcref.func.export.string_appeared_here.result.i32.i32.const.0.table.table.ref.is_null.func.export.string_appeared_here.i32.const.0.ref.null.func.table.table.func.export.string_appeared_here.i32.const.0.ref.func.inc.table.table.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.const.0.call_indirect.table.type.i2i.func.inc.export.string_appeared_here.param.i32.result.i32.local.0.i32.const.1.i32.add.async test):
* JSTests/wasm/ipint-tests/ipint-test-type-conversion.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.param.i64.result.i32.local.0.i32.wrap_i64.func.export.string_appeared_here.param.f32.result.i32.local.0.i32.trunc_f32_s.func.export.string_appeared_here.param.f32.result.i32.local.0.i32.trunc_f32_u.func.export.string_appeared_here.param.f64.result.i32.local.0.i32.trunc_f64_s.func.export.string_appeared_here.param.f64.result.i32.local.0.i32.trunc_f64_u.func.export.string_appeared_here.param.i32.result.i64.local.0.i64.extend_i32_s.func.export.string_appeared_here.param.i32.result.i64.local.0.i64.extend_i32_u.func.export.string_appeared_here.param.f32.result.i64.local.0.i64.trunc_f32_s.func.export.string_appeared_here.param.f32.result.i64.local.0.i64.trunc_f32_u.func.export.string_appeared_here.param.f64.result.i64.local.0.i64.trunc_f64_s.func.export.string_appeared_here.param.f64.result.i64.local.0.i64.trunc_f64_u.func.export.string_appeared_here.param.i32.result.f32.local.0.f32.convert_i32_s.func.export.string_appeared_here.param.i32.result.f32.local.0.f32.convert_i32_u.func.export.string_appeared_here.param.i64.result.f32.local.0.f32.convert_i64_s.func.export.string_appeared_here.param.i64.result.f32.local.0.f32.convert_i64_u.func.export.string_appeared_here.param.f64.result.f32.local.0.f32.demote_f64.func.export.string_appeared_here.param.i32.result.f64.local.0.f64.convert_i32_s.func.export.string_appeared_here.param.i32.result.f64.local.0.f64.convert_i32_u.func.export.string_appeared_here.param.i64.result.f64.local.0.f64.convert_i64_s.func.export.string_appeared_here.param.i64.result.f64.local.0.f64.convert_i64_u.func.export.string_appeared_here.param.f32.result.f64.local.0.f64.promote_f32.func.export.string_appeared_here.param.f32.result.i32.local.0.i32.reinterpret_f32.func.export.string_appeared_here.param.f64.result.i64.local.0.i64.reinterpret_f64.func.export.string_appeared_here.param.i32.result.f32.local.0.f32.reinterpret_i32.func.export.string_appeared_here.param.i64.result.f64.local.0.f64.reinterpret_i64.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.extend8_s.func.export.string_appeared_here.param.i32.result.i32.local.0.i32.extend16_s.func.export.string_appeared_here.param.i64.result.i64.local.0.i64.extend8_s.func.export.string_appeared_here.param.i64.result.i64.local.0.i64.extend16_s.func.export.string_appeared_here.param.i64.result.i64.local.0.i64.extend32_s.close):
(y.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::IPIntCallee::IPIntCallee):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addSignature):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addRefFunc):
(JSC::Wasm::IPIntGenerator::addTableGet):
(JSC::Wasm::IPIntGenerator::addTableSet):
(JSC::Wasm::IPIntGenerator::addCallCommonData):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmSlowPaths.h:

Canonical link: <a href="https://commits.webkit.org/266368@main">https://commits.webkit.org/266368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e3e08f511fc3edab6ab9755c39a469a23655582

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15397 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12977 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15662 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16096 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19356 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11643 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15701 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10891 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13704 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12279 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3571 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16609 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14091 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1577 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12852 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3379 "Passed tests") | 
<!--EWS-Status-Bubble-End-->