### PR TITLE
Keyboard scroll doesn't stop after pressing down arrow if `keyup` is default prevented

### DIFF
--- a/LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented.html
+++ b/LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ScrollAnimatorEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <meta name="viewport" content="initial-scale=1.5, user-scalable=no">
+    <script>
+        jsTestIsAsync = true;
+
+        async function runTest()
+        {
+            document.body.addEventListener('keyup', (e) => e.preventDefault());
+
+            if (window.eventSender) {
+                await UIHelper.startMonitoringWheelEvents();
+                await UIHelper.rawKeyDown("downArrow");
+                await UIHelper.renderingUpdate();
+                await UIHelper.rawKeyUp("downArrow");
+
+                await UIHelper.waitForScrollCompletion();
+                finishJSTest();
+            }
+        }
+    </script>
+</head>
+<body onload="runTest()">
+    <div style="height: 5000px;">
+    </div>
+</body>
+</html>

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3738,6 +3738,9 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown)
         matchedAnAccessKey = handleAccessKey(initialKeyEvent);
 
+    if (initialKeyEvent.type() == PlatformEvent::Type::KeyUp)
+        stopKeyboardScrolling();
+
     // FIXME: it would be fair to let an input method handle KeyUp events before DOM dispatch.
     if (initialKeyEvent.type() == PlatformEvent::Type::KeyUp || initialKeyEvent.type() == PlatformEvent::Type::Char)
         return !element->dispatchKeyEvent(initialKeyEvent);
@@ -3965,6 +3968,9 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
 {
     Ref protectedFrame { m_frame };
 
+    // 'keyup' is handled preemptively in `EventHandler::internalKeyEvent` so that keyboard scrolls
+    // can be properly terminated even if the event is default-prevented.
+
     if (event.type() == eventNames().keydownEvent) {
         m_frame.editor().handleKeyboardEvent(event);
         if (event.defaultHandled())
@@ -3998,8 +4004,6 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
         if (event.charCode() == ' ')
             defaultSpaceEventHandler(event);
     }
-    if (event.type() == eventNames().keyupEvent)
-        stopKeyboardScrolling();
 }
 
 #if ENABLE(DRAG_SUPPORT)


### PR DESCRIPTION
#### 768a90b9b462c18ff01d2a58b8ac14693a8afd6b
<pre>
Keyboard scroll doesn&apos;t stop after pressing down arrow if `keyup` is default prevented
<a href="https://bugs.webkit.org/show_bug.cgi?id=259623">https://bugs.webkit.org/show_bug.cgi?id=259623</a>
rdar://112396756

Reviewed by Tim Horton.

If a page prevents the default handling of the `keyup` event, but not `keydown`, a keyboard
scroll will be able to be started, but will never end because `EventHandler::defaultKeyboardEventHandler`
will never get called.

Fix by preemptively handling `keyup` in `EventHandler::internalKeyEvent` so that keyboard scrolls
will always be properly terminated even if the event is default-prevented.

* LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/keyboard-scroll-stops-with-keyup-prevented.html: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::defaultKeyboardEventHandler):

Canonical link: <a href="https://commits.webkit.org/266425@main">https://commits.webkit.org/266425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1574e80cc8cf138b2f98e6d147c2dc2814cb0dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15512 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16214 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12426 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19465 "3 flakes 112 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12927 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12289 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3360 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->