### PR TITLE
Check that the size of a cookie's path is not too large when setting a cookie with the Cookie Store API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt
@@ -19,4 +19,6 @@ PASS cookieStore.set default path is /
 PASS cookieStore.set adds / to path that does not end with /
 PASS cookieStore.set with path that does not start with /
 PASS cookieStore.set with get result
+PASS cookieStore.set checks if the path is too long
+PASS cookieStore.set checks if the domain is too long
 

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js
@@ -285,3 +285,27 @@ promise_test(async testCase => {
   assert_equals(cookie.name, 'cookie-name');
   assert_equals(cookie.value, 'new-cookie-value');
 }, 'cookieStore.set with get result');
+
+promise_test(async testCase => {
+  // The maximum attribute value size is specified as 1024 bytes at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
+  await cookieStore.delete('cookie-name');
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'cookie-name',
+        value: 'cookie-value',
+        path: '/' + 'a'.repeat(1023) + '/' }));
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.set checks if the path is too long');
+
+promise_test(async testCase => {
+  // The maximum attribute value size is specified as 1024 bytes at https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size.
+  await cookieStore.delete('cookie-name');
+
+  await promise_rejects_js(testCase, TypeError, cookieStore.set(
+      { name: 'cookie-name',
+        value: 'cookie-value',
+        domain: 'a'.repeat(1025) }));
+  const cookie = await cookieStore.get('cookie-name');
+  assert_equals(cookie, null);
+}, 'cookieStore.set checks if the domain is too long');

--- a/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt
@@ -19,4 +19,6 @@ FAIL cookieStore.set default path is / promise_test: Unhandled rejection with va
 FAIL cookieStore.set adds / to path that does not end with / promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: cookieStore"
 FAIL cookieStore.set with path that does not start with / promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: cookieStore"
 FAIL cookieStore.set with get result promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: cookieStore"
+FAIL cookieStore.set checks if the path is too long promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: cookieStore"
+FAIL cookieStore.set checks if the domain is too long promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: cookieStore"
 


### PR DESCRIPTION
#### d7472f0d81e69ab8c62df926720430d69fdba732
<pre>
Check that the size of a cookie&apos;s path is not too large when setting a cookie with the Cookie Store API
<a href="https://bugs.webkit.org/show_bug.cgi?id=259571">https://bugs.webkit.org/show_bug.cgi?id=259571</a>

Reviewed by Alex Christensen.

The spec (<a href="https://wicg.github.io/cookie-store/#set-cookie-algorithm)">https://wicg.github.io/cookie-store/#set-cookie-algorithm)</a>
dictates that in the set function, if the byte sequence length of the
path (in UTF8 format) is greater than the maximum attribute value size
(currently 1024 bytes according to
<a href="https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size)">https://wicg.github.io/cookie-store/#cookie-maximum-attribute-value-size)</a>,
then the promise should be rejected with a TypeError. This patch adds
this check the same way a previous patch added the same check for a
cookie&apos;s domain. It also adds testing for the length check for both path
and domain.

* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.js:
(promise_test.async testCase):
* LayoutTests/imported/w3c/web-platform-tests/cookie-store/cookieStore_set_arguments.https.any.serviceworker-expected.txt:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::set):

Canonical link: <a href="https://commits.webkit.org/266410@main">https://commits.webkit.org/266410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a7a98909772e229ec524c4a9d17dce8bef1a1ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15480 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16180 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19429 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15772 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10963 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12357 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3346 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->