### PR TITLE
[IPC][Hardening] Update isFilePasteboardType() to also check for kUTTypeFileURL

### DIFF
--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -43,7 +43,11 @@ namespace WebCore {
 
 static bool isFilePasteboardType(const String& type)
 {
-    return [legacyFilenamesPasteboardType() isEqualToString:type] || [legacyFilesPromisePasteboardType() isEqualToString:type];
+    return [legacyFilenamesPasteboardType() isEqualToString:type]
+        || [legacyFilesPromisePasteboardType() isEqualToString:type]
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        || [(NSString *)kUTTypeFileURL isEqualToString:type];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 static bool canWritePasteboardType(const String& type)


### PR DESCRIPTION
#### 7ccd31a178fe32c5b3e2225a30942282000e4514
<pre>
[IPC][Hardening] Update isFilePasteboardType() to also check for kUTTypeFileURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=258519">https://bugs.webkit.org/show_bug.cgi?id=258519</a>
rdar://112940684

Reviewed by Wenson Hsieh.

* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::isFilePasteboardType):

Originally-landed-as: 259548.853@safari-7615-branch (bb70e32b88ed). rdar://111187390
Canonical link: <a href="https://commits.webkit.org/266391@main">https://commits.webkit.org/266391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6189333b2fce7f4344308e056d2738af893e943

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13593 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15604 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14402 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16028 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19300 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12765 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15637 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10837 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16544 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1586 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->