### PR TITLE
RealtimeOutgoingVideoSource black frame size computation is wrong in case of rotation

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1777,6 +1777,7 @@ fast/mediastream/get-user-media-ideal-constraints.html [ Failure ]
 fast/mediastream/mediastreamtrack-video-frameRate-clone-increasing.html [ Failure ]
 fast/mediastream/video-rotation.html [ Skip ]
 webrtc/video-rotation-no-cvo.html [ Failure ]
+webrtc/video-rotation-black.html [ Failure ]
 
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2773,6 +2773,7 @@ fast/mediastream/getDisplayMedia-size.html [ Skip ]
 webkit.org/b/177401 webrtc/captureCanvas-webrtc.html [ Pass Timeout Failure ]
 
 webkit.org/b/210173 webrtc/h265.html [ Skip ]
+webrtc/video-rotation-black.html [ Slow ]
 
 webkit.org/b/209878  [ Debug ] webrtc/datachannel/multiple-connections.html [ Slow ]
 

--- a/LayoutTests/webrtc/video-rotation-black-expected.txt
+++ b/LayoutTests/webrtc/video-rotation-black-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Rotated disabled track should keep sending the same intrinsic size video if CVO is on
+

--- a/LayoutTests/webrtc/video-rotation-black.html
+++ b/LayoutTests/webrtc/video-rotation-black.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id="localVideo" autoplay playsInline width=100px ></video>
+        <video id="remoteVideo" autoplay playsInline width=100px></video>
+        <canvas id="canvas0" width="640" height="480"></canvas>
+        <script src ="routines.js"></script>
+        <script>
+function isVideoBlack(video, canvasId)
+{
+    var canvas = document.getElementById(canvasId);
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    imageData = canvas.getContext('2d').getImageData(0, 0, canvas.width, canvas.height);
+    data = imageData.data;
+    for (var cptr = 0; cptr < canvas.width * canvas.height; ++cptr) {
+        // Approximatively black pixels.
+        if (data[4 * cptr] > 30 || data[4 * cptr + 1] > 30 || data[4 * cptr + 2] > 30)
+            return false;
+    }
+    return true;
+}
+
+function pollVideoBlackCheck(expected, video, canvasId, resolve)
+{
+    if (isVideoBlack(video, canvasId) === expected) {
+        resolve();
+        return;
+    }
+
+    setTimeout(() => pollVideoBlackCheck(expected, video, canvasId, resolve), 100);
+}
+
+function checkVideoBlack(expected, video, canvasId)
+{
+    return new Promise((resolve, reject) => {
+        pollVideoBlackCheck(expected, video, canvasId, resolve);
+        setTimeout(() => reject("checkVideoBlack timed out for '" + canvasId + "', expected " + expected), 15000);
+    });
+}
+
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video: {width: 640, height: 480}});
+    if (window.testRunner)
+        testRunner.setMockCameraOrientation(90);
+
+    localVideo.srcObject = localStream;
+    await localVideo.play();
+
+    let track;
+    const remoteStream = await new Promise((resolve, reject) => {
+        track = localStream.getVideoTracks()[0].clone();
+        createConnections((firstConnection) => {
+            firstConnection.addTrack(track, localStream);
+        }, (secondConnection) => {
+            secondConnection.ontrack = (trackEvent) => {
+                resolve(trackEvent.streams[0]);
+            };
+        });
+        setTimeout(() => reject("Test timed out"), 5000);
+    });
+
+    remoteVideo.srcObject = remoteStream;
+    await remoteVideo.play();
+    track.enabled = false;
+
+    await checkVideoBlack(true, remoteVideo, "canvas0");
+
+    assert_equals(remoteVideo.videoWidth, 480);
+    assert_equals(remoteVideo.videoHeight, 640);
+}, "Rotated disabled track should keep sending the same intrinsic size video if CVO is on");
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -214,8 +214,9 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
     if (!m_blackFrame) {
         auto width = m_width;
         auto height = m_height;
-        if (m_shouldApplyRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
+        if (!m_shouldApplyRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
             std::swap(width, height);
+
         m_blackFrame = createBlackFrame(width, height);
         ASSERT(m_blackFrame);
         if (!m_blackFrame) {


### PR DESCRIPTION
#### 50d6b4d81168e9a238f3c8b0ba540871ef465a4b
<pre>
RealtimeOutgoingVideoSource black frame size computation is wrong in case of rotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=259472">https://bugs.webkit.org/show_bug.cgi?id=259472</a>
rdar://112823005

Reviewed by Eric Carlson.

The black frame size is computed from the source settings, which applies the rotation.
In case we use CVO, we should use the intrinsic size before rotation.
Update RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded accordingly.
This ensures we do not resize on receiver side whenever the sender is sending black frames.

Marking test as slow in iOS as it can take more than 14 seconds sometimes.
Marking test as slow in iOS a
Marking test as slow in iOS a* LayoutTests/platform/glib/TestExpectations:
Marking test as slow in iOS a* LayoutTests/platform/ios/TestExpectations:
Marking test as slow in iOS a* LayoutTests/webrtc/video-rotation-black-expected.txt: Added.
Marking test as slow in iOS a* LayoutTests/webrtc/video-rotation-black.html: Added.
* Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp:
(WebCore::RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded):

Canonical link: <a href="https://commits.webkit.org/266358@main">https://commits.webkit.org/266358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/124ea16e71b7b2730b010b86f6a606e15a2283b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16062 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19328 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12245 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12153 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16575 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->