### PR TITLE
Web Inspector: Deeply nested console logging can cause ConsoleMessage to be destroyed while we are still trying to log it

### DIFF
--- a/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
@@ -53,7 +53,7 @@ ScriptCallStack::ScriptCallStack(Vector<ScriptCallFrame>&& frames, bool truncate
     , m_truncated(truncated)
     , m_parentStackTrace(parentStackTrace)
 {
-    ASSERT(m_frames.size() < maxCallStackSizeToCapture);
+    ASSERT(m_frames.size() <= maxCallStackSizeToCapture);
 }
 
 ScriptCallStack::~ScriptCallStack()

--- a/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp
@@ -252,15 +252,14 @@ void InspectorConsoleAgent::addConsoleMessage(std::unique_ptr<ConsoleMessage> co
         if (m_enabled)
             previousMessage->updateRepeatCountInConsole(*m_frontendDispatcher);
     } else {
-        ConsoleMessage* newMessage = consoleMessage.get();
-        m_consoleMessages.append(WTFMove(consoleMessage));
         if (m_enabled) {
             auto generatePreview = !m_isAddingMessageToFrontend;
             SetForScope isAddingMessageToFrontend(m_isAddingMessageToFrontend, true);
 
-            newMessage->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, generatePreview);
+            consoleMessage->addToFrontend(*m_frontendDispatcher, m_injectedScriptManager, generatePreview);
         }
 
+        m_consoleMessages.append(WTFMove(consoleMessage));
         if (m_consoleMessages.size() >= maximumConsoleMessages) {
             m_expiredConsoleMessageCount += expireConsoleMessagesStep;
             m_consoleMessages.remove(0, expireConsoleMessagesStep);


### PR DESCRIPTION
#### e1d780dcb545a6a90b4ae0909c29b5c70d95a922
<pre>
Web Inspector: Deeply nested console logging can cause ConsoleMessage to be destroyed while we are still trying to log it
<a href="https://bugs.webkit.org/show_bug.cgi?id=256932">https://bugs.webkit.org/show_bug.cgi?id=256932</a>
rdar://108063640

Reviewed by Mark Lam.

InspectorConsoleAgent has been incorrectly managing the lifetime of each ConsoleMessage by moving messages into a vector
of messages before we have passed those messages on to the frontend. This means that a console message that causes
another console message to be logged may eventually cause our original message to be dropped from the vector if this
occurs deeply enough. At that point, when we unwind back to the original message, it has been destroyed while we are
trying to send it to the frontend, which results in a bad time because we are still inside a function on the
ConsoleMessage that tries to access its own member variables like m_arguments, and fails because the message object
itself has been destroyed, taking its members with it.

This also fixes a subtle message inversion in the backlog of messages and what is logged to the console when Web
Inspector is open, since the message is sent to the frontend after all other processing, but we were previously adding
the message to the vector of past messages before that processing (which may in turn cause more logging before the
actual logging we called in to perform) to occur.

A second minor issue is that ScriptCallStack is incorrectly asserting in its constructor, which preventing investigation
of this issue initially. The call stack should be less than __or equal to__ the max call stack, not just less than.

* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
(Inspector::ConsoleMessage::addToFrontend):
* Source/JavaScriptCore/inspector/InjectedScript.cpp:
(Inspector::InjectedScript::wrapObject const):
(Inspector::InjectedScript::wrapTable const):
* Source/JavaScriptCore/inspector/ScriptCallStack.cpp:
(Inspector::ScriptCallStack::ScriptCallStack):
* Source/JavaScriptCore/inspector/agents/InspectorConsoleAgent.cpp:
(Inspector::InspectorConsoleAgent::addConsoleMessage):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::messageWithTypeAndLevel):

Originally-landed-as: 259548.777@safari-7615-branch (e74d4b07ad38). rdar://108063640
Canonical link: <a href="https://commits.webkit.org/266438@main">https://commits.webkit.org/266438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7b3258318645c552ab348a22fb70019d9078569

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15491 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15740 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16192 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11831 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19444 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15788 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13024 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10975 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13797 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12368 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3593 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16701 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14184 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1610 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12942 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3402 "Passed tests") | 
<!--EWS-Status-Bubble-End-->