### PR TITLE
[iOS] editing/selection/ios/change-selection-by-tapping-with-existing-selection.html fails

### DIFF
--- a/LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html
+++ b/LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html
@@ -49,7 +49,7 @@ addEventListener("load", async () => {
     description("Verifies that tapping to change selection works when we already have a selection in the same editable root but do not currently have a focused node in the UIKit sense.");
 
     var target = document.getElementById("target");
-    window.getSelection().setBaseAndExtent(target, 0, target, 1);
+    window.getSelection().setBaseAndExtent(target.firstChild, 0, target.firstChild, 2);
 
     document.querySelector("#selection-before").textContent = selectionToString();
     await tapAndWaitForSelectionChange(5, 5);


### PR DESCRIPTION
#### 0f709caa10acadb30de4b784fe3e6d8e49d1dcbb
<pre>
[iOS] editing/selection/ios/change-selection-by-tapping-with-existing-selection.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=259619">https://bugs.webkit.org/show_bug.cgi?id=259619</a>

Reviewed by Wenson Hsieh.

This test fails on iOS because the test was expecting the selection end points to be canonicalized.
Use canonicalized positions so that the output matches the expectation.

* LayoutTests/editing/selection/ios/change-selection-by-tapping-with-existing-selection.html:

Canonical link: <a href="https://commits.webkit.org/266413@main">https://commits.webkit.org/266413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ead9b420d88379223726c12b06c3d1782975ac1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15508 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13081 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16210 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19462 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15806 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12284 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16718 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1593 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->