### PR TITLE
Make IntersectionObserver and ResizeObserver classes be ISO-allocated.

### DIFF
--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -46,6 +46,7 @@
 #include "RenderView.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -122,6 +123,8 @@ ExceptionOr<Ref<IntersectionObserver>> IntersectionObserver::create(Document& do
 
     return adoptRef(*new IntersectionObserver(document, WTFMove(callback), root.get(), rootMarginOrException.releaseReturnValue(), WTFMove(thresholds)));
 }
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(IntersectionObserver);
 
 IntersectionObserver::IntersectionObserver(Document& document, Ref<IntersectionObserverCallback>&& callback, ContainerNode* root, LengthBox&& parsedRootMargin, Vector<double>&& thresholds)
     : m_root(root)

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -66,6 +66,7 @@ struct IntersectionObserverData {
 };
 
 class IntersectionObserver : public RefCounted<IntersectionObserver>, public CanMakeWeakPtr<IntersectionObserver> {
+    WTF_MAKE_ISO_ALLOCATED(IntersectionObserver);
 public:
     struct Init {
         std::optional<std::variant<RefPtr<Element>, RefPtr<Document>>> root;

--- a/Source/WebCore/page/IntersectionObserverEntry.cpp
+++ b/Source/WebCore/page/IntersectionObserverEntry.cpp
@@ -28,8 +28,11 @@
 #include "IntersectionObserverEntry.h"
 
 #include "Element.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(IntersectionObserverEntry);
 
 IntersectionObserverEntry::IntersectionObserverEntry(const Init& init)
     : m_time(init.time)

--- a/Source/WebCore/page/IntersectionObserverEntry.h
+++ b/Source/WebCore/page/IntersectionObserverEntry.h
@@ -40,7 +40,7 @@ namespace WebCore {
 class Element;
 
 class IntersectionObserverEntry : public RefCounted<IntersectionObserverEntry> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_ISO_ALLOCATED(IntersectionObserverEntry);
 public:
 
     struct Init {

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -32,6 +32,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderElementInlines.h"
 #include "SVGElement.h"
+#include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
 
@@ -39,6 +40,8 @@ Ref<ResizeObservation> ResizeObservation::create(Element& target, ResizeObserver
 {
     return adoptRef(*new ResizeObservation(target, observedBox));
 }
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ResizeObservation);
 
 ResizeObservation::ResizeObservation(Element& element, ResizeObserverBoxOptions observedBox)
     : m_target { element }

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -42,7 +42,7 @@ class Element;
 class WeakPtrImplWithEventTargetData;
 
 class ResizeObservation : public RefCounted<ResizeObservation> {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_ISO_ALLOCATED(ResizeObservation);
 public:
     static Ref<ResizeObservation> create(Element& target, ResizeObserverBoxOptions);
 

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -36,6 +36,7 @@
 #include "ResizeObserverOptions.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/AbstractSlotVisitorInlines.h>
+#include <wtf/IsoMallocInlines.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -49,6 +50,8 @@ Ref<ResizeObserver> ResizeObserver::createNativeObserver(Document& document, Nat
 {
     return adoptRef(*new ResizeObserver(document, { WTFMove(nativeCallback) }));
 }
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ResizeObserver);
 
 ResizeObserver::ResizeObserver(Document& document, JSOrNativeResizeObserverCallback&& callback)
     : m_document(document)

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -53,6 +53,7 @@ using NativeResizeObserverCallback = void (*)(const Vector<Ref<ResizeObserverEnt
 using JSOrNativeResizeObserverCallback = std::variant<RefPtr<ResizeObserverCallback>, NativeResizeObserverCallback>;
 
 class ResizeObserver : public RefCounted<ResizeObserver>, public CanMakeWeakPtr<ResizeObserver> {
+    WTF_MAKE_ISO_ALLOCATED(ResizeObserver);
 public:
     static Ref<ResizeObserver> create(Document&, Ref<ResizeObserverCallback>&&);
     static Ref<ResizeObserver> createNativeObserver(Document&, NativeResizeObserverCallback&&);


### PR DESCRIPTION
#### 9df05cfae49ddb1d0df34f535185bee801d3b1b7
<pre>
Make IntersectionObserver and ResizeObserver classes be ISO-allocated.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259572">https://bugs.webkit.org/show_bug.cgi?id=259572</a>
rdar://112989166

Reviewed by Ryosuke Niwa.

Make the following classes be ISO-allocated: IntersectionObserver, IntersectionObserverEntry,
ResizeObserver, ResizeObservation.

* Source/WebCore/page/IntersectionObserver.cpp:
* Source/WebCore/page/IntersectionObserver.h:
* Source/WebCore/page/IntersectionObserverEntry.cpp:
* Source/WebCore/page/IntersectionObserverEntry.h:
* Source/WebCore/page/ResizeObservation.cpp:
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.cpp:
* Source/WebCore/page/ResizeObserver.h:

Canonical link: <a href="https://commits.webkit.org/266369@main">https://commits.webkit.org/266369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ec90a97f5ee7e8df3ff52fd6eb2091b64c285fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16481 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15657 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16094 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11742 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19353 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12817 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15691 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12277 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3323 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->