### PR TITLE
Add preprocessor conditions to SerializedTypeInfo

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -757,19 +757,18 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, t
             continue
 
         serialized_members = type.serialized_members()
-        for i in range(len(serialized_members)):
-            member = type.members[i]
-            if i == 0:
-                result.append('            {')
+        for member in serialized_members:
+            if member.condition is not None:
+                result.append('#if ' + member.condition)
+            result.append('            {')
             if 'Nullable' in member.attributes:
                 result.append('                "std::optional<' + member.type + '>"_s,')
             else:
                 result.append('                "' + member.type + '"_s,')
             result.append('                "' + member.name + '"_s')
-            if i == len(serialized_members) - 1:
-                result.append('            }')
-            else:
-                result.append('            }, {')
+            result.append('            },')
+            if member.condition is not None:
+                result.append('#endif')
         result.append('        } },')
     for typedef in typedefs:
         result.append('        { "' + typedef[0] + '"_s, {')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -64,115 +64,133 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "FirstMemberType"_s,
                 "firstMemberName"_s
-            }, {
+            },
+#if ENABLE(SECOND_MEMBER)
+            {
                 "SecondMemberType"_s,
                 "secondMemberName"_s
-            }, {
+            },
+#endif
+            {
                 "std::optional<RetainPtr<CFTypeRef>>"_s,
                 "nullableTestMember"_s
-            }
+            },
         } },
         { "Namespace::OtherClass"_s, {
             {
                 "int"_s,
                 "a"_s
-            }, {
+            },
+            {
                 "bool"_s,
                 "b"_s
-            }, {
+            },
+            {
                 "RetainPtr<NSArray>"_s,
                 "dataDetectorResults"_s
-            }
+            },
         } },
         { "Namespace::ReturnRefClass"_s, {
             {
                 "double"_s,
                 "functionCall().member1"_s
-            }, {
+            },
+            {
                 "double"_s,
                 "functionCall().member2"_s
-            }, {
+            },
+            {
                 "std::unique_ptr<int>"_s,
                 "uniqueMember"_s
-            }
+            },
         } },
         { "Namespace::EmptyConstructorStruct"_s, {
             {
                 "int"_s,
                 "m_int"_s
-            }, {
+            },
+            {
                 "double"_s,
                 "m_double"_s
-            }
+            },
         } },
         { "Namespace::EmptyConstructorWithIf"_s, {
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
             {
                 "MemberType"_s,
                 "m_type"_s
-            }, {
+            },
+#endif
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
+            {
                 "OtherMemberType"_s,
                 "m_value"_s
-            }
+            },
+#endif
         } },
         { "WithoutNamespace"_s, {
             {
                 "int"_s,
                 "a"_s
-            }
+            },
         } },
         { "WithoutNamespaceWithAttributes"_s, {
             {
                 "int"_s,
                 "a"_s
-            }
+            },
         } },
         { "WebCore::InheritsFrom"_s, {
             {
                 "float"_s,
                 "b"_s
-            }
+            },
         } },
         { "WebCore::InheritanceGrandchild"_s, {
             {
                 "double"_s,
                 "c"_s
-            }
+            },
         } },
         { "Seconds"_s, {
             {
                 "double"_s,
                 "value()"_s
-            }
+            },
         } },
         { "CreateUsingClass"_s, {
             {
                 "double"_s,
                 "value"_s
-            }
+            },
         } },
         { "WebCore::FloatBoxExtent"_s, {
             {
                 "float"_s,
                 "top()"_s
-            }, {
+            },
+            {
                 "float"_s,
                 "right()"_s
-            }, {
+            },
+            {
                 "float"_s,
                 "bottom()"_s
-            }, {
+            },
+            {
                 "float"_s,
                 "left()"_s
-            }
+            },
         } },
         { "NullableSoftLinkedMember"_s, {
             {
                 "std::optional<RetainPtr<DDActionContext>>"_s,
                 "firstMember"_s
-            }, {
+            },
+            {
                 "RetainPtr<DDActionContext>"_s,
                 "secondMember"_s
-            }
+            },
         } },
         { "WebCore::TimingFunction"_s, {
             { "std::variant<WebCore::LinearTimingFunction, WebCore::CubicBezierTimingFunction, WebCore::StepsTimingFunction, WebCore::SpringTimingFunction>"_s, "subclasses"_s }
@@ -181,19 +199,19 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "int"_s,
                 "value"_s
-            }
+            },
         } },
         { "Namespace::CommonClass"_s, {
             {
                 "int"_s,
                 "value"_s
-            }
+            },
         } },
         { "Namespace::AnotherCommonClass"_s, {
             {
                 "int"_s,
                 "value"_s
-            }
+            },
         } },
         { "WebCore::MoveOnlyBaseClass"_s, {
             { "std::variant<WebCore::MoveOnlyDerivedClass>"_s, "subclasses"_s }
@@ -202,22 +220,23 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "std::optional<int>"_s,
                 "firstMember"_s
-            }, {
+            },
+            {
                 "int"_s,
                 "secondMember"_s
-            }
+            },
         } },
         { "WebKit::PlatformClass"_s, {
             {
                 "int"_s,
                 "value"_s
-            }
+            },
         } },
         { "WebKit::CustomEncoded"_s, {
             {
                 "int"_s,
                 "value"_s
-            }
+            },
         } },
         { "WebCore::SharedStringHash"_s, {
             { "uint32_t"_s, "alias"_s }


### PR DESCRIPTION
#### 3796f239ba33ecf6c7c889e3edbba2892260510e
<pre>
Add preprocessor conditions to SerializedTypeInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=259548">https://bugs.webkit.org/show_bug.cgi?id=259548</a>
rdar://112958638

Reviewed by Youenn Fablet.

This exposes the correct metadata to the IPC testing API.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):

Canonical link: <a href="https://commits.webkit.org/266359@main">https://commits.webkit.org/266359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b1ddef450c13213ae65a5f952cd6b62089b3d8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13618 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12935 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16053 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13709 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11709 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19322 "5 flakes 81 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12784 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15659 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1573 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12811 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->