### PR TITLE
[visionOS] Media: “…” options menu doesn’t present (when in full screen)

### DIFF
--- a/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h
@@ -90,6 +90,7 @@ typedef void (^MRUIWindowSceneResizeRequestCompletion)(CGSize grantedSize, NSErr
 
 @interface MRUIPlatterOrnament : NSObject
 @property (nonatomic, assign, getter=_depthDisplacement, setter=_setDepthDisplacement:) CGFloat depthDisplacement;
+@property (nonatomic, readwrite, strong) UIViewController *viewController;
 @end
 
 @interface MRUIPlatterOrnamentManager : NSObject
@@ -98,7 +99,6 @@ typedef void (^MRUIWindowSceneResizeRequestCompletion)(CGSize grantedSize, NSErr
 
 @interface UIWindowScene (MRUIPlatterOrnaments)
 @property (nonatomic, readonly) MRUIPlatterOrnamentManager *_mrui_platterOrnamentManager;
-@property (nonatomic, readwrite) BOOL prefersOrnamentsHidden_forLMKOnly;
 @end
 
 #endif // PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -467,6 +467,30 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 @end
 
+@interface WKMRUIPlatterOrnamentProperties : NSObject
+
+@property (nonatomic, readonly) CGFloat depthDisplacement;
+@property (nonatomic, readonly) CGFloat windowAlpha;
+
+- (instancetype)initWithOrnament:(MRUIPlatterOrnament *)ornament;
+
+@end
+
+@implementation WKMRUIPlatterOrnamentProperties
+
+- (instancetype)initWithOrnament:(MRUIPlatterOrnament *)ornament
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _depthDisplacement = ornament._depthDisplacement;
+    _windowAlpha = ornament.viewController.view.window.alpha;
+
+    return self;
+}
+
+@end
+
 @interface WKFullScreenParentWindowState : NSObject
 
 @property (nonatomic, readonly) CATransform3D transform3D;
@@ -475,16 +499,15 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 @property (nonatomic, readonly) RSSSceneChromeOptions sceneChromeOptions;
 @property (nonatomic, readonly) MRUISceneResizingBehavior sceneResizingBehavior;
 @property (nonatomic, readonly) MRUIDarknessPreference preferredDarkness;
-@property (nonatomic, readonly) BOOL prefersOrnamentsHidden;
 
-@property (nonatomic, readonly) NSMapTable<MRUIPlatterOrnament *, NSNumber *> *ornamentDepths;
+@property (nonatomic, readonly) NSMapTable<MRUIPlatterOrnament *, WKMRUIPlatterOrnamentProperties *> *ornamentProperties;
 
 - (id)initWithWindow:(UIWindow *)window;
 
 @end
 
 @implementation WKFullScreenParentWindowState {
-    RetainPtr<NSMapTable<MRUIPlatterOrnament *, NSNumber *>> _ornamentDepths;
+    RetainPtr<NSMapTable<MRUIPlatterOrnament *, WKMRUIPlatterOrnamentProperties *>> _ornamentProperties;
 }
 
 - (id)initWithWindow:(UIWindow *)window
@@ -500,20 +523,21 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     _sceneMinimumSize = windowScene.sizeRestrictions.minimumSize;
     _sceneChromeOptions = windowScene.mrui_placement.preferredChromeOptions;
     _sceneResizingBehavior = windowScene.mrui_placement.preferredResizingBehavior;
-    _prefersOrnamentsHidden = windowScene.prefersOrnamentsHidden_forLMKOnly;
 
-    _ornamentDepths = [NSMapTable weakToStrongObjectsMapTable];
+    _ornamentProperties = [NSMapTable weakToStrongObjectsMapTable];
 
     MRUIPlatterOrnamentManager *ornamentManager = windowScene._mrui_platterOrnamentManager;
-    for (MRUIPlatterOrnament *ornament in ornamentManager.ornaments)
-        [_ornamentDepths setObject:@(ornament._depthDisplacement) forKey:ornament];
+    for (MRUIPlatterOrnament *ornament in ornamentManager.ornaments) {
+        auto properties = adoptNS([[WKMRUIPlatterOrnamentProperties alloc] initWithOrnament:ornament]);
+        [_ornamentProperties setObject:properties.get() forKey:ornament];
+    }
 
     return self;
 }
 
