### PR TITLE
[fullscreen] Add iframe testcase for 266309@main

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe-expected.txt
@@ -1,0 +1,7 @@
+
+Test passes if the lightgreen area is fullscreen after clicking the button.
+
+EXPECTED (iframe.offsetWidth > 400 == 'true') OK
+EXPECTED (iframe.offsetHeight > 400 == 'true') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe.html
+++ b/LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that containing block changes are reflected when going fullscreen</title>
+</head>
+<body>
+    <!-- will-change: transform creates a containing-block for fixed positioned elements, but the top layer overrides it --->
+    <div style="height: 400px; width: 400px; will-change: transform;">
+        <!-- container-type: size triggers layout during style resolution -->
+        <iframe style="container-type: size; width: 100%; height: 100%; background: lightgreen;" id="iframe"></iframe>
+    </div>
+    <p>Test passes if the lightgreen area is fullscreen after clicking the button.</p>
+    <script src="full-screen-test.js"></script>
+    <script>
+        async function test() {
+            await new Promise(resolve => {
+                iframe.addEventListener("load", resolve, {once: true});
+                iframe.src = "resources/inner.html";
+            });
+            await new Promise(resolve => {
+                internals.withUserGesture(() => {
+                    iframe.contentDocument.documentElement.requestFullscreen().then(resolve);   
+                });
+            });
+
+            testExpected("iframe.offsetWidth > 400", true);
+            testExpected("iframe.offsetHeight > 400", true);
+            endTest();
+        }
+
+        test();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
#### 72f6ace047bfeab77a9c9e887fb3c177f4e258af
<pre>
[fullscreen] Add iframe testcase for 266309@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=259533">https://bugs.webkit.org/show_bug.cgi?id=259533</a>
rdar://112934625

Reviewed by Simon Fraser.

Add test for a case that was initially missed for the fix in 266309@main, to avoid regressing it.

* LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe-expected.txt: Added.
* LayoutTests/fullscreen/fullscreen-containing-block-change-with-iframe.html: Added.

Canonical link: <a href="https://commits.webkit.org/266342@main">https://commits.webkit.org/266342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cacbdd9bbaa77ff7f14e61e12123dacbc8ff8a20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15587 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16016 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12242 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10819 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->