### PR TITLE
Incorrect CORS mode for ApplicationManifest

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3233,6 +3233,8 @@ http/tests/privateClickMeasurement [ Skip ]
 # Application Manifest tests
 webkit.org/b/153152 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Skip ]
 webkit.org/b/153152 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Skip ]
+webkit.org/b/153152 http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Skip ]
+webkit.org/b/153152 http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Skip ]
 webkit.org/b/158205 applicationmanifest/ [ Skip ]
 
 webkit.org/b/178785 perf/object-keys.html [ Pass Failure ]

--- a/LayoutTests/http/wpt/content-security-policy/manifest.json
+++ b/LayoutTests/http/wpt/content-security-policy/manifest.json
@@ -1,0 +1,3 @@
+{
+  "name": "manifest"
+}

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
@@ -1,0 +1,5 @@
+http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html - didFinishLoading
+CONSOLE MESSAGE: Origin null is not allowed by Access-Control-Allow-Origin. Status code: 200
+http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json">
+CONSOLE MESSAGE: Fetched manifest: http://127.0.0.1:8800/WebKit/content-security-policy/manifest.json
+

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
@@ -1,0 +1,16 @@
+<head>
+    <link
+        rel="manifest"
+        href="http://{{hosts[alt][]}}:{{ports[http][0]}}/WebKit/content-security-policy/manifest.json"
+    />
+</head>
+<script>
+    testRunner?.dumpAsText();
+    testRunner?.dumpResourceLoadCallbacks();
+    testRunner?.waitUntilDone();
+    testRunner?.getApplicationManifestThen(() => {
+        const elem = document.querySelector("link");
+        console.log(`Fetched manifest: ${elem.href}`);
+        testRunner.notifyDone();
+    });
+</script>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts;

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
@@ -1,0 +1,5 @@
+http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked.html - didFinishLoading
+CONSOLE MESSAGE: Origin null is not allowed by Access-Control-Allow-Origin. Status code: 200
+http://localhost:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://localhost:8800/WebKit/content-security-policy/manifest.json">
+CONSOLE MESSAGE: Fetched manifest: http://localhost:8800/WebKit/content-security-policy/manifest.json
+

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
@@ -1,0 +1,13 @@
+<head>
+    <link rel="manifest" href="manifest.json" />
+</head>
+<script>
+    testRunner?.dumpAsText();
+    testRunner?.dumpResourceLoadCallbacks();
+    testRunner?.waitUntilDone();
+    testRunner?.getApplicationManifestThen(() => {
+        const elem = document.querySelector("link");
+        console.log(`Fetched manifest: ${elem.href}`);
+        testRunner.notifyDone();
+    });
+</script>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts;

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -126,6 +126,8 @@ webkit.org/b/259089 imported/w3c/web-platform-tests/css/css-ui/text-overflow-028
 
 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Pass ]
 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Pass ]
 applicationmanifest/ [ Pass ]
 
 # Skipped because of <rdar://problem/45388584>.

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -100,6 +100,8 @@ imported/w3c/web-platform-tests/payment-request/rejects_if_not_active.https.html
 
 http/tests/security/contentSecurityPolicy/manifest-src-allowed.html [ Pass ]
 http/tests/security/contentSecurityPolicy/manifest-src-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked.html [ Pass ]
+http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html [ Pass ]
 applicationmanifest/ [ Pass ]
 
 webkit.org/b/187183 http/tests/security/pasteboard-file-url.html [ Pass ]

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -67,6 +67,8 @@ bool ApplicationManifestLoader::startLoading()
 #endif
 
     auto credentials = m_useCredentials ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
+    // The "linked resource fetch setup steps" are defined as part of:
+    // https://html.spec.whatwg.org/#link-type-manifest
     auto options = ResourceLoaderOptions(
         SendCallbackPolicy::SendCallbacks,
         ContentSniffingPolicy::SniffContent,
@@ -75,12 +77,13 @@ bool ApplicationManifestLoader::startLoading()
         ClientCredentialPolicy::CannotAskClientForCredentials,
         credentials,
         SecurityCheckPolicy::DoSecurityCheck,
-        FetchOptions::Mode::NoCors,
+        FetchOptions::Mode::Cors,
         CertificateInfoPolicy::DoNotIncludeCertificateInfo,
         ContentSecurityPolicyImposition::DoPolicyCheck,
         DefersLoadingPolicy::AllowDefersLoading,
         CachingPolicy::AllowCaching);
     options.destination = FetchOptions::Destination::Manifest;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     CachedResourceRequest request(WTFMove(resourceRequest), options);
 
     auto cachedResource = frame->document()->cachedResourceLoader().requestApplicationManifest(WTFMove(request));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -83,7 +83,9 @@ TEST(ApplicationManifest, Basic)
 
     done = false;
     NSDictionary *manifestObject = @{ @"name": @"Test" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *manifestString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json];
