### PR TITLE
Media Controls: Time stamps should update as you slide

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js
@@ -51,7 +51,9 @@ class ScrubbingSupport extends MediaControllerSupport
     controlValueDidChange(control)
     {
         const media = this.mediaController.media;
-        media.fastSeek(control.value * media.duration);
+        const seekTime = control.value * media.duration;
+        media.fastSeek(seekTime);
+        this.mediaController.controls.timeControl.currentTime = seekTime;
     }
 
     controlValueDidStopChanging(control)


### PR DESCRIPTION
#### 1d898475f9be69641277070c061b7e173e615c01
<pre>
Media Controls: Time stamps should update as you slide
<a href="https://bugs.webkit.org/show_bug.cgi?id=259516">https://bugs.webkit.org/show_bug.cgi?id=259516</a>
rdar://112875698

Reviewed by Tim Horton.

Timestamps in the media controls should be updated as soon as the control value changes,
instead of waiting for the `timeupdate` event to be dispatched.

* Source/WebCore/Modules/modern-media-controls/media/scrubbing-support.js:
(ScrubbingSupport.prototype.controlValueDidChange):

Canonical link: <a href="https://commits.webkit.org/266339@main">https://commits.webkit.org/266339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc7605c1e1c210740d1b993031033560a51930fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15242 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15530 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15946 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19233 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10751 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12134 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3306 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->