### PR TITLE
[iOS] Tap to revert does not always display an accurate prompt for multi-word autocorrections

### DIFF
--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -78,6 +78,7 @@ public:
 
     WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersFor(Node&, OptionSet<DocumentMarker::MarkerType> = DocumentMarker::allMarkers());
     WEBCORE_EXPORT Vector<RenderedDocumentMarker*> markersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
+    WEBCORE_EXPORT Vector<SimpleRange> rangesForMarkersInRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
     void clearDescriptionOnMarkersIntersectingRange(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>);
 
     WEBCORE_EXPORT void updateRectsForInvalidatedMarkersOfType(DocumentMarker::MarkerType);
@@ -101,7 +102,7 @@ private:
     };
     Vector<TextRange> collectTextRanges(const SimpleRange&);
 
-    void forEach(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>, const Function<bool(RenderedDocumentMarker&)>);
+    void forEach(const SimpleRange&, OptionSet<DocumentMarker::MarkerType>, const Function<bool(Node&, RenderedDocumentMarker&)>);
     void forEachOfTypes(OptionSet<DocumentMarker::MarkerType>, const Function<bool(Node&, RenderedDocumentMarker&)>);
 
     using MarkerMap = HashMap<RefPtr<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1523,6 +1523,12 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 #endif
 
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
+@interface UIWKDocumentContext (Staging_112795757)
+@property (nonatomic, copy) NSArray<NSValue *> *autocorrectedRanges;
+@end
+#endif
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/Shared/DocumentEditingContext.h
+++ b/Source/WebKit/Shared/DocumentEditingContext.h
@@ -48,6 +48,7 @@ struct DocumentEditingContextRequest {
         Annotation = 1 << 4,
         MarkedTextRects = 1 << 5,
         SpatialAndCurrentSelection = 1 << 6,
+        AutocorrectedRanges = 1 << 7,
     };
 
     OptionSet<Options> options;
@@ -82,6 +83,7 @@ struct DocumentEditingContext {
     };
 
     Vector<TextRectAndRange> textRects;
+    Vector<Range> autocorrectedRanges;
 };
 
 }
@@ -119,7 +121,8 @@ template<> struct EnumTraits<WebKit::DocumentEditingContextRequest::Options> {
         WebKit::DocumentEditingContextRequest::Options::Spatial,
         WebKit::DocumentEditingContextRequest::Options::Annotation,
         WebKit::DocumentEditingContextRequest::Options::MarkedTextRects,
-        WebKit::DocumentEditingContextRequest::Options::SpatialAndCurrentSelection
+        WebKit::DocumentEditingContextRequest::Options::SpatialAndCurrentSelection,
+        WebKit::DocumentEditingContextRequest::Options::AutocorrectedRanges
     >;
 };
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -192,6 +192,10 @@
 #import <pal/ios/QuickLookSoftLink.h>
 #import <pal/spi/ios/DataDetectorsUISoftLink.h>
 
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
+#define UIWKDocumentRequestAutocorrectedRanges (1 << 7)
+#endif
+
 #if HAVE(LINK_PREVIEW) && USE(UICONTEXTMENU)
 static NSString * const webkitShowLinkPreviewsPreferenceKey = @"WebKitShowLinkPreviews";
 #endif
@@ -9613,6 +9617,10 @@ static inline OptionSet<WebKit::DocumentEditingContextRequest::Options> toWebDoc
         options.add(WebKit::DocumentEditingContextRequest::Options::MarkedTextRects);
     if (flags & UIWKDocumentRequestSpatialAndCurrentSelection)
         options.add(WebKit::DocumentEditingContextRequest::Options::SpatialAndCurrentSelection);
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
+    if (flags & UIWKDocumentRequestAutocorrectedRanges)
+        options.add(WebKit::DocumentEditingContextRequest::Options::AutocorrectedRanges);
+#endif
 
     return options;
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5017,6 +5017,16 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest reques
         context.annotatedText = m_textCheckingControllerProxy->annotatedSubstringBetweenPositions(contextBeforeStart, contextAfterEnd);
 #endif
 
+    if (request.options.contains(DocumentEditingContextRequest::Options::AutocorrectedRanges)) {
+        if (auto contextRange = makeSimpleRange(contextBeforeStart, contextAfterEnd)) {
+            auto ranges = frame->document()->markers().rangesForMarkersInRange(*contextRange, DocumentMarker::MarkerType::CorrectionIndicator);
+            context.autocorrectedRanges = ranges.map([&] (auto& range) {
+                auto characterRangeInContext = characterRange(*contextRange, range);
+                return DocumentEditingContext::Range { characterRangeInContext.location, characterRangeInContext.length };
+            });
+        }
+    }
+
     completionHandler(context);
 }
 

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -376,4 +376,10 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionEvent) {
 
 #endif
 
+#if HAVE(AUTOCORRECTION_ENHANCEMENTS)
+@interface UIWKDocumentContext (Staging_112795757)
+@property (nonatomic, copy) NSArray<NSValue *> *autocorrectedRanges;
+@end
+#endif
+
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 65175743b6594e4416f01632b471641d6795bd0f
<pre>
[iOS] Tap to revert does not always display an accurate prompt for multi-word autocorrections
<a href="https://bugs.webkit.org/show_bug.cgi?id=259595">https://bugs.webkit.org/show_bug.cgi?id=259595</a>
rdar://113036177

Reviewed by Wenson Hsieh.

UIKit requires additional information in order to detect that a tapped word is
part of a multi-word correction. Specifically, they require the entire
corrected string given a single tapped word, in order to look up the right
autocorrection record.

To support this requirement, add support for obtaining autocorrected ranges in
a document editing context. WebKit will provide `autocorrectedRanges` on
`UIWKDocumentContext`, when the `UIWKDocumentRequest` has
`UIWKDocumentRequestAutocorrectedRanges` specified in its flags. Then, with the
existing properties on `UIWKDocumentContext`, UIKit can determine the corrected
string nearest to the current selection.

* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::forEach):

Pass the node into the callback function so that it may be used to obtain a
`SimpleRange` from the `DocumentMarker`.

(WebCore::DocumentMarkerController::rangesForMarkersInRange):

Return a `SimpleRange` for each `DocumentMarker`.

(WebCore::DocumentMarkerController::hasMarkers):
(WebCore::DocumentMarkerController::clearDescriptionOnMarkersIntersectingRange):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
* Source/WebKit/Shared/DocumentEditingContext.h:
* Source/WebKit/Shared/DocumentEditingContext.mm:
(WebKit::DocumentEditingContext::toPlatformContext):
(IPC::ArgumentCoder&lt;WebKit::DocumentEditingContext&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::DocumentEditingContext&gt;::decode):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(toWebDocumentRequestOptions):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:

Resolve the `SimpleRange` from each marker as a character range, using a
`SimpleRange` representing the current context.

Populate `context.autocorrectedRanges` to be sent back to the UI process and UIKit.

(WebKit::WebPage::requestDocumentEditingContext):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST):
* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Canonical link: <a href="https://commits.webkit.org/266398@main">https://commits.webkit.org/266398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/672cd6c07265d8fb8afdca00d856b86eb861eebf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15700 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11606 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16148 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19401 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15742 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10935 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12326 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->