### PR TITLE
When there are two elements with the same ID, xlink:href should refer to the first.

### DIFF
--- a/LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    const rect1 = document.getElementById('rect1');
+    const rect2 = rect1.cloneNode();
+    rect2.setAttribute('fill', 'green');
+    rect1.before(rect2);
+    rect1.style.visibility = 'hidden';
+}
+
+function finishTest() {
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect id="rect1" x="0" y="0" width="50" height="100" fill="red"/>
+    <animate href="#rect1" attributeName="width" begin="0s" dur="0.01s" by="100" fill="freeze" onend="finishTest()"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><rect id="rect1" x="0" y="0" width="100" height="100" fill="green"/></defs>
+    <filter id="filter"><feImage href="#rect1"></filter>
+    <rect x="0" y="0" width="100" height="100" filter="url(#filter)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const rect1 = document.getElementById('rect1');
+            rect1.getBoundingClientRect();
+            const rect2 = rect1.cloneNode();
+            rect2.setAttribute('fill', 'green');
+            rect1.before(rect2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <rect id="rect1" x="0" y="0" width="100" height="100" fill="red"/>
+    </defs>
+    <filter id="filter"><feImage href="#rect1"></filter>
+    <rect x="0" y="0" width="100" height="100" filter="url(#filter)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><radialGradient id="gradient"><stop offset="0%" stop-color="green" /></radialGradient></defs>
+    <rect x="0" y="0" width="100" height="100" fill="url(#gradient)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const gradient1 = document.getElementById('gradient1');
+            gradient1.getBoundingClientRect();
+            const gradient2 = gradient1.cloneNode(true);
+            gradient2.querySelector('stop').setAttribute('stop-color', 'green');
+            gradient1.before(gradient2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><radialGradient id="gradient1"><stop offset="0%" stop-color="red" /></radialGradient></defs>
+    <rect x="0" y="0" width="100" height="100" fill="url(#gradient1)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><rect id="rect" x="0" y="0" width="100" height="100" fill="green"/></defs>
+    <filter id="filter"><feImage href="#rect"></filter>
+    <rect x="0" y="0" width="100" height="100" filter="url(#filter)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const filter1 = document.getElementById('filter1');
+            filter1.getBoundingClientRect();
+            const filter2 = filter1.cloneNode(true);
+            filter2.querySelector('feImage').setAttribute('href', '#rect2');
+            filter1.before(filter2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <rect id="rect1" x="0" y="0" width="100" height="100" fill="red"/>
+        <rect id="rect2" x="0" y="0" width="100" height="100" fill="green"/>
+    </defs>
+    <filter id="filter1"><feImage href="#rect1"></filter>
+    <rect x="0" y="0" width="100" height="100" filter="url(#filter1)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="gradient"><stop offset="0" stop-color="green" /></linearGradient>
+    <rect id="rect" width="100" height="100" fill="url(#gradient)">
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const gradient1 = document.getElementById('gradient1');
+            const gradient2 = gradient1.cloneNode(true);
+            gradient2.querySelector('stop').setAttribute('stop-color', 'green');
+            gradient1.before(gradient2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="gradient1"><stop offset="0" stop-color="red" /></linearGradient>
+    <linearGradient id="gradientUse" href="#gradient1"></linearGradient>
+    <rect id="rect" width="100" height="100" fill="url(#gradientUse)">
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <marker id="marker1" viewBox="0 0 10 10" markerWidth="50" markerHeight="50"><rect x="0" y="0" width="10" height="10" fill="green"/></marker>
+    <polyline fill="none" stroke="none" points="0,50 50,50" marker-start="url(#marker1)" marker-end="url(#marker1)" />
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const marker1 = document.getElementById('marker1');
+            marker1.getBoundingClientRect();
+            const marker2 = marker1.cloneNode(true);
+            marker2.querySelector('rect').setAttribute('fill', 'green');
+            marker1.before(marker2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <marker id="marker1" viewBox="0 0 10 10" markerWidth="50" markerHeight="50"><rect x="0" y="0" width="10" height="10" fill="red"/></marker>
+    <polyline fill="none" stroke="none" points="0,50 50,50" marker-start="url(#marker1)" marker-end="url(#marker1)" />
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <mask id="mask1"><rect x="0" y="0" width="100" height="100" fill="white" /></mask>
+    <rect x="0" y="0" width="100" height="100" fill="green" mask="url(#mask1)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const mask1 = document.getElementById('mask1');
+            mask1.getBoundingClientRect();
+            const mask2 = mask1.cloneNode(true);
+            mask2.querySelector('rect').setAttribute('fill', 'white');
+            mask1.before(mask2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <mask id="mask1"><rect x="0" y="0" width="100" height="100" fill="black" /></mask>
+    <rect x="0" y="0" width="100" height="100" fill="green" mask="url(#mask1)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect id="rect1" x="50" y="50" width="50" height="50" fill="green"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    const path1 = document.getElementById('path1');
+    const path2 = path1.cloneNode();
+    path2.setAttribute('d', 'M0,50 L50,50');
+    path1.before(path2);
+}
+
+function finishTest() {
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path id="path1" d="M0,50 L100,50"/>
+    <rect id="rect1" x="0" y="0" width="50" height="50" fill="green">
+        <animateMotion href="#rect1" dur="0.01s" repeatCount="1" fill="freeze" onend="finishTest()">
+            <mpath href="#path1"/>
+        </animateMotion>
+    </rect>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <pattern id="pattern" viewbox="0 0 10 10" width="10" height="10"><rect width="10" height="10" fill="green"/></pattern>
+    </defs>
+    <rect x="0" y="0" width="100" height="100" fill="url(#pattern)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const pattern1 = document.getElementById('pattern1');
+            pattern1.getBoundingClientRect();
+            const pattern2 = pattern1.cloneNode(true);
+            pattern2.setAttribute('fill', 'green');
+            pattern1.before(pattern2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <pattern id="pattern1" viewbox="0 0 10 10" width="10" height="10" fill="red"><rect width="10" height="10"/></pattern>
+        <pattern id="pattern" viewbox="0 0 10 10" width="10" height="10" href="#pattern1"></pattern>
+    </defs>
+    <rect x="0" y="0" width="100" height="100" fill="url(#pattern)"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <radialGradient id="gradient"><stop offset="0%" stop-color="green" /></radialGradient>
+    <rect id="rect" width="100" height="100" fill="url(#gradient)">
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const gradient1 = document.getElementById('gradient1');
+            const gradient2 = gradient1.cloneNode(true);
+            gradient2.querySelector('stop').setAttribute('stop-color', 'green');
+            gradient1.before(gradient2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <radialGradient id="gradient1"><stop offset="0%" stop-color="red" /></radialGradient>
+    <radialGradient id="gradientUse" href="#gradient1"></radialGradient>
+    <rect id="rect" width="100" height="100" fill="url(#gradientUse)">
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><radialGradient id="gradient"><stop offset="0%" stop-color="green" /></radialGradient></defs>
+    <rect x="0" y="0" width="100" height="100" fill="none" stroke="url(#gradient)" stroke-width="20"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function doTest() {
+    requestAnimationFrame(() => {
+        setTimeout(() => {
+            const gradient1 = document.getElementById('gradient1');
+            gradient1.getBoundingClientRect();
+            const gradient2 = gradient1.cloneNode(true);
+            gradient2.querySelector('stop').setAttribute('stop-color', 'green');
+            gradient1.before(gradient2);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, 0);
+    });
+}
+
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs><radialGradient id="gradient1"><stop offset="0%" stop-color="red" /></radialGradient></defs>
+    <rect x="0" y="0" width="100" height="100" fill="none" stroke="url(#gradient1)" stroke-width="20"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path id="path1" stroke="green" stroke-width="10" d="M 0 50 L 100 50"/>
+    <text>
+        <textPath href="#path1">PASS</textPath>
+    </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function doTest() {
+    const path1 = document.getElementById('path1');
+    path1.getBoundingClientRect();
+    const path2 = path1.cloneNode();
+    path2.setAttribute('d', 'M 0 50 L 100 50');
+    path1.before(path2);
+    path1.style.visibility = 'hidden';
+}
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path id="path1" stroke="green" stroke-width="10" d="M 50 0 L 50 100"/>
+    <text>
+        <textPath href="#path1">PASS</textPath>
+    </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2-expected.html
+++ b/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <text x="50" y="50">
+        PASS
+    </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2.html
+++ b/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function doTest() {
+    const text1 = document.getElementById('text1');
+    const text2 = text1.cloneNode();
+    text2.textContent = 'PASS';
+    text1.before(text2);
+}
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g style="visibility: hidden">
+        <text id="text1">FAIL</text>
+    </g>
+    <text x="50" y="50">
+        <tref href="#text1"></tref>
+    </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="10cm" height="3cm" viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <text x="100" y="100" font-size="45" fill="green" >
+    PASS
+  </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- Test that when two elements with the same id are in the document,
+     elements that reference the duplicated id end up referring to the
+     first of the two. -->
+<!-- If this test passes, you should see the word "PASS". -->
+<script>
+  function doTest() {
+    var defs2 = document.getElementById('defs2');
+    var referencedText2 = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    referencedText2.setAttribute("id", "ReferencedText");
+    referencedText2.textContent = "FAIL";
+    defs2.appendChild(referencedText2);
+
+    var defs1 = document.getElementById('defs1');
+    var referencedText2 = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    referencedText2.setAttribute("id", "ReferencedText");
+    referencedText2.textContent = "PASS";
+    defs1.appendChild(referencedText2);
+  }
+</script>
+</head>
+<body onload="doTest()">
+<svg width="10cm" height="3cm" viewBox="0 0 1000 300" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs id="defs1"></defs>
+  <defs id="defs2"></defs>
+  <text x="100" y="100" font-size="45" fill="green" >
+    <tref xlink:href="#ReferencedText"/>
+  </text>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-use-dynamic-duplicate-id-expected.html
+++ b/LayoutTests/svg/dom/svg-use-dynamic-duplicate-id-expected.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/dom/svg-use-dynamic-duplicate-id.html
+++ b/LayoutTests/svg/dom/svg-use-dynamic-duplicate-id.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function doTest() {
+    const rect1 = document.getElementById('rect1');
+    const rect2 = rect1.cloneNode();
+    rect2.setAttribute('fill', 'green');
+    rect1.before(rect2);
+    rect1.style.visibility = 'hidden';
+}
+</script>
+</head>
+<body onload="doTest()">
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <rect id="rect1" x="0" y="0" width="100" height="50" fill="red"/>
+    <use href="#rect1" y="50"/>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -140,8 +140,9 @@ public:
     void clearHasPendingSVGResourcesIfPossible(SVGElement&);
     void removeElementFromPendingSVGResources(SVGElement&);
     WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData> removePendingSVGResource(const AtomString&);
-    void markPendingSVGResourcesForRemoval(const AtomString&);
-    RefPtr<SVGElement> takeElementFromPendingSVGResourcesForRemovalMap(const AtomString&);
+    void addResolvedSVGReferences(const AtomString&, WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>&&);
+    void addResolvedSVGReference(const AtomString&, SVGElement&);
+    const WeakHashSet<SVGElement, WeakPtrImplWithEventTargetData>* resolvedSVGReferences(const AtomString&);
 
 protected:
     TreeScope(ShadowRoot&, Document&);

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -70,6 +70,7 @@ public:
     void setHasPendingResources() { setNodeFlag(NodeFlag::HasPendingResources); }
     void clearHasPendingResources() { clearNodeFlag(NodeFlag::HasPendingResources); }
     virtual void buildPendingResource() { }
+    virtual void rebuildResourceReference() { buildPendingResource(); }
 
     virtual bool isSVGGraphicsElement() const { return false; }
     virtual bool isSVGGeometryElement() const { return false; }

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -108,10 +108,19 @@ void SVGFEImageElement::buildPendingResource()
             treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (is<SVGElement>(*target.element))
+        return;
+    }
+    treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, *this);
+    if (is<SVGElement>(*target.element))
         downcast<SVGElement>(*target.element).addReferencingElement(*this);
 
     updateSVGRendererForElementChange();
+}
+
+void SVGFEImageElement::rebuildResourceReference()
+{
+    buildPendingResource();
+    markFilterEffectForRebuild();
 }
 
 void SVGFEImageElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -61,6 +61,7 @@ private:
     void requestImageResource();
 
     void buildPendingResource() override;
+    void rebuildResourceReference() override;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -149,6 +149,7 @@ bool SVGLinearGradientElement::collectGradientAttributes(LinearGradientAttribute
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
         if (is<SVGGradientElement>(target.element)) {
+            treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, current);
             current = downcast<SVGGradientElement>(*target.element);
 
             // Cycle detection

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -67,7 +67,10 @@ void SVGMPathElement::buildPendingResource()
             treeScope.addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (is<SVGElement>(*target.element))
+        return;
+    }
+    treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, *this);
+    if (is<SVGElement>(*target.element))
         downcast<SVGElement>(*target.element).addReferencingElement(*this);
 
     targetPathChanged();

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -162,6 +162,7 @@ bool SVGRadialGradientElement::collectGradientAttributes(RadialGradientAttribute
         // Respect xlink:href, take attributes from referenced element
         auto target = SVGURIReference::targetElementFromIRIString(current->href(), treeScopeForSVGReferences());
         if (is<SVGGradientElement>(target.element)) {
+            treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, *current);
             current = downcast<SVGGradientElement>(target.element.get());
 
             // Cycle detection

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -234,7 +234,8 @@ void SVGTRefElement::buildPendingResource()
         treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);
         ASSERT(hasPendingResources());
         return;
-    }
+    } else if (!target.identifier.isNull())
+        treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, const_cast<SVGTRefElement&>(*this));
 
     // Don't set up event listeners if this is a shadow tree node.
     // SVGUseElement::transferEventListenersToShadowTree() handles this task, and addEventListener()

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -157,7 +157,10 @@ void SVGTextPathElement::buildPendingResource()
             treeScope.addPendingSVGResource(target.identifier, *this);
             ASSERT(hasPendingResources());
         }
-    } else if (target.element->hasTagName(SVGNames::pathTag))
+        return;
+    }
+    treeScopeForSVGReferences().addResolvedSVGReference(target.identifier, *this);
+    if (target.element->hasTagName(SVGNames::pathTag))
         downcast<SVGElement>(*target.element).addReferencingElement(*this);
 }
 

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -96,18 +96,18 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
     if (externalDocument) {
         // Enforce that the referenced url matches the url of the document that we've loaded for it!
         ASSERT(equalIgnoringFragmentIdentifier(url, externalDocument->url()));
-        return { externalDocument->getElementById(id), WTFMove(id) };
+        return { externalDocument->getElementById(id), WTFMove(id), true };
     }
 
     // Exit early if the referenced url is external, and we have no externalDocument given.
     if (isExternalURIReference(iri, document))
