### PR TITLE
SWServerJobQueue::scriptContextStarted might have a null registration

### DIFF
--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1207,6 +1207,10 @@ void SWServer::unregisterServiceWorkerClient(const ClientOrigin& clientOrigin, S
     bool didUnregister = false;
     if (auto registration = m_serviceWorkerPageIdentifierToRegistrationMap.get(clientIdentifier)) {
         removeFromScopeToRegistrationMap(registration->key());
+        if (auto* preinstallingServiceWorker = registration->preInstallationWorker()) {
+            if (auto* jobQueue = m_jobQueues.get(registration->key()))
+                jobQueue->cancelJobsFromServiceWorker(preinstallingServiceWorker->identifier());
+        }
         registration->clear();
         ASSERT(!m_serviceWorkerPageIdentifierToRegistrationMap.contains(clientIdentifier));
         didUnregister = true;

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -158,6 +158,10 @@ void SWServerJobQueue::scriptContextFailedToStart(const ServiceWorkerJobDataIden
     // If an uncaught runtime script error occurs during the above step, then:
     auto* registration = m_server.getRegistration(m_registrationKey);
     ASSERT(registration);
+    if (!registration || !registration->preInstallationWorker()) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWServerJobQueue::scriptContextFailedToStart registration is null (%d) or pre installation worker is null", !registration);
+        return;
+    }
 
     ASSERT(registration->preInstallationWorker());
     registration->preInstallationWorker()->terminate();
@@ -181,6 +185,10 @@ void SWServerJobQueue::scriptContextStarted(const ServiceWorkerJobDataIdentifier
 
     auto* registration = m_server.getRegistration(m_registrationKey);
     ASSERT(registration);
+    if (!registration) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWServerJobQueue::scriptContextStarted registration is null");
+        return;
+    }
 
     install(*registration, identifier);
 }


### PR DESCRIPTION
#### 3cb928bc8c15b75620a673dd9e08ba2d54e3c94a
<pre>
SWServerJobQueue::scriptContextStarted might have a null registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=259591">https://bugs.webkit.org/show_bug.cgi?id=259591</a>
rdar://112997411

Reviewed by Alex Christensen.

From logs, it appears SWServerJobQueue::scriptContextStarted might have a nullptr registration.
One possibility is the following:
- A main thread service worker page is created.
- The service worker is being installed (in main thread) and succeeds. This triggers a callOnMainThread to execute the callback that will notify network process to continue its processing
- Before the callback is executed, the service worker page is closed and the network process is notified about this.
- The network process removes the registration from its map in SWServer::unregisterServiceWorkerClient.
- The network process processes the message to continue installing the service worker and continue with the current job.

To prevent this, we are now making sure to cancel the job of a preinstalling service worker whose registration is removed in SWServer::unregisterServiceWorkerClient.
Since this is a speculative fix, we transform the ASSERT(registration) in an if+ASSERT.
We add logging to make sure to keep track of this, in case this might trigger job queue hangs.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::unregisterServiceWorkerClient):
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptContextFailedToStart):
(WebCore::SWServerJobQueue::scriptContextStarted):

Canonical link: <a href="https://commits.webkit.org/266419@main">https://commits.webkit.org/266419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84644fdd4f056478710ba96ef2f8fe14fa01d9ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15790 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16246 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19492 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11027 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12420 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3352 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->