### PR TITLE
Parameters to throw alias with stack elements in WASM LLInt

### DIFF
--- a/JSTests/wasm/stress/throw-multiple-values.js
+++ b/JSTests/wasm/stress/throw-multiple-values.js
@@ -1,0 +1,31 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (global i32 i32.const 42)
+    (tag (param i32 i32 i32))
+
+    (func (export "test") (param i32 i32 i32) (result i32)
+        global.get 0
+        local.get 0
+        local.get 1
+        local.get 2
+        try (param i32 i32 i32) (result i32)
+            throw 0
+        catch 0
+            i32.add
+            i32.add
+        end
+        i32.add
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { exceptions: true });
+    const { test } = instance.exports;
+    assert.eq(test(1, 2, 3), 48);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/throw-with-live-value-on-stack.js
+++ b/JSTests/wasm/stress/throw-with-live-value-on-stack.js
@@ -1,0 +1,27 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (global i32 i32.const 42)
+    (tag (param i32))
+
+    (func (export "test") (param i32) (result i32)
+        global.get 0
+        local.get 0
+        try (param i32)
+            throw 0
+        catch 0
+            br 0
+        end
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { exceptions: true });
+    const { test } = instance.exports;
+    assert.eq(test(41), 42);
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -1247,7 +1247,7 @@ auto LLIntGenerator::addThrow(unsigned exceptionIndex, Vector<ExpressionType>& a
     // delayed moves, but the wasm_throw opcode expects all the arguments to be contiguous
     // in the stack. The reason we don't call materializeConstantsAndLocals here is that
     // it expects a stack, not a vector of ExpressionType arguments.
-    walkExpressionStack(args, [&](VirtualRegister& arg, VirtualRegister slot) {
+    walkExpressionStack(args, m_stackSize + args.size(), [&](VirtualRegister& arg, VirtualRegister slot) {
         if (arg == slot)
             return;
         WasmMov::emit(this, slot, arg);


### PR DESCRIPTION
#### ad8dd02f9e83f1b5199e57dfd59f785223da57c5
<pre>
Parameters to throw alias with stack elements in WASM LLInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=256818">https://bugs.webkit.org/show_bug.cgi?id=256818</a>
rdar://108036137

Reviewed by Yusuke Suzuki.

Correctly computes stack offsets when materializing the operands of
a wasm_throw instruction in the WasmLLIntGenerator by counting relative
to the stack height before the operands were popped as opposed to after.

* JSTests/wasm/stress/throw-multiple-values.js: Added.
(async test):
* JSTests/wasm/stress/throw-with-live-value-on-stack.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::addThrow):

Originally-landed-as: 259548.762@safari-7615-branch (7fb3ced7874a). rdar://108036137
Canonical link: <a href="https://commits.webkit.org/266447@main">https://commits.webkit.org/266447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c91a5847afae3aeef79337e3be2ce3f0a7c41c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14405 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16195 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12408 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19446 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11735 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15790 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13027 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10980 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13800 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12371 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3596 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16704 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14187 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1619 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12945 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3405 "Passed tests") | 
<!--EWS-Status-Bubble-End-->