### PR TITLE
Crash in GridBaselineAlignment::baselineGroupForChild

### DIFF
--- a/LayoutTests/fast/css-grid-layout/baseline-masonry-crash-expected.html
+++ b/LayoutTests/fast/css-grid-layout/baseline-masonry-crash-expected.html
@@ -1,0 +1,15 @@
+<style>
+grid {
+  display: inline-grid;
+  grid-template-columns: auto;
+  grid-template-rows: repeat(4,auto);
+}
+</style>
+
+<p>This test passes if it does not crash.</p>
+
+<grid>
+  <<item>3</item>/item>
+  <item>4</item>
+  <item style="-webkit-align-self: baseline;">
+</grid>

--- a/LayoutTests/fast/css-grid-layout/baseline-masonry-crash.html
+++ b/LayoutTests/fast/css-grid-layout/baseline-masonry-crash.html
@@ -1,0 +1,15 @@
+<style>
+grid {
+  display: inline-grid;
+  grid-template-columns: masonry;
+  grid-template-rows: repeat(4,auto);
+}
+</style>
+
+<p>This test passes if it does not crash.</p>
+
+<grid>
+  <<item>3</item>/item>
+  <item>4</item>
+  <item style="-webkit-align-self: baseline;">
+</grid>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1833,6 +1833,11 @@ std::optional<LayoutUnit> RenderGrid::inlineBlockBaseline(LineDirectionMode) con
 
 LayoutUnit RenderGrid::columnAxisBaselineOffsetForChild(const RenderBox& child) const
 {
+    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
+    if (isMasonry())
+        return LayoutUnit { };
+
     if (isSubgridRows()) {
         RenderGrid* outer = downcast<RenderGrid>(parent());
         if (GridLayoutFunctions::isOrthogonalChild(*outer, *this))
@@ -1844,6 +1849,11 @@ LayoutUnit RenderGrid::columnAxisBaselineOffsetForChild(const RenderBox& child) 
 
 LayoutUnit RenderGrid::rowAxisBaselineOffsetForChild(const RenderBox& child) const
 {
+    // FIXME : CSS Masonry does not properly handle baseline calculations currently.
+    // We will just skip this running this step if we detect the RenderGrid is Masonry for now.
+    if (isMasonry())
+        return LayoutUnit { };
+
     if (isSubgridColumns()) {
         RenderGrid* outer = downcast<RenderGrid>(parent());
         if (GridLayoutFunctions::isOrthogonalChild(*outer, *this))


### PR DESCRIPTION
#### 2524ce648b831949a2646a984cea076e73a0093b
<pre>
Crash in GridBaselineAlignment::baselineGroupForChild
<a href="https://bugs.webkit.org/show_bug.cgi?id=257509">https://bugs.webkit.org/show_bug.cgi?id=257509</a>
rdar://110027455

Reviewed by Alan Baradlay.

Certain baseline properties are not properly handled in CSS Masonry.
We will just disable these calculations for now and then remove this in the future.

* LayoutTests/fast/css-grid-layout/baseline-masonry-crash-expected.html: Added.
* LayoutTests/fast/css-grid-layout/baseline-masonry-crash.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::columnAxisBaselineOffsetForChild const):
(WebCore::RenderGrid::rowAxisBaselineOffsetForChild const):

Originally-landed-as: 259548.835@safari-7615-branch (b63d45649891). rdar://110027455
Canonical link: <a href="https://commits.webkit.org/266429@main">https://commits.webkit.org/266429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebd87c07128b4307f1d13f22b8dbb0d7de501d4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15727 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16175 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15770 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10961 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12251 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16685 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1597 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->