### PR TITLE
[JSC][armv7] Enable concurrent JIT

### DIFF
--- a/Source/JavaScriptCore/bytecode/ValueProfile.h
+++ b/Source/JavaScriptCore/bytecode/ValueProfile.h
@@ -62,12 +62,12 @@ struct ValueProfileBase {
     void clearBuckets()
     {
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i)
-            m_buckets[i] = JSValue::encode(JSValue());
+            clearEncodedJSValueConcurrent(m_buckets[i]);
     }
     
     const ClassInfo* classInfo(unsigned bucket) const
     {
-        JSValue value = JSValue::decode(m_buckets[bucket]);
+        JSValue value = JSValue::decodeConcurrent(&m_buckets[bucket]);
         if (!!value) {
             if (!value.isCell())
                 return nullptr;
@@ -80,7 +80,7 @@ struct ValueProfileBase {
     {
         unsigned result = 0;
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i) {
-            if (!!JSValue::decode(m_buckets[i]))
+            if (!!JSValue::decodeConcurrent(&m_buckets[i]))
                 result++;
         }
         return result;
@@ -96,7 +96,7 @@ struct ValueProfileBase {
     bool isLive() const
     {
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i) {
-            if (!!JSValue::decode(m_buckets[i]))
+            if (!!JSValue::decodeConcurrent(&m_buckets[i]))
                 return true;
         }
         return false;
@@ -132,13 +132,13 @@ struct ValueProfileBase {
     {
         SpeculatedType merged = SpecNone;
         for (unsigned i = 0; i < totalNumberOfBuckets; ++i) {
-            JSValue value = JSValue::decode(m_buckets[i]);
+            JSValue value = JSValue::decodeConcurrent(&m_buckets[i]);
             if (!value)
                 continue;
             
             mergeSpeculation(merged, speculationFromValue(value));
-            
-            m_buckets[i] = JSValue::encode(JSValue());
+
+            updateEncodedJSValueConcurrent(m_buckets[i], JSValue::encode(JSValue()));
         }
 
         mergeSpeculation(m_prediction, merged);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -77,6 +77,33 @@ public:
 #endif
     }
 
+#if USE(JSVALUE32_64)
+    template <typename Tag, typename Payload, typename Dst>
+    void storeAndFence32(Tag&& tag, Payload&& payload, Dst&& dst)
+    {
+        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
+
+        auto const finish = [&](auto&& tagDst) {
+            if (Options::useConcurrentJIT()) {
+                store32(TrustedImm32(JSValue::InvalidTag), tagDst);
+                storeFence();
+                store32(payload, dst);
+                storeFence();
+                store32(tag, tagDst);
+            } else {
+                store32(payload, dst);
+                store32(tag, tagDst);
+            }
+        };
+
+        if constexpr (std::is_pointer_v<std::remove_reference_t<Dst>>) {
+            void* tagAddr = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(dst) + TagOffset);
+            finish(tagAddr);
+        } else
+            finish(dst.withOffset(TagOffset));
+    }
+#endif
+
 #if ENABLE(WEBASSEMBLY)
     void prepareWasmCallOperation(GPRReg instanceGPR);
 #endif
@@ -145,38 +172,54 @@ public:
 #endif
     }
 
+#if USE(JSVALUE64)
     template<typename T, typename U>
     void storeCell(T cell, U address)
     {
-#if USE(JSVALUE64)
         store64(cell, address);
-#else
-        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        storePair32(cell, TrustedImm32(JSValue::CellTag), address);
-#endif
     }
+#else
+    void storeCell(GPRReg cell, Address address)
+    {
+        storeAndFence32(TrustedImm32(JSValue::CellTag), cell, address);
+    }
+#endif
 
+#if USE(JSVALUE64)
     template<typename U>
-    void storeCell(JSValueRegs regs, U address)
+    void storeCell(GPRReg cell, U address)
+    {
+        store64(cell, address);
+    }
+#else
+    void storeCell(GPRReg cell, void* address)
+    {
+        storeAndFence32(TrustedImm32(JSValue::CellTag), cell, address);
+    }
+#endif
+
+    void storeCell(JSValueRegs regs, void* address)
     {
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
 #else
-        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
         move(AssemblyHelpers::TrustedImm32(JSValue::CellTag), regs.tagGPR());
-        storePair32(regs.payloadGPR(), regs.tagGPR(), address);
+        storeAndFence32(regs.tagGPR(), regs.payloadGPR(), address);
 #endif
     }
 
 #if USE(JSVALUE32_64)
+    void storeCell(TrustedImmPtr cell, Address address)
+    {
+#if USE(JSVALUE64)
+        store64(cell, address);
+#else
+        storeAndFence32(TrustedImm32(JSValue::CellTag), TrustedImm32(cell.asIntptr()), address);
+#endif
+    }
+
     void storeCell(const void* address)
     {
-#if ENABLE(CONCURRENT_JS)
-        if (Options::useConcurrentJIT()) {
-            store32Concurrently(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
-            return;
-        }
-#endif
         store32(AssemblyHelpers::TrustedImm32(JSValue::CellTag), address);
     }
 #endif
@@ -195,8 +238,7 @@ public:
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
 #else
-        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        storePair32(regs.payloadGPR(), regs.tagGPR(), address);
+        storeAndFence32(regs.tagGPR(), regs.payloadGPR(), address);
 #endif
     }
     
@@ -205,8 +247,7 @@ public:
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
 #else
-        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        storePair32(regs.payloadGPR(), regs.tagGPR(), address);
+        storeAndFence32(regs.tagGPR(), regs.payloadGPR(), address);
 #endif
     }
     
@@ -215,8 +256,7 @@ public:
 #if USE(JSVALUE64)
         store64(regs.gpr(), address);
 #else
-        static_assert(!PayloadOffset && TagOffset == 4, "Assumes little-endian system");
-        storePair32(regs.payloadGPR(), regs.tagGPR(), address);
+        storeAndFence32(regs.tagGPR(), regs.payloadGPR(), address);
 #endif
     }
 
@@ -321,7 +361,7 @@ public:
 #if USE(JSVALUE64)
         store64(TrustedImm64(JSValue::encode(value)), address);
 #else
-        storePair32(TrustedImm32(value.payload()), TrustedImm32(value.tag()), address);
+        storeAndFence32(TrustedImm32(value.tag()), TrustedImm32(value.payload()), address);
 #endif
     }
 
