### PR TITLE
Web Inspector: Elements: add an editor for CSS `steps()`

### DIFF
--- a/Source/WebInspectorUI/.eslintrc
+++ b/Source/WebInspectorUI/.eslintrc
@@ -133,6 +133,7 @@
         "createCodeMirrorCubicBezierTimingFunctionTextMarkers": true,
         "createCodeMirrorGradientTextMarkers": true,
         "createCodeMirrorSpringTimingFunctionTextMarkers": true,
+        "createCodeMirrorStepsTimingFunctionTextMarkers": true,
     },
     "rules": {
         "array-bracket-spacing": [2, "never"],

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -607,6 +607,7 @@ localizedStrings["Edit Local Override\u2026"] = "Edit Local Override\u2026";
 localizedStrings["Edit \u201Cbox-shadow\u201D"] = "Edit \u201Cbox-shadow\u201D";
 localizedStrings["Edit \u201Ccubic-bezier\u201D function"] = "Edit \u201Ccubic-bezier\u201D function";
 localizedStrings["Edit \u201Cspring\u201D function"] = "Edit \u201Cspring\u201D function";
+localizedStrings["Edit \u201Csteps\u201D function"] = "Edit \u201Csteps\u201D function";
 localizedStrings["Edit configuration"] = "Edit configuration";
 localizedStrings["Edit custom gradient"] = "Edit custom gradient";
 /* Title of icon indiciating that the selected audit is being edited. */

--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorStepsTimingFunctionEditingController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorStepsTimingFunctionEditingController.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.CodeMirrorStepsTimingFunctionEditingController = class CodeMirrorStepsTimingFunctionEditingController extends WI.CodeMirrorEditingController
+{
+    // Public
+
+    get initialValue()
+    {
+        return WI.StepsTimingFunction.fromString(this.text);
+    }
+
+    get cssClassName()
+    {
+        return "steps";
+    }
+
+    // WI.Popover delegate
+
+    popoverWillPresent(popover)
+    {
+        this._stepsTimingFunctionEditor = new WI.StepsTimingFunctionEditor;
+        this._stepsTimingFunctionEditor.addEventListener(WI.StepsTimingFunctionEditor.Event.StepsTimingFunctionChanged, this._handleStepsTimingFunctionEditorStepsTimingFunctionChanged, this);
+        popover.content = this._stepsTimingFunctionEditor.element;
+    }
+
+    popoverDidPresent(popover)
+    {
+        this._stepsTimingFunctionEditor.stepsTimingFunction = this.value;
+    }
+
+    // Private
+
+    _handleStepsTimingFunctionEditorStepsTimingFunctionChanged(event)
+    {
+        this.value = event.data.stepsTimingFunction;
+    }
+};

--- a/Source/WebInspectorUI/UserInterface/Main.html
+++ b/Source/WebInspectorUI/UserInterface/Main.html
@@ -239,6 +239,7 @@
     <link rel="stylesheet" href="Views/SpreadsheetRulesStyleDetailsPanel.css">
     <link rel="stylesheet" href="Views/SpringTimingFunctionEditor.css">
     <link rel="stylesheet" href="Views/StackTraceView.css">
+    <link rel="stylesheet" href="Views/StepsTimingFunctionEditor.css">
     <link rel="stylesheet" href="Views/StorageIcons.css">
     <link rel="stylesheet" href="Views/StorageSidebarPanel.css">
     <link rel="stylesheet" href="Views/StyleRuleIcons.css">
@@ -899,6 +900,7 @@
     <script src="Views/StackTraceView.js"></script>
     <script src="Views/StackedAreaChart.js"></script>
     <script src="Views/StackedColumnChart.js"></script>
+    <script src="Views/StepsTimingFunctionEditor.js"></script>
     <script src="Views/StorageSidebarPanel.js"></script>
     <script src="Views/SymbolicBreakpointPopover.js"></script>
     <script src="Views/SymbolicBreakpointTreeElement.js"></script>
@@ -943,6 +945,7 @@
     <script src="Controllers/CodeMirrorDragToAdjustNumberController.js"></script>
     <script src="Controllers/CodeMirrorGradientEditingController.js"></script>
     <script src="Controllers/CodeMirrorSpringTimingFunctionEditingController.js"></script>
+    <script src="Controllers/CodeMirrorStepsTimingFunctionEditingController.js"></script>
     <script src="Controllers/CodeMirrorTokenTrackingController.js"></script>
     <script src="Controllers/CodeMirrorTextKillController.js"></script>
     <script src="Controllers/ConsoleManager.js"></script>

--- a/Source/WebInspectorUI/UserInterface/Models/TextMarker.js
+++ b/Source/WebInspectorUI/UserInterface/Models/TextMarker.js
@@ -79,9 +79,10 @@ WI.TextMarker = class TextMarker
 
 WI.TextMarker.Type = {
     Color: "text-marker-type-color",
+    CubicBezierTimingFunction: "text-marker-type-cubic-bezier-timing-function",
     Gradient: "text-marker-type-gradient",
     Plain: "text-marker-type-plain",
-    CubicBezierTimingFunction: "text-marker-type-cubic-bezier-timing-function",
     SpringTimingFunction: "text-marker-type-spring-timing-function",
+    StepsTimingFunction: "text-marker-type-steps-timing-function",
     Variable: "text-marker-type-variable",
 };

--- a/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js
@@ -240,6 +240,7 @@ WI.AnimationDetailsSidebarPanel = class AnimationDetailsSidebarPanel extends WI.
                 createCodeMirrorGradientTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.Gradient));
                 createCodeMirrorCubicBezierTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.CubicBezierTimingFunction));
                 createCodeMirrorSpringTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.SpringTimingFunction));
