### PR TITLE
[JSC] PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() should take all put() overrides into account

### DIFF
--- a/JSTests/stress/regress-108468977.js
+++ b/JSTests/stress/regress-108468977.js
@@ -1,0 +1,79 @@
+const STRING = new String('a');
+
+
+function opt(use_string, proxy) {
+    let tmp = Object.create(null);
+    if (use_string)
+        tmp = Object.create(STRING);
+
+    tmp.length = 1;
+
+    tmp.a0 = 0x1111;
+    tmp.a1 = 0x2222;
+    tmp.a2 = 0x3333;
+    tmp.a3 = 0x4444;
+    tmp.a4 = 0x5555;
+    tmp.a5 = 0x6666;
+    
+    proxy.set_getter_on = tmp;
+
+    const value = tmp.a5;
+
+    return value;
+}
+
+
+function initialize() {
+    {
+        const object = Object.create(STRING);
+        Object.defineProperty(object, 'length', {value: 1, writable: true, enumerable: true, configurable: true});
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+
+    {
+        const object = Object.create(STRING);
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+}
+
+
+function main() {
+    const proxy_handler = {set: (object, property, value) => {
+        const tmp = {};
+        tmp[26] = 2.3023e-320;
+        value[26] = 1.1;
+
+        return true;
+    }};
+
+    const proxy = new Proxy({}, proxy_handler);
+
+    initialize();
+
+    for (let i = 0; i < 1000; i++) {
+        opt(/* use_string */ false, /* proxy */ 1.1);
+        opt(/* use_string */ true, /* proxy */ 1.1);
+    }
+    
+    setTimeout(() => {
+        const value = opt(/* use_string */ true, proxy);
+
+        // Should crash here.
+        value.x = 1234;
+    }, 100);
+}
+
+
+main();

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -875,15 +875,16 @@ bool JSObject::putInlineSlow(JSGlobalObject* globalObject, PropertyName property
     return putInlineFast(globalObject, propertyName, value, slot);
 }
 
-static bool canDefinePropertyOnReceiverFast(VM& vm, JSObject* receiver, PropertyName propertyName)
+bool JSObject::mightBeSpecialProperty(VM& vm, JSType type, UniquedStringImpl* uid)
 {
-    switch (receiver->type()) {
+    switch (type) {
     case ArrayType:
-        return propertyName != vm.propertyNames->length;
+    case DerivedArrayType:
+        return uid == vm.propertyNames->length.impl();
     case JSFunctionType:
-        return propertyName != vm.propertyNames->length && propertyName != vm.propertyNames->name && propertyName != vm.propertyNames->prototype;
+        return uid == vm.propertyNames->length.impl() || uid == vm.propertyNames->name.impl() || uid == vm.propertyNames->prototype.impl();
     default:
-        return false;
+        return true;
     }
 }
 
@@ -932,7 +933,7 @@ bool JSObject::definePropertyOnReceiver(JSGlobalObject* globalObject, PropertyNa
         receiver = jsCast<JSGlobalProxy*>(receiver)->target();
 
     if (slot.isTaintedByOpaqueObject() || receiver->methodTable()->defineOwnProperty != JSObject::defineOwnProperty) {
-        if (!canDefinePropertyOnReceiverFast(vm, receiver, propertyName))
+        if (mightBeSpecialProperty(vm, receiver->type(), propertyName.uid()))
             return definePropertyOnReceiverSlow(globalObject, propertyName, value, receiver, slot.isStrictMode());
     }
 

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -205,6 +205,7 @@ public:
     static bool putInlineForJSObject(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
+    static bool mightBeSpecialProperty(VM&, JSType, UniquedStringImpl*);
     JS_EXPORT_PRIVATE NEVER_INLINE static bool definePropertyOnReceiver(JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     // putByIndex assumes that the receiver is this JSCell object.
     JS_EXPORT_PRIVATE static bool putByIndex(JSCell*, JSGlobalObject*, unsigned propertyName, JSValue, bool shouldThrow);


### PR DESCRIPTION
#### 7225cf04ea3d003ba0698f620a447be04902fd34
<pre>
[JSC] PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() should take all put() overrides into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=257271">https://bugs.webkit.org/show_bug.cgi?id=257271</a>
&lt;rdar://108468977&gt;

Reviewed by Yusuke Suzuki.

Currently, PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() is not taking into account
all existing put() overrides when analyzing side effects of AbsenceOfSetEffect condition, which leads
to incorrect results for e.g. StringObject&apos;s &quot;length&quot;, which is no-op in sloppy mode yet we rely on
structure being transitioned.

This patch fixes AbsenceOfSetEffect validity check to be more pessimistic when there is overriden put(),
unless it&apos;s a common assigment target like JSArray or JSFunction to avoid performance regressions,
all while the helper that checks for special properties with JSObject::definePropertyOnReceiver().

* JSTests/stress/regress-108468977.js: Added.
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):
(JSC::nonStructurePropertyMayBecomeReadOnlyWithoutTransition): Deleted.
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::mightBeSpecialProperty):
(JSC::JSObject::definePropertyOnReceiver):
(JSC::canDefinePropertyOnReceiverFast): Deleted.
* Source/JavaScriptCore/runtime/JSObject.h:

Originally-landed-as: 259548.797@safari-7615-branch (169a4b7e3f48). rdar://108468977
Canonical link: <a href="https://commits.webkit.org/266436@main">https://commits.webkit.org/266436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f1a98d923ccd7c8c286d81ca708d923630d167e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13060 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16188 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19440 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11728 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15784 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13020 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10972 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13793 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12364 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3591 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16697 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14180 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1609 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12938 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3401 "Passed tests") | 
<!--EWS-Status-Bubble-End-->