### PR TITLE
Safari crashes when showing the downloads menu for a download with no MIME type

### DIFF
--- a/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
+++ b/Source/WebCore/loader/mac/LoaderNSURLExtras.mm
@@ -60,6 +60,9 @@ NSString *suggestedFilenameWithMIMEType(NSURL *url, const String& mimeType)
         extension = [filename pathExtension];
     }
 
+    if (!mimeType)
+        return filename;
+
     // Do not correct filenames that are reported with a mime type of tar, and 
     // have a filename which has .tar in it or ends in .tgz
     if ((mimeType == "application/tar"_s || mimeType == "application/x-tar"_s)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 		5C2C01A82734883600F89D37 /* CrossThreadCopierTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278DE64B22B8D611004E0E7A /* CrossThreadCopierTests.cpp */; };
 		5C4259462266A68A0039AA7A /* BasicProposedCredentialPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C42594422669E9B0039AA7A /* BasicProposedCredentialPlugIn.mm */; };
 		5C581D3227C8A01C006B3BC4 /* YouTubePluginReplacement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C581D3127C8A01C006B3BC4 /* YouTubePluginReplacement.cpp */; };
-		5C6E27A7224EEBEA00128736 /* URLCanonicalization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C6E27A6224EEBEA00128736 /* URLCanonicalization.mm */; };
+		5C6E27A7224EEBEA00128736 /* URLExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C6E27A6224EEBEA00128736 /* URLExtras.mm */; };
 		5C7101C725DD98B600686200 /* test_print.pdf in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5C7101C625DD988700686200 /* test_print.pdf */; };
 		5C75716122124C5200B9E5AC /* BundleRetainPagePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C75715F221249BD00B9E5AC /* BundleRetainPagePlugIn.mm */; };
 		5C7964101EB0278D0075D74C /* EventModifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C79640F1EB0269B0075D74C /* EventModifiers.cpp */; };
@@ -2616,7 +2616,7 @@
 		5C581D3127C8A01C006B3BC4 /* YouTubePluginReplacement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = YouTubePluginReplacement.cpp; sourceTree = "<group>"; };
 		5C5E633D1D0B67940085A025 /* UniqueRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UniqueRef.cpp; sourceTree = "<group>"; };
 		5C69BDD41F82A7EB000F4F4B /* JavaScriptDuringNavigation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JavaScriptDuringNavigation.mm; sourceTree = "<group>"; };
-		5C6E27A6224EEBEA00128736 /* URLCanonicalization.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = URLCanonicalization.mm; sourceTree = "<group>"; };
+		5C6E27A6224EEBEA00128736 /* URLExtras.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = URLExtras.mm; sourceTree = "<group>"; };
 		5C7101C625DD988700686200 /* test_print.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = test_print.pdf; sourceTree = "<group>"; };
 		5C7148942123A40700FDE3C5 /* WKWebsiteDatastore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebsiteDatastore.mm; sourceTree = "<group>"; };
 		5C72E8CD244FFCE300381EB7 /* TestLegacyDownloadDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestLegacyDownloadDelegate.h; path = cocoa/TestLegacyDownloadDelegate.h; sourceTree = "<group>"; };
@@ -4579,7 +4579,7 @@
 				6B306105218A372900F5A802 /* ClosingWebView.mm */,
 				9BAD7F3D22690F1400F8DA66 /* DeallocWebViewInEventListener.mm */,
 				5CF540E82257E64B00E6BC0E /* DownloadThread.mm */,
-				5C6E27A6224EEBEA00128736 /* URLCanonicalization.mm */,
+				5C6E27A6224EEBEA00128736 /* URLExtras.mm */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -6669,7 +6669,7 @@
 				5CABDBD22735C9BD00B88BCB /* UnifiedSource48-mm.mm in Sources */,
 				5CABDBC12735C9BD00B88BCB /* UnifiedSource49-mm.mm in Sources */,
 				5CABDBC02735C9BD00B88BCB /* UnifiedSource50-mm.mm in Sources */,
-				5C6E27A7224EEBEA00128736 /* URLCanonicalization.mm in Sources */,
+				5C6E27A7224EEBEA00128736 /* URLExtras.mm in Sources */,
 				E3A1E77F21B25B39008C6007 /* URLParserTextEncoding.cpp in Sources */,
 				7CCE7F2D1A411B1000447C4C /* UserContentTest.mm in Sources */,
 				E5AA42F2259128AE00410A3D /* UserInterfaceIdiomUpdate.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/URLExtras.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/URLExtras.mm
@@ -25,6 +25,7 @@
 
 #import "config.h"
 
+#import "PlatformUtilities.h"
 #import "Test.h"
 #import <WebKit/WebNSURLExtras.h>
 
@@ -35,6 +36,15 @@ TEST(WebKit, URLCanonicalization)
     NSURL *url = [NSURL URLWithString:@"http://a@/"];
     EXPECT_NOT_NULL(url);
     EXPECT_NULL([url _webkit_canonicalize_with_wtf]);
+}
+
+TEST(WebKit, SuggestedFilenameWithMIMEType)
+{
+    NSURL *url = [NSURL URLWithString:@"http://webkit.org/a"];
+    EXPECT_NOT_NULL(url);
+
+    EXPECT_WK_STREQ([url _webkit_suggestedFilenameWithMIMEType:nil], @"a");
+    EXPECT_WK_STREQ([url _webkit_suggestedFilenameWithMIMEType:@"image/jpeg"], @"a.jpg");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### d94ee98c76194e8e618a849534b8401c984f3c7f
<pre>
Safari crashes when showing the downloads menu for a download with no MIME type
<a href="https://bugs.webkit.org/show_bug.cgi?id=259622">https://bugs.webkit.org/show_bug.cgi?id=259622</a>
rdar://113058721

Reviewed by Wenson Hsieh.

* Source/WebCore/loader/mac/LoaderNSURLExtras.mm:
Add a null check.

* Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/URLExtras.mm: Renamed from Tools/TestWebKitAPI/Tests/WebKitLegacy/mac/URLCanonicalization.mm.
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
Rename URLCanonicalization to URLExtras and add a (very simple) positive and
negative test for _webkit_suggestedFilenameWithMIMEType, which was what
was triggering this crash.

Canonical link: <a href="https://commits.webkit.org/266414@main">https://commits.webkit.org/266414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3462a94965086644b889c4e7fcc8a3895edde8a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14170 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15763 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16213 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19464 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10997 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12388 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3348 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->