@@ -330,7 +370,7 @@ public:
 #if USE(JSVALUE64)
         store64(TrustedImm64(JSValue::encode(value)), address);
 #else
-        storePair32(TrustedImm32(value.payload()), TrustedImm32(value.tag()), address);
+        storeAndFence32(TrustedImm32(value.tag()), TrustedImm32(value.payload()), address);
 #endif
     }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -218,6 +218,7 @@ else
     const CellTag = constexpr JSValue::CellTag
     const EmptyValueTag = constexpr JSValue::EmptyValueTag
     const DeletedValueTag = constexpr JSValue::DeletedValueTag
+    const InvalidTag = constexpr JSValue::InvalidTag
     const LowestTag = constexpr JSValue::LowestTag
 end
 
@@ -1690,11 +1691,16 @@ macro functionInitialization(profileArgSkip)
         subp sizeof ArgumentValueProfile, t3
         storeq t2, profileArgSkip * sizeof ArgumentValueProfile + ValueProfile::m_buckets[t3]
     else
-        loadi ThisArgumentOffset + TagOffset - 8 + profileArgSkip * 8[cfr, t0], t2
         subp sizeof ArgumentValueProfile, t3
-        storei t2, profileArgSkip * sizeof ArgumentValueProfile + ValueProfile::m_buckets + TagOffset[t3]
+        loadi ThisArgumentOffset + TagOffset - 8 + profileArgSkip * 8[cfr, t0], t1
         loadi ThisArgumentOffset + PayloadOffset - 8 + profileArgSkip * 8[cfr, t0], t2
