### PR TITLE
[macOS] Crash when presenting a datalist dropdown for a transformed element

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash-expected.txt
@@ -1,0 +1,2 @@
+PASS if no crash.
+

--- a/LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash.html
+++ b/LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash.html
@@ -1,0 +1,21 @@
+<style>
+* { transform: skew(180deg, 90deg); }
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function load() {
+    input.focus();
+    document.execCommand("insertHTML", false, "A");
+}
+
+</script>
+<body onload="load()">
+    <div>PASS if no crash.</div>
+    <input id="input" list="list">
+    <datalist id="list">
+        <option id="option">AAAAAAAAAA</option>
+    </datalist>
+</body>

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -439,7 +439,13 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
 
 - (NSRect)dropdownRectForElementRect:(const WebCore::IntRect&)rect
 {
-    NSRect windowRect = [[_presentingView window] convertRectToScreen:[_presentingView convertRect:rect toView:nil]];
+    NSWindow *presentingWindow = [_presentingView window];
+    NSRect screenRect = presentingWindow.screen.visibleFrame;
+    NSRect windowRect = [presentingWindow convertRectToScreen:[_presentingView convertRect:rect toView:nil]];
+
+    windowRect = CGRectIntersection(windowRect, screenRect);
+    if (CGRectIsNull(windowRect))
+        return NSZeroRect;
 
     CGFloat totalCellHeight = 0;
     for (auto& suggestion : _suggestions)
@@ -449,11 +455,11 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     if (_suggestions.size() > 1)
         totalIntercellSpacingAndPadding += (_suggestions.size() - 1) * [_table intercellSpacing].height;
 
-    CGSize mainScreenFrameSize = NSScreen.mainScreen.frame.size;
-    CGFloat width = std::min<CGFloat>(rect.width(), mainScreenFrameSize.width);
-    CGFloat height = std::min<CGFloat>(totalIntercellSpacingAndPadding + std::min(totalCellHeight, maximumTotalHeightForDropdownCells), mainScreenFrameSize.height);
-    CGFloat originX = std::max<CGFloat>(NSMinX(windowRect), std::numeric_limits<int>::min());
-    CGFloat originY = std::max<CGFloat>(NSMinY(windowRect) - height - dropdownTopMargin, std::numeric_limits<int>::min());
+    CGFloat width = std::min<CGFloat>(rect.width(), screenRect.size.width);
+    CGFloat height = std::min<CGFloat>(totalIntercellSpacingAndPadding + std::min(totalCellHeight, maximumTotalHeightForDropdownCells), screenRect.size.height);
+    CGFloat originX = std::max<CGFloat>(NSMinX(windowRect), 0);
+    CGFloat originY = std::max<CGFloat>(NSMinY(windowRect) - height - dropdownTopMargin, 0);
+
     return NSMakeRect(originX, originY, width, height);
 }
 


### PR DESCRIPTION
#### d3e0ced4e0f153c656e4effc2920d7e82e0891eb
<pre>
[macOS] Crash when presenting a datalist dropdown for a transformed element
<a href="https://bugs.webkit.org/show_bug.cgi?id=256029">https://bugs.webkit.org/show_bug.cgi?id=256029</a>
rdar://105190475

Reviewed by Wenson Hsieh.

AppKit throws an exception when an `NSWindow` is constructed with an
invalid frame. The `&lt;datalist&gt;` dropdown is an `NSWindow` with a frame derived
from the rect of its associated element. When this element is off-screen or
abnormally large, the frame used for the window may be invalid.

Fix by ensuring the frame can never be outside the screen.

* LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash-expected.txt: Added.
* LayoutTests/fast/forms/datalist/datalist-dropdown-transformed-element-crash.html: Added.
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(-[WKDataListSuggestionsController dropdownRectForElementRect:]):

1. Use the presenting window&apos;s screen, rather than the main screen for correctness.
2. Take the intersection of the screen&apos;s visible frame and the element&apos;s visible frame to avoid using an invalid rect.
3. Ensure the minimum origin of the window is (0, 0).

Originally-landed-as: 259548.702@safari-7615-branch (d7114d64c320). rdar://105190475
Canonical link: <a href="https://commits.webkit.org/266448@main">https://commits.webkit.org/266448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9ffe2c0ec01e011b368d318ca8681b623691928

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15501 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13074 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16203 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19453 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12911 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15797 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12276 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16711 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1622 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->