### PR TITLE
Remove unnecessary attributes from *.serialization.in files

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -43,9 +43,9 @@ import sys
 # Supported member attributes:
 #
 # BitField - work around the need for http://wg21.link/P0572 and don't check that the serialization order matches the memory layout.
-# Nullable - check if the member is truthy before serializing.
 # Validator - additional C++ to validate the value when decoding
 # NotSerialized - member is present in structure but intentionally not serialized.
+# SecureCodingAllowed - ObjC classes to allow when decoding.
 
 class SerializedType(object):
     def __init__(self, struct_or_class, namespace, name, parent_class_name, members, condition, attributes, other_metadata=None):
@@ -394,14 +394,7 @@ def encode_type(type):
     for member in type.serialized_members():
         if member.condition is not None:
             result.append('#if ' + member.condition)
-        if 'Nullable' in member.attributes:
-            result.append('    encoder << !!instance.' + member.name + ';')
-            result.append('    if (!!instance.' + member.name + ')')
-            if type.rvalue:
-                result.append('        encoder << WTFMove(instance.' + member.name + ');')
-            else:
-                result.append('        encoder << instance.' + member.name + ';')
-        elif member.is_subclass:
+        if member.is_subclass:
             result.append('    if (auto* subclass = dynamicDowncast<' + member.namespace + "::" + member.name + '>(instance)) {')
             result.append('        encoder << ' + type.subclass_enum_name() + "::" + member.name + ";")
             if type.rvalue:
@@ -452,37 +445,7 @@ def decode_type(type):
             result.append('    }')
         else:
             assert len(decodable_classes) == 0
-            r = re.compile(r"SoftLinkedClass='(.*)'")
-            soft_linked_classes = [r.match(m).groups()[0] for m in list(filter(r.match, member.attributes))]
-            if len(soft_linked_classes) == 1:
-                match = re.search("RetainPtr<(.*)>", member.type)
-                assert match
-                indentation = 1
-                if 'Nullable' in member.attributes:
-                    indentation = 2
-                    result.append('    auto has' + sanitized_variable_name + ' = decoder.decode<bool>();')
-                    result.append('    if (UNLIKELY(!decoder.isValid()))')
-                    result.append('        return std::nullopt;')
-                    result.append('    std::optional<' + member.type + '> ' + sanitized_variable_name + ';')
-                    result.append('    if (*has' + sanitized_variable_name + ') {')
-                auto_specifier = '' if 'Nullable' in member.attributes else 'auto '
-                result.append(indent(indentation) + auto_specifier + sanitized_variable_name + ' = IPC::decode<' + match.groups()[0] + '>(decoder, ' + soft_linked_classes[0] + ');')
-                if 'Nullable' in member.attributes:
-                    result.append('    } else')
-                    result.append('        ' + sanitized_variable_name + ' = std::optional<' + member.type + '> { ' + member.type + ' { } };')
-            elif 'Nullable' in member.attributes:
-                result.append('    auto has' + sanitized_variable_name + ' = decoder.decode<bool>();')
-                result.append('    if (UNLIKELY(!decoder.isValid()))')
-                result.append('        return std::nullopt;')
-                result.append('    std::optional<' + member.type + '> ' + sanitized_variable_name + ';')
-                result.append('    if (*has' + sanitized_variable_name + ') {')
-                # FIXME: This should be below
-                result.append('        ' + sanitized_variable_name + ' = decoder.decode<' + member.type + '>();')
-                result.append('    } else')
-                result.append('        ' + sanitized_variable_name + ' = std::optional<' + member.type + '> { ' + member.type + ' { } };')
-            else:
-                assert len(soft_linked_classes) == 0
-                result.append('    auto ' + sanitized_variable_name + ' = decoder.decode<' + member.type + '>();')
+            result.append('    auto ' + sanitized_variable_name + ' = decoder.decode<' + member.type + '>();')
         for attribute in member.attributes:
             match = re.search(r'Validator=\'(.*)\'', attribute)
             if match:
@@ -761,10 +724,7 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, t
             if member.condition is not None:
                 result.append('#if ' + member.condition)
             result.append('            {')
-            if 'Nullable' in member.attributes:
-                result.append('                "std::optional<' + member.type + '>"_s,')
-            else:
-                result.append('                "' + member.type + '"_s,')
+            result.append('                "' + member.type + '"_s,')
             result.append('                "' + member.name + '"_s')
             result.append('            },')
             if member.condition is not None:
@@ -946,11 +906,6 @@ def parse_serialized_types(file, file_name):
             if match:
                 complete, _, allow_list, _ = match.groups()
                 member_attributes.append(allow_list)
