### PR TITLE
[GBM] Fixes for WEBKIT_WEB_RENDER_DEVICE_FILE handling

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -488,6 +488,12 @@ static String drmRenderNodeFromPrimaryDeviceFile(const String& primaryDeviceFile
 const String& PlatformDisplay::drmRenderNodeFile()
 {
     if (!m_drmRenderNodeFile.has_value()) {
+        const char* envDeviceFile = getenv("WEBKIT_WEB_RENDER_DEVICE_FILE");
+        if (envDeviceFile && *envDeviceFile) {
+            m_drmRenderNodeFile = String::fromUTF8(envDeviceFile);
+            return m_drmRenderNodeFile.value();
+        }
+
         if (EGLDeviceEXT device = eglDevice()) {
             if (GLContext::isExtensionSupported(eglQueryDeviceStringEXT(device, EGL_EXTENSIONS), "EGL_EXT_device_drm_render_node")) {
                 m_drmRenderNodeFile = String::fromUTF8(eglQueryDeviceStringEXT(device, EGL_DRM_RENDER_NODE_FILE_EXT));
@@ -506,10 +512,9 @@ const String& PlatformDisplay::drmRenderNodeFile()
 struct gbm_device* PlatformDisplay::gbmDevice()
 {
     auto& device = GBMDevice::singleton();
-    if (!device.isInitialized()) {
-        const char* envDeviceFile = getenv("WEBKIT_WEB_RENDER_DEVICE_FILE");
-        device.initialize(envDeviceFile && *envDeviceFile ? String::fromUTF8(envDeviceFile) : drmRenderNodeFile());
-    }
+    if (!device.isInitialized())
+        device.initialize(drmRenderNodeFile());
+
     return device.device();
 }
 #endif


### PR DESCRIPTION
#### 522fb197d28fa011ad6d5fa81bb470b9a4d1a525
<pre>
[GBM] Fixes for WEBKIT_WEB_RENDER_DEVICE_FILE handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=259561">https://bugs.webkit.org/show_bug.cgi?id=259561</a>

Reviewed by Carlos Garcia Campos.

Without this patch setting the WEBKIT_WEB_RENDER_DEVICE_FILE has no effect, since the GBMDevice is
not re-initialized after setting the env var.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::drmRenderNodeFile):
(WebCore::PlatformDisplay::gbmDevice):

Canonical link: <a href="https://commits.webkit.org/266382@main">https://commits.webkit.org/266382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e90b66d33ff789b7f887299340c351eb3cb7d2c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16142 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19395 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15736 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10930 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12320 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3329 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12893 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->