-- (NSMapTable<MRUIPlatterOrnament *, NSNumber *> *)ornamentDepths
+- (NSMapTable<MRUIPlatterOrnament *, WKMRUIPlatterOrnamentProperties *> *)ornamentProperties
 {
-    return _ornamentDepths.get();
+    return _ornamentProperties.get();
 }
 
 @end
@@ -1562,6 +1586,18 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     });
 }
 
+- (void)_setOrnamentsHidden:(BOOL)hidden
+{
+    for (MRUIPlatterOrnament *ornament in [_parentWindowState ornamentProperties]) {
+        if (hidden)
+            ornament.viewController.view.window.alpha = 0.0;
+        else {
+            CGFloat originalAlpha = [[[_parentWindowState ornamentProperties] objectForKey:ornament] windowAlpha];
+            ornament.viewController.view.window.alpha = originalAlpha;
+        }
+    }
+}
+
 - (void)_performSpatialFullScreenTransition:(BOOL)enter completionHandler:(CompletionHandler<void()>&&)completionHandler
 {
     WKFullScreenWindowController *controller = self;
@@ -1579,9 +1615,10 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     }
 
     [UIView animateWithDuration:kOutgoingWindowFadeDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
-        outWindow.alpha = 0;
         if (enter)
-            outWindow.windowScene.prefersOrnamentsHidden_forLMKOnly = YES;
+            [self _setOrnamentsHidden:YES];
+
+        outWindow.alpha = 0;
     } completion:nil];
 
     [UIView animateWithDuration:kWindowTranslationDuration delay:0 options:UIViewAnimationOptionCurveEaseInOut animations:^{
@@ -1592,8 +1629,8 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         inWindow.transform3D = originalState.transform3D;
     } completion:nil];
 
-    for (MRUIPlatterOrnament *ornament in originalState.ornamentDepths) {
-        CGFloat originalDepth = [[originalState.ornamentDepths objectForKey:ornament] floatValue];
+    for (MRUIPlatterOrnament *ornament in originalState.ornamentProperties) {
+        CGFloat originalDepth = [[originalState.ornamentProperties objectForKey:ornament] depthDisplacement];
         CGFloat finalDepth = originalDepth;
         if (enter)
             finalDepth += kOutgoingWindowZOffset;
@@ -1632,9 +1669,10 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     });
 
     [UIView animateWithDuration:kIncomingWindowFadeDuration delay:kIncomingWindowFadeDelay options:UIViewAnimationOptionCurveEaseInOut animations:^{
-        inWindow.alpha = 1;
         if (!enter)
-            inWindow.windowScene.prefersOrnamentsHidden_forLMKOnly = originalState.prefersOrnamentsHidden;
+            [self _setOrnamentsHidden:NO];
+
+        inWindow.alpha = 1;
     } completion:completion.get()];
 }
 


### PR DESCRIPTION
#### 4776571d7bd69cdb89bb3315120497f74cc23064
<pre>
[visionOS] Media: “…” options menu doesn’t present (when in full screen)
<a href="https://bugs.webkit.org/show_bug.cgi?id=259589">https://bugs.webkit.org/show_bug.cgi?id=259589</a>
rdar://112867127

Reviewed by Tim Horton and Aditya Keerthi.

Instead of preventing any ornament from showing at all when in full screen, only hide/show the
ornaments that are present in the window when entering/exiting full screen.

* Source/WebKit/Platform/spi/visionos/MRUIKitSPI.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKMRUIPlatterOrnamentProperties initWithDepthDisplacement:windowAlpha:]):
(-[WKFullScreenParentWindowState initWithWindow:]):
(-[WKFullScreenParentWindowState ornamentProperties]):
(-[WKFullScreenWindowController _setOrnamentsHidden:]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenParentWindowState ornamentDepths]): Deleted.

Canonical link: <a href="https://commits.webkit.org/266454@main">https://commits.webkit.org/266454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ee2d3c8c65574f2802b2cc2c65a548ff051e7e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13158 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14247 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16293 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11923 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19537 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11072 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12466 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3364 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->