### PR TITLE
jsc_fuz/wktr: null ptr deref in WebCore::IDBRequest::dispatchEvent(WebCore::Event&)

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-expected.txt
@@ -1,0 +1,11 @@
+This test verifies dispatching untrusted event should not cause crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+image = new Image();
+openRequest = indexedDB.open(dbname);
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private-expected.txt
@@ -1,0 +1,11 @@
+This test verifies dispatching untrusted event should not cause crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+image = new Image();
+openRequest = indexedDB.open(dbname);
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private.html
+++ b/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/request-dispatch-untrusted-event.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event.html
+++ b/LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/request-dispatch-untrusted-event.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/modern/resources/request-dispatch-untrusted-event.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/request-dispatch-untrusted-event.js
@@ -1,0 +1,24 @@
+description("This test verifies dispatching untrusted event should not cause crash.");
+
+setDBNameFromPath();
+
+function loadImage()
+{
+    evalAndLog("image = new Image();");
+    image.onerror = (error) => {
+        imageError = error;
+        openDatabase();
+    };
+    // Generate an error event.
+    image.src = 'data:';
+}
+
+function openDatabase()
+{
+    evalAndLog("openRequest = indexedDB.open(dbname);");
+    openRequest.onupgradeneeded = () => { openRequest.dispatchEvent(imageError); };
+    // Ensure there is no crash after error event is dispatched.
+    openRequest.onerror = () => { setTimeout(finishJSTest, 0); };
+}
+
+loadImage();


### PR DESCRIPTION
#### c35fc03694c2696aeeb50657fd250645c75d758c
<pre>
jsc_fuz/wktr: null ptr deref in WebCore::IDBRequest::dispatchEvent(WebCore::Event&amp;)
rdar://110459666

Reviewed by Brady Eidson.

Make sure untrusted event does not change the internal state of IDBRequest. Also, move the assert that request must have
pending activity when event is being dispatched to a later point, because IDBRequest::dispatchEvent might be invoked
from JavaScript code (i.e. request does not actually have pending activity).

Test: storage/indexeddb/modern/request-dispatch-untrusted-event.html
      storage/indexeddb/modern/request-dispatch-untrusted-event-private.html

* LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event-private.html: Added.
* LayoutTests/storage/indexeddb/modern/request-dispatch-untrusted-event.html: Added.
* LayoutTests/storage/indexeddb/modern/resources/request-dispatch-untrusted-event.js: Added.
(loadImage):
(openDatabase):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::dispatchEvent):

Originally-landed-as: 259548.825@safari-7615-branch (9b3d228ec2cb). rdar://110459666
Canonical link: <a href="https://commits.webkit.org/266390@main">https://commits.webkit.org/266390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0295f1adde7eb9f1664f8840ac8beb31b80a87bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16076 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19341 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12804 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15678 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10875 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3334 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->