+    [webView synchronouslyLoadHTMLString:manifestString];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
         EXPECT_TRUE([manifest.name isEqualToString:@"Test"]);
         done = true;
@@ -99,7 +101,8 @@ TEST(ApplicationManifest, Basic)
         @"scope": @"http://example.com/app",
         @"theme_color": @"red",
     };
-    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]];
+    json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", json];
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://example.com/app/index"]];
     [webView _test_waitForDidFinishNavigation];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {
@@ -150,12 +153,13 @@ TEST(ApplicationManifest, DisplayMode)
     }];
 }
 
-TEST(ApplicationManifest, AlwaysFetch)
+TEST(ApplicationManifest, AlwaysFetchData)
 {
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -180,8 +184,10 @@ TEST(ApplicationManifest, OnlyFirstManifest)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"red" };
+    NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
     NSDictionary *manifestObject2 = @{ @"theme_color": @"blue" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0], [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json2 = [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json1, json2]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -223,8 +229,10 @@ TEST(ApplicationManifest, MediaAttriute)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject1 = @{ @"theme_color": @"blue" };
+    NSString *json1 = [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0];
     NSDictionary *manifestObject2 = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"invalid\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"screen\">", [[NSJSONSerialization dataWithJSONObject:manifestObject1 options:0 error:nil] base64EncodedStringWithOptions:0], [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json2 = [[NSJSONSerialization dataWithJSONObject:manifestObject2 options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"invalid\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\" media=\"screen\">", json1, json2]];
 
     {
         auto sRGBColorSpace = adoptCF(CGColorSpaceCreateWithName(kCGColorSpaceSRGB));
@@ -266,7 +274,8 @@ TEST(ApplicationManifest, Blocked)
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSZeroRect]);
 
     NSDictionary *manifestObject = @{ @"theme_color": @"red" };
-    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<meta http-equiv=\"Content-Security-Policy\" content=\"manifest-src 'none'\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    [webView synchronouslyLoadHTMLString:[NSString stringWithFormat:@"<meta http-equiv=\"Content-Security-Policy\" content=\"manifest-src 'none'\"><link rel=\"manifest\" href=\"data:application/manifest+json;charset=utf-8;base64,%@\">", json]];
 
     EXPECT_NULL([webView themeColor]);
 
@@ -309,7 +318,8 @@ TEST(ApplicationManifest, Icons)
         @"theme_color": @"red",
         @"icons": expectedIcons
     };
-    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0]];
+    NSString *json = [[NSJSONSerialization dataWithJSONObject:manifestObject options:0 error:nil] base64EncodedStringWithOptions:0];
+    NSString *htmlString = [NSString stringWithFormat:@"<link rel=\"manifest\" href=\"data:text/plain;charset=utf-8;base64,%@\">", json];
     [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"http://example.com/app/index"]];
     [webView _test_waitForDidFinishNavigation];
     [webView _getApplicationManifestWithCompletionHandler:^(_WKApplicationManifest *manifest) {


### PR DESCRIPTION
#### 96d46f011c855886264adcf82113952c1e554d1a
<pre>
Incorrect CORS mode for ApplicationManifest
<a href="https://bugs.webkit.org/show_bug.cgi?id=256686">https://bugs.webkit.org/show_bug.cgi?id=256686</a>
rdar://109154572

Reviewed by Brent Fulgham.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/content-security-policy/manifest.json: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html.headers: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html: Added.
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html.headers: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST):

Originally-landed-as: 259548.816@safari-7615-branch (8437c2302b67). rdar://109154572
Canonical link: <a href="https://commits.webkit.org/266438@main">https://commits.webkit.org/266438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1fbedbbccff1949e36a69b092696ca30e1c66c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13057 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13829 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15734 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16197 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19448 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15792 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12361 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12268 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16694 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1606 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->