### PR TITLE
Specialize appendChild for cloneNodeInternal

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -203,6 +203,7 @@ ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRem
         // FIXME: Merge these two code paths. It's a bug in the parser not to update connectedSubframeCount in time.
         disconnectSubframesIfNeeded(*this, SubframeDisconnectPolicy::DescendantsOnly);
     } else {
+        ASSERT(source == ChildChange::Source::API);
         if (auto containerChild = dynamicDowncast<ContainerNode>(childToRemove))
             disconnectSubframesIfNeeded(*containerChild, SubframeDisconnectPolicy::RootAndDescendants);
     }
@@ -267,6 +268,13 @@ static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& con
         source,
         changeType == ContainerNode::ChildChange::Type::ElementInserted ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No
     };
+}
+
+enum class ClonedChildIncludesElements { No, Yes };
+static ContainerNode::ChildChange makeChildChangeForCloneInsertion(ClonedChildIncludesElements clonedChildIncludesElements)
+{
+    return { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, ContainerNode::ChildChange::Source::Clone,
+        clonedChildIncludesElements == ClonedChildIncludesElements::Yes ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No };
 }
 
 template<typename DOMInsertionWork>
@@ -896,11 +904,30 @@ void ContainerNode::childrenChanged(const ChildChange& change)
 void ContainerNode::cloneChildNodes(ContainerNode& clone)
 {
     Document& targetDocument = clone.document();
-    for (Node* child = firstChild(); child; child = child->nextSibling()) {
-        auto clonedChild = child->cloneNodeInternal(targetDocument, CloningOperation::SelfWithTemplateContent);
-        if (!clone.appendChild(clonedChild).hasException() && is<ContainerNode>(*child))
-            downcast<ContainerNode>(*child).cloneChildNodes(downcast<ContainerNode>(clonedChild.get()));
+
+    NodeVector postInsertionNotificationTargets;
+    bool hadElement = false;
+    for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
+        RefPtr<Node> clonedChild;
+        {
+            WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
+            ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+
+            clonedChild = child->cloneNodeInternal(targetDocument, CloningOperation::SelfWithTemplateContent);
+            clonedChild->setTreeScopeRecursively(clone.treeScope());
+
+            clone.appendChildCommon(*clonedChild);
+            notifyChildNodeInserted(clone, *clonedChild, postInsertionNotificationTargets);
+
+            hadElement = hadElement || is<Element>(clonedChild);
+        }
+        if (is<ContainerNode>(*child))
+            downcast<ContainerNode>(*child).cloneChildNodes(downcast<ContainerNode>(*clonedChild));
     }
+    clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
+
+    for (auto& target : postInsertionNotificationTargets)
+        target->didFinishInsertingNode();
 }
 
 unsigned ContainerNode::countChildNodes() const

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -77,7 +77,7 @@ public:
 
     struct ChildChange {
         enum class Type : uint8_t { ElementInserted, ElementRemoved, TextInserted, TextRemoved, TextChanged, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, AllChildrenReplaced };
-        enum class Source : bool { Parser, API };
+        enum class Source : uint8_t { Parser, API, Clone };
         enum class AffectsElements : uint8_t { Unknown, No, Yes };
 
         ChildChange::Type type;

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -84,6 +84,7 @@ const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child)
 Ref<HTMLDetailsElement> HTMLDetailsElement::create(const QualifiedName& tagName, Document& document)
 {
     auto details = adoptRef(*new HTMLDetailsElement(tagName, document));
+    ScriptDisallowedScope::EventAllowedScope allowedScope(details);
     details->addShadowRoot(ShadowRoot::create(document, makeUnique<DetailsSlotAssignment>()));
     return details;
 }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -261,8 +261,10 @@ void HTMLOptionElement::childrenChanged(const ChildChange& change)
     for (auto& dataList : ancestors)
         dataList->optionElementChildrenChanged();
 #endif
-    if (RefPtr select = ownerSelectElement())
-        select->optionElementChildrenChanged();
+    if (change.source != ChildChange::Source::Clone) {
+        if (RefPtr select = ownerSelectElement())
+            select->optionElementChildrenChanged();
+    }
     HTMLElement::childrenChanged(change);
 }
 

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -79,6 +79,7 @@ Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagNam
 {
     ASSERT_UNUSED(tagName, tagName == textareaTag);
     auto textArea = adoptRef(*new HTMLTextAreaElement(document, form));
+    ScriptDisallowedScope::EventAllowedScope allowedScope(textArea);
     textArea->ensureUserAgentShadowRoot();
     return textArea;
 }


### PR DESCRIPTION
#### 2ba17c0b95a472d1090d6fed21ba6d78f10dfd64
<pre>
Specialize appendChild for cloneNodeInternal
<a href="https://bugs.webkit.org/show_bug.cgi?id=259542">https://bugs.webkit.org/show_bug.cgi?id=259542</a>

Reviewed by NOBODY (OOPS!).

Merge the contents of appendChild into cloneNodeInternal. This patch also introduces ChildChange::Source::Clone to
distinguish cloning operation in childrenChanged function calls.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeNodeWithScriptAssertion): Assert that source is either Source::API or Source::Parser.
(WebCore::makeChildChangeForCloneInsertion): Added.
(WebCore::ContainerNode::cloneChildNodes): Merged appendChild into this function.

* Source/WebCore/dom/ContainerNode.h:

* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::create): Create an event allowed scope on the newly created element as we&apos;re about to add
a shadow root to it.

* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::childrenChanged): Don&apos;t notify select element if we&apos;re in the middle of cloning operation.
Without this change, we would hit a debug assertion in HTMLSelectElement::listItems() because cloning operation now
calls childrenChanged on an option element before the select element.

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::create): Create an event allowed scope on the newly created element as we&apos;re about to
add a shadow root to it.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ba17c0b95a472d1090d6fed21ba6d78f10dfd64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13622 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13936 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14269 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15358 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12938 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13703 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16444 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14017 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15358 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13788 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16444 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14269 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16057 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16444 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14269 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16057 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16444 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14269 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16057 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12971 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10859 "1 failures") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12240 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14269 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16570 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12813 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->