### PR TITLE
Expand list of URL spoofing characters

### DIFF
--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -203,8 +203,12 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     
     if (!u_isprint(codePoint)
         || u_isUWhiteSpace(codePoint)
-        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT)
-        || ublock_getCode(codePoint) == UBLOCK_IPA_EXTENSIONS)
+        || u_hasBinaryProperty(codePoint, UCHAR_DEFAULT_IGNORABLE_CODE_POINT))
+        return true;
+
+    auto block = ublock_getCode(codePoint);
+    if (block == UBLOCK_IPA_EXTENSIONS
+        || block == UBLOCK_DESERET)
         return true;
 
     switch (codePoint) {
@@ -214,6 +218,10 @@ static bool isLookalikeCharacter(const std::optional<UChar32>& previousCodePoint
     /* 0x0131 LATIN SMALL LETTER DOTLESS I is intentionally not considered a lookalike character because it is visually distinguishable from i and it has legitimate use in the Turkish language. */
     case 0x01C0: /* LATIN LETTER DENTAL CLICK */
     case 0x01C3: /* LATIN LETTER RETROFLEX CLICK */
+    case 0x1E9C: /* LATIN SMALL LETTER LONG S WITH DIAGONAL STROKE */
+    case 0x1E9D: /* LATIN SMALL LETTER LONG S WITH HIGH STROKE */
+    case 0x1EFE: /* LATIN CAPITAL LETTER Y WITH LOOP */
+    case 0x1EFF: /* LATIN SMALL LETTER Y WITH LOOP */
     case 0x0237: /* LATIN SMALL LETTER DOTLESS J */
     case 0x0251: /* LATIN SMALL LETTER ALPHA */
     case 0x0261: /* LATIN SMALL LETTER SCRIPT G */

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm
@@ -163,6 +163,10 @@ TEST(WTF_URLExtras, URLExtras_Spoof)
         "xn--n-uwf"_s, // 'n' U+0E01
         "xn--3hb112n"_s, // U+065B
         "xn--a-ypc062v"_s, // 'a' U+065B
+        "xn--2j8c"_s, // U+1043D
+        "xn--ikg"_s, // U+1E9C
+        "xn--jkg"_s, // U+1E9D
+        "xn--cng"_s, // U+1EFE or U+1EFF
     };
     for (auto& host : punycodedSpoofHosts) {
         auto url = makeString("http://", host, "/").utf8();


### PR DESCRIPTION
#### a0d7fe498f7500a4f750d6c9dafee42fe1142e9b
<pre>
Expand list of URL spoofing characters
<a href="https://bugs.webkit.org/show_bug.cgi?id=256813">https://bugs.webkit.org/show_bug.cgi?id=256813</a>
rdar://109105078, rdar://109056841, and rdar://109056217

Reviewed by Tim Horton.

U+1E9C and U+1E9D are Medievalist characters, which means they haven&apos;t been used much
in the last several centuries.  They look kind of like &apos;f&apos; and other browsers punycode
encode them when seen in URL hosts, so let&apos;s do the same.  Same with U+1EFE and U+1EFF.

Deseret has been used much more recently, but still not much since the late 1800&apos;s.
There is a sign in a restaurant in the Salt Lake City airport that uses it, but it
seems to be a historical reference.  Classify Deseret like we do the International
Phonetic Alphabet and punycode encode it if seen in URL hosts.

* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isLookalikeCharacter):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/URLExtras.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 259548.832@safari-7615-branch (aecf4d579f39). rdar://109105078
Canonical link: <a href="https://commits.webkit.org/266433@main">https://commits.webkit.org/266433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c20f69c5705b0f436904c332c3750120d07778ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15477 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15728 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16177 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19433 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11718 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15776 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13010 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10964 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13783 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12354 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3587 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16687 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14170 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/1755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12928 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3396 "Passed tests") | 
<!--EWS-Status-Bubble-End-->