-        return { nullptr, WTFMove(id) };
+        return { nullptr, WTFMove(id), false };
 
     RefPtr shadowHost = treeScope.rootNode().shadowHost();
     if (is<SVGUseElement>(shadowHost))
-        return { shadowHost->treeScope().getElementById(id), WTFMove(id) };
+        return { shadowHost->treeScope().getElementById(id), WTFMove(id), false };
 
-    return { treeScope.getElementById(id), WTFMove(id) };
+    return { treeScope.getElementById(id), WTFMove(id), false };
 }
 
 bool SVGURIReference::haveLoadedRequiredResources() const

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -41,6 +41,7 @@ public:
     struct TargetElementResult {
         RefPtr<Element> element;
         AtomString identifier;
+        bool isExternal { false };
     };
     static TargetElementResult targetElementFromIRIString(const String&, const TreeScope&, RefPtr<Document> externalDocument = nullptr);
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -209,8 +209,10 @@ void SVGSMILElement::buildPendingResource()
             treeScopeForSVGReferences().addPendingSVGResource(id, *this);
             ASSERT(hasPendingResources());
         }
-    } else
+    } else {
+        treeScopeForSVGReferences().addResolvedSVGReference(id, *this);
         svgTarget->addReferencingElement(*this);
+    }
 }
 
 inline QualifiedName SVGSMILElement::constructAttributeName() const


