### PR TITLE
[JSC] Use DFG::Call when calling typed array constructor without keyword new

### DIFF
--- a/JSTests/stress/construct-typed-array-without-new-in-dfg-and-ftl.js
+++ b/JSTests/stress/construct-typed-array-without-new-in-dfg-and-ftl.js
@@ -1,0 +1,33 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0.001")
+let typedArrayConstructors = [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+    BigInt64Array,
+    BigUint64Array,
+];
+
+function test(typedArrayConstructor) {
+    function opt(f) {
+        let shouldThrow = f != typedArrayConstructor;
+        try {
+            f(typedArrayConstructor);
+        } catch (e) {
+            shouldThrow = e.toString() == `TypeError: calling ${typedArrayConstructor.name} constructor without new is invalid`;
+        }
+        if (!shouldThrow)
+            throw new Error("bad!");
+    }
+
+    for (let i = 0; i < 10; i++)
+        opt(opt);
+}
+
+for (let i = 0; i < typedArrayConstructors.length; i++)
+    test(typedArrayConstructors[i]);


### PR DESCRIPTION
#### 3cb7aade1a113efd062754a20578b12b1efe3dc5
<pre>
[JSC] Use DFG::Call when calling typed array constructor without keyword new
<a href="https://bugs.webkit.org/show_bug.cgi?id=259523">https://bugs.webkit.org/show_bug.cgi?id=259523</a>
rdar://111952807

Reviewed by Keith Miller.

We should emit DFG::Call for calling typed array constructor without
keyword new in DFG. Then, we can use call slow path to trigger
callConstructor for throwing exception.

* JSTests/stress/construct-typed-array-without-new-in-dfg-and-ftl.js: Added.
(test.opt):
(test):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleTypedArrayConstructor):
(JSC::DFG::ByteCodeParser::handleConstantFunction):

Canonical link: <a href="https://commits.webkit.org/266331@main">https://commits.webkit.org/266331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79dc8f71528ecc25f63ee4083d8b2732b120dc13

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12878 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15980 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19266 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11539 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15601 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12820 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10784 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13583 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12168 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3301 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16496 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13968 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12743 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3347 "Passed tests") | 
<!--EWS-Status-Bubble-End-->