### PR TITLE
Remove CheckInBounds when pure monotonic operations have updated relationships.

### DIFF
--- a/JSTests/stress/bounds-check-zlib.js
+++ b/JSTests/stress/bounds-check-zlib.js
@@ -64,7 +64,7 @@ function provableRedundantBitshift(b, d) {
     return sum
 }
 noInline(provableRedundantBitshift)
-tests.push({ fn: provableRedundantBitshift, before: 11, after: 1 })
+tests.push({ fn: provableRedundantBitshift, before: 11, after: 2 })
 
 function provableRedundantBitshiftNegative(b, d) {
     "use strict";
@@ -97,7 +97,7 @@ function provableRedundantBitshiftNegative(b, d) {
     return sum
 }
 noInline(provableRedundantBitshiftNegative)
-tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 3 })
+tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 1 })
 
 function provableRedundantBitshiftReversed(b, d) {
     "use strict";
@@ -129,7 +129,7 @@ function provableRedundantBitshiftReversed(b, d) {
     return sum
 }
 noInline(provableRedundantBitshiftReversed)
-tests.push({ fn: provableRedundantBitshiftReversed, before: 11, after: 1 })
+tests.push({ fn: provableRedundantBitshiftReversed, before: 11, after: 2 })
 
 function main() {
     for (test of tests) {

--- a/JSTests/stress/bounds-check-zlib.js
+++ b/JSTests/stress/bounds-check-zlib.js
@@ -97,7 +97,7 @@ function provableRedundantBitshiftNegative(b, d) {
     return sum
 }
 noInline(provableRedundantBitshiftNegative)
-tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 3 })
+tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 2 })
 
 function provableRedundantBitshiftReversed(b, d) {
     "use strict";

--- a/JSTests/stress/bounds-check-zlib.js
+++ b/JSTests/stress/bounds-check-zlib.js
@@ -97,7 +97,7 @@ function provableRedundantBitshiftNegative(b, d) {
     return sum
 }
 noInline(provableRedundantBitshiftNegative)
-tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 1 })
+tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 3 })
 
 function provableRedundantBitshiftReversed(b, d) {
     "use strict";

--- a/JSTests/stress/bounds-check-zlib.js
+++ b/JSTests/stress/bounds-check-zlib.js
@@ -64,7 +64,7 @@ function provableRedundantBitshift(b, d) {
     return sum
 }
 noInline(provableRedundantBitshift)
-tests.push({ fn: provableRedundantBitshift, before: 11, after: 2 })
+tests.push({ fn: provableRedundantBitshift, before: 11, after: 1 })
 
 function provableRedundantBitshiftNegative(b, d) {
     "use strict";
@@ -129,7 +129,7 @@ function provableRedundantBitshiftReversed(b, d) {
     return sum
 }
 noInline(provableRedundantBitshiftReversed)
-tests.push({ fn: provableRedundantBitshiftReversed, before: 11, after: 2 })
+tests.push({ fn: provableRedundantBitshiftReversed, before: 11, after: 1 })
 
 function main() {
     for (test of tests) {

--- a/JSTests/stress/bounds-check-zlib.js
+++ b/JSTests/stress/bounds-check-zlib.js
@@ -1,0 +1,136 @@
+//@skip if $memoryLimited
+//@ runDefault("--useConcurrentJIT=0", "--useDollarVM=1", "--jitAllowList=provableRedundantBitshift,provableRedundantEasy,provableRedundantBitshiftNegative")
+
+// jsc JSTests/stress/bounds-check-zlib.js --useConcurrentJIT=0 --useDollarVM=1 --jitAllowList=provableRedundantBitshift,provableRedundantEasy,provableRedundantBitshiftNegative --dumpDisassembly=0
+// Based on:
+// jsc -e "testList = ['octane-zlib'];" cli.js --useConcurrentJIT=0 --jitAllowList=a6#A8KgFt --dumpDisassembly=1 --forceICFailure=1
+
+let arr = Array(1000).fill(0)
+let tests = []
+let reachedFTL = false;
+
+function provableRedundantEasy(b, d) {
+    "use strict";
+
+    reachedFTL |= $vm.ftlTrue();
+
+    b = b | 0
+    d = d | 0
+
+    let sum = 0
+
+    if (arr.length != 1000 || b < 0 || d < 0 || d > 499)
+        return sum;
+
+    // There should be no checks.
+    sum += arr[d + 500] | 0
+    sum += arr[d + 400] | 0
+
+    return sum
+}
+noInline(provableRedundantEasy)
+tests.push({ fn: provableRedundantEasy, before: 2, after: 0 })
+
+function provableRedundantBitshift(b, d) {
+    "use strict";
+
+    reachedFTL |= $vm.ftlTrue();
+
+    b = b | 0
+    d = d | 0
+
+    if (arr.length != 1000 || b < 0 || d < 0 || d > 499)
+        return;
+
+    let sum = 0
+
+    // Needed
+    sum += arr[(b + 500) >>> 2] | 0
+    // Now b + 500 < 4000, so (b + 500) >>> 3 < 500
+    sum += arr[(b + 500) >>> 3] | 0
+    sum += arr[(b + 500) >>> 4] | 0
+
+    sum += arr[(b + 400) >>> 2] | 0
+    sum += arr[(b + 300) >>> 2] | 0
+    sum += arr[(b + 200) >>> 2] | 0
+    sum += arr[(b + 100) >>> 2] | 0
+
+    // These should all be immediately redundant.
+    sum += arr[(d + 500) >>> 2] | 0
+    sum += arr[(d + 500) >>> 3] | 0
+    sum += arr[(d + 500) >>> 4] | 0
+    sum += arr[(d + 400) >>> 2] | 0
+
+    return sum
+}
+noInline(provableRedundantBitshift)
+tests.push({ fn: provableRedundantBitshift, before: 11, after: 1 })
+
+function provableRedundantBitshiftNegative(b, d) {
+    "use strict";
+
+    reachedFTL |= $vm.ftlTrue();
+
+    b = b | 0
+    d = d | 0
+    let sum = 0
+
+    if (arr.length < 1000)
+        return sum
+
+    // Needed
+    sum += arr[(b + 500) >> 2] | 0
+    // 0 <= (b + 500) / 4 < 1000
+    // 0 <= (b + 500) < 4000
+    // -500 <= b < 3500
+    sum += arr[(b + 100) >> 20] | 0
+    // 0 <= (b + 100) >> 20
+    // 0 <= (b + 100)
+    // -100 <= b
+
+    sum += arr[(b + 500) >>> 4] | 0
+    sum += arr[(b + 400) >>> 3] | 0
+    sum += arr[(b + 300) >>> 2] | 0
+    sum += arr[(b + 200) >>> 2] | 0
+    sum += arr[(b + 100) >>> 2] | 0
+
+    return sum
+}
+noInline(provableRedundantBitshiftNegative)
+tests.push({ fn: provableRedundantBitshiftNegative, before: 7, after: 2 })
+
+function main() {
+    for (test of tests) {
+        reachedFTL = false
+
+        for (let i = 0; i < arr.length; ++i)
+            arr[i] = i
+
+        $vm.startDebugRecordingIRO()
+        let compare = test.fn(5, 9);
+
+        for (let i = 0; i < 100000; ++i) {
+            if (test.fn(5, 9) != compare)
+                throw "unexpected change in value"
+            test.fn(i % 1500, i % 10)
+        }
+
+        let result = $vm.stopDebugRecordingIRO()
+        let before = result & 0xFFFFFFFFn;
+        let after = (result >> 32n) & 0xFFFFFFFFn;
+
+        if (!reachedFTL)
+            throw "We did not reach FTL"
+
+        if (before != test.before)
+            throw "Test " + test.fn + " failed: expected " + test.before + " checks before IRO, found " + before
+        if (after != test.after)
+            throw "Test " + test.fn + " failed: expected " + test.after + " checks after IRO, found " + after
+
+        test.fn(1500, 10)
+        test.fn(15000, 100)
+    }
+}
+noInline(main)
+
+main()

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4532,6 +4532,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case AssertInBounds:
         break;
 
+    case MultiCheckInBounds:
+        RELEASE_ASSERT_NOT_REACHED();
+
     case CheckInBounds: {
         JSValue left = forNode(node->child1()).value();
         JSValue right = forNode(node->child2()).value();

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -222,7 +222,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case CompareEqPtr:
         def(PureValue(node, node->cellOperand()->cell()));
         return;
-        
+
     case ArithIMul:
     case ArithPow:
     case GetScope:
@@ -244,6 +244,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case IsTypedArrayView:
     case ToBoolean:
     case LogicalNot:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case DoubleRep:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -373,6 +373,9 @@ private:
                 break;
             }
 
+            case MultiCheckInBounds:
+                RELEASE_ASSERT_NOT_REACHED();
+
             case CheckInBounds: {
                 JSValue left = m_state.forNode(node->child1()).value();
                 JSValue right = m_state.forNode(node->child2()).value();

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -182,6 +182,7 @@ bool doesGC(Graph& graph, Node* node)
     case InvalidationPoint:
     case NotifyWrite:
     case AssertInBounds:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2357,6 +2357,7 @@ private:
         case CheckTierUpAtReturn:
         case CheckTierUpAndOSREnter:
         case AssertInBounds:
+        case MultiCheckInBounds:
         case CheckInBounds:
         case CheckInBoundsInt52:
         case ConstantStoragePointer:

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -154,6 +154,30 @@ private:
     bool m_enabled { true };
 };
 
+class MultiCheckInBoundsCheckData final {
+public:
+    int32_t neededLowerBound = std::numeric_limits<int32_t>::min();
+    int32_t neededUpperBound = std::numeric_limits<int32_t>::max();
+    bool alreadyNonNegative = false;
+    bool alreadyLessThanLength = false;
+    Edge expr = Edge();
+    Edge bounds = Edge();
+
+    MultiCheckInBoundsCheckData(Edge expr, Edge bounds)
+        : expr(expr)
+        , bounds(bounds)
+    {}
+};
+
+class MultiCheckInBoundsData final {
+public:
+    int32_t assertedLowerBound = std::numeric_limits<int32_t>::min();
+    int32_t assertedUpperBound = std::numeric_limits<int32_t>::max();
+    bool doesAssert = false;
+    Node* significantValue = nullptr;
+    Vector<MultiCheckInBoundsCheckData> checks;
+};
+
 //
 // === Graph ===
 //
@@ -1293,7 +1317,7 @@ public:
     HashSet<Node*> m_slowGetByVal;
     HashSet<Node*> m_slowPutByVal;
 
-    Vector<Vector<Edge>> m_multiCheckInBoundsData;
+    Vector<MultiCheckInBoundsData> m_multiCheckInBoundsData;
 
 private:
     template<typename Visitor> void visitChildrenImpl(Visitor&);

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1293,6 +1293,8 @@ public:
     HashSet<Node*> m_slowGetByVal;
     HashSet<Node*> m_slowPutByVal;
 
+    Vector<Vector<Edge>> m_multiCheckInBoundsData;
+
 private:
     template<typename Visitor> void visitChildrenImpl(Visitor&);
 

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -42,8 +42,8 @@ namespace JSC { namespace DFG {
 namespace {
 
 namespace DFGIntegerRangeOptimizationPhaseInternal {
-static constexpr bool verbose = true;
-static constexpr bool verboseCounting = true;
+static constexpr bool verbose = false;
+static constexpr bool verboseCounting = false;
 
 static bool shouldRecordCheckInBoundsCounts = false;
 static uint64_t checkInBoundsCountBeforeIRO = 0;

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.h
@@ -29,6 +29,9 @@
 
 namespace JSC { namespace DFG {
 
+void startDebugRecordingIRO();
+uint64_t stopDebugRecordingIRO();
+
 class Graph;
 
 // Removes overflow checks and out-of-bounds checks by doing a forward flow analysis to prove

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -445,6 +445,8 @@ void printInternal(PrintStream& out, Node* node)
         return;
     }
     out.print("D@", node->index());
+    if (node->isInt32Constant())
+        out.print("[=", node->asInt32(), "]");
     if (node->hasDoubleResult())
         out.print("<Double>");
     else if (node->hasInt52Result())

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -579,6 +579,7 @@ public:
         case CheckIsConstant:
         case CheckNotEmpty:
         case CheckBadValue:
+        case MultiCheckInBounds:
         case CheckInBounds:
         case CheckInBoundsInt52:
         case CheckIdent:
@@ -3504,6 +3505,18 @@ public:
     {
         m_opInfo = OpInfoWrapper();
         m_opInfo2 = OpInfoWrapper();
+    }
+
+    uint64_t multiCheckInBoundsData()
+    {
+        ASSERT(m_op == MultiCheckInBounds);
+        return static_cast<unsigned>(m_opInfo.as<uint64_t>());
+    }
+
+    void setMultiCheckInBoundsData(uint64_t index)
+    {
+        ASSERT(m_op == MultiCheckInBounds);
+        m_opInfo = index;
     }
 
     void dumpChildren(PrintStream& out)

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -298,6 +298,7 @@ namespace JSC { namespace DFG {
     macro(AssertNotEmpty, NodeMustGenerate) \
     macro(CheckBadValue, NodeMustGenerate) \
     macro(AssertInBounds, NodeMustGenerate) \
+    macro(MultiCheckInBounds, NodeMustGenerate | NodeResultJS) \
     macro(CheckInBounds, NodeMustGenerate | NodeResultJS) \
     macro(CheckInBoundsInt52, NodeMustGenerate | NodeResultJS) \
     macro(CheckIdent, NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1493,6 +1493,7 @@ private:
         case CheckTierUpAtReturn:
         case CheckTierUpAndOSREnter:
         case AssertInBounds:
+        case MultiCheckInBounds:
         case CheckInBounds:
         case CheckInBoundsInt52:
         case ValueToInt32:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -289,6 +289,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ExtractOSREntryLocal:
     case ExtractCatchLocal:
     case AssertInBounds:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4260,6 +4260,7 @@ void SpeculativeJIT::compile(Node* node)
     case FiatInt52:
     case Int52Constant:
     case AssertInBounds:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ArithIMul:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6263,6 +6263,7 @@ void SpeculativeJIT::compile(Node* node)
     case Upsilon:
     case ExtractOSREntryLocal:
     case AssertInBounds:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ArithIMul:

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -672,6 +672,7 @@ private:
                 case Phi:
                 case Upsilon:
                 case AssertInBounds:
+                case MultiCheckInBounds:
                 case CheckInBounds:
                 case CheckInBoundsInt52:
                 case PhantomNewObject:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -205,6 +205,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ToBoolean:
     case LogicalNot:
     case AssertInBounds:
+    case MultiCheckInBounds:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case ConstantStoragePointer:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1066,6 +1066,9 @@ private:
         case AssertInBounds:
             compileAssertInBounds();
             break;
+        case MultiCheckInBounds:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
         case CheckInBounds:
             compileCheckInBounds();
             break;

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -44,7 +44,9 @@ FunctionAllowlist::FunctionAllowlist(const char* filename)
     if (!f) {
         if (errno == ENOENT) {
             m_hasActiveAllowlist = true;
-            m_entries.add(String::fromLatin1(filename));
+            auto functions = String::fromLatin1(filename).split(',');
+            for (auto& function : functions)
+                m_entries.add(function);
         } else
             dataLogF("Failed to open file %s. Did you add the file-read-data entitlement to WebProcess.sb? Error code: %s\n", filename, safeStrerror(errno).data());
         return;


### PR DESCRIPTION
#### eff48a783bc4f0274cd866c457ddad016e33c87e
<pre>
https://bugs.webkit.org/show_bug.cgi?id=259617
rdar://problem/113060659

Reviewed by NOBODY (OOPS!).

- Remove CheckInBounds when a pure monotonic expression has new information.

Consider:

@y = PureMonotonicOp(@x)
prove something about @x (ex: CheckInBounds(@x))
CheckInBounds(@y)

Today, we can't see anything about @y because we do not re-evaluate it
abstractly.

Now, we can evaluate it (and un-evaluate it) to extract more bounds.

TODO perf testing

- Add a helper to test IntegerRangeOptimization. This lets us write tests
that ensure that checks are removed as expected.


</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc98f1abfc97159bd9441d416b00872bf27267b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15996 "Failed to checkout and rebase branch from PR 16197") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15017 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/16183 "Failed to checkout and rebase branch from PR 16197") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17459 "Passed tests") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/16188 "Failed to checkout and rebase branch from PR 16197") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18522 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/14459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21322 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13767 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17867 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15234 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12903 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/16196 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14459 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4047 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18828 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17360 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15043 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3841 "Passed tests") | 
<!--EWS-Status-Bubble-End-->