### PR DESCRIPTION
#### 61c24afbe82ea82668f077fe17e5d1a47b50ae87
<pre>
When there are two elements with the same ID, xlink:href should refer to the first.
<a href="https://bugs.webkit.org/show_bug.cgi?id=99893">https://bugs.webkit.org/show_bug.cgi?id=99893</a>

Reviewed by NOBODY (OOPS!).

This PR fixes the bug by introducing a new hash set (resolvedResources) of elements
referencing a given ID, and uses it to rebuild referenced resources when the newly
inserted element is the first element of the given ID.

This PR also replaces the use of markPendingSVGResourcesForRemoval
and takeElementFromPendingSVGResourcesForRemovalMap by removePendingSVGResource
for clarity &amp; simplicity. This lets us eliminate pendingResourcesForRemoval.

Finally, this PR adds a whole bunch of tests to make sure SVG references gets updated
when a new element with the referenced id gets inserted before the existing element.

* LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-animate-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-feimage-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-fill-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-filter-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-lineargradient-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-marker-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-mask-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-mpath-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-pattern-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-radialgradient-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-stroke-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-textpath-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2-expected.html: Added.
* LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-2.html: Added.
* LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-tref-dynamic-duplicate-id.html: Added.
* LayoutTests/svg/dom/svg-use-dynamic-duplicate-id-expected.html: Added.
* LayoutTests/svg/dom/svg-use-dynamic-duplicate-id.html: Added.
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::removeElementFromPendingSVGResources):
(WebCore::TreeScope::addResolvedSVGReferences): Added.
(WebCore::TreeScope::addResolvedSVGReference): Added.
(WebCore::TreeScope::resolvedSVGReferences): Added.
(WebCore::TreeScope::markPendingSVGResourcesForRemoval): Deleted.
(WebCore::TreeScope::takeElementFromPendingSVGResourcesForRemovalMap): Deleted.
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/rendering/svg/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::insertedIntoAncestor): Rebuild the SVG resource references when
&quot;this&quot; element has an ID which is referenced by other elements and it&apos;s now the first
of its kind in the trees scope.
(WebCore::SVGElement::buildPendingResourcesIfNeeded): Simplified the code by
replacing the use of markPendingSVGResourcesForRemoval and
takeElementFromPendingSVGResourcesForRemovalMap with removePendingSVGResource.
Also added the logic to add resolved resources back into the new hash set.
* Source/WebCore/svg/SVGElement.h:
(WebCore::SVGElement::rebuildResourceReference):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::buildPendingResource):
(WebCore::SVGFEImageElement::rebuildResourceReference):
* Source/WebCore/svg/SVGFEImageElement.h:
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::buildPendingResource):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::collectGradientAttributes):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::buildPendingResource):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::buildPendingResource):
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::targetElementFromIRIString):
* Source/WebCore/svg/SVGURIReference.h:
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::findTarget const):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::buildPendingResource):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61c24afbe82ea82668f077fe17e5d1a47b50ae87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15692 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16136 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19391 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12855 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15732 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10927 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12216 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->