+                createCodeMirrorStepsTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.StepsTimingFunction));
 
                 let row = new WI.DetailsSectionRow;
                 row.element.classList.add("styles");

--- a/Source/WebInspectorUI/UserInterface/Views/CodeMirrorTextMarkers.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CodeMirrorTextMarkers.js
@@ -201,3 +201,9 @@ function createCodeMirrorSpringTimingFunctionTextMarkers(codeMirror, range, opti
     const pattern = /(spring\([^)]+\))/g;
     return createCodeMirrorTextMarkers({codeMirror, range, type: "SpringTimingFunction", pattern, ...options});
 }
+
+function createCodeMirrorStepsTimingFunctionTextMarkers(codeMirror, range, options = {})
+{
+    const pattern = /(steps\([^)]+\))/g;
+    return createCodeMirrorTextMarkers({codeMirror, range, type: "StepsTimingFunction", pattern, ...options});
+}

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css
@@ -53,19 +53,19 @@
     background-repeat: no-repeat;
 }
 
-.inline-swatch:is(.cubic-bezier-timing-function, .spring-timing-function, .variable) {
+.inline-swatch:is(.cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable) {
     color: var(--glyph-color-active);
 }
 
-.inline-swatch:is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable) {
+.inline-swatch:is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable) {
     margin-right: 2px;
 }
 
-.inline-swatch:not(.read-only):is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable, .alignment):hover {
+.inline-swatch:not(.read-only):is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable, .alignment):hover {
     filter: brightness(0.9);
 }
 
-.inline-swatch:not(.read-only):is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable, .alignment):active {
+.inline-swatch:not(.read-only):is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable, .alignment):active {
     filter: brightness(0.8);
 }
 
@@ -97,7 +97,7 @@
     border-color: hsl(0, 0%, 25%);
 }
 
