### PR TITLE
Third Party IFrame Navigation Block Bypass via Content Security Policy Sandbox

### DIFF
--- a/LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp-expected.txt
@@ -1,0 +1,13 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp.html' from frame with URL 'http://127.0.0.1:8000/security/resources/attempt-top-level-navigation-with-csp.py'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+
+CONSOLE MESSAGE: SecurityError: The operation is insecure.
+Test blocking of top-level navigations by a third-party iframe which gives itself a sandbox which allows top navigation via CSP.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS All navigations by subframes have been blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test blocking of top-level navigations by a third-party iframe which gives itself a sandbox which allows top navigation via CSP.");
+jsTestIsAsync = true;
+onload = () => {
+    setTimeout(() => {
+        testPassed("All navigations by subframes have been blocked");
+        finishJSTest();
+    }, 10);
+};
+</script>
+<iframe id="testFrame" src="/security/resources/attempt-top-level-navigation-with-csp.py"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/attempt-top-level-navigation-with-csp.py
+++ b/LayoutTests/http/tests/security/resources/attempt-top-level-navigation-with-csp.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Security-Policy: sandbox allow-scripts allow-top-navigation\r\n'
+    'Content-Type: text/html\r\n\r\n'
+    '<!DOCTYPE html>\n'
+    '<script>top.location = "http://localhost:8000/security/resources/should-not-have-loaded.html";</script>\n'
+)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3906,9 +3906,11 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame&
     if (m_frame->hasHadUserInteraction())
         return false;
 
-    // Only prevent navigations by unsandboxed iframes. Such navigations by unsandboxed iframes would have already been blocked unless
+    // Only prevent navigations by unsandboxed iframes. Such navigations by sandboxed iframes would have already been blocked unless
     // "allow-top-navigation" / "allow-top-navigation-by-user-activation" was explicitly specified.
-    if (sandboxFlags() != SandboxNone) {
+    // We also want to guard against bypassing this block via an iframe-provided CSP sandbox.
+    auto* ownerElement = m_frame->ownerElement();
+    if ((!ownerElement || ownerElement->sandboxFlags() == sandboxFlags()) && sandboxFlags() != SandboxNone) {
         // Navigation is only allowed if the parent of the sandboxed iframe is first-party.
         RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
         RefPtr parentDocument = parentFrame ? parentFrame->document() : nullptr;


### PR DESCRIPTION
#### 900265400e127db69a5ae3234151f005a3e769d3
<pre>
Third Party IFrame Navigation Block Bypass via Content Security Policy Sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=257903">https://bugs.webkit.org/show_bug.cgi?id=257903</a>
rdar://109059471

Reviewed by Brent Fulgham.

If a third-party iframe is unsandboxed we will prevent top navigation
without user interaction with the frame. However, this is bypassable if
the iframe gives itself a sandbox which allows top navigation via CSP.

This change checks to see if the iframe element was unsandboxed and
proceeds with the more strict third-party checks if so.

* LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp-expected.txt: Added.
* LayoutTests/http/tests/security/block-top-level-navigations-by-third-party-iframe-sandboxed-by-own-csp.html: Added.
* LayoutTests/http/tests/security/resources/attempt-top-level-navigation-with-csp.py: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):

Originally-landed-as: 259548.823@safari-7615-branch (18a05c43972c). rdar://109059471
Canonical link: <a href="https://commits.webkit.org/266433@main">https://commits.webkit.org/266433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a81dcd7a8213b608a2756877f7aa6e7f8919d042

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15730 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16187 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12395 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19437 "6 flakes 86 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15780 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10965 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12257 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16691 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1601 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->