### PR TITLE
Add logging when SQLite transaction fails to start

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -980,7 +980,7 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
     FileSystem::makeAllDirectories(FileSystem::parentPath(databasePath));
     m_sqliteDB = makeUnique<SQLiteDatabase>();
     if (!m_sqliteDB->open(databasePath, SQLiteDatabase::OpenMode::ReadWriteCreate, SQLiteDatabase::OpenOptions::CanSuspendWhileLocked)) {
-        LOG_ERROR("Failed to open SQLite database at path '%s'", databasePath.utf8().data());
+        RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteIDBBackingStore::getOrEstablishDatabaseInfo: Failed to open database at path '%" PUBLIC_LOG_STRING "' (%d) - %" PUBLIC_LOG_STRING, this, databasePath.utf8().data(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
         closeSQLiteDB();
     }
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -443,16 +443,32 @@ void SQLiteDatabase::setBusyHandler(int(*handler)(void*, int))
         LOG(SQLDatabase, "Busy handler set on non-open database");
 }
 
-bool SQLiteDatabase::executeCommandSlow(StringView query)
+int SQLiteDatabase::executeSlow(StringView query)
 {
     auto statement = prepareStatementSlow(query);
-    return statement && statement->executeCommand();
+    if (!statement)
+        return statement.error();
+
+    return statement->step();
+}
+
+int SQLiteDatabase::execute(ASCIILiteral query)
+{
+    auto statement = prepareStatement(query);
+    if (!statement)
+        return statement.error();
+
+    return statement->step();
+}
+
+bool SQLiteDatabase::executeCommandSlow(StringView query)
+{
+    return executeSlow(query) == SQLITE_DONE;
 }
 
 bool SQLiteDatabase::executeCommand(ASCIILiteral query)
 {
-    auto statement = prepareStatement(query);
-    return statement && statement->executeCommand();
+    return execute(query) == SQLITE_DONE;
 }
 
 bool SQLiteDatabase::tableExists(StringView tableName)

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -68,6 +68,8 @@ public:
     bool isOpen() const { return m_db; }
     WEBCORE_EXPORT void close();
 
+    WEBCORE_EXPORT int executeSlow(StringView);
+    WEBCORE_EXPORT int execute(ASCIILiteral);
     WEBCORE_EXPORT bool executeCommandSlow(StringView);
     WEBCORE_EXPORT bool executeCommand(ASCIILiteral);
     


### PR DESCRIPTION
#### 9646bf57444f2b10651b26f9ed9ca34d3e4e374b
<pre>
Add logging when SQLite transaction fails to start
<a href="https://bugs.webkit.org/show_bug.cgi?id=259612">https://bugs.webkit.org/show_bug.cgi?id=259612</a>
rdar://113048804

Reviewed by Chris Dumez.

It&apos;s possible that a database is simultaneously accessed by two processes, and transaction fails to start with
SQLITE_BUSY error. Add error log to help us discover these cases.

* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::getOrEstablishDatabaseInfo):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::executeSlow):
(WebCore::SQLiteDatabase::execute):
(WebCore::SQLiteDatabase::executeCommandSlow):
(WebCore::SQLiteDatabase::executeCommand):
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/platform/sql/SQLiteTransaction.cpp:
(WebCore::SQLiteTransaction::begin):

Canonical link: <a href="https://commits.webkit.org/266520@main">https://commits.webkit.org/266520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a3e4023a3d1da9692e2489eccd342168f6d8d03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13316 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15987 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14200 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16478 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12651 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16025 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11229 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12640 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16974 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->