-                member_attributes_s = member_attributes_s.replace(complete, "")
-            match = re.search(r"((, |^)+(SoftLinkedClass='.*?'))(, |$)?", member_attributes_s)
-            if match:
-                complete, _, soft_linked_class, _ = match.groups()
-                member_attributes.append(soft_linked_class)
                 member_attributes_s = member_attributes_s.replace(complete, "")
             member_attributes += [member_attribute.strip() for member_attribute in member_attributes_s.split(",")]
             members.append(MemberVariable(member_type, member_name, member_condition, member_attributes))

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -126,9 +126,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
 #endif
-    encoder << !!instance.nullableTestMember;
-    if (!!instance.nullableTestMember)
-        encoder << instance.nullableTestMember;
+    encoder << instance.nullableTestMember;
 }
 
 void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& encoder, const Namespace::Subnamespace::StructName& instance)
@@ -157,9 +155,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
 #if ENABLE(SECOND_MEMBER)
     encoder << instance.secondMemberName;
 #endif
-    encoder << !!instance.nullableTestMember;
-    if (!!instance.nullableTestMember)
-        encoder << instance.nullableTestMember;
+    encoder << instance.nullableTestMember;
 }
 
 std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subnamespace::StructName>::decode(Decoder& decoder)
@@ -168,14 +164,7 @@ std::optional<Namespace::Subnamespace::StructName> ArgumentCoder<Namespace::Subn
 #if ENABLE(SECOND_MEMBER)
     auto secondMemberName = decoder.decode<SecondMemberType>();
 #endif
-    auto hasnullableTestMember = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    std::optional<RetainPtr<CFTypeRef>> nullableTestMember;
-    if (*hasnullableTestMember) {
-        nullableTestMember = decoder.decode<RetainPtr<CFTypeRef>>();
-    } else
-        nullableTestMember = std::optional<RetainPtr<CFTypeRef>> { RetainPtr<CFTypeRef> { } };
+    auto nullableTestMember = decoder.decode<RetainPtr<CFTypeRef>>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
@@ -531,40 +520,31 @@ std::optional<WebCore::FloatBoxExtent> ArgumentCoder<WebCore::FloatBoxExtent>::d
     };
 }
 
-void ArgumentCoder<NullableSoftLinkedMember>::encode(Encoder& encoder, const NullableSoftLinkedMember& instance)
+void ArgumentCoder<SoftLinkedMember>::encode(Encoder& encoder, const SoftLinkedMember& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.firstMember)>, RetainPtr<DDActionContext>>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMember)>, RetainPtr<DDActionContext>>);
-    struct ShouldBeSameSizeAsNullableSoftLinkedMember : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<NullableSoftLinkedMember>, false> {
+    struct ShouldBeSameSizeAsSoftLinkedMember : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<SoftLinkedMember>, false> {
         RetainPtr<DDActionContext> firstMember;
         RetainPtr<DDActionContext> secondMember;
     };
-    static_assert(sizeof(ShouldBeSameSizeAsNullableSoftLinkedMember) == sizeof(NullableSoftLinkedMember));
+    static_assert(sizeof(ShouldBeSameSizeAsSoftLinkedMember) == sizeof(SoftLinkedMember));
     static_assert(MembersInCorrectOrder<0
-        , offsetof(NullableSoftLinkedMember, firstMember)
-        , offsetof(NullableSoftLinkedMember, secondMember)
+        , offsetof(SoftLinkedMember, firstMember)
+        , offsetof(SoftLinkedMember, secondMember)
     >::value);
-    encoder << !!instance.firstMember;
-    if (!!instance.firstMember)
-        encoder << instance.firstMember;
+    encoder << instance.firstMember;
     encoder << instance.secondMember;
 }
 