-        storei t2, profileArgSkip * sizeof ArgumentValueProfile + ValueProfile::m_buckets + PayloadOffset[t3]
+        storeJSValueConcurrent(
+            macro (val, offset)
+                storei val, profileArgSkip * sizeof ArgumentValueProfile + ValueProfile::m_buckets + offset[t3]
+            end,
+            t1,
+            t2
+        )
     end
     baddpnz -8, t0, .argumentProfileLoop
 .argumentProfileDone:

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -66,6 +66,19 @@ macro getOperandWide32Wasm(opcodeStruct, fieldName, dst)
     loadis constexpr %opcodeStruct%_%fieldName%_index * 4 + OpcodeIDWide32SizeWasm[PB, PC, 1], dst
 end
 
+macro storeJSValueConcurrent(store, tag, payload)
+    if JIT
+        store(InvalidTag, TagOffset)
+        writefence
+        store(payload, PayloadOffset)
+        writefence
+        store(tag, TagOffset)
+    else
+        store(payload, PayloadOffset)
+        store(tag, TagOffset)
+    end
+end
+
 macro makeReturn(get, dispatch, fn)
     fn(macro(tag, payload)
         move tag, t5
@@ -731,8 +744,13 @@ end
 macro valueProfile(size, opcodeStruct, profileName, tag, payload, scratch)
     getu(size, opcodeStruct, profileName, scratch)
     muli constexpr (-sizeof(ValueProfile)), scratch
-    storei tag, constexpr (-sizeof(UnlinkedMetadataTable::LinkingData)) + ValueProfile::m_buckets + TagOffset[metadataTable, scratch, 1]
-    storei payload, constexpr (-sizeof(UnlinkedMetadataTable::LinkingData)) + ValueProfile::m_buckets + PayloadOffset[metadataTable, scratch, 1]
+    storeJSValueConcurrent(
+        macro(val, offset)
+            storei val, constexpr (-sizeof(UnlinkedMetadataTable::LinkingData)) + ValueProfile::m_buckets + offset[metadataTable, scratch, 1]
+        end,
+        tag,
+        payload
+    )
 end
 
 
@@ -1510,8 +1528,13 @@ macro storePropertyAtVariableOffset(propertyOffsetAsInt, objectAndStorage, tag, 
 .isInline:
     addp sizeof JSObject - (firstOutOfLineOffset - 2) * 8, objectAndStorage
 .ready:
-    storei tag, TagOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffsetAsInt, 8]
-    storei payload, PayloadOffset + (firstOutOfLineOffset - 2) * 8[objectAndStorage, propertyOffsetAsInt, 8]
+    storeJSValueConcurrent(
+        macro(val, offset)
+            storei val, (firstOutOfLineOffset - 2) * 8 + offset[objectAndStorage, propertyOffsetAsInt, 8]
+        end,
+        tag,
+        payload
+    )
 end
 
 
@@ -1937,8 +1960,13 @@ macro putByValOp(opcodeName, opcodeStruct, osrExitPoint)
                 const tag = scratch
                 const payload = operand
                 loadConstantOrVariable2Reg(size, operand, tag, payload)
-                storei tag, TagOffset[base, index, 8]
-                storei payload, PayloadOffset[base, index, 8]
+                storeJSValueConcurrent(
+                    macro (val, offset)
+                        storei val, offset[base, index, 8]
+                    end,
+                    tag,
+                    payload
+                )
             end)
 
     .opPutByValNotContiguous:
@@ -1948,8 +1976,13 @@ macro putByValOp(opcodeName, opcodeStruct, osrExitPoint)
     .opPutByValArrayStorageStoreResult:
         get(m_value, t2)
         loadConstantOrVariable2Reg(size, t2, t1, t2)
