### PR TITLE
Renderinline::offsetForInFlowPositionedInline causes a null-deref of a laybox on repaint.

### DIFF
--- a/LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint-expected.txt
+++ b/LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint.html
+++ b/LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint.html
@@ -1,0 +1,17 @@
+<style>
+.class7 { position: relative; }
+</style>
+<script>
+function test() {
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  document.all[5].appendChild(htmlvar);
+  document.body.innerHTML = 'PASS if no crash.';
+}
+</script>
+<body onload=test()>
+<image src="data:image/gif;base64"></image>
+<table id="htmlvar" layout="fixed"></table>
+<font class="class7">
+<dialog open="true">

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -894,6 +894,11 @@ LayoutSize RenderInline::offsetForInFlowPositionedInline(const RenderBox* child)
         inlinePosition = LayoutUnit::fromFloatRound(firstLineBox()->logicalLeft());
         blockPosition = firstLineBox()->logicalTop();
     } else if (LayoutIntegration::LineLayout::containing(*this)) {
+        if (!layoutBox()) {
+            // Repaint may be issued on subtrees during content mutation with newly inserted renderers.
+            ASSERT(needsLayout());
+            return LayoutSize();
+        }
         if (auto inlineBox = InlineIterator::firstInlineBoxFor(*this)) {
             inlinePosition = LayoutUnit::fromFloatRound(inlineBox->logicalLeftIgnoringInlineDirection());
             blockPosition = inlineBox->logicalTop();


### PR DESCRIPTION
#### 51d7c7775f9625ce5679c11768b50eea2520b905
<pre>
Renderinline::offsetForInFlowPositionedInline causes a null-deref of a laybox on repaint.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255552.">https://bugs.webkit.org/show_bug.cgi?id=255552.</a>
rdar://107952390.

Reviewed by Alan Baradlay.

Line layout codepath invalidation is triggered by JS which issues a repaint on the newly inserted renderer. The newly inserted renderer is used for geometry computations and which calls offsetForInFlowPositionedInline in case of inline boxes. This tries to access the lineBoxes assocaited with the renderers but they invalidated by previous repaints. This leads to null deref of the lineboxes.

* LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint-expected.txt: Added.
* LayoutTests/fast/inline/layoutBox-null-deref-crash-on-repaint.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::isLineLayoutPresent const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::offsetForInFlowPositionedInline const):

Originally-landed-as: 259548.678@safari-7615-branch (7c662f5b36e3). rdar://107952390
Canonical link: <a href="https://commits.webkit.org/266452@main">https://commits.webkit.org/266452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863a85ffdee149ed8528d2d380cb2a31bb91e9c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13078 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14555 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19456 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15800 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12382 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12277 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16715 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1626 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->