### PR TITLE
WebXR build fails on visionOS

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -81,8 +81,8 @@ static GL::EGLImageSource makeEGLImageSource(const std::tuple<WTF::MachSendRight
 {
     auto [imageHandle, isSharedTexture] = imageSource;
     if (isSharedTexture)
-        return GL::EGLImageSourceMTLSharedTextureHandle { imageHandle };
-    return GL::EGLImageSourceIOSurfaceHandle { imageHandle };
+        return GL::EGLImageSourceMTLSharedTextureHandle { WTF::MachSendRight(imageHandle) };
+    return GL::EGLImageSourceIOSurfaceHandle { WTF::MachSendRight(imageHandle) };
 }
 #endif
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -294,8 +294,8 @@ public:
             std::unique_ptr<WebCore::IOSurface> surface;
             bool isShared { false };
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-            std::tuple<MachSendRight, bool> colorTexture = { { }, false };
-            std::tuple<MachSendRight, bool> depthStencilBuffer = { { }, false };
+            std::tuple<MachSendRight, bool> colorTexture = { MachSendRight(), false };
+            std::tuple<MachSendRight, bool> depthStencilBuffer = { MachSendRight(), false };
 #else
             PlatformGLObject opaqueTexture { 0 };
 #endif
@@ -585,8 +585,8 @@ void Device::FrameData::LayerData::encode(Encoder& encoder) const
     encoder << surfaceSendRight;
     encoder << isShared;
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    encoder << colorTexture;
-    encoder << depthStencilBuffer;
+    encoder << std::make_tuple(MachSendRight(std::get<0>(colorTexture)), std::get<1>(colorTexture));
+    encoder << std::make_tuple(MachSendRight(std::get<0>(depthStencilBuffer)), std::get<1>(depthStencilBuffer));
 #else
     encoder << opaqueTexture;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp
@@ -32,10 +32,10 @@
 
 namespace WebKit {
 
-void CGDisplayList::encode(IPC::Encoder& encoder) const
+void CGDisplayList::encode(IPC::Encoder& encoder) &&
 {
     encoder << m_displayList;
-    encoder << m_surfaces;
+    encoder << WTFMove(m_surfaces);
 }
 
 bool CGDisplayList::decode(IPC::Decoder& decoder, CGDisplayList& displayList)

--- a/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h
@@ -54,7 +54,7 @@ public:
     RefPtr<WebCore::SharedBuffer> buffer() const { return m_displayList; }
     Vector<MachSendRight> takeSurfaces() { return std::exchange(m_surfaces, { }); }
 
-    void encode(IPC::Encoder&) const;
+    void encode(IPC::Encoder&) &&;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, CGDisplayList&);
 
 private:


### PR DESCRIPTION
#### 543e3c1db166e5ee704c71ca609ff1a376a0e6bc
<pre>
WebXR build fails on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=259535">https://bugs.webkit.org/show_bug.cgi?id=259535</a>
&lt;radar://112938443&gt;

Reviewed by Matt Woodrow and Dean Jackson.

Fix build for visionOS after 266327@main

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::makeEGLImageSource):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::FrameData::LayerData::encode const):
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.cpp:
(WebKit::CGDisplayList::encode):
(WebKit::CGDisplayList::encode const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/CGDisplayList.h:

Canonical link: <a href="https://commits.webkit.org/266347@main">https://commits.webkit.org/266347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57b6aab82dd13da09659763ba9f9b0ca4872ce51

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13586 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15595 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16022 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11679 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12754 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12427 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15632 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12207 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3311 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->