### PR TITLE
Properly handle errors in the cookie's domain when setting a cookie with the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt
@@ -1,16 +1,16 @@
 
 PASS cookieStore.delete with positional name
 PASS cookieStore.delete with name in options
-FAIL cookieStore.delete domain starts with "." assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.delete with domain that is not equal current host assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.delete with domain set to the current hostname assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.delete with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.delete with path set to the current directory assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete domain starts with "."
+PASS cookieStore.delete with domain that is not equal current host
+PASS cookieStore.delete with domain set to the current hostname
+PASS cookieStore.delete with domain set to a subdomain of the current hostname
+PASS cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname
+PASS cookieStore.delete with path set to the current directory
 PASS cookieStore.delete with path set to subdirectory of the current directory
-FAIL cookieStore.delete with missing / at the end of path assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete with missing / at the end of path
 PASS cookieStore.delete with path that does not start with /
-FAIL cookieStore.delete with get result assert_equals: expected null but got object "[object Object]"
+PASS cookieStore.delete with get result
 FAIL cookieStore.delete with positional empty name promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL cookieStore.delete with empty name in options promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt
@@ -1,4 +1,4 @@
 
 FAIL cookieStore.get() sees cookieStore.set() in frame promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'frameCookie.value')"
-FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'cookie.value')"
+FAIL cookieStore.get() in frame sees cookieStore.set() promise_test: Unhandled rejection with value: object "TypeError: The domain must be a part of the current host"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt
@@ -1,4 +1,4 @@
 
-PASS cookieStore in non-sandboxed iframe should not throw
+FAIL cookieStore in non-sandboxed iframe should not throw assert_equals: cookieStore ${apiCall} should not throw expected "no exception" but got "TypeError"
 PASS cookieStore in sandboxed iframe should throw SecurityError
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -7,16 +7,16 @@ PASS cookieStore.set with expires set to a future Date
 PASS cookieStore.set with expires set to a past Date
 PASS cookieStore.set with expires set to a future timestamp
 PASS cookieStore.set with expires set to a past timestamp
-FAIL cookieStore.set domain starts with "." assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with domain that is not equal current host assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS cookieStore.set domain starts with "."
+PASS cookieStore.set with domain that is not equal current host
 PASS cookieStore.set with domain set to the current hostname
-FAIL cookieStore.set with domain set to a subdomain of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set with domain set to a non-domain-matching suffix of the current hostname assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL cookieStore.set default domain is null and differs from current hostname assert_array_equals: expected property 0 to be "cookie-value1" but got "cookie-value" (expected array ["cookie-value1", "cookie-value2"] got ["cookie-value", "cookie-value2"])
+PASS cookieStore.set with domain set to a subdomain of the current hostname
+PASS cookieStore.set with domain set to a non-domain-matching suffix of the current hostname
+FAIL cookieStore.set default domain is null and differs from current hostname assert_equals: expected 2 but got 1
 PASS cookieStore.set with path set to the current directory
-FAIL cookieStore.set with path set to a subdirectory of the current directory assert_equals: expected null but got object "[object Object]"
-FAIL cookieStore.set default path is / assert_equals: expected 1 but got 2
+PASS cookieStore.set with path set to a subdirectory of the current directory
+PASS cookieStore.set default path is /
 PASS cookieStore.set adds / to path that does not end with /
 PASS cookieStore.set with path that does not start with /
-FAIL cookieStore.set with get result assert_equals: expected "old-cookie-value" but got "cookie-value"
+PASS cookieStore.set with get result
 


### PR DESCRIPTION
#### 58f6a2dd0bf84e0bba186126c6474a0ff1064353
<pre>
Properly handle errors in the cookie&apos;s domain when setting a cookie with the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259529">https://bugs.webkit.org/show_bug.cgi?id=259529</a>

Reviewed by Alex Christensen.

The spec (<a href="https://wicg.github.io/cookie-store/#set-cookie-algorithm)">https://wicg.github.io/cookie-store/#set-cookie-algorithm)</a>
dictates that in the set function, if the domain is not null, then if
the domain begins with a &apos;.&apos;, the promise should be rejected with a
TypeError. If the domain does not begin with a &apos;.&apos; but the url&apos;s host
is not equal to domain and it does not end with a &apos;.&apos; followed by the
domain, the promise should be rejected with a TypeError. Additionally,
if the byte sequence length of the domain (in UTF8 format) is greater
than the maximum attribute value size (current 1024 bytes according to
<a href="https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size)">https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size)</a>,
then the promise should be rejected with a TypeError. This patch adds
these checks.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_delete_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_get_set_across_frames.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_opaque_origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/266351@main">https://commits.webkit.org/266351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24fff31431b8915f695a3fd246770e7025861d1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13590 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15326 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12909 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16025 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19296 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12421 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15633 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10834 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12211 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3313 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->