-std::optional<NullableSoftLinkedMember> ArgumentCoder<NullableSoftLinkedMember>::decode(Decoder& decoder)
+std::optional<SoftLinkedMember> ArgumentCoder<SoftLinkedMember>::decode(Decoder& decoder)
 {
-    auto hasfirstMember = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    std::optional<RetainPtr<DDActionContext>> firstMember;
-    if (*hasfirstMember) {
-        firstMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
-    } else
-        firstMember = std::optional<RetainPtr<DDActionContext>> { RetainPtr<DDActionContext> { } };
-    auto secondMember = IPC::decode<DDActionContext>(decoder, PAL::getDDActionContextClass());
+    auto firstMember = IPC::decode<DDActionContext>(decoder, @[ PAL::getDDActionContextClass() ]);
+    auto secondMember = IPC::decode<DDActionContext>(decoder, @[ PAL::getDDActionContextClass() ]);
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;
     return {
-        NullableSoftLinkedMember {
+        SoftLinkedMember {
             WTFMove(*firstMember),
             WTFMove(*secondMember)
         }
@@ -761,22 +741,13 @@ void ArgumentCoder<WebCore::MoveOnlyDerivedClass>::encode(Encoder& encoder, WebC
         , offsetof(WebCore::MoveOnlyDerivedClass, firstMember)
         , offsetof(WebCore::MoveOnlyDerivedClass, secondMember)
     >::value);
-    encoder << !!instance.firstMember;
-    if (!!instance.firstMember)
-        encoder << WTFMove(instance.firstMember);
+    encoder << WTFMove(instance.firstMember);
     encoder << WTFMove(instance.secondMember);
 }
 
 std::optional<WebCore::MoveOnlyDerivedClass> ArgumentCoder<WebCore::MoveOnlyDerivedClass>::decode(Decoder& decoder)
 {
-    auto hasfirstMember = decoder.decode<bool>();
-    if (UNLIKELY(!decoder.isValid()))
-        return std::nullopt;
-    std::optional<int> firstMember;
-    if (*hasfirstMember) {
-        firstMember = decoder.decode<int>();
-    } else
-        firstMember = std::optional<int> { int { } };
+    auto firstMember = decoder.decode<int>();
     auto secondMember = decoder.decode<int>();
     if (UNLIKELY(!decoder.isValid()))
         return std::nullopt;

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -54,7 +54,7 @@ namespace WebCore {
 template<typename, typename> class ScrollSnapOffsetsInfo;
 using FloatBoxExtent = ScrollSnapOffsetsInfo<float, double>;
 }
-struct NullableSoftLinkedMember;
+struct SoftLinkedMember;
 namespace WebCore { class TimingFunction; }
 #if ENABLE(TEST_FEATURE)
 namespace Namespace { class ConditionalCommonClass; }
@@ -131,9 +131,9 @@ template<> struct ArgumentCoder<WebCore::FloatBoxExtent> {
     static std::optional<WebCore::FloatBoxExtent> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<NullableSoftLinkedMember> {
-    static void encode(Encoder&, const NullableSoftLinkedMember&);
-    static std::optional<NullableSoftLinkedMember> decode(Decoder&);
+template<> struct ArgumentCoder<SoftLinkedMember> {
+    static void encode(Encoder&, const SoftLinkedMember&);
+    static std::optional<SoftLinkedMember> decode(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::TimingFunction> {

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -72,7 +72,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             },
 #endif
             {
-                "std::optional<RetainPtr<CFTypeRef>>"_s,
+                "RetainPtr<CFTypeRef>"_s,
                 "nullableTestMember"_s
             },
         } },
@@ -182,9 +182,9 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "left()"_s
             },
         } },
-        { "NullableSoftLinkedMember"_s, {
+        { "SoftLinkedMember"_s, {
             {
-                "std::optional<RetainPtr<DDActionContext>>"_s,
+                "RetainPtr<DDActionContext>"_s,
                 "firstMember"_s
             },
             {
@@ -218,7 +218,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
         } },
         { "WebCore::MoveOnlyDerivedClass"_s, {
             {
-                "std::optional<int>"_s,
+                "int"_s,
                 "firstMember"_s
             },
             {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -9,7 +9,7 @@ headers: "StructHeader.h" "FirstMemberType.h" "SecondMemberType.h"
     #if ENABLE(SECOND_MEMBER)
     SecondMemberType secondMemberName;
     #endif
-    [Nullable] RetainPtr<CFTypeRef> nullableTestMember;
+    RetainPtr<CFTypeRef> nullableTestMember;
 }
 #endif
 
@@ -95,9 +95,9 @@ class WTF::Seconds {
     float left()
 };
 
-struct NullableSoftLinkedMember {
-    [Nullable, SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> firstMember;
-    [SoftLinkedClass='PAL::getDDActionContextClass()'] RetainPtr<DDActionContext> secondMember;
+struct SoftLinkedMember {
+    [SecureCodingAllowed=[PAL::getDDActionContextClass()]] RetainPtr<DDActionContext> firstMember;
+    [SecureCodingAllowed=[PAL::getDDActionContextClass()]] RetainPtr<DDActionContext> secondMember;
 }
 
 [RefCounted] class WebCore::TimingFunction subclasses {
@@ -160,7 +160,7 @@ headers: "CommonHeader.h"
 }
 
 [RValue] class WebCore::MoveOnlyDerivedClass {
-    [Nullable] int firstMember;
+    int firstMember;
     int secondMember;
 }
 

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.cpp
@@ -51,12 +51,6 @@
 namespace IPC {
 using namespace WebCore;
 
-CFTypeRef tokenNullptrTypeRef()
-{
-    static CFStringRef tokenNullptrType = CFSTR("WKNull");
-    return tokenNullptrType;
-}
-
 enum class CFType : uint8_t {
     CFArray,
     CFBoolean,
@@ -84,9 +78,7 @@ enum class CFType : uint8_t {
 
 static CFType typeFromCFTypeRef(CFTypeRef type)
 {
-    ASSERT(type);
-
-    if (type == tokenNullptrTypeRef())
+    if (!type)
         return CFType::Nullptr;
 
     CFTypeID typeID = CFGetTypeID(type);
@@ -326,7 +318,7 @@ std::optional<RetainPtr<CFTypeRef>> ArgumentCoder<RetainPtr<CFTypeRef>>::decode(
         return WTFMove(*trust);
     }
     case CFType::Nullptr:
-        return tokenNullptrTypeRef();
+        return nullptr;
     case CFType::Unknown:
         break;
     }

--- a/Source/WebKit/Shared/cf/ArgumentCodersCF.h
+++ b/Source/WebKit/Shared/cf/ArgumentCodersCF.h
@@ -165,6 +165,4 @@ template<> struct ArgumentCoder<RetainPtr<SecTrustRef>> : CFRetainPtrArgumentCod
     template<typename Decoder> static std::optional<RetainPtr<SecTrustRef>> decode(Decoder&);
 };
 
-CFTypeRef tokenNullptrTypeRef();
-
 } // namespace IPC

--- a/Source/WebKit/Shared/mac/SecItemResponseData.serialization.in
+++ b/Source/WebKit/Shared/mac/SecItemResponseData.serialization.in
@@ -22,5 +22,5 @@
 
 class WebKit::SecItemResponseData {
     OSStatus m_resultCode;
-    [Nullable] RetainPtr<CFTypeRef> m_resultObject;
+    RetainPtr<CFTypeRef> m_resultObject;
 }

--- a/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
+++ b/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
@@ -25,7 +25,7 @@ headers: <WebCore/TextIndicator.h>
 #if PLATFORM(MAC)
 header: "WebHitTestResultData.h" <pal/mac/DataDetectorsSoftLink.h>
 [CustomHeader] struct WebKit::WebHitTestResultPlatformData {
-    [Nullable, SoftLinkedClass='PAL::getWKDDActionContextClass()'] RetainPtr<WKDDActionContext> detectedDataActionContext;
+    [SecureCodingAllowed=[PAL::getWKDDActionContextClass()]] RetainPtr<WKDDActionContext> detectedDataActionContext;
     WebCore::FloatRect detectedDataBoundingBox;
     RefPtr<WebCore::TextIndicator> detectedDataTextIndicator;
     WebCore::PageOverlay::PageOverlayID detectedDataOriginatingPageOverlay;


### PR DESCRIPTION
#### 50287cebf65d21fd47c4926000d7a51e26a18613
<pre>
Remove unnecessary attributes from *.serialization.in files
<a href="https://bugs.webkit.org/show_bug.cgi?id=259559">https://bugs.webkit.org/show_bug.cgi?id=259559</a>
rdar://112975705

Reviewed by Youenn Fablet.

Nullable is only used when serializing RetainPtr, which can already handle null state.
SoftLinkedClass does the same thing as SecureCodingAllowed.  Remove the former in favor of the latter.
Add SecureCodingAllowed to the comment documentation at the beginning of generate-serializers.py.

* Source/WebKit/Scripts/generate-serializers.py:
(encode_type):
(decode_type):
(generate_serialized_type_info):
(parse_serialized_types):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::decode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::encode):
(IPC::ArgumentCoder&lt;SoftLinkedMember&gt;::decode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::MoveOnlyDerivedClass&gt;::decode):
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::decode): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/mac/SecItemResponseData.h:
(WebKit::SecItemResponseData::SecItemResponseData):
(WebKit::SecItemResponseData::resultObject):
* Source/WebKit/Shared/mac/SecItemResponseData.serialization.in:
* Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

Canonical link: <a href="https://commits.webkit.org/266374@main">https://commits.webkit.org/266374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/094a5dd6656e5ccf0bc824a6312a829315379536

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15673 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16115 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13772 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11759 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12499 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10905 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12296 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16627 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1579 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->