### PR TITLE
REGRESSION(257456@main): Scrollbar shows up on sites that initiate fullscreen from an iframe

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root-expected.html
+++ b/LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Test that scrollbars are removed on ancestor document root elements when iframe is fullscreened</title>
+</head>
+<body>
+    <iframe id="iframe"></iframe>
+    <p>Test passes if the fullscreen request originating from the iframe hides the scrollbar on the parent document.</p>
+    <script>
+        async function test() {
+            await new Promise(resolve => {
+                iframe.addEventListener("load", resolve, {once: true});
+                iframe.src = "resources/inner.html";
+            });
+            await new Promise(resolve => {
+                internals.withUserGesture(() => {
+                    iframe.contentDocument.documentElement.requestFullscreen().then(resolve);
+                });
+            });
+
+            document.documentElement.classList.remove("reftest-wait");
+        }
+        test();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root.html
+++ b/LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Test that scrollbars are removed on ancestor document root elements when iframe is fullscreened</title>
+</head>
+<body>
+    <iframe id="iframe"></iframe>
+    <p>Test passes if the fullscreen request originating from the iframe hides the scrollbar on the parent document.</p>
+    <div style="height: 200vh"></div>
+    <script>
+        async function test() {
+            await new Promise(resolve => {
+                iframe.addEventListener("load", resolve, {once: true});
+                iframe.src = "resources/inner.html";
+            });
+            await new Promise(resolve => {
+                internals.withUserGesture(() => {
+                    iframe.contentDocument.documentElement.requestFullscreen().then(resolve);
+                });
+            });
+
+            document.documentElement.classList.remove("reftest-wait");
+        }
+        test();
+    </script>
+</body>
+</html>

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -445,9 +445,7 @@ ALWAYS_INLINE bool matchesFullScreenDocumentPseudoClass(const Element& element)
 {
     // While a Document is in the fullscreen state, the 'full-screen-document' pseudoclass applies
     // to all elements of that Document.
-    if (!element.document().fullscreenManager().isFullscreen())
-        return false;
-    return true;
+    return element.document().fullscreenManager().fullscreenElement();
 }
 
 ALWAYS_INLINE bool matchesFullScreenControlsHiddenPseudoClass(const Element& element)


### PR DESCRIPTION
#### 0d8538115ee0a3fb26afd3e5d3a2fd1f9291d1c3
<pre>
REGRESSION(257456@main): Scrollbar shows up on sites that initiate fullscreen from an iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=255197">https://bugs.webkit.org/show_bug.cgi?id=255197</a>
rdar://108096981

Reviewed by Simon Fraser.

The following UA stylesheet rule was not applying:
```
:root:-webkit-full-screen-document:not(:fullscreen) {
    overflow: hidden !important;
}
```
because :-webkit-full-screen-document used isFullscreen() (exposed as a legacy API), did not take in account documents fullscreened implicitly by their child frame.

Switch to fullscreenElement() which queries from the top layer, and includes implicitly fullscreened elements.

* LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root-expected.html: Added.
* LayoutTests/fullscreen/fullscreen-no-scrollbars-on-ancestor-root.html: Added.
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesFullScreenDocumentPseudoClass):

Canonical link: <a href="https://commits.webkit.org/266340@main">https://commits.webkit.org/266340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2c5137b51611e4e6191fb3d9d54d80c1f87e57f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15315 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/12903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13659 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14387 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16018 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11675 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/12246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12750 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12414 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/10821 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12111 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3305 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->