### PR TITLE
Fix type confusion in StyleBuilder::ConvertGridTrackSizeList.

### DIFF
--- a/LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion-expected.txt
+++ b/LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion.html
+++ b/LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion.html
@@ -1,0 +1,9 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    d.attributeStyleMap.set('grid-auto-columns', 'fit-content(calc(0px + 0cqmin))');
+  };
+</script>
+<div id="d"></div>
+<p>PASS if no crash.</p>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1304,11 +1304,16 @@ inline Vector<GridTrackSize> BuilderConverter::convertGridTrackSizeList(BuilderS
         return trackSizes;
     }
 
-    auto& valueList = downcast<CSSValueList>(value);
     Vector<GridTrackSize> trackSizes;
-    trackSizes.reserveInitialCapacity(valueList.length());
-    for (auto& currentValue : valueList)
-        validateValueAndAppend(trackSizes, currentValue);
+    if (is<CSSValueList>(value))  {
+        auto& valueList = downcast<CSSValueList>(value);
+        trackSizes.reserveInitialCapacity(valueList.length());
+        for (auto& currentValue : valueList)
+            validateValueAndAppend(trackSizes, currentValue);
+    } else {
+        trackSizes.reserveInitialCapacity(1);
+        validateValueAndAppend(trackSizes, value);
+    }
     return trackSizes;
 }
 


### PR DESCRIPTION
#### 64b84dc3788d87886b69f38a58f9a693f7443c10
<pre>
Fix type confusion in StyleBuilder::ConvertGridTrackSizeList.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256055.">https://bugs.webkit.org/show_bug.cgi?id=256055.</a>
rdar://108501981.

Reviewed by Antti Koivisto.

This change fixes convertGridTrackSizeList so that it can deal with single
values instead of expecting a list of values towards the end.

* LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion-expected.txt: Added.
* LayoutTests/fast/css/style-builder-convert-grid-track-size-list-type-confusion.html: Added.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertGridTrackSizeList):

Originally-landed-as: 259548.746@safari-7615-branch (1b98f8905ce2). rdar://108501981
Canonical link: <a href="https://commits.webkit.org/266445@main">https://commits.webkit.org/266445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3719ab85b3335854c58b05b1247e040af8b69abf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13844 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15748 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11835 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19451 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10984 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12273 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16709 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1618 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->