-        storei t1, ArrayStorage::m_vector + TagOffset[t0, t3, 8]
-        storei t2, ArrayStorage::m_vector + PayloadOffset[t0, t3, 8]
+        storeJSValueConcurrent(
+            macro (val, offset)
+                storei val, ArrayStorage::m_vector + offset[t0, t3, 8]
+            end,
+            t1,
+            t2
+        )
         dispatch()
 
     .opPutByValArrayStorageEmpty:
@@ -2827,16 +2860,26 @@ llintOpWithMetadata(op_put_to_scope, OpPutToScope, macro (size, get, dispatch, m
         notifyWrite(t3, .pDynamic)
     .noVariableWatchpointSet:
         loadp OpPutToScope::Metadata::m_operand[t5], t0
-        storei t1, TagOffset[t0]
-        storei t2, PayloadOffset[t0]
+        storeJSValueConcurrent(
+            macro (val, offset)
+                storei val, offset[t0]
+            end,
+            t1,
+            t2
+        )
     end
 
     macro putClosureVar()
         get(m_value, t1)
         loadConstantOrVariable(size, t1, t2, t3)
         loadp OpPutToScope::Metadata::m_operand[t5], t1
-        storei t2, JSLexicalEnvironment_variables + TagOffset[t0, t1, 8]
-        storei t3, JSLexicalEnvironment_variables + PayloadOffset[t0, t1, 8]
+        storeJSValueConcurrent(
+            macro (val, offset)
+                storei val, JSLexicalEnvironment_variables + offset[t0, t1, 8]
+            end,
+            t2,
+            t3
+        )
     end
 
     macro putResolvedClosureVar()
@@ -2847,8 +2890,13 @@ llintOpWithMetadata(op_put_to_scope, OpPutToScope, macro (size, get, dispatch, m
         notifyWrite(t1, .pDynamic)
     .noVariableWatchpointSet:
         loadp OpPutToScope::Metadata::m_operand[t5], t1
-        storei t2, JSLexicalEnvironment_variables + TagOffset[t0, t1, 8]
-        storei t3, JSLexicalEnvironment_variables + PayloadOffset[t0, t1, 8]
+        storeJSValueConcurrent(
+            macro (val, offset)
+                storei val, JSLexicalEnvironment_variables + offset[t0, t1, 8]
+            end,
+            t2,
+            t3
+        )
     end
 
     macro checkTDZInGlobalPutToScopeIfNecessary()
@@ -2962,8 +3010,13 @@ llintOp(op_put_to_arguments, OpPutToArguments, macro (size, get, dispatch)
     get(m_value, t1)
     loadConstantOrVariable(size, t1, t2, t3)
     getu(size, OpPutToArguments, m_index, t1)
-    storei t2, DirectArguments_storage + TagOffset[t0, t1, 8]
-    storei t3, DirectArguments_storage + PayloadOffset[t0, t1, 8]
+    storeJSValueConcurrent(
+        macro (val, offset)
+            storei val, DirectArguments_storage + offset[t0, t1, 8]
+        end,
+        t2,
+        t3
+    )
     dispatch()
 end)
 
@@ -2993,8 +3046,13 @@ llintOpWithMetadata(op_profile_type, OpProfileType, macro (size, get, dispatch, 
     loadp TypeProfilerLog::m_currentLogEntryPtr[t1], t2
 
     # Store the JSValue onto the log entry.
-    storei t5, TypeProfilerLog::LogEntry::value + TagOffset[t2]
-    storei t0, TypeProfilerLog::LogEntry::value + PayloadOffset[t2]
+    storeJSValueConcurrent(
+        macro (val, offset)
+            storei val, TypeProfilerLog::LogEntry::value + offset[t2]
+        end,
+        t5,
+        t0
+    )
 
     # Store the TypeLocation onto the log entry.
     loadp OpProfileType::Metadata::m_typeLocation[t3], t3
@@ -3207,8 +3265,13 @@ llintOp(op_put_internal_field, OpPutInternalField, macro (size, get, dispatch)
     get(m_value, t1)
     loadConstantOrVariable(size, t1, t2, t3)
     getu(size, OpPutInternalField, m_index, t1)
-    storei t2, JSInternalFieldObjectImpl_internalFields + TagOffset[t0, t1, SlotSize]
-    storei t3, JSInternalFieldObjectImpl_internalFields + PayloadOffset[t0, t1, SlotSize]
+    storeJSValueConcurrent(
+        macro (val, offset)
+            storei val, JSInternalFieldObjectImpl_internalFields + offset[t0, t1, SlotSize]
+        end,
+        t2,
+        t3
+    )
     writeBarrierOnOperand(size, get, m_base)
     dispatch()
 end)
@@ -3236,8 +3299,13 @@ llintOp(op_log_shadow_chicken_tail, OpLogShadowChickenTail, macro (size, get, di
     storep cfr, ShadowChicken::Packet::frame[t0]
     storep ShadowChickenTailMarker, ShadowChicken::Packet::callee[t0]
     loadVariable(get, m_thisValue, t3, t2, t1)
-    storei t2, TagOffset + ShadowChicken::Packet::thisValue[t0]
-    storei t1, PayloadOffset + ShadowChicken::Packet::thisValue[t0]
+    storeJSValueConcurrent(
+        macro (val, offset)
+            storei val, ShadowChicken::Packet::thisValue + offset[t0]
+        end,
+        t2,
+        t1
+    )
     get(m_scope, t1)
     loadi PayloadOffset[cfr, t1, 8], t1
     storep t1, ShadowChicken::Packet::scope[t0]

--- a/Source/JavaScriptCore/offlineasm/arm.rb
+++ b/Source/JavaScriptCore/offlineasm/arm.rb
@@ -939,6 +939,8 @@ class Instruction
             $asm.puts "dmb sy"
         when "fence"
             $asm.puts "dmb ish"
+        when "writefence"
+            $asm.puts "dmb ishst"
         when "clrbp"
             $asm.puts "bic #{operands[2].armOperand}, #{operands[0].armOperand}, #{operands[1].armOperand}"
         when "globaladdr"

--- a/Source/JavaScriptCore/offlineasm/instructions.rb
+++ b/Source/JavaScriptCore/offlineasm/instructions.rb
@@ -402,6 +402,7 @@ ARM_INSTRUCTIONS =
      "storecondh",
      "storecondi",
      "storecond2i",
+     "writefence",
     ]
 
 ARM64_INSTRUCTIONS =

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -87,7 +87,10 @@ enum PreferredPrimitiveType : uint8_t { NoPreference, PreferNumber, PreferString
 struct CallData;
 
 typedef int64_t EncodedJSValue;
-    
+
+inline void updateEncodedJSValueConcurrent(EncodedJSValue&, EncodedJSValue);
+inline void clearEncodedJSValueConcurrent(EncodedJSValue&);
+
 union EncodedValueDescriptor {
     int64_t asInt64;
 #if USE(JSVALUE32_64)
@@ -165,12 +168,18 @@ public:
     static constexpr uint32_t NativeCalleeTag = 0xfffffffa;
     static constexpr uint32_t EmptyValueTag =   0xfffffff9;
     static constexpr uint32_t DeletedValueTag = 0xfffffff8;
+    static constexpr uint32_t InvalidTag      = 0xfffffff7;
 
-    static constexpr uint32_t LowestTag =  DeletedValueTag;
+    static constexpr uint32_t LowestTag =  InvalidTag;
 #endif
 
     static EncodedJSValue encode(JSValue);
     static JSValue decode(EncodedJSValue);
+
+    /* read a JSValue from storage not owned by this thread
+     * on 64-bit ports, or when JIT is not enabled, equivalent to
+     * JSValue::decode(*ptr) */
+    static JSValue decodeConcurrent(const volatile EncodedJSValue *);
 
     enum JSNullTag { JSNull };
     enum JSUndefinedTag { JSUndefined };
@@ -728,5 +737,65 @@ public:
 private:
     JSValue m_value;
 };
+
+#if USE(JSVALUE64) || !ENABLE(CONCURRENT_JS)
+
+inline JSValue JSValue::decodeConcurrent(const volatile EncodedJSValue* encodedJSValue)
+{
+    return JSValue::decode(*encodedJSValue);
+}
+
+inline void updateEncodedJSValueConcurrent(EncodedJSValue& dest, EncodedJSValue value)
+{
+    dest = value;
+}
+
+inline void clearEncodedJSValueConcurrent(EncodedJSValue& dest)
+{
+    dest = JSValue::encode(JSValue());
+}
+
+#elif USE(JSVALUE32_64)
+
+inline JSValue JSValue::decodeConcurrent(const volatile EncodedJSValue *encodedJSValue)
+{
+    for (;;) {
+        auto v = JSValue::decode(reinterpret_cast<const volatile std::atomic<EncodedJSValue>*>(encodedJSValue)->load());
+        if (v.tag() != InvalidTag)
+            return v;
+    }
+}
+
+inline void updateEncodedJSValueConcurrent(EncodedJSValue& dest, EncodedJSValue value)
+{
+    auto destDesc = const_cast<volatile EncodedValueDescriptor*>(reinterpret_cast<EncodedValueDescriptor*>(&dest));
+
+    EncodedValueDescriptor desc;
+    memcpy(&desc, &value, sizeof(value));
+
+    auto destTag = const_cast<volatile int32_t*>(&destDesc->asBits.tag);
+    auto destPayload = const_cast<volatile int32_t*>(&destDesc->asBits.payload);
+
+    *destTag = JSValue::InvalidTag;
+    WTF::storeStoreFence();
+    *destPayload = desc.asBits.payload;
+    WTF::storeStoreFence();
+    *destTag = desc.asBits.tag;
+}
+
+inline void clearEncodedJSValueConcurrent(EncodedJSValue& dest)
+{
+    auto destDesc = const_cast<volatile EncodedValueDescriptor*>(reinterpret_cast<EncodedValueDescriptor*>(&dest));
+    auto destTag = const_cast<volatile int32_t*>(&destDesc->asBits.tag);
+    auto destPayload = const_cast<volatile int32_t*>(&destDesc->asBits.payload);
+
+    *destTag = JSValue::EmptyValueTag;
+    WTF::storeStoreFence();
+    *destPayload = 0;
+}
+
+#else
+#  error "Unsupported configuration"
+#endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -167,7 +167,7 @@ public:
 
     JSValue get() const
     {
-        return JSValue::decode(m_value);
+        return JSValue::decodeConcurrent(&m_value);
     }
     void clear() { m_value = JSValue::encode(JSValue()); }
     void setUndefined() { m_value = JSValue::encode(jsUndefined()); }

--- a/Source/JavaScriptCore/runtime/WriteBarrierInlines.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrierInlines.h
@@ -57,7 +57,7 @@ inline void WriteBarrierBase<T, Traits>::setEarlyValue(VM& vm, const JSCell* own
 inline void WriteBarrierBase<Unknown, RawValueTraits<Unknown>>::set(VM& vm, const JSCell* owner, JSValue value)
 {
     ASSERT(!Options::useConcurrentJIT() || !isCompilationThread());
-    m_value = JSValue::encode(value);
+    updateEncodedJSValueConcurrent(m_value, JSValue::encode(value));
     vm.writeBarrier(owner, value);
 }
 

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -777,11 +777,7 @@
 #define ENABLE_DFG_DOES_GC_VALIDATION 0
 #endif
 
-/* Concurrent JS only works on 64-bit platforms because it requires that
-   values get stored to atomically. This is trivially true on 64-bit platforms,
-   but not true at all on 32-bit platforms where values are composed of two
-   separate sub-values. */
-#if ENABLE(JIT) && USE(JSVALUE64)
+#if ENABLE(JIT)
 #define ENABLE_CONCURRENT_JS 1
 #endif
 


### PR DESCRIPTION
#### 0e5f4888c8bb1f7d0a4407d044089f664bc857df
<pre>
[JSC][armv7] Enable concurrent JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=239821">https://bugs.webkit.org/show_bug.cgi?id=239821</a>

Reviewed by NOBODY (OOPS!).

Here we are again--the goal is to enable concurrent JIT support on ARMv7--the
problem, of course, is we don&apos;t have a way to update a JSValue atomically, with
the current encoding.

** Approach

Previous passes at this have tried to cope with the possibility of reading a
&quot;spliced JSValue&quot;--i.e., a value observed with a CellTag and a not-Cell
payload; this seems to work but isn&apos;t great and we don&apos;t have a way to get
reasonable answers from e.g. value profiles when this happens.

Instead, we develop the following protocol for updating a JSValue:

- Write a newly-reserved tag value, `InvalidTag` to the tag part of the value,
- Write the new payload word
- Write the new tag word

Now, when _reading_ a JSValue from threads other than the mutator, we can use
doubleword atomics and retry until the tag value is not `InvalidTag`.

Unfortunately, although in practice I&apos;ve been unable to find any hardware where
store reordering seems to be observable, the architecture requires us to insert
store-store fences (`dmb ishst`) between these writes; this isn&apos;t free, as
discussed below.

** Implementation

We add a few new primitives for manipulating JSValues in memory that are used in
some key places where JSValues are accessed concurrently: ValueProfiles and any
JSValue behind a WriteBarrier (which addresses most things in the heap.)

As discussed above, for writes, we perform the 3 fenced stores, in order; reads
are retried until the tag is not InvalidTag; and a
`clearEncodedJSValueConcurrent` is provided since this operation does not
require fences (only the tag is modified)

** Performance

The addition of fences adds a nontrivial performance cost, especially for code
that spends a lot of time in the interpreter; however, this is still an
improvement for JetStream2 first-run times on some benchmarks, overall, the
performance is about the same for JS2.

I expect a regression to code size because of the extra stores--though I
believe there&apos;s opportunity to optimize some of these away in the JITs based on
speculation--if we know the JSValue is already a cell or non-cell, the
InvalidTag store is unnecssary and can be omitted.

* Source/JavaScriptCore/bytecode/ValueProfile.h:
(JSC::ValueProfileBase::clearBuckets):
(JSC::ValueProfileBase::classInfo const):
(JSC::ValueProfileBase::numberOfSamples const):
(JSC::ValueProfileBase::isLive const):
(JSC::ValueProfileBase::computeUpdatedPrediction):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::storeAndFence32):
(JSC::AssemblyHelpers::storeCell):
(JSC::AssemblyHelpers::storeValue):
(JSC::AssemblyHelpers::storeTrustedValue):
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/offlineasm/arm.rb:
* Source/JavaScriptCore/offlineasm/instructions.rb:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
(JSC::JSValue::decodeConcurrent):
(JSC::updateEncodedJSValueConcurrent):
(JSC::clearEncodedJSValueConcurrent):
* Source/JavaScriptCore/runtime/WriteBarrier.h:
* Source/JavaScriptCore/runtime/WriteBarrierInlines.h:
(JSC::RawValueTraits&lt;Unknown&gt;&gt;::set):
* Source/WTF/wtf/PlatformEnable.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e5f4888c8bb1f7d0a4407d044089f664bc857df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/26400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/5013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/27660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/28552 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/24163 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/6816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/2441 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/24154 "27 flakes 144 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/26660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/3870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/22703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/3426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/3459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/23680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/29097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/23017 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/24084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/24081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/29739 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/25614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/3473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/1698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/27633 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/4899 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/33061 "Built successfully") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/3954 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/7190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/3798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->