### PR TITLE
[JSC] Micro optimize bitops in IC

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -187,6 +187,8 @@ public:
 
 #if CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)
     using MacroAssemblerBase::and64;
+    using MacroAssemblerBase::or64;
+    using MacroAssemblerBase::xor64;
     using MacroAssemblerBase::convertInt32ToDouble;
     using MacroAssemblerBase::store64;
 #endif
@@ -1625,6 +1627,15 @@ public:
             and64(key.value2, dest);
         } else
             and64(imm.asTrustedImm32(), dest);
+    }
+
+    void and64(Imm32 imm, RegisterID src, RegisterID dest)
+    {
+        if (shouldBlind(imm)) {
+            move(src, dest);
+            and64(imm, dest);
+        } else
+            and64(imm.asTrustedImm32(), src, dest);
     }
 
 #endif // USE(JSVALUE64)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -441,17 +441,22 @@ public:
         m_assembler.and_<64>(dest, dest, src);
     }
 
-    void and64(TrustedImm32 imm, RegisterID dest)
+    void and64(TrustedImm32 imm, RegisterID src, RegisterID dest)
     {
         LogicalImmediate logicalImm = LogicalImmediate::create64(static_cast<intptr_t>(static_cast<int64_t>(imm.m_value)));
 
         if (logicalImm.isValid()) {
-            m_assembler.and_<64>(dest, dest, logicalImm);
+            m_assembler.and_<64>(dest, src, logicalImm);
             return;
         }
 
         signExtend32ToPtr(imm, getCachedDataTempRegisterIDAndInvalidate());
-        m_assembler.and_<64>(dest, dest, dataTempRegister);
+        m_assembler.and_<64>(dest, src, dataTempRegister);
+    }
+
+    void and64(TrustedImm32 imm, RegisterID dest)
+    {
+        and64(imm, dest, dest);
     }
 
     void and64(TrustedImmPtr imm, RegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -479,6 +479,12 @@ public:
         }
     }
 
+    void and64(TrustedImm32 imm, RegisterID src, RegisterID dest)
+    {
+        move(src, dest);
+        and64(imm, dest);
+    }
+
     void countLeadingZeros64(RegisterID src, RegisterID dst)
     {
         if (supportsLZCNT()) {

--- a/Source/JavaScriptCore/jit/JITBitAndGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitAndGenerator.cpp
@@ -51,24 +51,23 @@ void JITBitAndGenerator::generateFastPath(CCallHelpers& jit)
         // Try to do intVar & intConstant.
         m_slowPathJumpList.append(jit.branchIfNotInt32(var));
         
-        jit.moveValueRegs(var, m_result);
         if (constOpr.asConstInt32() != static_cast<int32_t>(0xffffffff)) {
 #if USE(JSVALUE64)
-            jit.and64(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
+            jit.and64(CCallHelpers::Imm32(constOpr.asConstInt32()), var.payloadGPR(), m_result.payloadGPR());
             if (constOpr.asConstInt32() >= 0)
                 jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
 #else
+            jit.moveValueRegs(var, m_result);
             jit.and32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
 #endif
-        }
-
+        } else
+            jit.moveValueRegs(var, m_result);
     } else {
         ASSERT(!m_leftOperand.isConstInt32() && !m_rightOperand.isConstInt32());
         
         // Try to do intVar & intVar.
 #if USE(JSVALUE64)
-        jit.move(m_left.payloadGPR(), m_scratchGPR);
-        jit.and64(m_right.payloadGPR(), m_scratchGPR);
+        jit.and64(m_left.payloadGPR(), m_right.payloadGPR(), m_scratchGPR);
         m_slowPathJumpList.append(jit.branchIfNotInt32(m_scratchGPR));
         jit.move(m_scratchGPR, m_result.payloadGPR());
 #else

--- a/Source/JavaScriptCore/jit/JITBitOrGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitOrGenerator.cpp
@@ -42,17 +42,22 @@ void JITBitOrGenerator::generateFastPath(CCallHelpers& jit)
         
         // Try to do intVar | intConstant.
         m_slowPathJumpList.append(jit.branchIfNotInt32(var));
-        
-        jit.moveValueRegs(var, m_result);
+
         if (constOpr.asConstInt32()) {
 #if USE(JSVALUE64)
+#if CPU(ARM64)
+            jit.or64(CCallHelpers::TrustedImm64(static_cast<uint64_t>(static_cast<uint32_t>(constOpr.asConstInt32()))), var.payloadGPR(), m_result.payloadGPR());
+#else
+            jit.moveValueRegs(var, m_result);
             jit.or32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
             jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
+#endif
 #else
+            jit.moveValueRegs(var, m_result);
             jit.or32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
 #endif
-        }
-
+        } else
+            jit.moveValueRegs(var, m_result);
     } else {
         ASSERT(!m_leftOperand.isConstInt32() && !m_rightOperand.isConstInt32());
         
@@ -60,10 +65,10 @@ void JITBitOrGenerator::generateFastPath(CCallHelpers& jit)
         m_slowPathJumpList.append(jit.branchIfNotInt32(m_left));
         m_slowPathJumpList.append(jit.branchIfNotInt32(m_right));
 
-        jit.moveValueRegs(m_left, m_result);
 #if USE(JSVALUE64)
-        jit.or64(m_right.payloadGPR(), m_result.payloadGPR());
+        jit.or64(m_right.payloadGPR(), m_left.payloadGPR(), m_result.payloadGPR());
 #else
+        jit.moveValueRegs(m_left, m_result);
         jit.or32(m_right.payloadGPR(), m_result.payloadGPR());
 #endif
     }

