### PR TITLE
[JSC] MarkedVector::fill should register itself as a root

### DIFF
--- a/JSTests/stress/marked-buffer-fill-should-be-gc-aware.js
+++ b/JSTests/stress/marked-buffer-fill-should-be-gc-aware.js
@@ -1,0 +1,10 @@
+//@ runDefault("--slowPathAllocsBetweenGCs=10", "--jitPolicyScale=0")
+let a = new BigUint64Array(1000);
+
+function foo(a0) {
+  ~a0;
+}
+
+for (let i = 0; i < 1000; i++) {
+  foo.apply(null, a);
+}

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2393,7 +2393,7 @@ static void handleVarargsCheckpoint(VM& vm, CallFrame* callFrame, JSGlobalObject
     unsigned firstVarArg = bytecode.m_firstVarArg;
 
     MarkedArgumentBuffer args;
-    args.fill(argumentCountIncludingThis - 1, [&] (JSValue* buffer) {
+    args.fill(vm, argumentCountIncludingThis - 1, [&](JSValue* buffer) {
         loadVarargs(globalObject, buffer, callFrame->r(bytecode.m_arguments).jsValue(), firstVarArg, argumentCountIncludingThis - 1);
     });
     if (args.hasOverflowed()) {

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -208,14 +208,21 @@ public:
     }
 
     template<typename Functor>
-    void fill(size_t count, const Functor& func)
+    void fill(VM& vm, size_t count, const Functor& func)
     {
         ASSERT(!m_size);
         ensureCapacity(count);
         if (OverflowHandler::hasOverflowed())
             return;
+        if (LIKELY(!m_markSet)) {
+            m_markSet = &vm.heap.markListSet();
+            m_markSet->add(this);
+        }
         m_size = count;
-        func(reinterpret_cast<JSValue*>(&slotFor(0)));
+        auto* buffer = reinterpret_cast<JSValue*>(&slotFor(0));
+        for (unsigned i = 0; i < count; ++i)
+            buffer[i] = JSValue();
+        func(buffer);
     }
 
 private:


### PR DESCRIPTION
#### 929c0df4fd46d057005e2f6c953838dc2bad4b4d
<pre>
[JSC] MarkedVector::fill should register itself as a root
<a href="https://bugs.webkit.org/show_bug.cgi?id=255951">https://bugs.webkit.org/show_bug.cgi?id=255951</a>
rdar://108261913

Reviewed by Alexey Shvayka and Justin Michaud.

1. MarkedVector::fill is not registering itself as a strong root of GC. This patch fixes it with m_markSet-&gt;add.
2. Initialize buffer with empty value in MarkedVector::fill. This buffer can be scanned via GC when GC is invoked from
   a passed lambda.

* JSTests/stress/marked-buffer-fill-should-be-gc-aware.js: Added.
(foo):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::handleVarargsCheckpoint):
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::MarkedVector::fill):

Originally-landed-as: 259548.690@safari-7615-branch (b05050e0cc00). rdar://108261913
Canonical link: <a href="https://commits.webkit.org/266449@main">https://commits.webkit.org/266449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d022bff16de091982d31c658d93c0c47ac6eb652

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13075 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15760 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16204 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19463 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11743 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15807 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10993 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13808 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12379 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3599 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16712 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14195 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1623 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12953 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3409 "Passed tests") | 
<!--EWS-Status-Bubble-End-->