### PR TITLE
JSObject::getDirectConcurrently should take the cell lock.

### DIFF
--- a/JSTests/stress/get-concurrently-should-take-cell-lock.js
+++ b/JSTests/stress/get-concurrently-should-take-cell-lock.js
@@ -1,0 +1,79 @@
+/*
+diff --git a/Source/JavaScriptCore/dfg/DFGGraph.cpp b/Source/JavaScriptCore/dfg/DFGGraph.cpp
+index 07aed18ca1b4..157a836cf50e 100644
+--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
++++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include "config.h"
+ #include "DFGGraph.h"
++#include "runtime/JSCast.h"
+ 
+ #if ENABLE(DFG_JIT)
+ 
+@@ -1337,6 +1338,10 @@ JSValue Graph::tryGetConstantProperty(
+     Structure* structure = object->structure();
+     if (!structureSet.toStructureSet().contains(structure))
+         return JSValue();
++    
++    if (jsDynamicCast<JSArray*>(object)) {
++        usleep(1000 * 1000);
++    }
+ 
+     return object->getDirectConcurrently(structure, offset);
+ }
+diff --git a/Source/JavaScriptCore/runtime/JSArray.cpp b/Source/JavaScriptCore/runtime/JSArray.cpp
+index 7b8907517f9e..f18e5b3a9e0c 100644
+--- a/Source/JavaScriptCore/runtime/JSArray.cpp
++++ b/Source/JavaScriptCore/runtime/JSArray.cpp
+@@ -1033,6 +1033,9 @@ bool JSArray::unshiftCountWithArrayStorage(JSGlobalObject* globalObject, unsigne
+         Structure* structure = this->structure();
+         ConcurrentJSLocker structureLock(structure->lock());
+         Butterfly* newButterfly = storage->butterfly()->unshift(structure, count);
++
++        usleep(1000 * 2000);
++
+         storage = newButterfly->arrayStorage();
+         storage->m_indexBias -= count;
+         storage->setVectorLength(vectorLength + count);
+*/
+
+async function sleep(ms) {
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve();
+        }, ms);
+    });
+}
+
+const container = {};
+
+function opt() {
+    const object = container.abc;
+
+    return object.x;
+}
+
+async function main() {
+    const array = [];
+    array[1000] = 1.1;
+    array.fill(1.1);
+    array.unshift(1.1);
+
+    array.__defineGetter__('x', () => 1);
+
+    container.abc = array;
+
+    for (let i = 0; i < 0x10000; i++) {
+        opt();
+    }
+
+    await sleep(250);
+
+    array.y = 0x2222;
+    array.unshift(1.1, 2.2, 3.3);
+
+    await sleep(2000);
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -230,13 +230,23 @@ ObjectPropertyCondition generateCondition(
         break;
     }
     case PropertyCondition::Equivalence: {
-        unsigned attributes;
-        PropertyOffset offset = structure->get(vm, concurrency, uid, attributes);
-        if (offset == invalidOffset)
-            return ObjectPropertyCondition();
-        JSValue value = object->getDirect(concurrency, structure, offset);
-        if (!value)
-            return ObjectPropertyCondition();
+        JSValue value;
+        {
+            Locker<JSCellLock> cellLocker { NoLockingNecessary };
+            if (concurrency != Concurrency::MainThread) {
+                cellLocker = Locker { object->cellLock() };
+                if (object->structure() != structure)
+                    return ObjectPropertyCondition();
+                // The structure might change from now on, but we are guaranteed to have a sane view of the butterfly.
+            }
+            unsigned attributes;
+            PropertyOffset offset = structure->get(vm, concurrency, uid, attributes);
+            if (offset == invalidOffset)
+                return ObjectPropertyCondition();
+            value = object->getDirect(cellLocker, concurrency, structure, offset);
+            if (!value)
+                return ObjectPropertyCondition();
+        }
         result = ObjectPropertyCondition::equivalence(vm, owner, object, uid, value);
         break;
     }

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -282,6 +282,9 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
     }
         
     case Equivalence: {
+        Locker<JSCellLock> cellLocker { NoLockingNecessary };
+        if (concurrency != Concurrency::MainThread && base)
+            cellLocker = Locker { base->cellLock() };
         if (!base || base->structure() != structure) {
             // Conservatively return false, since we cannot verify this one without having the
             // object.
@@ -306,8 +309,8 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
             return false;
         }
 
-        JSValue currentValue = base->getDirect(concurrency, structure, currentOffset);
-        if (currentValue != requiredValue()) {
+        JSValue currentValue = base->getDirect(cellLocker, concurrency, structure, currentOffset);
+        if (currentValue != requiredValue() || !currentValue) {
             if (PropertyConditionInternal::verbose) {
                 dataLog(
                     "Invalid because the value is ", currentValue, " but we require ", requiredValue(),
@@ -509,9 +512,13 @@ bool PropertyCondition::isValidValueForPresence(JSValue value) const
 
 PropertyCondition PropertyCondition::attemptToMakeEquivalenceWithoutBarrier(JSObject* base) const
 {
-    Structure* structure = base->structure();
+    JSValue value;
+    {
+        Locker cellLocker { base->cellLock() };
+        Structure* structure = base->structure();
 
-    JSValue value = base->getDirectConcurrently(structure, offset());
+        value = base->getDirectConcurrently(cellLocker, structure, offset());
+    }
     if (!isValidValueForPresence(value))
         return PropertyCondition();
     return equivalenceWithoutBarrier(uid(), value);

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1341,11 +1341,12 @@ JSValue Graph::tryGetConstantProperty(
     // incompatible with the getDirect we're trying to do. The easiest way to do that is to
     // determine if the structure belongs to the proven set.
 
+    Locker cellLock { object->cellLock() };
     Structure* structure = object->structure();
     if (!structureSet.toStructureSet().contains(structure))
         return JSValue();
 
-    return object->getDirectConcurrently(structure, offset);
+    return object->getDirectConcurrently(cellLock, structure, offset);
 }
 
 JSValue Graph::tryGetConstantProperty(JSValue base, Structure* structure, PropertyOffset offset)

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1034,6 +1034,7 @@ bool JSArray::unshiftCountWithArrayStorage(JSGlobalObject* globalObject, unsigne
         Structure* structure = this->structure();
         ConcurrentJSLocker structureLock(structure->lock());
         Butterfly* newButterfly = storage->butterfly()->unshift(structure, count);
+
         storage = newButterfly->arrayStorage();
         storage->m_indexBias -= count;
         storage->setVectorLength(vectorLength + count);

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -138,12 +138,12 @@ public:
     
     // Each cell has a built-in lock. Currently it's simply available for use if you need it. It's
     // a full-blown WTF::Lock. Note that this lock is currently used in JSArray and that lock's
-    // ordering with the Structure lock is that the Structure lock must be acquired first.
+    // ordering with the Structure lock is that the cell lock must be acquired first.
 
     // We use this abstraction to make it easier to grep for places where we lock cells.
     // to lock a cell you can just do:
-    // Locker locker { cell->cellLocker() };
-    JSCellLock& cellLock() { return *reinterpret_cast<JSCellLock*>(this); }
+    // Locker locker { cell->cellLock() };
+    JSCellLock& cellLock() const { return *reinterpret_cast<JSCellLock*>(const_cast<JSCell*>(this)); }
     
     JSType type() const;
     IndexingType indexingTypeAndMisc() const;

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -823,8 +823,8 @@ public:
 
     // Fast access to known property offsets.
     ALWAYS_INLINE JSValue getDirect(PropertyOffset offset) const { return locationForOffset(offset)->get(); }
-    JSValue getDirect(Concurrency, Structure* expectedStructure, PropertyOffset) const;
-    JSValue getDirectConcurrently(Structure* expectedStructure, PropertyOffset) const;
+    JSValue getDirect(Locker<JSCellLock>&, Concurrency, Structure* expectedStructure, PropertyOffset) const;
+    JSValue getDirectConcurrently(Locker<JSCellLock>&, Structure* expectedStructure, PropertyOffset) const;
     void putDirectOffset(VM& vm, PropertyOffset offset, JSValue value) { locationForOffset(offset)->set(vm, this, value); }
     void putDirectWithoutBarrier(PropertyOffset offset, JSValue value) { locationForOffset(offset)->setWithoutWriteBarrier(value); }
 
@@ -1421,22 +1421,25 @@ inline JSValue JSObject::getPrototype(VM&, JSGlobalObject* globalObject)
 // shrink the butterfly when we are holding the Structure's ConcurrentJSLock, such as when we
 // flatten an object.
 IGNORE_RETURN_TYPE_WARNINGS_BEGIN
-ALWAYS_INLINE JSValue JSObject::getDirect(Concurrency concurrency, Structure* expectedStructure, PropertyOffset offset) const
+ALWAYS_INLINE JSValue JSObject::getDirect(Locker<JSCellLock>& cellLock, Concurrency concurrency, Structure* expectedStructure, PropertyOffset offset) const
 {
     switch (concurrency) {
     case Concurrency::MainThread:
         ASSERT(!isCompilationThread() && !Thread::mayBeGCThread());
         return getDirect(offset);
     case Concurrency::ConcurrentThread:
-        return getDirectConcurrently(expectedStructure, offset);
+        return getDirectConcurrently(cellLock, expectedStructure, offset);
     }
 }
 IGNORE_RETURN_TYPE_WARNINGS_END
 
-inline JSValue JSObject::getDirectConcurrently(Structure* structure, PropertyOffset offset) const
+inline JSValue JSObject::getDirectConcurrently(Locker<JSCellLock>&, Structure* expectedStructure, PropertyOffset offset) const
 {
-    ConcurrentJSLocker locker(structure->lock());
-    if (!structure->isValidOffset(offset))
+    // We always take the cell lock before the structure lock.
+    // We must take the cell lock to prevent places like JSArray::unshiftCountWithArrayStorage
+    // from changing the butterfly out from under us.
+    ConcurrentJSLocker locker { expectedStructure->lock() };
+    if (!expectedStructure->isValidOffset(offset))
         return { };
     return getDirect(offset);
 }


### PR DESCRIPTION
#### 14530da9c09d490a1759b96da2231698f1aae0af
<pre>
JSObject::getDirectConcurrently should take the cell lock.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257285">https://bugs.webkit.org/show_bug.cgi?id=257285</a>
rdar://108166258

Reviewed by Yusuke Suzuki.

`JSArray::unshiftCountWithArrayStorage` takes the cell lock and then the
structure lock to prevent the compiler thread from accessing the butterfly
before it is fully initialized.

`JSObject::getDirectConcurrently` only takes the structure lock. This means
that the compiler can take the structure lock, the cell can transition
to a new structure, then unshift can mess up the butterfly, and finally
the compiler thread proceeds to see garbage.

The attached POC only reproduces if waits are introduced to extend the race window.

It seems that the comment above cellLock is outdated, as our current concurrency
protocol to prevent deadlocks is to take the cell lock then the structure lock.
I could not find anywhere that uses the reverse, but if I missed something,
a deadlock will be pretty easy to debug.

* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::unshiftCountWithArrayStorage):
* Source/JavaScriptCore/runtime/JSCell.h:
(JSC::JSCell::cellLock const):
(JSC::JSCell::cellLock): Deleted.
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::JSObject::getDirectConcurrently const):

Originally-landed-as: 259548.798@safari-7615-branch (b7e3ebd9c372). rdar://108166258
Canonical link: <a href="https://commits.webkit.org/266435@main">https://commits.webkit.org/266435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1be7b95dff503f53c93d3392d497bb4bd4fa960

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13059 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15750 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16186 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19458 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11727 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15802 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13019 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10974 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13792 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12363 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3590 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16696 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14179 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1608 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12937 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3399 "Passed tests") | 
<!--EWS-Status-Bubble-End-->