-.inline-swatch:is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable) > span {
+.inline-swatch:is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable) > span {
     display: none;
 }
 

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
@@ -39,6 +39,7 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
         switch (this._variableType || this._type) {
         case WI.InlineSwatch.Type.CubicBezierTimingFunction:
         case WI.InlineSwatch.Type.SpringTimingFunction:
+        case WI.InlineSwatch.Type.StepsTimingFunction:
             this._swatchElement = WI.ImageUtilities.useSVGSymbol("Images/CubicBezier.svg");
             break;
 
@@ -87,6 +88,10 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
 
             case WI.InlineSwatch.Type.SpringTimingFunction:
                 this._swatchElement.title = WI.UIString("Edit \u201Cspring\u201D function");
+                break;
+
+            case WI.InlineSwatch.Type.StepsTimingFunction:
+                this._swatchElement.title = WI.UIString("Edit \u201Csteps\u201D function");
                 break;
 
             case WI.InlineSwatch.Type.Variable:
@@ -164,6 +169,8 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             this._valueEditor.removeEventListener(WI.GradientEditor.Event.GradientChanged, this._valueEditorValueDidChange, this);
         else if (this._valueEditor instanceof WI.SpringTimingFunctionEditor)
             this._valueEditor.removeEventListener(WI.SpringTimingFunctionEditor.Event.SpringTimingFunctionChanged, this._valueEditorValueDidChange, this);
+        else if (this._valueEditor instanceof WI.StepsTimingFunctionEditor)
+            this._valueEditor.removeEventListener(WI.StepsTimingFunctionEditor.Event.StepsTimingFunctionChanged, this._valueEditorValueDidChange, this);
         else if (this._valueEditor instanceof WI.AlignmentEditor)
             this._valueEditor.removeEventListener(WI.AlignmentEditor.Event.ValueChanged, this._valueEditorValueDidChange, this);
 
@@ -187,6 +194,8 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             return WI.Gradient.fromString("linear-gradient(transparent, transparent)");
         case WI.InlineSwatch.Type.SpringTimingFunction:
             return WI.SpringTimingFunction.fromString("1 100 10 0");
+        case WI.InlineSwatch.Type.StepsTimingFunction:
+            return WI.StepsTimingFunction.fromString("step-end");
         default:
             return null;
         }
@@ -356,6 +365,11 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             this._valueEditor.addEventListener(WI.SpringTimingFunctionEditor.Event.SpringTimingFunctionChanged, this._valueEditorValueDidChange, this);
             break;
 
+        case WI.InlineSwatch.Type.StepsTimingFunction:
+            this._valueEditor = new WI.StepsTimingFunctionEditor;
+            this._valueEditor.addEventListener(WI.StepsTimingFunctionEditor.Event.StepsTimingFunctionChanged, this._valueEditorValueDidChange, this);
+            break;
+
         case WI.InlineSwatch.Type.Alignment:
             // FIXME: <https://webkit.org/b/233055> Web Inspector: Add a swatch for justify-content, justify-items, and justify-self
             this._valueEditor = new WI.AlignmentEditor;
@@ -410,6 +424,10 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             this._valueEditor.springTimingFunction = value;
             break;
 
+        case WI.InlineSwatch.Type.StepsTimingFunction:
+            this._valueEditor.stepsTimingFunction = value;
+            break;
+
         case WI.InlineSwatch.Type.Variable: {
             if (this._variableType === WI.InlineSwatch.Type.Color) {
                 let colorVariable = this._findMatchingColorVariable(value.toString());
@@ -438,6 +456,7 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             createCodeMirrorGradientTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.Gradient));
             createCodeMirrorCubicBezierTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.CubicBezierTimingFunction));
             createCodeMirrorSpringTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.SpringTimingFunction));
+            createCodeMirrorStepsTimingFunctionTextMarkers(codeMirror, range, optionsForType(WI.InlineSwatch.Type.StepsTimingFunction));
             break;
         }
         }
@@ -474,6 +493,10 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
 
         case WI.InlineSwatch.Type.SpringTimingFunction:
             this._value = event.data.springTimingFunction;
+            break;
+
+        case WI.InlineSwatch.Type.StepsTimingFunction:
+            this._value = event.data.stepsTimingFunction;
             break;
 
         case WI.InlineSwatch.Type.Alignment:
