### PR TITLE
[WebKit] [iOS] Respect `NSUnderlineStyleAttributeName` when setting attributed marked text

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5737,8 +5737,13 @@ static Vector<WebCore::CompositionUnderline> extractUnderlines(NSAttributedStrin
 
     Vector<WebCore::CompositionUnderline> underlines;
     [string enumerateAttributesInRange:NSMakeRange(0, string.length) options:0 usingBlock:[&underlines](NSDictionary<NSAttributedStringKey, id> *attributes, NSRange range, BOOL *) {
-        bool thick = attributes[NSBackgroundColorAttributeName];
-        underlines.append({ static_cast<unsigned>(range.location), static_cast<unsigned>(NSMaxRange(range)), WebCore::CompositionUnderlineColor::GivenColor, WebCore::Color::black, thick });
+        underlines.append({
+            static_cast<unsigned>(range.location),
+            static_cast<unsigned>(NSMaxRange(range)),
+            WebCore::CompositionUnderlineColor::GivenColor,
+            WebCore::Color::black,
+            [attributes[NSUnderlineStyleAttributeName] isEqual:@(NSUnderlineStyleThick)] || attributes[NSBackgroundColorAttributeName]
+        });
     }];
 
     std::sort(underlines.begin(), underlines.end(), [](auto& a, auto& b) {

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "CGImagePixelReader.h"
 #import "PlatformUtilities.h"
 #import "TestCocoa.h"
 #import "TestInputDelegate.h"
@@ -41,6 +42,7 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKitLegacy/WebEvent.h>
 #import <cmath>
+#import <pal/spi/cocoa/NSAttributedStringSPI.h>
 
 namespace TestWebKitAPI {
 
@@ -1048,6 +1050,77 @@ TEST(KeyboardInputTests, NoCrashWhenDiscardingMarkedText)
 
     Util::runFor(100_ms);
 }
+
+#if HAVE(REDESIGNED_TEXT_CURSOR)
+
+TEST(KeyboardInputTests, MarkedTextSegmentsWithUnderlines)
+{
+    auto frame = CGRectMake(0, 0, 100, 100);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:frame configuration:configuration.get() addToWindow:NO]);
+
+    auto window = adoptNS([[UIWindow alloc] initWithFrame:[webView frame]]);
+    [window addSubview:webView.get()];
+
+    [webView _setEditable:YES];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width'><meta charset='utf-8'><body>なんですか？</body>"];
+    [webView selectAll:nil];
+
+    auto setMarkedTextWithUnderlines = [&](NSUnderlineStyle firstUnderlineStyle, NSUnderlineStyle secondUnderlineStyle) {
+        auto composition = adoptNS([[NSMutableAttributedString alloc] initWithString:@"なんですか？"]);
+        [composition addAttributes:@{
+            NSMarkedClauseSegmentAttributeName: @(0),
+            NSUnderlineStyleAttributeName: @(firstUnderlineStyle),
+            NSUnderlineColorAttributeName: UIColor.tintColor
+        } range:NSMakeRange(0, 5)];
+
+        [composition addAttributes:@{
+            NSMarkedClauseSegmentAttributeName: @(1),
+            NSUnderlineStyleAttributeName: @(secondUnderlineStyle),
+            NSUnderlineColorAttributeName: UIColor.tintColor
+        } range:NSMakeRange(5, 1)];
+
+        [[webView textInputContentView] setAttributedMarkedText:composition.get() selectedRange:NSMakeRange(0, 6)];
+    };
+
+    setMarkedTextWithUnderlines(NSUnderlineStyleSingle, NSUnderlineStyleThick);
+    [webView waitForNextPresentationUpdate];
+
+    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    [snapshotConfiguration setAfterScreenUpdates:YES];
+
+    auto takeSnapshot = [&] {
+        __block RetainPtr<CGImage> result;
+        __block bool done = false;
+        [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(UIImage *snapshot, NSError *error) {
+            result = snapshot.CGImage;
+            done = true;
+        }];
+        Util::run(&done);
+        return result;
+    };
+
+    auto snapshotBefore = takeSnapshot();
+
+    setMarkedTextWithUnderlines(NSUnderlineStyleThick, NSUnderlineStyleSingle);
+    [webView waitForNextPresentationUpdate];
+
+    auto snapshotAfter = takeSnapshot();
+
+    CGImagePixelReader snapshotReaderBefore { snapshotBefore.get() };
+    CGImagePixelReader snapshotReaderAfter { snapshotAfter.get() };
+
+    unsigned numberOfDifferentPixels = 0;
+    for (int x = 0; x < 200; ++x) {
+        for (int y = 0; y < 200; ++y) {
+            if (snapshotReaderBefore.at(x, y) != snapshotReaderAfter.at(x, y))
+                numberOfDifferentPixels++;
+        }
+    }
+    EXPECT_GT(numberOfDifferentPixels, 0U);
+}
+
+#endif // HAVE(REDESIGNED_TEXT_CURSOR)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 92ab43385d577be31ad30ed584400ed0d7b96940
<pre>
[WebKit] [iOS] Respect `NSUnderlineStyleAttributeName` when setting attributed marked text
<a href="https://bugs.webkit.org/show_bug.cgi?id=259604">https://bugs.webkit.org/show_bug.cgi?id=259604</a>
rdar://113036183

Reviewed by Richard Robinson.

After the changes in rdar://108610748, UIKit will use `NSUnderlineStyle` with an attribute value of
`NSUnderlineStyleThick` to indicate &quot;highlighted&quot; segments of marked text when live conversion is
active. Currently, our code only checks against `NSBackgroundColor`, so without the changes in this
patch, it would no longer be possible to know which segment in marked text is the selected segment
when using live conversion.

Fix this by checking for this case, alongside the existing `NSBackgroundColor` check.

Test: KeyboardInputTests.MarkedTextSegmentsWithUnderlines

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(extractUnderlines):
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:

Canonical link: <a href="https://commits.webkit.org/266401@main">https://commits.webkit.org/266401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a67d03cc67aa8b3b8e43b7dc515b76b846ee0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15713 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16160 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19409 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15752 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10947 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12338 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->