### PR TITLE
Drop MessageName::Terminate IPC message

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -45,7 +45,6 @@
 #if PLATFORM(COCOA)
 #include "ArgumentCodersDarwin.h"
 #include "MachMessage.h"
-#include "WKCrashReporter.h"
 #endif
 
 #if USE(UNIX_DOMAIN_SOCKETS)
@@ -884,16 +883,6 @@ void Connection::processIncomingSyncReply(std::unique_ptr<Decoder> decoder)
     // This can happen if the send timed out, so it's fine to ignore.
 }
 
-static NEVER_INLINE NO_RETURN_DUE_TO_CRASH void terminateDueToIPCTerminateMessage()
-{
-#if PLATFORM(COCOA)
-    WebKit::logAndSetCrashLogMessage("Receives Terminate message");
-#else
-    WTFLogAlways("Receives Terminate message");
-#endif
-    CRASH();
-}
-
 void Connection::processIncomingMessage(std::unique_ptr<Decoder> message)
 {
     ASSERT(message->messageReceiverName() != ReceiverName::Invalid);
@@ -902,9 +891,6 @@ void Connection::processIncomingMessage(std::unique_ptr<Decoder> message)
         processIncomingSyncReply(WTFMove(message));
         return;
     }
-
-    if (message->messageName() == MessageName::Terminate)
-        return terminateDueToIPCTerminateMessage();
 
     if (!MessageReceiveQueueMap::isValidMessage(*message)) {
         dispatchDidReceiveInvalidMessage(message->messageName());

--- a/Source/WebKit/Scripts/webkit/model.py
+++ b/Source/WebKit/Scripts/webkit/model.py
@@ -79,7 +79,6 @@ ipc_receiver = MessageReceiver(name="IPC", superclass=None, attributes=[BUILTIN_
     Message('LegacySessionState', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('SetStreamDestinationID', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
     Message('ProcessOutOfStreamMessage', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
-    Message('Terminate', [], [], attributes=[BUILTIN_ATTRIBUTE], condition=None),
 ], condition=None)
 
 

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.cpp
@@ -130,7 +130,6 @@ const MessageDescription messageDescriptions[static_cast<size_t>(MessageName::Co
     { "ProcessOutOfStreamMessage", ReceiverName::IPC, false, false },
     { "SetStreamDestinationID", ReceiverName::IPC, false, false },
     { "SyncMessageReply", ReceiverName::IPC, false, false },
-    { "Terminate", ReceiverName::IPC, false, false },
 #if USE(AVFOUNDATION)
     { "TestWithCVPixelBuffer_ReceiveCVPixelBufferReply", ReceiverName::AsyncReply, false, false },
 #endif

--- a/Source/WebKit/Scripts/webkit/tests/MessageNames.h
+++ b/Source/WebKit/Scripts/webkit/tests/MessageNames.h
@@ -149,7 +149,6 @@ enum class MessageName : uint16_t {
     ProcessOutOfStreamMessage,
     SetStreamDestinationID,
     SyncMessageReply,
-    Terminate,
 #if USE(AVFOUNDATION)
     TestWithCVPixelBuffer_ReceiveCVPixelBufferReply,
 #endif

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -108,33 +108,12 @@ namespace WebKit {
 using namespace WebCore;
 
 static constexpr Seconds networkProcessResponsivenessTimeout = 6_s;
-static constexpr int unresponsivenessCountLimit = 3;
-static constexpr Seconds unresponsivenessCheckPeriod = 15_s;
 
 static HashSet<NetworkProcessProxy*>& networkProcessesSet()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<HashSet<NetworkProcessProxy*>> set;
     return set;
-}
-
-static bool shouldTerminateNetworkProcessBySendingMessage()
-{
-    static WallTime unresponsivenessPeriodStartTime = WallTime::now();
-    static int unresponsivenessCountDuringThisPeriod = 0;
-    auto now = WallTime::now();
-
-    if (now - unresponsivenessPeriodStartTime > unresponsivenessCheckPeriod) {
-        unresponsivenessCountDuringThisPeriod = 1;
-        unresponsivenessPeriodStartTime = now;
-        return false;
-    }
-
-    ++unresponsivenessCountDuringThisPeriod;
-    if (unresponsivenessCountDuringThisPeriod >= unresponsivenessCountLimit)
-        return true;
-
-    return false;
 }
 
 Vector<Ref<NetworkProcessProxy>> NetworkProcessProxy::allNetworkProcesses()
@@ -177,21 +156,6 @@ void NetworkProcessProxy::requestTermination()
 void NetworkProcessProxy::didBecomeUnresponsive()
 {
     RELEASE_LOG_ERROR(Process, "NetworkProcessProxy::didBecomeUnresponsive: NetworkProcess with PID %d became unresponsive, terminating it", processID());
-
-    // Let network process terminates itself and generate crash report for investigation of hangs.
-    // We currently only do this when network process becomes unresponsive multiple times in a short
-    // time period to avoid generating too many crash reports with same back trace on user's device.
-    if (shouldTerminateNetworkProcessBySendingMessage()) {
-        sendMessage(makeUniqueRef<IPC::Encoder>(IPC::MessageName::Terminate, 0), { });
-        RunLoop::main().dispatchAfter(1_s, [weakThis = WeakPtr { *this }] () mutable {
-            if (weakThis) {
-                weakThis->terminate();
-                weakThis->networkProcessDidTerminate(ProcessTerminationReason::Unresponsive);
-            }
-
-        });
-        return;
-    }
 
     terminate();
     networkProcessDidTerminate(ProcessTerminationReason::Unresponsive);


### PR DESCRIPTION
#### 41dcd0b76687719b14a4f34c155deb15f05772cb
<pre>
Drop MessageName::Terminate IPC message
<a href="https://bugs.webkit.org/show_bug.cgi?id=256373">https://bugs.webkit.org/show_bug.cgi?id=256373</a>
rdar://108899132

Reviewed by Sihui Liu.

Drop MessageName::Terminate IPC message as it could easily be abused by a
compromised WebProcess to kill the UIProcess.

It was temporarily introduced in 243810@main to investigate NetworkProcess
hangs we were seeing and should no longer be needed. This reverts 243810@main.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::processIncomingMessage):
(IPC::terminateDueToIPCTerminateMessage): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::didBecomeUnresponsive):
(WebKit::shouldTerminateNetworkProcessBySendingMessage): Deleted.

Originally-landed-as: 259548.751@safari-7615-branch (9fc652968e3c). rdar://108899132
Canonical link: <a href="https://commits.webkit.org/266446@main">https://commits.webkit.org/266446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de482b8e516631ce1d8b75bab7120741cbcd903

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15496 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13069 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15747 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16198 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13950 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11838 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19450 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15794 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10985 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16706 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1620 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->