@@ -639,14 +662,15 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
 };
 
 WI.InlineSwatch.Type = {
-    Color: "inline-swatch-type-color",
-    Gradient: "inline-swatch-type-gradient",
-    CubicBezierTimingFunction: "inline-swatch-type-cubic-bezier-timing-function",
-    BoxShadow: "inline-swatch-type-box-shadow",
-    SpringTimingFunction: "inline-swatch-type-spring-timing-function",
-    Variable: "inline-swatch-type-variable",
-    Image: "inline-swatch-type-image",
     Alignment: "inline-swatch-type-alignment",
+    BoxShadow: "inline-swatch-type-box-shadow",
+    Color: "inline-swatch-type-color",
+    CubicBezierTimingFunction: "inline-swatch-type-cubic-bezier-timing-function",
+    Gradient: "inline-swatch-type-gradient",
+    Image: "inline-swatch-type-image",
+    SpringTimingFunction: "inline-swatch-type-spring-timing-function",
+    StepsTimingFunction: "inline-swatch-type-steps-timing-function",
+    Variable: "inline-swatch-type-variable",
 };
 
 WI.InlineSwatch.Event = {

--- a/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js
@@ -2141,6 +2141,7 @@ WI.SourceCodeTextEditor = class SourceCodeTextEditor extends WI.TextEditor
             this.createGradientMarkers(range);
             this.createCubicBezierTimingFunctionMarkers(range);
             this.createSpringTimingFunctionMarkers(range);
+            this.createStepsTimingFunctionMarkers(range);
         }
 
         this._updateTokenTrackingControllerState();

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -673,6 +673,7 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
         if (this._property.isVariable || WI.CSSKeywordCompletions.isTimingFunctionAwareProperty(this._property.name)) {
             tokens = this._addTimingFunctionTokens(tokens, "cubic-bezier");
             tokens = this._addTimingFunctionTokens(tokens, "spring");
+            tokens = this._addTimingFunctionTokens(tokens, "steps");
         }
 
         tokens = this._addVariableTokens(tokens);
@@ -811,14 +812,22 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
                 let text = this._resolveVariables(rawTokens.map((token) => token.value).join(""));
                 rawTokens = this._addVariableTokens(rawTokens);
 
-                let valueObject;
+                let valueObject = null;
                 let inlineSwatchType;
-                if (tokenType === "cubic-bezier") {
+                switch (tokenType) {
+                case "cubic-bezier":
                     valueObject = WI.CubicBezierTimingFunction.fromString(text);
                     inlineSwatchType = WI.InlineSwatch.Type.CubicBezierTimingFunction;
-                } else if (tokenType === "spring") {
+                    break;
+
+                case "spring":
                     valueObject = WI.SpringTimingFunction.fromString(text);
                     inlineSwatchType = WI.InlineSwatch.Type.SpringTimingFunction;
+                    break;
+
+                case "steps":
+                    valueObject = WI.StepsTimingFunction.fromString(text);
+                    inlineSwatchType = WI.InlineSwatch.Type.StepsTimingFunction;
                 }
 
                 if (valueObject)
@@ -829,6 +838,8 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
                 startIndex = NaN;
             } else if (token.value in WI.CubicBezierTimingFunction.keywordValues)
                 newTokens.push(this._createInlineSwatch(WI.InlineSwatch.Type.CubicBezierTimingFunction, [token], WI.CubicBezierTimingFunction.fromString(token.value)));
+            else if (token.value in WI.StepsTimingFunction.keywordValues)
+                newTokens.push(this._createInlineSwatch(WI.InlineSwatch.Type.StepsTimingFunction, [token], WI.StepsTimingFunction.fromString(token.value)));
             else if (isNaN(startIndex))
                 newTokens.push(token);
         }
@@ -953,6 +964,7 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
                         fallbackTokens = this._addColorTokens(fallbackTokens);
                         fallbackTokens = this._addTimingFunctionTokens(fallbackTokens, "cubic-bezier");
                         fallbackTokens = this._addTimingFunctionTokens(fallbackTokens, "spring");
+                        fallbackTokens = this._addTimingFunctionTokens(fallbackTokens, "steps");
                         fallbackTokens = this._addVariableTokens(fallbackTokens);
                         contents.pushAll(fallbackTokens);
                     } else

