### PR TITLE
Fix PlayStation build following 266368@main

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -26,10 +26,11 @@
 #include "config.h"
 #include "InPlaceInterpreter.h"
 
+#if ENABLE(WEBASSEMBLY)
+
 #include "ArithProfile.h"
 #include "CodeBlock.h"
 #include "JSCConfig.h"
-#include "LLIntCLoop.h"
 #include "LLIntPCRanges.h"
 #include "LLIntSlowPaths.h"
 #include "LLIntThunks.h"
@@ -57,3 +58,5 @@ void initialize()
 }
 
 } }
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(WEBASSEMBLY)
+
 extern "C" void ipint_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
@@ -226,3 +228,5 @@ namespace JSC { namespace IPInt {
 void initialize();
 
 } }
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -103,8 +103,10 @@ void initialize()
         JITOperationList::populatePointersInJavaScriptCore();
 
         AssemblyCommentRegistry::initialize();
+#if ENABLE(WEBASSEMBLY)
         if (UNLIKELY(Options::useWasmIPInt()))
             IPInt::initialize();
+#endif
         LLInt::initialize();
         DisallowGC::initialize();
 


### PR DESCRIPTION
#### 1f29fc26239e2b130b4836fac7470ecb33c0f74e
<pre>
Fix PlayStation build following 266368@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=259586">https://bugs.webkit.org/show_bug.cgi?id=259586</a>

Unreviewed build fix.

* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
IPInt is a wasm feature; it must be guarded by ENABLE(WEBASSEMBLY).

Canonical link: <a href="https://commits.webkit.org/266378@main">https://commits.webkit.org/266378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ab395ba7396dcea49289363c58d09572ee592dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15431 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14090 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12346 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15724 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/12964 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13737 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12310 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3326 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16641 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14124 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12881 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3391 "Passed tests") | 
<!--EWS-Status-Bubble-End-->