### PR TITLE
CallVarargs should identify that it can read inline call frame arguments.

### DIFF
--- a/JSTests/stress/putstacksinking-callvarargs.js
+++ b/JSTests/stress/putstacksinking-callvarargs.js
@@ -1,0 +1,33 @@
+//@ runDefault("--useConcurrentJIT=0")
+var iter;
+function main() {
+    function opt(i) {
+        function x() {
+            return y(...[1]);
+        }
+
+        function y() {
+            return z.apply(this, arguments);
+        }
+
+        function z() {
+            if (iter > 10136) {
+                if (x.arguments[2] != 1.3)
+                    throw "Wrong value"
+                return x.arguments;
+            }
+        }
+        noInline(z);
+
+        x(1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.21, 1.22);
+    }
+
+    noInline(opt);
+    for (let i = 0; i < 20000; ++i) {
+        iter = i;
+        opt(i);
+    }
+}
+noDFG(main);
+
+main();

--- a/JSTests/stress/putstacksinking-tailcallvarargs.js
+++ b/JSTests/stress/putstacksinking-tailcallvarargs.js
@@ -1,0 +1,34 @@
+//@ runDefault("--useConcurrentJIT=0")
+var iter;
+function main() {
+    function opt(i) {
+        function x() {
+            return y(...[1]);
+        }
+
+        function y() {
+            "use strict"
+            return z.apply(this, arguments);
+        }
+
+        function z() {
+            if (iter > 10136) {
+                if (x.arguments[2] != 1.3)
+                    throw "Wrong value"
+                return x.arguments;
+            }
+        }
+        noInline(z);
+
+        x(1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.21, 1.22);
+    }
+
+    noInline(opt);
+    for (let i = 0; i < 20000; ++i) {
+        iter = i;
+        opt(i);
+    }
+}
+noDFG(main);
+
+main();

--- a/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h
@@ -190,13 +190,19 @@ private:
         case CreateRest: {
             bool isForwardingNode = false;
             bool isPhantomNode = false;
+            bool mayReadArguments = false;
             switch (m_node->op()) {
             case ForwardVarargs:
+            // This is used iff allInlineFramesAreTailCalls, so we will
+            // actually do a real tail call and destroy our frame.
+            case TailCallForwardVarargs:
+                isForwardingNode = true;
+                break;
             case CallForwardVarargs:
             case ConstructForwardVarargs:
-            case TailCallForwardVarargs:
             case TailCallForwardVarargsInlinedCaller:
                 isForwardingNode = true;
+                mayReadArguments = true;
                 break;
             case PhantomDirectArguments:
             case PhantomClonedArguments:
@@ -208,7 +214,10 @@ private:
 
             if (isPhantomNode && m_graph.m_plan.isFTL())
                 break;
-            
+
+            if (mayReadArguments)
+                readWorld(m_node);
+
             if (isForwardingNode && m_node->hasArgumentsChild() && m_node->argumentsChild()
                 && (m_node->argumentsChild()->op() == PhantomNewArrayWithSpread || m_node->argumentsChild()->op() == PhantomSpread)) {
                 if (m_node->argumentsChild()->op() == PhantomNewArrayWithSpread)


### PR DESCRIPTION
#### e5652c93dbd1e78bf2f4a0f38022287b30420da0
<pre>
CallVarargs should identify that it can read inline call frame arguments.
rdar://112936988

Reviewed by Yusuke Suzuki.

Call already does this, but CallVarargs has a special case that forgot.

We should not be allowed to push PutStacks below a call of any kind, since
it might access our call frame&apos;s arguments via foo.arguments, unless
we are strict.

The only exception is TailCall (but not TailCallForwardVarargsInlinedCaller),
because it will destroy the entire frame.

We do not un-pessimize TailCall yet to reduce risk, but it could be made
to match TailCallForwardVarargs in the future.

* JSTests/stress/putstacksinking-callvarargs.js: Added.
(main.opt.x):
(main.opt.y):
(main.opt.z):
(main.opt):
(main):
* JSTests/stress/putstacksinking-tailcallvarargs.js: Added.
(main.opt.x):
(main.opt.y):
(main.opt.z):
(main.opt):
(main):
* Source/JavaScriptCore/dfg/DFGPreciseLocalClobberize.h:
(JSC::DFG::PreciseLocalClobberizeAdaptor::readTop):

Originally-landed-as: 259548.856@safari-7615-branch (c3d2e3627b45). rdar://111361499
Canonical link: <a href="https://commits.webkit.org/266393@main">https://commits.webkit.org/266393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566a0becc92edf1f1b0e47a3253c0ff21c1c5905

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16010 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19288 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11564 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15625 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12849 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10811 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12196 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3554 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16524 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/13998 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1587 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12771 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3357 "Passed tests") | 
<!--EWS-Status-Bubble-End-->