### PR TITLE
[JSC] putByValWithThis shouldn't bypass definePropertyOnReceiverSlow

### DIFF
--- a/JSTests/stress/define-property-on-receiver-jsfunction-prototype-no-crash.js
+++ b/JSTests/stress/define-property-on-receiver-jsfunction-prototype-no-crash.js
@@ -1,0 +1,41 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (String(error) !== errorMessage)
+            throw new Error(`Bad error: ${error}`);
+    }
+    if (!errorThrown)
+        throw new Error("Didn't throw!");
+}
+
+class MyFunction extends Function {
+    constructor() {
+        super();
+
+        super.prototype = 1;
+    }
+}
+
+function test1() {
+    const f = new MyFunction();
+    f.__defineGetter__("prototype", () => {}); // should throw
+}
+
+function test2(i) {
+    const f = new MyFunction();
+    try { f.__defineGetter__("prototype", () => {}); } catch {}
+    f.prototype.x = i; // should not crash
+}
+
+(function() {
+    for (var i = 0; i < 1e4; i++)
+        shouldThrow(test1, "TypeError: Attempting to change configurable attribute of unconfigurable property.");
+})();
+
+(function() {
+    for (var i = 0; i < 1e4; i++)
+        test2();
+})();


### PR DESCRIPTION
#### 1b0741f400ee2d31931ae30f2ddebe66e8fb0945
<pre>
[JSC] putByValWithThis shouldn&apos;t bypass definePropertyOnReceiverSlow
<a href="https://bugs.webkit.org/show_bug.cgi?id=257164">https://bugs.webkit.org/show_bug.cgi?id=257164</a>
&lt;rdar://108759737&gt;

Reviewed by Yusuke Suzuki.

The OrdinarySet revamp in <a href="https://webkit.org/b/217916">https://webkit.org/b/217916</a> assumed that there are only 2 cases to take the slow path
for altered receivers: overriden [[Set]] in prototype chain and Reflect.set(). I thought that it&apos;s unobservable
to take the fast path otherwise since overriden methods were already called.

However, the third case was missed: put_by_val_with_this bytecode op, which is emitted for setting a property
on `super` base, and with <a href="https://webkit.org/b/252602">https://webkit.org/b/252602</a>, for ProxyObjectStore IC when the trap is missing.

Among other minor web compatibility bugs, missing that case caused properties to be put right on ProxyObject&apos;s
structure, where they are unaccessible, skipping calls to &quot;set&quot; and &quot;defineProperty&quot; traps.

This change relaxes the condition for taking the definePropertyOnReceiverSlow() while ensuring all common
[[Set]] targets like JSArray or `class X extends Y {}` are just as fast.

* JSTests/stress/define-property-on-receiver-jsfunction-prototype-no-crash.js: Added.
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::canDefinePropertyOnReceiverFast):
(JSC::JSObject::definePropertyOnReceiver):

Originally-landed-as: 259548.774@safari-7615-branch (23e9761b5751). rdar://108759737
Canonical link: <a href="https://commits.webkit.org/266439@main">https://commits.webkit.org/266439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69d0daf742b82230f07e2a65ace9202f3175f15b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15492 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13065 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16193 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11845 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19442 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11733 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15786 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13025 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13101 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10978 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13798 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12369 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3594 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16702 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14185 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1611 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12943 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3403 "Passed tests") | 
<!--EWS-Status-Bubble-End-->