### PR TITLE
jsc_fuzz: ASSERTION FAILED: !is8Bit() || isEmpty() in stringProtoFuncToWellFormed()

### DIFF
--- a/JSTests/stress/regress-255806.js
+++ b/JSTests/stress/regress-255806.js
@@ -1,0 +1,4 @@
+let s0 = '000'.toLocaleUpperCase();
+let s1 = s0.slice(1);
+s1[s0] = undefined;
+s1.toWellFormed();

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -2046,6 +2046,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncToWellFormed, (JSGlobalObject* globalObj
     String string = stringValue->value(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    if (string.is8Bit())
+        return JSValue::encode(stringValue);
+
     const UChar* characters = string.characters16();
     unsigned length = string.length();
     auto firstIllFormedIndex = illFormedIndex(characters, length);


### PR DESCRIPTION
#### 8b034b74da84999cc6b0367194a106bfaa4a9fdf
<pre>
jsc_fuzz: ASSERTION FAILED: !is8Bit() || isEmpty() in stringProtoFuncToWellFormed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255806">https://bugs.webkit.org/show_bug.cgi?id=255806</a>
&lt;rdar://108256807&gt;

Reviewed by Yusuke Suzuki.

It&apos;s necessary to resolve a rope to determine if a string is 8-bit: JSRopeString&apos;s is8BitInPointer merely
implies it can be represented as 8-bit, but after the rope is resolved, it can become a 16-bit string.

* JSTests/stress/regress-255806.js: Added.
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Originally-landed-as: 259548.689@safari-7615-branch (a75d564e8c5f). rdar://108256807
Canonical link: <a href="https://commits.webkit.org/266450@main">https://commits.webkit.org/266450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79422d5c9caa3df287a1945ff832e5e1dd6895e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15503 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13076 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15754 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16205 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19454 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11744 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15798 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13036 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10989 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13809 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12380 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3600 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16713 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14196 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12954 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3408 "Passed tests") | 
<!--EWS-Status-Bubble-End-->