### PR TITLE
Sync 'fullscreen' UA stylesheet with Web Spec and also extend some changes to WebKit specific rules

### DIFF
--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -26,7 +26,9 @@
 
 /* https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults */
 
-:not(:root):fullscreen {
+@namespace "http://www.w3.org/1999/xhtml";
+
+*|*:not(:root):fullscreen {
   position: fixed !important;
   inset: 0 !important;
   margin: 0 !important;
@@ -40,14 +42,14 @@
   transform: none !important;
 
   /* intentionally not !important */
-  object-fit:contain;
+  object-fit: contain;
 }
 
-:root:-webkit-full-screen-document:not(:fullscreen) {
+*|*:root:-webkit-full-screen-document:not(:fullscreen) {
     overflow: hidden !important;
 }
 
-:fullscreen video,
+*|*:fullscreen video,
 video:fullscreen {
     -webkit-cursor-visibility: auto-hide;
 }
@@ -63,7 +65,7 @@ iframe:fullscreen {
     padding: 0 !important;
 }
 
-:not(:root):fullscreen::backdrop {
+*|*:not(:root):fullscreen::backdrop {
     background: black;
 }
 


### PR DESCRIPTION
#### 3b59a010c260d324fbbddb60cf43d9637b680084
<pre>
Sync &apos;fullscreen&apos; UA stylesheet with Web Spec and also extend some changes to WebKit specific rules

<a href="https://bugs.webkit.org/show_bug.cgi?id=259597">https://bugs.webkit.org/show_bug.cgi?id=259597</a>

Reviewed by Tim Nguyen.

This patch is just correctness fixes by adding namespace and add *|* part
to some CSS to apply them across all namespaces. We are also extending
*|* to some WebKit specific rules as well.

[1] <a href="https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults">https://fullscreen.spec.whatwg.org/#user-agent-level-style-sheet-defaults</a>

* Source/WebCore/css/fullscreen.css:

Canonical link: <a href="https://commits.webkit.org/266394@main">https://commits.webkit.org/266394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22a7e5de6056ed86a3b316457a45919d6b4665cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13795 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15701 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16149 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19400 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12866 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15755 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12327 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12900 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->