### PR TITLE
[macOS] Remove unneeded deprecated declaration guards from ScreenCaptureKitCaptureSource

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
@@ -129,7 +129,6 @@ using namespace WebCore;
 namespace WebCore {
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 bool ScreenCaptureKitCaptureSource::isAvailable()
 {
@@ -266,8 +265,6 @@ RetainPtr<SCStreamConfiguration> ScreenCaptureKitCaptureSource::streamConfigurat
     if (m_streamConfiguration)
         return m_streamConfiguration;
 
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     m_streamConfiguration = adoptNS([PAL::allocSCStreamConfigurationInstance() init]);
     [m_streamConfiguration setPixelFormat:preferedPixelBufferFormat()];
     [m_streamConfiguration setShowsCursor:YES];
@@ -391,6 +388,8 @@ void ScreenCaptureKitCaptureSource::commitConfiguration(const RealtimeMediaSourc
     m_height = settings.height();
     m_frameRate = settings.frameRate();
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, IntSize(m_width, m_height), ", ", m_frameRate);
+
     if (!contentStream())
         return;
 
@@ -479,7 +478,6 @@ std::optional<CaptureDevice> ScreenCaptureKitCaptureSource::windowCaptureDeviceW
     return CaptureDevice(String::number(windowID.value()), CaptureDevice::DeviceType::Window, emptyString(), emptyString(), true);
 }
 
-ALLOW_DEPRECATED_DECLARATIONS_END
 ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 } // namespace WebCore


### PR DESCRIPTION
#### 01d1f208e1d0f948abf664645d00e05ec7ca193c
<pre>
[macOS] Remove unneeded deprecated declaration guards from ScreenCaptureKitCaptureSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=259596">https://bugs.webkit.org/show_bug.cgi?id=259596</a>
rdar://113036793

Reviewed by Youenn Fablet.

Remove unnecessary deprecated declaration guards from ScreenCaptureKitCaptureSource since
it no longer used deprecated APIs. Minor cleanup of some logging.

* Source/WebCore/platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm:
(WebCore::ScreenCaptureKitCaptureSource::streamConfiguration): Remove logging, all of the
methods that call this already log.
(WebCore::ScreenCaptureKitCaptureSource::commitConfiguration): Add logging so we know when
the configuration is changed.

Canonical link: <a href="https://commits.webkit.org/266402@main">https://commits.webkit.org/266402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863b6f435cc9fc5d97961cad1967c8dadda2c2db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16147 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19402 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15743 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12325 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->