--- a/Source/JavaScriptCore/jit/JITBitXorGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITBitXorGenerator.cpp
@@ -43,11 +43,11 @@ void JITBitXorGenerator::generateFastPath(CCallHelpers& jit)
         // Try to do intVar ^ intConstant.
         m_slowPathJumpList.append(jit.branchIfNotInt32(var));
         
-        jit.moveValueRegs(var, m_result);
 #if USE(JSVALUE64)
-        jit.xor32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
+        jit.xor32(CCallHelpers::Imm32(constOpr.asConstInt32()), var.payloadGPR(), m_result.payloadGPR());
         jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
 #else
+        jit.moveValueRegs(var, m_result);
         jit.xor32(CCallHelpers::Imm32(constOpr.asConstInt32()), m_result.payloadGPR());
 #endif
         
@@ -58,11 +58,11 @@ void JITBitXorGenerator::generateFastPath(CCallHelpers& jit)
         m_slowPathJumpList.append(jit.branchIfNotInt32(m_left));
         m_slowPathJumpList.append(jit.branchIfNotInt32(m_right));
         
-        jit.moveValueRegs(m_left, m_result);
 #if USE(JSVALUE64)
-        jit.xor64(m_right.payloadGPR(), m_result.payloadGPR());
+        jit.xor32(m_right.payloadGPR(), m_left.payloadGPR(), m_result.payloadGPR());
         jit.or64(GPRInfo::numberTagRegister, m_result.payloadGPR());
 #else
+        jit.moveValueRegs(m_left, m_result);
         jit.xor32(m_right.payloadGPR(), m_result.payloadGPR());
 #endif
     }


### PR DESCRIPTION
#### ab2034db4691e6702c65d14324382c577a2d4878
<pre>
[JSC] Micro optimize bitops in IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=259547">https://bugs.webkit.org/show_bug.cgi?id=259547</a>
rdar://112956788

Reviewed by Mark Lam.

This patch micro-optimizes bitops in IC in Baseline by using three-operand machine codes.

* Source/JavaScriptCore/assembler/MacroAssembler.h:
(JSC::MacroAssembler::and64):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::and64):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::and64):
* Source/JavaScriptCore/jit/JITBitAndGenerator.cpp:
(JSC::JITBitAndGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITBitOrGenerator.cpp:
(JSC::JITBitOrGenerator::generateFastPath):
* Source/JavaScriptCore/jit/JITBitXorGenerator.cpp:
(JSC::JITBitXorGenerator::generateFastPath):

Canonical link: <a href="https://commits.webkit.org/266367@main">https://commits.webkit.org/266367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09f0ce0050fe7c95286bbea87e569e69652ae09a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12932 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15623 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16050 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19320 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11600 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12448 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15657 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10853 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13658 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12235 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3560 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16565 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14045 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1576 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12808 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3367 "Passed tests") | 
<!--EWS-Status-Bubble-End-->