### PR TITLE
Tweak the Interaction Region effect

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h
@@ -37,6 +37,7 @@
 
 @interface RCPGLowEffectLayer : CALayer
 @property (nonatomic, copy) void (^effectGroupConfigurator)(CARemoteEffectGroup *group);
+- (void)setBrightnessMultiplier:(CGFloat)multiplier forInputTypes:(RCPRemoteEffectInputTypes)inputTypes;
 @end
 
 @interface CARemoteEffect ()


### PR DESCRIPTION
#### eab190cac6db1d621116abd34e246aa80e6a4b5f
<pre>
Tweak the Interaction Region effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=259574">https://bugs.webkit.org/show_bug.cgi?id=259574</a>
&lt;rdar://111230277&gt;

Reviewed by Tim Horton.

Set the custom brightness multiplier and make it configurable for future
adjustments.

* Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h:
Introduce the new SPI method.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::brightnessMultiplier):
(WebKit::configureLayerForInteractionRegion):
Set the brightness multiplier on interaction effect layers, default to
1.5 but read potential overrides from a user default.

Canonical link: <a href="https://commits.webkit.org/266381@main">https://commits.webkit.org/266381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3637d659c23953879a46e283eb78a37867cbb138

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13010 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15690 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16135 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11777 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19389 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15730 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10924 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12315 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3328 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->