--- a/Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.css
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+.steps-timing-function-editor {
+    width: calc(var(--steps-timing-function-editor-width) + (2 * var(--steps-timing-function-editor-inline-margin)));
+    height: 249px;
+
+    --steps-timing-function-preview-start: 0;
+    --steps-timing-function-preview-end: calc(var(--steps-timing-function-editor-width) - var(--steps-timing-function-editor-inline-margin) - var(--steps-timing-function-editor-timing-size) - var(--steps-timing-function-editor-timing-inline-margin));
+}
+
+.steps-timing-function-editor > .preview {
+    width: calc(100% - 10px);
+    height: 25px;
+    margin: 5px var(--steps-timing-function-editor-inline-margin) 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.steps-timing-function-editor > .preview > div {
+    width: 20px;
+    height: 20px;
+    background-color: var(--glyph-color-active);
+    border-radius: 50%;
+}
+
+.steps-timing-function-editor > .timing {
+    position: absolute;
+    top: 34px;
+    margin-inline-start: var(--steps-timing-function-editor-timing-inline-margin);
+    border-inline: var(--steps-timing-function-editor-timing-size) solid transparent;
+    border-top: var(--steps-timing-function-editor-timing-size) solid var(--text-color);
+}
+
+.steps-timing-function-editor > .preview.animate > div,
+.steps-timing-function-editor > .timing.animate {
+    animation: StepsTimingFunctionPreview 2.5s linear 250ms infinite;
+}
+
+@keyframes StepsTimingFunctionPreview {
+    from { transform: translateX(var(--steps-timing-function-preview-start)); }
+    10% { transform: translateX(var(--steps-timing-function-preview-start)); }
+    90% { transform: translateX(var(--steps-timing-function-preview-end)); }
+    to { transform: translateX(var(--steps-timing-function-preview-end)); }
+}
+
+.steps-timing-function-editor > svg {
+    margin: 8px var(--steps-timing-function-editor-inline-margin);
+}
+
+.steps-timing-function-editor > svg path {
+    fill: none;
+    stroke: var(--text-color);
+    stroke-width: var(--steps-timing-function-editor-stroke-width);
+}
+
+.steps-timing-function-editor > .parameter-editors {
+    display: flex;
+    width: calc(100% - 10px);
+    margin: 0 var(--steps-timing-function-editor-inline-margin);
+    padding: 7px 2px 0;
+    border-top: 1px solid var(--border-color);
+}
+
+.steps-timing-function-editor > .parameter-editors > input {
+    width: 100%;
+    margin-inline-start: 0.5em;
+    text-align: end;
+}

--- a/Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.js
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2023 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+WI.StepsTimingFunctionEditor = class StepsTimingFunctionEditor extends WI.Object
+{
+    constructor()
+    {
+        super();
+
+        this._element = document.createElement("div");
+        this._element.classList.add("steps-timing-function-editor");
+        this._element.dir = "ltr";
+
+        const width = 190;
+        this._element.style.setProperty("--steps-timing-function-editor-width", width + "px");
+
+        const inlineMargin = 5;
+        this._element.style.setProperty("--steps-timing-function-editor-inline-margin", inlineMargin + "px");
+
+        const timingSize = 4;
+        this._element.style.setProperty("--steps-timing-function-editor-timing-size", timingSize + "px");
+
+        const timingInlineMargin = 11;
+        this._element.style.setProperty("--steps-timing-function-editor-timing-inline-margin", timingInlineMargin + "px");
+
+        const strokeWidth = 2;
+        this._element.style.setProperty("--steps-timing-function-editor-stroke-width", strokeWidth + "px");
+
+        const indent = timingInlineMargin + timingSize - inlineMargin - (strokeWidth / 2);
+        const height = width - (indent * 2);
+        this._previewWidth = width - (indent * 2) - strokeWidth;
+        this._previewHeight = height - strokeWidth;
+
+        this._previewContainer = this._element.appendChild(document.createElement("div"))
+        this._previewContainer.classList.add("preview");
+        this._previewContainer.title = WI.UIString("Restart animation");
+        this._previewContainer.addEventListener("mousedown", this._resetPreviewAnimation.bind(this));
+
+        this._previewElement = this._previewContainer.appendChild(document.createElement("div"));
+
+        this._timingElement = this._element.appendChild(document.createElement("div"))
+        this._timingElement.classList.add("timing");
+
+        let pathContainer = this._element.appendChild(createSVGElement("svg"));
+        pathContainer.setAttribute("width", width);
+        pathContainer.setAttribute("height", height);
+
+        let svgGroup = pathContainer.appendChild(createSVGElement("g"));
+        svgGroup.setAttribute("transform", `translate(${indent + (strokeWidth / 2)}, ${strokeWidth / 2})`);
+
+        this._pathElement = svgGroup.appendChild(createSVGElement("path"));
+
+        let parameterEditorsContainer = this._element.appendChild(document.createElement("div"))
+        parameterEditorsContainer.classList.add("parameter-editors");
+
+        this._typeSelectElement = parameterEditorsContainer.appendChild(document.createElement("select"));
+        this._typeSelectElement.addEventListener("change", this._handleTypeSelectElementChanged.bind(this));
+
+        let createTypeSelectOption = (type, label) => {
+            let optionElement = this._typeSelectElement.appendChild(document.createElement("option"));
+            optionElement.value = type;
+            optionElement.label = label;
+        };
+        createTypeSelectOption(WI.StepsTimingFunction.Type.JumpStart, WI.unlocalizedString("jump-start"));
+        createTypeSelectOption(WI.StepsTimingFunction.Type.JumpEnd, WI.unlocalizedString("jump-end"));
+        createTypeSelectOption(WI.StepsTimingFunction.Type.JumpNone, WI.unlocalizedString("jump-none"));
+        createTypeSelectOption(WI.StepsTimingFunction.Type.JumpBoth, WI.unlocalizedString("jump-both"));
+        createTypeSelectOption(WI.StepsTimingFunction.Type.Start, WI.unlocalizedString("start"));
+        createTypeSelectOption(WI.StepsTimingFunction.Type.End, WI.unlocalizedString("end"));
+
+        this._countInputElement = parameterEditorsContainer.appendChild(document.createElement("input"));
+        this._countInputElement.type = "number";
+        this._countInputElement.min = 1;
+        this._countInputElement.addEventListener("input", this._handleCountInputElementInput.bind(this));
+    }
+
+    // Public
+
+    get element() { return this._element; }
+
+    set stepsTimingFunction(stepsTimingFunction)
+    {
+        if (!stepsTimingFunction)
+            return;
+
+        let isSteps = stepsTimingFunction instanceof WI.StepsTimingFunction;
+        console.assert(isSteps);
+        if (!isSteps)
+            return;
+
+        this._stepsTimingFunction = stepsTimingFunction;
+
+        this._typeSelectElement.value = this._stepsTimingFunction.type;
+        this._countInputElement.value = this._stepsTimingFunction.count;
+
+        this._updatePreview();
+    }
+
+    get stepsTimingFunction()
+    {
+        return this._stepsTimingFunction;
+    }
+
+    // Private
+
+    _updateStepsTimingFunction()
+    {
+        let count = this._countInputElement.valueAsNumber;
+        if (count <= 0 || isNaN(count))
+            return;
+
+        let type = this._typeSelectElement.value;
+        console.assert(Object.values(WI.StepsTimingFunction.Type).includes(type), type);
+
+        this._stepsTimingFunction = new WI.StepsTimingFunction(type, count);
+
+        this._updatePreview();
+
+        this.dispatchEventToListeners(WI.StepsTimingFunctionEditor.Event.StepsTimingFunctionChanged, {stepsTimingFunction: this._stepsTimingFunction});
+    }
+
+    _updatePreview()
+    {
+        let goUpFirst = false;
+        let stepStartAdjust = 0;
+        let stepCountAdjust = 0;
+
+        switch (this._stepsTimingFunction.type) {
+        case WI.StepsTimingFunction.Type.JumpStart:
+        case WI.StepsTimingFunction.Type.Start:
+            goUpFirst = true;
+            break;
+
+        case WI.StepsTimingFunction.Type.JumpNone:
+            --stepCountAdjust;
+            break;
+
+        case WI.StepsTimingFunction.Type.JumpBoth:
+            ++stepStartAdjust;
+            ++stepCountAdjust;
+            break;
+        }
+
+        let stepCount = this._stepsTimingFunction.count + stepCountAdjust;
+        let stepX = this._previewWidth / this._stepsTimingFunction.count; // Always use the defined number of steps to divide the duration.
+        let stepY = this._previewHeight / stepCount;
+
+        let path = [];
+        for (let i = stepStartAdjust; i <= stepCount; ++i) {
+            let x = stepX * (i - stepStartAdjust);
+            let y = this._previewHeight - (stepY * i);
+
+            if (goUpFirst) {
+                if (i)
+                    path.push("H", x);
+
+                if (i < stepCount)
+                    path.push("V", y - stepY);
+            } else {
+                path.push("V", y);
+
+                if (i < stepCount || stepCountAdjust < 0)
+                    path.push("H", x + stepX);
+            }
+        }
+        this._pathElement.setAttribute("d", `M 0 ${this._previewHeight} ${path.join(" ")} L ${this._previewWidth} 0`);
+
+        this._triggerPreviewAnimation();
+    }
+
+    _triggerPreviewAnimation()
+    {
+        this._previewElement.style.animationTimingFunction = this._stepsTimingFunction.toString();
+        this._previewContainer.classList.add("animate");
+        this._timingElement.classList.add("animate");
+    }
+
+    _resetPreviewAnimation()
+    {
+        let parent = this._previewElement.parentNode;
+        parent.removeChild(this._previewElement);
+        parent.appendChild(this._previewElement);
+
+        this._element.removeChild(this._timingElement);
+        this._element.appendChild(this._timingElement);
+    }
+
+    _handleTypeSelectElementChanged(event)
+    {
+        this._updateStepsTimingFunction();
+    }
+
+    _handleCountInputElementInput(event)
+    {
+        this._updateStepsTimingFunction();
+    }
+};
+
+WI.StepsTimingFunctionEditor.Event = {
+    StepsTimingFunctionChanged: "steps-timing-function-editor-steps-timing-function-changed"
+};

--- a/Source/WebInspectorUI/UserInterface/Views/TextEditor.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TextEditor.js
@@ -693,6 +693,11 @@ WI.TextEditor = class TextEditor extends WI.View
         return createCodeMirrorSpringTimingFunctionTextMarkers(this._codeMirror, range);
     }
 
