### PR TITLE
Crash under WebCore::JSRequestAnimationFrameCallback::~JSRequestAnimationFrameCallback()

### DIFF
--- a/LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction-expected.txt
+++ b/LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction.html
+++ b/LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<body>
+This test passes if it doesn't crash.
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function popupReloaded()
+{
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+
+open("resources/pending-requestAnimationFrame-upon-destruction-popup.html");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/workers/resources/pending-requestAnimationFrame-upon-destruction-popup.html
+++ b/LayoutTests/fast/workers/resources/pending-requestAnimationFrame-upon-destruction-popup.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<canvas id="canvas"></canvas>
+<img>
+
+<script>
+if (location.search == "") {
+  const trigger = noWorkers => {
+  let canvas, ctx;
+  const window = {
+    CP: {
+      aa(a) {
+      },
+      ab(e) {} } };
+      requestAnimationFrame(function foo(){});
+};
+
+const createWorker = fn => {
+  const URL = window.URL || window.webkitURL;
+  return new Worker(URL.createObjectURL(new Blob(["(" + fn + ")()"])));
+};
+
+const texture = document.createElement("canvas");
+worker = createWorker(trigger);
+window.location.href += "?foo=bar";
+} else
+    opener.popupReloaded();
+</script>
+</html>

--- a/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -69,6 +69,7 @@ bool WorkerAnimationController::virtualHasPendingActivity() const
 void WorkerAnimationController::stop()
 {
     m_animationTimer.stop();
+    m_animationCallbacks.clear();
 }
 
 void WorkerAnimationController::suspend(ReasonForSuspension)


### PR DESCRIPTION
#### 4b6edc53e68ce12d8b4d0e89704aab3793a221be
<pre>
Crash under WebCore::JSRequestAnimationFrameCallback::~JSRequestAnimationFrameCallback()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258058">https://bugs.webkit.org/show_bug.cgi?id=258058</a>
rdar://110530772

Reviewed by Ryosuke Niwa.

JSRequestAnimationFrameCallback were outliving the VM and thus using the VM
after-free in their destructor. JS Wrapper should never outlive the VM.

JSRequestAnimationFrameCallback are subclasses of RequestAnimationFrameCallback,
which were being kept alive by the WorkerAnimationController via its
m_animationCallbacks vector.

To address the issue, WorkerAnimationController now clears m_animationCallbacks
in stop(), which gets called when the global scope (and thus the VM) are about
to go away.

* LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction-expected.txt: Added.
* LayoutTests/fast/workers/pending-requestAnimationFrame-upon-destruction.html: Added.
* LayoutTests/fast/workers/resources/pending-requestAnimationFrame-upon-destruction-popup.html: Added.
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::stop):

Originally-landed-as: 259548.833@safari-7615-branch (c60c40574fc5). rdar://110530772
Canonical link: <a href="https://commits.webkit.org/266430@main">https://commits.webkit.org/266430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f751d9f66a11d4beba54505f2fb05a744ee67e5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14387 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15731 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16176 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19428 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15771 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12253 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16686 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1598 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->