### PR TITLE
[Win][MiniBrowser] Download a file, if a MIME type is not supported.

### DIFF
--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -510,7 +510,21 @@ void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef page, WKNa
         text << L"URL: " << createString(adoptWK(WKURLResponseCopyURL(response.get())).get());
         MessageBox(thisWindow.m_hMainWnd, text.str().c_str(), L"No Content", MB_OK | MB_ICONWARNING);
     }
-    WKFramePolicyListenerUse(listener);
+
+    if (WKNavigationResponseCanShowMIMEType(navigationResponse))
+        WKFramePolicyListenerUse(listener);
+    else {
+        std::wstringstream text;
+        text << L"Do you want to save this file?" << std::endl;
+        text << std::endl;
+        text << L"MIME type: " << createString(adoptWK(WKURLResponseCopyMIMEType(response.get())).get()) << std::endl;
+        text << L"URL: " << createString(adoptWK(WKURLResponseCopyURL(response.get())).get());
+
+        if (MessageBox(thisWindow.hwnd(), text.str().c_str(), L"Unsupported MIME type", MB_OKCANCEL | MB_ICONWARNING) == IDOK)
+            WKFramePolicyListenerDownload(listener);
+        else
+            WKFramePolicyListenerIgnore(listener);
+    }
 }
 
 void WebKitBrowserWindow::didFailProvisionalNavigation(WKPageRef page, WKNavigationRef navigation, WKErrorRef error, WKTypeRef userData, const void* clientInfo)


### PR DESCRIPTION
#### feb7a3b937dbcc3c247a4417dd65a6ae94f6b8de
<pre>
[Win][MiniBrowser] Download a file, if a MIME type is not supported.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259518">https://bugs.webkit.org/show_bug.cgi?id=259518</a>

Reviewed by Fujii Hironori.

If you select content with an unsupported MIME type, the binary data of
that file will be displayed. Therefore, for such content, download the
file.

* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::decidePolicyForNavigationResponse):

Canonical link: <a href="https://commits.webkit.org/266320@main">https://commits.webkit.org/266320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e06013881894230019f99efbcfcdf82701b73d71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13914 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15545 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15964 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11622 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19249 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15583 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10767 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16480 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1556 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->