+    createStepsTimingFunctionMarkers(range)
+    {
+        return createCodeMirrorStepsTimingFunctionTextMarkers(this._codeMirror, range);
+    }
+
     editingControllerForMarker(editableMarker)
     {
         switch (editableMarker.type) {
@@ -704,6 +709,8 @@ WI.TextEditor = class TextEditor extends WI.View
             return new WI.CodeMirrorCubicBezierTimingFunctionEditingController(this._codeMirror, editableMarker);
         case WI.TextMarker.Type.SpringTimingFunction:
             return new WI.CodeMirrorSpringTimingFunctionEditingController(this._codeMirror, editableMarker);
+        case WI.TextMarker.Type.StepsTimingFunction:
+            return new WI.CodeMirrorStepsTimingFunctionEditingController(this._codeMirror, editableMarker);
         default:
             return new WI.CodeMirrorEditingController(this._codeMirror, editableMarker);
         }


### PR DESCRIPTION
#### b56ed87ee07c4b8c343fa667da061b9cc96b2b73
<pre>
Web Inspector: Elements: add an editor for CSS `steps()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=259567">https://bugs.webkit.org/show_bug.cgi?id=259567</a>

Reviewed by Patrick Angle.

We have visual previews/editors for `cubic-bezier()` and `spring()`, so we should also have something for `steps()`.

This will help developers visualize the behavior of their `steps()` function, as well as allow for better editing since there&apos;s an immediate visual feedback/preview.

* Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.js: Added.
(WI.StepsTimingFunctionEditor):
(WI.StepsTimingFunctionEditor.prototype.get element):
(WI.StepsTimingFunctionEditor.prototype.set stepsTimingFunction):
(WI.StepsTimingFunctionEditor.prototype.get stepsTimingFunction):
(WI.StepsTimingFunctionEditor.prototype._updateStepsTimingFunction):
(WI.StepsTimingFunctionEditor.prototype._updatePreview):
(WI.StepsTimingFunctionEditor.prototype._triggerPreviewAnimation):
(WI.StepsTimingFunctionEditor.prototype._resetPreviewAnimation):
(WI.StepsTimingFunctionEditor.prototype._handleTypeSelectElementChanged):
(WI.StepsTimingFunctionEditor.prototype._handleCountInputElementInput):
* Source/WebInspectorUI/UserInterface/Views/StepsTimingFunctionEditor.css: Added.
(.steps-timing-function-editor):
(.steps-timing-function-editor &gt; .preview):
(.steps-timing-function-editor &gt; .preview &gt; div):
(.steps-timing-function-editor &gt; .timing):
(.steps-timing-function-editor &gt; .preview.animate &gt; div, .steps-timing-function-editor &gt; .timing.animate):
(.steps-timing-function-editor &gt; svg):
(.steps-timing-function-editor &gt; svg path):
(.steps-timing-function-editor &gt; .parameter-editors):
(.steps-timing-function-editor &gt; .parameter-editors &gt; input):

* Source/WebInspectorUI/UserInterface/Models/TextMarker.js:
* Source/WebInspectorUI/UserInterface/Views/CodeMirrorTextMarkers.js:
(createCodeMirrorStepsTimingFunctionTextMarkers): Added.
* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorStepsTimingFunctionEditingController.js: Added.
(WI.CodeMirrorStepsTimingFunctionEditingController.prototype.get initialValue):
(WI.CodeMirrorStepsTimingFunctionEditingController.prototype.get cssClassName):
(WI.CodeMirrorStepsTimingFunctionEditingController.prototype.popoverWillPresent):
(WI.CodeMirrorStepsTimingFunctionEditingController.prototype.popoverDidPresent):
(WI.CodeMirrorStepsTimingFunctionEditingController.prototype._handleStepsTimingFunctionEditorStepsTimingFunctionChanged):
* Source/WebInspectorUI/UserInterface/Views/AnimationDetailsSidebarPanel.js:
(WI.AnimationDetailsSidebarPanel.prototype._refreshEffectSection):
* Source/WebInspectorUI/UserInterface/Views/TextEditor.js:
(WI.TextEditor.prototype.createStepsTimingFunctionMarkers): Added.
(WI.TextEditor.prototype.editingControllerForMarker):
* Source/WebInspectorUI/UserInterface/Views/SourceCodeTextEditor.js:
(WI.SourceCodeTextEditor.prototype._updateEditableMarkers):
Add `WI.TextMarker.Type.StepsTimingFunction`.
Drive-by: Sort `WI.TextMarker.Type`.

* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
(WI.InlineSwatch):
(WI.InlineSwatch.prototype.didDismissPopover):
(WI.InlineSwatch.prototype._fallbackValue):
(WI.InlineSwatch.prototype._swatchElementClicked):
(WI.InlineSwatch.prototype._valueEditorValueDidChange):
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.css:
(.inline-swatch:is(.cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable)): Renamed from `.inline-swatch:is(.cubic-bezier-timing-function, .spring-timing-function, .variable)`.
(.inline-swatch:is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable)): Renamed from `.inline-swatch:is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable)`.
(.inline-swatch:not(.read-only):is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable, .alignment):hover): Renamed from `.inline-swatch:not(.read-only):is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable, .alignment):hover`.
(.inline-swatch:not(.read-only):is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable, .alignment):active): Renamed from `.inline-swatch:not(.read-only):is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable, .alignment):active`.
(.inline-swatch:is(.box-shadow, .cubic-bezier-timing-function, .spring-timing-function, .steps-timing-function, .variable) &gt; span): Renamed from `.inline-swatch:is(.cubic-bezier-timing-function, .box-shadow, .spring-timing-function, .variable) &gt; span`.
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype._replaceSpecialTokens):
(WI.SpreadsheetStyleProperty.prototype._addTimingFunctionTokens):
(WI.SpreadsheetStyleProperty.prototype._addVariableTokens):
Add `WI.InlineSwatch.Type.StepsTimingFunction`.
Drive-by: Sort `WI.InlineSwatch.Type`.

* Source/WebInspectorUI/.eslintrc:
* Source/WebInspectorUI/UserInterface/Main.html:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/267484@main">https://commits.webkit.org/267484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8579d93b95d2634a26ab710540e5b3a863f8b8a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17298 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/14476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19298 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/14542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/15160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/21912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15531 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/15326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19625 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15930 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/13512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15109 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4004 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->