### PR TITLE
Crash under WebKit::WebBackForwardCache::removeEntry()

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -47,7 +47,7 @@ class SuspendedPageProxy;
 class WebBackForwardCache;
 class WebBackForwardCacheEntry;
 
-class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem> {
+class WebBackForwardListItem : public API::ObjectImpl<API::Object::Type::BackForwardListItem>, public CanMakeWeakPtr<WebBackForwardListItem> {
 public:
     static Ref<WebBackForwardListItem> create(BackForwardListItemState&&, WebPageProxyIdentifier);
     virtual ~WebBackForwardListItem();

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -100,8 +100,8 @@ void WebBackForwardCache::removeEntry(WebBackForwardListItem& item)
 {
     ASSERT(m_itemsWithCachedPage.contains(&item));
     m_itemsWithCachedPage.removeFirst(&item);
-    item.setBackForwardCacheEntry(nullptr);
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::removeEntry: item=%s, size=%u/%u", item.itemID().toString().utf8().data(), size(), capacity());
+    item.setBackForwardCacheEntry(nullptr); // item may be dead after this call.
 }
 
 void WebBackForwardCache::removeEntry(SuspendedPageProxy& suspendedPage)
@@ -157,7 +157,7 @@ void WebBackForwardCache::removeEntriesForPageAndProcess(WebPageProxy& page, Web
 void WebBackForwardCache::removeEntriesMatching(const Function<bool(WebBackForwardListItem&)>& matches)
 {
     Vector<Ref<WebBackForwardListItem>> itemsWithEntriesToClear;
-    m_itemsWithCachedPage.removeAllMatching([&](auto* item) {
+    m_itemsWithCachedPage.removeAllMatching([&](auto& item) {
         if (matches(*item)) {
             itemsWithEntriesToClear.append(*item);
             return true;
@@ -173,7 +173,7 @@ void WebBackForwardCache::clear()
 {
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::clear");
     auto itemsWithCachedPage = WTFMove(m_itemsWithCachedPage);
-    for (auto* item : itemsWithCachedPage)
+    for (auto& item : itemsWithCachedPage)
         item->setBackForwardCacheEntry(nullptr);
 }
 

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -69,7 +69,8 @@ private:
 
     WebProcessPool& m_processPool;
     unsigned m_capacity { 0 };
-    Vector<WebBackForwardListItem*, 2> m_itemsWithCachedPage;
+    // Items cannot be null, we're using WeakPtr for hardening.
+    Vector<WeakPtr<WebBackForwardListItem>, 2> m_itemsWithCachedPage;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 31b24d6be480ea184a9a4eeee52d3d7d52a3bb2f
<pre>
Crash under WebKit::WebBackForwardCache::removeEntry()
<a href="https://bugs.webkit.org/show_bug.cgi?id=258698">https://bugs.webkit.org/show_bug.cgi?id=258698</a>
rdar://111524465

Reviewed by Ryosuke Niwa.

In WebBackForwardCache::removeEntry(), the call to `item.setBackForwardCacheEntry(nullptr)`
may cause the `item` to get destroyed. However, we were using `item` on the next line for
logging purpose. To fix the bug, I am moving the logging before the setBackForwardCacheEntry()
call.

for hardening purposes, I am also updating m_itemsWithCachedPage to contain WeakPtrs instead
of raw pointers.

* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntry):
(WebKit::WebBackForwardCache::removeEntriesMatching):
(WebKit::WebBackForwardCache::clear):
* Source/WebKit/UIProcess/WebBackForwardCache.h:

Originally-landed-as: 259548.865@safari-7615-branch (cb256ae0cae9). rdar://111524465
Canonical link: <a href="https://commits.webkit.org/266453@main">https://commits.webkit.org/266453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b220532a29a04e5cf525d2fdf3e214e5919f7cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16208 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11843 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19457 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16716 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1627 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->