### PR TITLE
Crash in GraphicsLayerCA::computeVisibleAndCoverageRect() caused by data detector highlights

### DIFF
--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -59,11 +59,7 @@ ServicesOverlayController::ServicesOverlayController(Page& page)
 {
 }
 
-ServicesOverlayController::~ServicesOverlayController()
-{
-    for (auto& highlight : m_highlights)
-        highlight.invalidate();
-}
+ServicesOverlayController::~ServicesOverlayController() = default;
 
 void ServicesOverlayController::willMoveToPage(PageOverlay&, Page* page)
 {

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -60,7 +60,7 @@ public:
     static Ref<DataDetectorHighlight> createForTelephoneNumber(Page&, DataDetectorHighlightClient&, RetainPtr<DDHighlightRef>&&, SimpleRange&&);
     static Ref<DataDetectorHighlight> createForImageOverlay(Page&, DataDetectorHighlightClient&, RetainPtr<DDHighlightRef>&&, SimpleRange&&);
 
-    ~DataDetectorHighlight() = default;
+    ~DataDetectorHighlight();
 
     void invalidate();
 

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -76,6 +76,11 @@ DataDetectorHighlight::DataDetectorHighlight(Page& page, DataDetectorHighlightCl
     layer().setOpacity(0);
 }
 
+DataDetectorHighlight::~DataDetectorHighlight()
+{
+    invalidate();
+}
+
 void DataDetectorHighlight::setHighlight(DDHighlightRef highlight)
 {
     if (!PAL::isDataDetectorsFrameworkAvailable())


### PR DESCRIPTION
#### 4a9d1a52a38c2feda07d32b7ec9790ef7a690b20
<pre>
Crash in GraphicsLayerCA::computeVisibleAndCoverageRect() caused by data detector highlights
<a href="https://bugs.webkit.org/show_bug.cgi?id=257684">https://bugs.webkit.org/show_bug.cgi?id=257684</a>
rdar://105900355

Reviewed by Aditya Keerthi.

It was possible for ServicesOverlayController to delete a DataDetectorHighlight, but leave its GraphicsLayer
parented in the page overlay, so the GraphicsLayer client() was deleted.

Fix by having the DataDetectorHighlight&apos;s destructor call invalidate(), which unparents the layer. The
ServicesOverlayController destructor no longer needs to explicitly call invalidate().

I attempted for several hours to make an API test for this, but was unable.

* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::~ServicesOverlayController): Deleted.
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::~DataDetectorHighlight):

Originally-landed-as: 259548.817@safari-7615-branch (9abef45e45a6). rdar://105900355
Canonical link: <a href="https://commits.webkit.org/266434@main">https://commits.webkit.org/266434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fe3ab57d25ac2cd1bb241f895abd0ccdaf43fba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15733 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16183 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12397 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19436 "2 flakes 116 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10968 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16693 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1605 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->