### PR TITLE
[ios] Prioritize text/plain MIME type over file extension for XML file types

### DIFF
--- a/LayoutTests/http/tests/mime/resources/.htaccess
+++ b/LayoutTests/http/tests/mime/resources/.htaccess
@@ -1,0 +1,6 @@
+<Files xml-with-html.xml>
+ForceType "text/plain"
+</Files>
+<Files svg-with-html.svg>
+ForceType "text/plain"
+</Files>

--- a/LayoutTests/http/tests/mime/resources/svg-with-html.svg
+++ b/LayoutTests/http/tests/mime/resources/svg-with-html.svg
@@ -1,0 +1,4 @@
+<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<html xmlns:html="http://www.w3.org/1999/xhtml">
+<html:script>console.log("Fail");</html:script>
+</html>

--- a/LayoutTests/http/tests/mime/resources/xml-with-html.xml
+++ b/LayoutTests/http/tests/mime/resources/xml-with-html.xml
@@ -1,0 +1,4 @@
+<?xml version=\'1.0\' encoding=\'utf-8\'?>
+<html xmlns:html="http://www.w3.org/1999/xhtml">
+<html:script>console.log("Fail");</html:script>
+</html>

--- a/LayoutTests/http/tests/mime/svg-with-html-expected.txt
+++ b/LayoutTests/http/tests/mime/svg-with-html-expected.txt
@@ -1,0 +1,2 @@
+svg-with-html.svg has MIME type text/plain
+

--- a/LayoutTests/http/tests/mime/svg-with-html.html
+++ b/LayoutTests/http/tests/mime/svg-with-html.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/svg-with-html.svg';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/LayoutTests/http/tests/mime/xml-with-html-expected.txt
+++ b/LayoutTests/http/tests/mime/xml-with-html-expected.txt
@@ -1,0 +1,2 @@
+xml-with-html.xml has MIME type text/plain
+

--- a/LayoutTests/http/tests/mime/xml-with-html.html
+++ b/LayoutTests/http/tests/mime/xml-with-html.html
@@ -1,0 +1,24 @@
+<html>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpResourceResponseMIMETypes();
+    testRunner.dumpAsText();
+}
+</script>
+<body>
+<script>
+function runTests() {
+    let iframe = document.createElement("iframe");
+    iframe.src = 'resources/xml-with-html.xml';
+    if (window.testRunner) {
+        iframe.onerror = testRunner.notifyDone();
+        iframe.onload = testRunner.notifyDone();
+    }
+    document.body.appendChild(iframe);
+}
+runTests();
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
+++ b/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
@@ -38,6 +38,11 @@
 
 namespace WebCore {
 
+static inline bool shouldPreferTextPlainMIMEType(const String& mimeType, const String& proposedMIMEType)
+{
+    return ("text/plain"_s == mimeType) && ((proposedMIMEType == "text/xml"_s) || (proposedMIMEType == "application/xml"_s) || (proposedMIMEType == "image/svg+xml"_s));
+}
+
 void adjustMIMETypeIfNecessary(CFURLResponseRef response, bool isMainResourceLoad)
 {
     auto type = CFURLResponseGetMIMEType(response);
@@ -63,7 +68,7 @@ void adjustMIMETypeIfNecessary(CFURLResponseRef response, bool isMainResourceLoa
             updatedType = (__bridge CFStringRef)quickLookType.get();
         else if (auto extension = filePathExtension(response))
             updatedType = preferredMIMETypeForFileExtensionFromUTType(extension.get());
-        if (updatedType && (!type || CFStringCompare(type, updatedType.get(), kCFCompareCaseInsensitive) != kCFCompareEqualTo)) {
+        if (updatedType && !shouldPreferTextPlainMIMEType(type, updatedType.get()) && (!type || CFStringCompare(type, updatedType.get(), kCFCompareCaseInsensitive) != kCFCompareEqualTo)) {
             CFURLResponseSetMIMEType(response, updatedType.get());
             return;
         }


### PR DESCRIPTION
#### d294c9bf0f3fe2c7bb92dff5efc544c886001681
<pre>
[ios] Prioritize text/plain MIME type over file extension for XML file types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257299">https://bugs.webkit.org/show_bug.cgi?id=257299</a>
rdar://107379119

Reviewed by David Kilzer.

When we receive a file with a text/plain resource, we try harder to find a
better match for the file content, but this can potentially lead to an issue
with some file types like XML. Therefore, if the server says that a file should
be treated as text/plain, and we decide that it is actually XML or SVG, we
prefer using text/plain.

* LayoutTests/http/tests/mime/resources/.htaccess: Added.
* LayoutTests/http/tests/mime/resources/svg-with-html.svg: Added.
* LayoutTests/http/tests/mime/resources/xml-with-html.xml: Added.
* LayoutTests/http/tests/mime/svg-with-html-expected.txt: Added.
* LayoutTests/http/tests/mime/svg-with-html.html: Added.
* LayoutTests/http/tests/mime/xml-with-html-expected.txt: Added.
* LayoutTests/http/tests/mime/xml-with-html.html: Added.
* Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm:
(WebCore::shouldPreferTextPlainMIMEType):
(WebCore::adjustMIMETypeIfNecessary):

Originally-landed-as: 259548.786@safari-7615-branch (c9d2edfda9b0). rdar://107379119
Canonical link: <a href="https://commits.webkit.org/266440@main">https://commits.webkit.org/266440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b275dea063a7458dd3ad7fecfac706a7194cdf06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15489 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14148 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15741 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16190 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19439 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15782 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10976 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12260 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16699 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1612 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12940 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->