### PR TITLE
ANGLE mtl_render_utils.h various classes have uninitialised std::array<> members

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
@@ -219,7 +219,7 @@ class ClearUtils final : angle::NonCopyable
     const std::string mFragmentShaderName;
 
     // Render pipeline cache for clear with draw:
-    std::array<RenderPipelineCache, kMaxRenderTargets + 1> mClearRenderPipelineCache;
+    std::array<RenderPipelineCache, kMaxRenderTargets + 1> mClearRenderPipelineCache { };
 };
 
 class ColorBlitUtils final : angle::NonCopyable
@@ -258,9 +258,9 @@ class ColorBlitUtils final : angle::NonCopyable
     using ColorBlitRenderPipelineCacheArray =
         std::array<std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount>,
                    kMaxRenderTargets>;
-    ColorBlitRenderPipelineCacheArray mBlitRenderPipelineCache;
-    ColorBlitRenderPipelineCacheArray mBlitPremultiplyAlphaRenderPipelineCache;
-    ColorBlitRenderPipelineCacheArray mBlitUnmultiplyAlphaRenderPipelineCache;
+    ColorBlitRenderPipelineCacheArray mBlitRenderPipelineCache {{}};
+    ColorBlitRenderPipelineCacheArray mBlitPremultiplyAlphaRenderPipelineCache {{}};
+    ColorBlitRenderPipelineCacheArray mBlitUnmultiplyAlphaRenderPipelineCache {{}};
 };
 
 class DepthStencilBlitUtils final : angle::NonCopyable
@@ -300,14 +300,14 @@ class DepthStencilBlitUtils final : angle::NonCopyable
         ContextMtl *ctx,
         const StencilBlitViaBufferParams &params);
 
-    std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount> mDepthBlitRenderPipelineCache;
-    std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount> mStencilBlitRenderPipelineCache;
+    std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount> mDepthBlitRenderPipelineCache {};
+    std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount> mStencilBlitRenderPipelineCache {};
     std::array<std::array<RenderPipelineCache, mtl_shader::kTextureTypeCount>,
                mtl_shader::kTextureTypeCount>
-        mDepthStencilBlitRenderPipelineCache;
+        mDepthStencilBlitRenderPipelineCache {{}};
 
     std::array<AutoObjCPtr<id<MTLComputePipelineState>>, mtl_shader::kTextureTypeCount>
-        mStencilBlitToBufferComPipelineCache;
+        mStencilBlitToBufferComPipelineCache {};
 
     // Intermediate buffer for storing copied stencil data. Used when device doesn't support
     // writing stencil in shader.
@@ -417,12 +417,12 @@ class IndexGeneratorUtils final : angle::NonCopyable
                                                  const IndexGenerationParams &params,
                                                  size_t *indicesGenerated);
 
-    IndexConversionPipelineArray mIndexConversionPipelineCaches;
+    IndexConversionPipelineArray mIndexConversionPipelineCaches {{}};
 
-    IndexConversionPipelineArray mTriFanFromElemArrayGeneratorPipelineCaches;
+    IndexConversionPipelineArray mTriFanFromElemArrayGeneratorPipelineCaches {{}};
     AutoObjCPtr<id<MTLComputePipelineState>> mTriFanFromArraysGeneratorPipeline;
 
-    IndexConversionPipelineArray mLineLoopFromElemArrayGeneratorPipelineCaches;
+    IndexConversionPipelineArray mLineLoopFromElemArrayGeneratorPipelineCaches {{}};
     AutoObjCPtr<id<MTLComputePipelineState>> mLineLoopFromArraysGeneratorPipeline;
 };
 
@@ -444,7 +444,7 @@ class VisibilityResultUtils final : angle::NonCopyable
     // Visibility combination compute pipeline:
     // - 0: This compute pipeline only combine the new values and discard old value.
     // - 1: This compute pipeline keep the old value and combine with new values.
-    std::array<AutoObjCPtr<id<MTLComputePipelineState>>, 2> mVisibilityResultCombPipelines;
+    std::array<AutoObjCPtr<id<MTLComputePipelineState>>, 2> mVisibilityResultCombPipelines {};
 };
 
 // Util class for handling mipmap generation
@@ -499,7 +499,7 @@ class CopyPixelsUtils final : angle::NonCopyable
     using PixelsCopyPipelineArray = std::array<
         std::array<AutoObjCPtr<id<MTLComputePipelineState>>, mtl_shader::kTextureTypeCount * 2>,
         angle::kNumANGLEFormats>;
-    PixelsCopyPipelineArray mPixelsCopyPipelineCaches;
+    PixelsCopyPipelineArray mPixelsCopyPipelineCaches {{}};
 
     const std::string mReadShaderName;
     const std::string mWriteShaderName;
@@ -565,8 +565,8 @@ class VertexFormatConversionUtils final : angle::NonCopyable
     using ConvertToFloatRenderPipelineArray =
         std::array<RenderPipelineCache, angle::kNumANGLEFormats>;
 
-    ConvertToFloatCompPipelineArray mConvertToFloatCompPipelineCaches;
-    ConvertToFloatRenderPipelineArray mConvertToFloatRenderPipelineCaches;
+    ConvertToFloatCompPipelineArray mConvertToFloatCompPipelineCaches {};
+    ConvertToFloatRenderPipelineArray mConvertToFloatRenderPipelineCaches {};
 
     AutoObjCPtr<id<MTLComputePipelineState>> mComponentsExpandCompPipeline;
     RenderPipelineCache mComponentsExpandRenderPipelineCache;


### PR DESCRIPTION
#### b09ccb2a5411e524e25e9f1f6f1e15a0fce44b2c
<pre>
ANGLE mtl_render_utils.h various classes have uninitialised std::array&lt;&gt; members
<a href="https://bugs.webkit.org/show_bug.cgi?id=255865">https://bugs.webkit.org/show_bug.cgi?id=255865</a>
rdar://90537480

Reviewed by Dean Jackson.

Initialize all needed std::array&lt;&gt;s via value initialization.
The default initialization does not initialize the array, leading to
uninitialized reads.

The std::array&lt;&gt;s in RenderUtils are value-initialized in the constructor.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h:
(rx::mtl::RenderUtils::angle::EnumSize&lt;PixelType&gt;):

Originally-landed-as: 259548.681@safari-7615-branch (1e04ec38d7f9). rdar://90537480
Canonical link: <a href="https://commits.webkit.org/266451@main">https://commits.webkit.org/266451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f75321125ff977113b22abe07b164737c8be137

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13077 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15753 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16206 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11839 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12413 "1 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19455 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15799 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10988 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16714 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1625 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->