### PR TITLE
Generate serialization for LayerProperties

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -45,6 +45,8 @@ import sys
 # Validator - additional C++ to validate the value when decoding
 # NotSerialized - member is present in structure but intentionally not serialized.
 # SecureCodingAllowed - ObjC classes to allow when decoding.
+# OptionalTupleBits - This member stores bits of whether each following member is serialized. Attribute must be on first member.
+# OptionalTupleBit - The name of the bit indicating whether this member is serialized.
 
 class SerializedType(object):
     def __init__(self, struct_or_class, namespace, name, parent_class_name, members, condition, attributes, other_metadata=None):
@@ -123,6 +125,11 @@ class SerializedType(object):
     def serialized_members(self):
         return list(filter(lambda member: 'NotSerialized' not in member.attributes, self.members))
 
+    def has_optional_tuple_bits(self):
+        if len(self.members) == 0:
+            return False
+        return 'OptionalTupleBits' in self.members[0].attributes
+
 
 class SerializedEnum(object):
     def __init__(self, namespace, name, underlying_type, valid_values, condition, attributes):
@@ -168,6 +175,20 @@ class MemberVariable(object):
         self.attributes = attributes
         self.namespace = namespace
         self.is_subclass = is_subclass
+
+    def optional_tuple_bit(self):
+        for attribute in self.attributes:
+            match = re.search(r'OptionalTupleBit=(.*)', attribute)
+            if match:
+                bit, = match.groups()
+                return bit
+        return None
+
+    def optional_tuple_bits(self):
+        for attribute in self.attributes:
+            if attribute == 'OptionalTupleBits':
+                return True
+        return False
 
 
 class EnumMember(object):
@@ -368,7 +389,7 @@ def check_type_members(type, checking_parent_class):
                     result.append('#endif')
             result.append('    };')
             result.append('    static_assert(sizeof(ShouldBeSameSizeAs' + type.name + ') == sizeof(' + type.namespace_and_name() + '));')
-        result.append('    static_assert(MembersInCorrectOrder<0')
+        result.append('    static_assert(MembersInCorrectOrder < 0')
         for member in type.members:
             if 'BitField' in member.attributes:
                 continue
@@ -378,6 +399,63 @@ def check_type_members(type, checking_parent_class):
             if member.condition is not None:
                 result.append('#endif')
         result.append('    >::value);')
+    return result
+
+
+def encode_optional_tuple(type):
+    result = []
+    serialized_members = type.serialized_members()
+    result.append('    static_assert(static_cast<uint64_t>(' + serialized_members[1].optional_tuple_bit() + ') == 1);')
+    result.append('    static_assert(BitsInIncreasingOrder<')
+    for i in range(len(serialized_members)):
+        member = serialized_members[i]
+        bit = member.optional_tuple_bit()
+        if bit is not None:
+            if member.condition is not None:
+                result.append('#if ' + member.condition)
+            result.append('        ' + (', ' if i > 1 else '') + 'static_cast<uint64_t>(' + bit + ')')
+            if member.condition is not None:
+                result.append('#endif')
+    result.append('    >::value);')
+
+    for member in serialized_members:
+        if member.condition is not None:
+            result.append('#if ' + member.condition)
+        if member.optional_tuple_bits():
+            result.append('    encoder << instance.' + member.name + ';')
+            bits_variable_name = member.name
+        bit = member.optional_tuple_bit()
+        if bit is not None:
+            result.append('    if (instance.' + bits_variable_name + ' & ' + bit + ')')
+            result.append('        encoder << instance.' + member.name + ';')
+        if member.condition is not None:
+            result.append('#endif')
+    return result
+
+
+def decode_optional_tuple(type):
+    result = []
+    bits_variable_name = None
+    result.append('    ' + type.namespace_and_name() + ' result;')
+    for member in type.serialized_members():
+        if member.optional_tuple_bits():
+            result.append('    auto bits = decoder.decode<' + member.type + '>();')
+            result.append('    if (!bits)')
+            result.append('        return std::nullopt;')
+            result.append('    result.' + member.name + ' = *bits;')
+        bit = member.optional_tuple_bit()
+        if bit is not None:
+            if member.condition is not None:
+                result.append('#if ' + member.condition)
+            result.append('    if (*bits & ' + bit + ') {')
+            result.append('        if (auto deserialized = decoder.decode<' + member.type + '>())')
+            result.append('            result.' + member.name + ' = WTFMove(*deserialized);')
+            result.append('        else')
+            result.append('            return std::nullopt;')
+            result.append('    }')
+            if member.condition is not None:
+                result.append('#endif')
+        result.append('')
     return result
 
 
@@ -506,9 +584,19 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             result.append('#endif')
     result.append('')
     result.append('template<size_t...> struct MembersInCorrectOrder;')
-    result.append('template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> { static constexpr bool value = true; };')
+    result.append('template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> {')
+    result.append('    static constexpr bool value = true;')
+    result.append('};')
     result.append('template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> struct MembersInCorrectOrder<firstOffset, secondOffset, remainingOffsets...> {')
     result.append('    static constexpr bool value = firstOffset > secondOffset ? false : MembersInCorrectOrder<secondOffset, remainingOffsets...>::value;')
+    result.append('};')
+    result.append('')
+    result.append('template<uint64_t...> struct BitsInIncreasingOrder;')
+    result.append('template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {')
+    result.append('    static constexpr bool value = true;')
+    result.append('};')
+    result.append('template<uint64_t firstBit, uint64_t secondBit, uint64_t... remainingBits> struct BitsInIncreasingOrder<firstBit, secondBit, remainingBits...> {')
+    result.append('    static constexpr bool value = firstBit == secondBit >> 1 && BitsInIncreasingOrder<secondBit, remainingBits...>::value;')
     result.append('};')
     result.append('')
     result.append('template<bool, bool> struct VirtualTableAndRefCountOverhead;')
@@ -577,7 +665,10 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
             result.append('{')
             if not type.members_are_subclasses:
                 result = result + check_type_members(type, False)
-            result = result + encode_type(type)
+            if type.has_optional_tuple_bits():
+                result = result + encode_optional_tuple(type)
+            else:
+                result = result + encode_type(type)
             if type.members_are_subclasses:
                 result.append('    ASSERT_NOT_REACHED();')
             result.append('}')
@@ -587,10 +678,14 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
         else:
             result.append('std::optional<' + type.namespace_and_name() + '> ArgumentCoder<' + type.namespace_and_name() + '>::decode(Decoder& decoder)')
         result.append('{')
-        result = result + decode_type(type)
+        if type.has_optional_tuple_bits():
+            result = result + decode_optional_tuple(type)
+        else:
+            result = result + decode_type(type)
         if not type.members_are_subclasses:
-            result.append('    if (UNLIKELY(!decoder.isValid()))')
-            result.append('        return std::nullopt;')
+            if not type.has_optional_tuple_bits():
+                result.append('    if (UNLIKELY(!decoder.isValid()))')
+                result.append('        return std::nullopt;')
             if type.populate_from_empty_constructor:
                 result.append('    ' + type.namespace_and_name() + ' result;')
                 for member in type.serialized_members():
@@ -599,6 +694,8 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
                     result.append('    result.' + member.name + ' = WTFMove(*' + member.name + ');')
                     if member.condition is not None:
                         result.append('#endif')
+                result.append('    return { WTFMove(result) };')
+            elif type.has_optional_tuple_bits():
                 result.append('    return { WTFMove(result) };')
             else:
                 result.append('    return {')
@@ -686,6 +783,24 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     return '\n'.join(result)
 
 
+def generate_optional_tuple_type_info(type):
+    result = []
+    result.append('            {')
+    result.append('                "OptionalTuple<"')
+    serialized_members = type.serialized_members()
+    for i in range(1, len(serialized_members)):
+        member = serialized_members[i]
+        if member.condition is not None:
+            result.append('#if ' + member.condition)
+        result.append('                    "' + (', ' if i > 1 else '') + member.type + '"')
+        if member.condition is not None:
+            result.append('#endif')
+    result.append('                ">"_s,')
+    result.append('                "optionalTuple"_s')
+    result.append('            },')
+    return result
+
+
 def generate_serialized_type_info(serialized_types, serialized_enums, headers, typedefs):
     result = []
     result.append(_license_header)
@@ -708,6 +823,10 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, t
     result.append('    return {')
     for type in serialized_types:
         result.append('        { "' + type.namespace_unless_wtf_and_name() + '"_s, {')
+        if type.has_optional_tuple_bits():
+            result = result + generate_optional_tuple_type_info(type)
+            result.append('        } },')
+            continue
         if type.members_are_subclasses:
             result.append('            { "std::variant<' + ', '.join([member.namespace + '::' + member.name for member in type.members]) + '>"_s, "subclasses"_s }')
             result.append('        } },')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -34,6 +34,7 @@
 #include "FirstMemberType.h"
 #endif
 #include "HeaderWithoutCondition"
+#include "LayerProperties.h"
 #if ENABLE(TEST_FEATURE)
 #include "SecondMemberType.h"
 #endif
@@ -53,9 +54,19 @@
 #include <wtf/Seconds.h>
 
 template<size_t...> struct MembersInCorrectOrder;
-template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> { static constexpr bool value = true; };
+template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> {
+    static constexpr bool value = true;
+};
 template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> struct MembersInCorrectOrder<firstOffset, secondOffset, remainingOffsets...> {
     static constexpr bool value = firstOffset > secondOffset ? false : MembersInCorrectOrder<secondOffset, remainingOffsets...>::value;
+};
+
+template<uint64_t...> struct BitsInIncreasingOrder;
+template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {
+    static constexpr bool value = true;
+};
+template<uint64_t firstBit, uint64_t secondBit, uint64_t... remainingBits> struct BitsInIncreasingOrder<firstBit, secondBit, remainingBits...> {
+    static constexpr bool value = firstBit == secondBit >> 1 && BitsInIncreasingOrder<secondBit, remainingBits...>::value;
 };
 
 template<bool, bool> struct VirtualTableAndRefCountOverhead;
@@ -115,7 +126,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder
         RetainPtr<CFTypeRef> nullableTestMember;
     };
     static_assert(sizeof(ShouldBeSameSizeAsStructName) == sizeof(Namespace::Subnamespace::StructName));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::Subnamespace::StructName, firstMemberName)
 #if ENABLE(SECOND_MEMBER)
         , offsetof(Namespace::Subnamespace::StructName, secondMemberName)
@@ -144,7 +155,7 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
         RetainPtr<CFTypeRef> nullableTestMember;
     };
     static_assert(sizeof(ShouldBeSameSizeAsStructName) == sizeof(Namespace::Subnamespace::StructName));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::Subnamespace::StructName, firstMemberName)
 #if ENABLE(SECOND_MEMBER)
         , offsetof(Namespace::Subnamespace::StructName, secondMemberName)
@@ -191,7 +202,7 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
         RetainPtr<NSArray> dataDetectorResults;
     };
     static_assert(sizeof(ShouldBeSameSizeAsOtherClass) == sizeof(Namespace::OtherClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::OtherClass, a)
         , offsetof(Namespace::OtherClass, dataDetectorResults)
     >::value);
@@ -251,7 +262,7 @@ void ArgumentCoder<Namespace::EmptyConstructorStruct>::encode(Encoder& encoder, 
         double m_double;
     };
     static_assert(sizeof(ShouldBeSameSizeAsEmptyConstructorStruct) == sizeof(Namespace::EmptyConstructorStruct));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::EmptyConstructorStruct, m_int)
         , offsetof(Namespace::EmptyConstructorStruct, m_double)
     >::value);
@@ -288,7 +299,7 @@ void ArgumentCoder<Namespace::EmptyConstructorWithIf>::encode(Encoder& encoder, 
 #endif
     };
     static_assert(sizeof(ShouldBeSameSizeAsEmptyConstructorWithIf) == sizeof(Namespace::EmptyConstructorWithIf));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
         , offsetof(Namespace::EmptyConstructorWithIf, m_type)
 #endif
@@ -331,7 +342,7 @@ void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutName
         int a;
     };
     static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespace) == sizeof(WithoutNamespace));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
     encoder << instance.a;
@@ -356,7 +367,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(Encoder& encoder, con
         int a;
     };
     static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespaceWithAttributes) == sizeof(WithoutNamespaceWithAttributes));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
     encoder << instance.a;
@@ -369,7 +380,7 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder
         int a;
     };
     static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespaceWithAttributes) == sizeof(WithoutNamespaceWithAttributes));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
     encoder << instance.a;
@@ -390,11 +401,11 @@ std::optional<WithoutNamespaceWithAttributes> ArgumentCoder<WithoutNamespaceWith
 void ArgumentCoder<WebCore::InheritsFrom>::encode(Encoder& encoder, const WebCore::InheritsFrom& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritsFrom, b)
     >::value);
     encoder << instance.a;
@@ -420,15 +431,15 @@ std::optional<WebCore::InheritsFrom> ArgumentCoder<WebCore::InheritsFrom>::decod
 void ArgumentCoder<WebCore::InheritanceGrandchild>::encode(Encoder& encoder, const WebCore::InheritanceGrandchild& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WithoutNamespace, a)
     >::value);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, float>);
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritsFrom, b)
     >::value);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.c)>, double>);
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::InheritanceGrandchild, c)
     >::value);
     encoder << instance.a;
@@ -481,7 +492,7 @@ void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::C
         double value;
     };
     static_assert(sizeof(ShouldBeSameSizeAsCreateUsingClass) == sizeof(WTF::CreateUsingClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WTF::CreateUsingClass, value)
     >::value);
     encoder << instance.value;
@@ -538,7 +549,7 @@ void ArgumentCoder<SoftLinkedMember>::encode(Encoder& encoder, const SoftLinkedM
         RetainPtr<DDActionContext> secondMember;
     };
     static_assert(sizeof(ShouldBeSameSizeAsSoftLinkedMember) == sizeof(SoftLinkedMember));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(SoftLinkedMember, firstMember)
         , offsetof(SoftLinkedMember, secondMember)
     >::value);
@@ -634,7 +645,7 @@ void ArgumentCoder<Namespace::ConditionalCommonClass>::encode(Encoder& encoder, 
         int value;
     };
     static_assert(sizeof(ShouldBeSameSizeAsConditionalCommonClass) == sizeof(Namespace::ConditionalCommonClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::ConditionalCommonClass, value)
     >::value);
     encoder << instance.value;
@@ -661,7 +672,7 @@ void ArgumentCoder<Namespace::CommonClass>::encode(Encoder& encoder, const Names
         int value;
     };
     static_assert(sizeof(ShouldBeSameSizeAsCommonClass) == sizeof(Namespace::CommonClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::CommonClass, value)
     >::value);
     encoder << instance.value;
@@ -688,7 +699,7 @@ void ArgumentCoder<Namespace::AnotherCommonClass>::encode(Encoder& encoder, cons
         double notSerialized;
     };
     static_assert(sizeof(ShouldBeSameSizeAsAnotherCommonClass) == sizeof(Namespace::AnotherCommonClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(Namespace::AnotherCommonClass, value)
         , offsetof(Namespace::AnotherCommonClass, notSerialized)
     >::value);
@@ -746,7 +757,7 @@ void ArgumentCoder<WebCore::MoveOnlyDerivedClass>::encode(Encoder& encoder, WebC
         int secondMember;
     };
     static_assert(sizeof(ShouldBeSameSizeAsMoveOnlyDerivedClass) == sizeof(WebCore::MoveOnlyDerivedClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WebCore::MoveOnlyDerivedClass, firstMember)
         , offsetof(WebCore::MoveOnlyDerivedClass, secondMember)
     >::value);
@@ -778,6 +789,86 @@ std::optional<WebKit::CustomEncoded> ArgumentCoder<WebKit::CustomEncoded>::decod
             WTFMove(*value)
         }
     };
+}
+
+void ArgumentCoder<WebKit::LayerProperties>::encode(Encoder& encoder, const WebKit::LayerProperties& instance)
+{
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.changedProperties)>, OptionSet<WebKit::LayerChange>>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nonSerializedMember)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.name)>, String>);
+#if ENABLE(FEATURE)
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.featureEnabledMember)>, std::unique_ptr<WebCore::TransformationMatrix>>);
+#endif
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.bitFieldMember)>, bool>);
+    struct ShouldBeSameSizeAsLayerProperties : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WebKit::LayerProperties>, false> {
+        OptionSet<WebKit::LayerChange> changedProperties;
+        int nonSerializedMember;
+        String name;
+#if ENABLE(FEATURE)
+        std::unique_ptr<WebCore::TransformationMatrix> featureEnabledMember;
+#endif
+        bool bitFieldMember : 1;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsLayerProperties) == sizeof(WebKit::LayerProperties));
+    static_assert(MembersInCorrectOrder < 0
+        , offsetof(WebKit::LayerProperties, changedProperties)
+        , offsetof(WebKit::LayerProperties, nonSerializedMember)
+        , offsetof(WebKit::LayerProperties, name)
+#if ENABLE(FEATURE)
+        , offsetof(WebKit::LayerProperties, featureEnabledMember)
+#endif
+    >::value);
+    static_assert(static_cast<uint64_t>(WebKit::LayerChange::NameChanged) == 1);
+    static_assert(BitsInIncreasingOrder<
+        static_cast<uint64_t>(WebKit::LayerChange::NameChanged)
+#if ENABLE(FEATURE)
+        , static_cast<uint64_t>(WebKit::LayerChange::TransformChanged)
+#endif
+        , static_cast<uint64_t>(WebKit::LayerChange::FeatureEnabledMember)
+    >::value);
+    encoder << instance.changedProperties;
+    if (instance.changedProperties & WebKit::LayerChange::NameChanged)
+        encoder << instance.name;
+#if ENABLE(FEATURE)
+    if (instance.changedProperties & WebKit::LayerChange::TransformChanged)
+        encoder << instance.featureEnabledMember;
+#endif
+    if (instance.changedProperties & WebKit::LayerChange::FeatureEnabledMember)
+        encoder << instance.bitFieldMember;
+}
+
+std::optional<WebKit::LayerProperties> ArgumentCoder<WebKit::LayerProperties>::decode(Decoder& decoder)
+{
+    WebKit::LayerProperties result;
+    auto bits = decoder.decode<OptionSet<WebKit::LayerChange>>();
+    if (!bits)
+        return std::nullopt;
+    result.changedProperties = *bits;
+
+    if (*bits & WebKit::LayerChange::NameChanged) {
+        if (auto deserialized = decoder.decode<String>())
+            result.name = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+
+#if ENABLE(FEATURE)
+    if (*bits & WebKit::LayerChange::TransformChanged) {
+        if (auto deserialized = decoder.decode<std::unique_ptr<WebCore::TransformationMatrix>>())
+            result.featureEnabledMember = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+#endif
+
+    if (*bits & WebKit::LayerChange::FeatureEnabledMember) {
+        if (auto deserialized = decoder.decode<bool>())
+            result.bitFieldMember = WTFMove(*deserialized);
+        else
+            return std::nullopt;
+    }
+
+    return { WTFMove(result) };
 }
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -65,6 +65,7 @@ namespace WebCore { class MoveOnlyBaseClass; }
 namespace WebCore { class MoveOnlyDerivedClass; }
 namespace WebKit { class PlatformClass; }
 namespace WebKit { class CustomEncoded; }
+namespace WebKit { class LayerProperties; }
 
 namespace IPC {
 
@@ -176,6 +177,11 @@ template<> struct ArgumentCoder<WebKit::PlatformClass> {
 template<> struct ArgumentCoder<WebKit::CustomEncoded> {
     static void encode(Encoder&, const WebKit::CustomEncoded&);
     static std::optional<WebKit::CustomEncoded> decode(Decoder&);
+};
+
+template<> struct ArgumentCoder<WebKit::LayerProperties> {
+    static void encode(Encoder&, const WebKit::LayerProperties&);
+    static std::optional<WebKit::LayerProperties> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -34,6 +34,7 @@
 #include "FirstMemberType.h"
 #endif
 #include "HeaderWithoutCondition"
+#include "LayerProperties.h"
 #include "PlatformClass.h"
 #if ENABLE(TEST_FEATURE)
 #include "SecondMemberType.h"
@@ -236,6 +237,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             {
                 "int"_s,
                 "value"_s
+            },
+        } },
+        { "WebKit::LayerProperties"_s, {
+            {
+                "OptionalTuple<"
+                    "String"
+#if ENABLE(FEATURE)
+                    ", std::unique_ptr<WebCore::TransformationMatrix>"
+#endif
+                    ", bool"
+                ">"_s,
+                "optionalTuple"_s
             },
         } },
         { "WebCore::SharedStringHash"_s, {

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -172,3 +172,13 @@ webkit_platform_headers: "PlatformClass.h"
 [CustomEncoder] class WebKit::CustomEncoded {
   int value;
 };
+
+class WebKit::LayerProperties {
+    [OptionalTupleBits] OptionSet<WebKit::LayerChange> changedProperties
+    [NotSerialized] int nonSerializedMember
+    [OptionalTupleBit=WebKit::LayerChange::NameChanged] String name;
+#if ENABLE(FEATURE)
+    [OptionalTupleBit=WebKit::LayerChange::TransformChanged] std::unique_ptr<WebCore::TransformationMatrix> featureEnabledMember;
+#endif
+    [OptionalTupleBit=WebKit::LayerChange::FeatureEnabledMember, BitField] bool bitFieldMember;
+};

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -28,9 +28,19 @@
 #include "PlatformClass.h"
 
 template<size_t...> struct MembersInCorrectOrder;
-template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> { static constexpr bool value = true; };
+template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> {
+    static constexpr bool value = true;
+};
 template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> struct MembersInCorrectOrder<firstOffset, secondOffset, remainingOffsets...> {
     static constexpr bool value = firstOffset > secondOffset ? false : MembersInCorrectOrder<secondOffset, remainingOffsets...>::value;
+};
+
+template<uint64_t...> struct BitsInIncreasingOrder;
+template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {
+    static constexpr bool value = true;
+};
+template<uint64_t firstBit, uint64_t secondBit, uint64_t... remainingBits> struct BitsInIncreasingOrder<firstBit, secondBit, remainingBits...> {
+    static constexpr bool value = firstBit == secondBit >> 1 && BitsInIncreasingOrder<secondBit, remainingBits...>::value;
 };
 
 template<bool, bool> struct VirtualTableAndRefCountOverhead;
@@ -75,7 +85,7 @@ void ArgumentCoder<WebKit::PlatformClass>::encode(Encoder& encoder, const WebKit
         int value;
     };
     static_assert(sizeof(ShouldBeSameSizeAsPlatformClass) == sizeof(WebKit::PlatformClass));
-    static_assert(MembersInCorrectOrder<0
+    static_assert(MembersInCorrectOrder < 0
         , offsetof(WebKit::PlatformClass, value)
     >::value);
     encoder << instance.value;

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -34,65 +34,76 @@ class RemoteLayerBackingStore;
 class RemoteLayerBackingStoreProperties;
 
 enum class LayerChange : uint64_t {
-    NameChanged                         = 1LLU << 1,
-    ChildrenChanged                     = 1LLU << 2,
-    PositionChanged                     = 1LLU << 3,
-    BoundsChanged                       = 1LLU << 4,
-    BackgroundColorChanged              = 1LLU << 5,
-    AnchorPointChanged                  = 1LLU << 6,
-    BorderWidthChanged                  = 1LLU << 7,
-    BorderColorChanged                  = 1LLU << 8,
-    OpacityChanged                      = 1LLU << 9,
-    TransformChanged                    = 1LLU << 10,
-    SublayerTransformChanged            = 1LLU << 11,
-    HiddenChanged                       = 1LLU << 12,
-    GeometryFlippedChanged              = 1LLU << 13,
-    DoubleSidedChanged                  = 1LLU << 14,
-    MasksToBoundsChanged                = 1LLU << 15,
-    OpaqueChanged                       = 1LLU << 16,
-    ContentsHiddenChanged               = 1LLU << 17,
-    MaskLayerChanged                    = 1LLU << 18,
-    ClonedContentsChanged               = 1LLU << 19,
-    ContentsRectChanged                 = 1LLU << 20,
-    ContentsScaleChanged                = 1LLU << 21,
-    CornerRadiusChanged                 = 1LLU << 22,
-    ShapeRoundedRectChanged             = 1LLU << 23,
-    ShapePathChanged                    = 1LLU << 24,
-    MinificationFilterChanged           = 1LLU << 25,
-    MagnificationFilterChanged          = 1LLU << 26,
-    BlendModeChanged                    = 1LLU << 27,
-    WindRuleChanged                     = 1LLU << 28,
-    SpeedChanged                        = 1LLU << 29,
-    TimeOffsetChanged                   = 1LLU << 30,
-    BackingStoreChanged                 = 1LLU << 31,
-    BackingStoreAttachmentChanged       = 1LLU << 32,
-    FiltersChanged                      = 1LLU << 33,
-    AnimationsChanged                   = 1LLU << 34,
-    AntialiasesEdgesChanged             = 1LLU << 35,
-    CustomAppearanceChanged             = 1LLU << 36,
+    NameChanged                         = 1LLU << 0,
+    TransformChanged                    = 1LLU << 1,
+    SublayerTransformChanged            = 1LLU << 2,
+    ShapeRoundedRectChanged             = 1LLU << 3,
+    ChildrenChanged                     = 1LLU << 4,
+    AnimationsChanged                   = 1LLU << 5,
+    PositionChanged                     = 1LLU << 6,
+    AnchorPointChanged                  = 1LLU << 7,
+    BoundsChanged                       = 1LLU << 8,
+    ContentsRectChanged                 = 1LLU << 9,
+    BackingStoreChanged                 = 1LLU << 10,
+    FiltersChanged                      = 1LLU << 11,
+    ShapePathChanged                    = 1LLU << 12,
+    MaskLayerChanged                    = 1LLU << 13,
+    ClonedContentsChanged               = 1LLU << 14,
+    TimeOffsetChanged                   = 1LLU << 15,
+    SpeedChanged                        = 1LLU << 16,
+    ContentsScaleChanged                = 1LLU << 17,
+    CornerRadiusChanged                 = 1LLU << 18,
+    BorderWidthChanged                  = 1LLU << 19,
+    OpacityChanged                      = 1LLU << 20,
+    BackgroundColorChanged              = 1LLU << 21,
+    BorderColorChanged                  = 1LLU << 22,
+    CustomAppearanceChanged             = 1LLU << 23,
+    MinificationFilterChanged           = 1LLU << 24,
+    MagnificationFilterChanged          = 1LLU << 25,
+    BlendModeChanged                    = 1LLU << 26,
+    WindRuleChanged                     = 1LLU << 27,
+    VideoGravityChanged                 = 1LLU << 28,
+    AntialiasesEdgesChanged             = 1LLU << 29,
+    HiddenChanged                       = 1LLU << 30,
+    BackingStoreAttachmentChanged       = 1LLU << 31,
+    GeometryFlippedChanged              = 1LLU << 32,
+    DoubleSidedChanged                  = 1LLU << 33,
+    MasksToBoundsChanged                = 1LLU << 34,
+    OpaqueChanged                       = 1LLU << 35,
+    ContentsHiddenChanged               = 1LLU << 36,
     UserInteractionEnabledChanged       = 1LLU << 37,
     EventRegionChanged                  = 1LLU << 38,
+#if ENABLE(SCROLLING_THREAD)
     ScrollingNodeIDChanged              = 1LLU << 39,
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    SeparatedChanged                    = 1LLU << 40,
+    SeparatedChanged                    = 1LLU << 39,
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    SeparatedPortalChanged              = 1LLU << 41,
-    DescendentOfSeparatedPortalChanged  = 1LLU << 42,
+    SeparatedPortalChanged              = 1LLU << 40,
+    DescendentOfSeparatedPortalChanged  = 1LLU << 41,
 #endif
 #endif
-    VideoGravityChanged                 = 1LLU << 44,
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CoverageRectChanged                 = 1LLU << 45,
+    CoverageRectChanged                 = 1LLU << 42,
 #endif
+};
+
+struct RemoteLayerBackingStoreOrProperties {
+    RemoteLayerBackingStoreOrProperties() = default;
+    ~RemoteLayerBackingStoreOrProperties();
+    RemoteLayerBackingStoreOrProperties(RemoteLayerBackingStoreOrProperties&&) = default;
+    RemoteLayerBackingStoreOrProperties& operator=(RemoteLayerBackingStoreOrProperties&&) = default;
+    RemoteLayerBackingStoreOrProperties(std::unique_ptr<RemoteLayerBackingStoreProperties>&& properties)
+        : properties(WTFMove(properties)) { }
+
+    // Used in the WebContent process.
+    std::unique_ptr<RemoteLayerBackingStore> store;
+    // Used in the UI process.
+    std::unique_ptr<RemoteLayerBackingStoreProperties> properties;
 };
 
 struct LayerProperties {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    LayerProperties();
-    LayerProperties(LayerProperties&&);
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, LayerProperties&);
 
     void notePropertiesChanged(OptionSet<LayerChange> changeFlags)
     {
@@ -115,28 +126,24 @@ struct LayerProperties {
 
     Vector<WebCore::PlatformLayerIdentifier> children;
 
-    Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
-    HashSet<String> keysOfAnimationsToRemove;
+    struct AnimationChanges {
+        Vector<std::pair<String, PlatformCAAnimationRemote::Properties>> addedAnimations;
+        HashSet<String> keysOfAnimationsToRemove;
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
-    Vector<Ref<WebCore::AcceleratedEffect>> effects;
-    WebCore::AcceleratedEffectValues baseValues;
+        Vector<Ref<WebCore::AcceleratedEffect>> effects;
+        WebCore::AcceleratedEffectValues baseValues;
 #endif
+    } animationChanges;
 
     WebCore::FloatPoint3D position;
     WebCore::FloatPoint3D anchorPoint { 0.5, 0.5, 0 };
     WebCore::FloatRect bounds;
     WebCore::FloatRect contentsRect { 0, 0, 1, 1 };
-    // Used in the WebContent process.
-    std::unique_ptr<RemoteLayerBackingStore> backingStore;
-    // Used in the UI process.
-    std::unique_ptr<RemoteLayerBackingStoreProperties> backingStoreProperties;
+    RemoteLayerBackingStoreOrProperties backingStoreOrProperties;
     std::unique_ptr<WebCore::FilterOperations> filters;
     WebCore::Path shapePath;
     Markable<WebCore::PlatformLayerIdentifier> maskLayerID;
     Markable<WebCore::PlatformLayerIdentifier> clonedLayerID;
-#if ENABLE(SCROLLING_THREAD)
-    WebCore::ScrollingNodeID scrollingNodeID { 0 };
-#endif
     double timeOffset { 0 };
     float speed { 1 };
     float contentsScale { 1 };
@@ -162,6 +169,9 @@ struct LayerProperties {
     bool userInteractionEnabled { true };
     WebCore::EventRegion eventRegion;
 
+#if ENABLE(SCROLLING_THREAD)
+    WebCore::ScrollingNodeID scrollingNodeID { 0 };
+#endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     WebCore::FloatRect coverageRect;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -251,6 +251,7 @@ class RemoteLayerBackingStoreProperties {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     RemoteLayerBackingStoreProperties() = default;
+    RemoteLayerBackingStoreProperties(RemoteLayerBackingStoreProperties&&) = default;
 
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteLayerBackingStoreProperties&);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -97,8 +97,8 @@ Vector<std::unique_ptr<WebCore::ThreadSafeImageBufferFlusher>> RemoteLayerBackin
     for (auto& layer : transaction.changedLayers()) {
         if (layer->properties().changedProperties & LayerChange::BackingStoreChanged) {
             needToScheduleVolatilityTimer = true;
-            if (layer->properties().backingStore)
-                flushers.appendVector(layer->properties().backingStore->takePendingFlushers());
+            if (layer->properties().backingStoreOrProperties.store)
+                flushers.appendVector(layer->properties().backingStoreOrProperties.store->takePendingFlushers());
         }
 
         layer->didCommit();

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -23,52 +23,54 @@
 header: "RemoteLayerTreeTransaction.h"
 [OptionSet] enum class WebKit::LayerChange : uint64_t {
     NameChanged
-    ChildrenChanged
-    PositionChanged
-    BoundsChanged
-    BackgroundColorChanged
-    AnchorPointChanged
-    BorderWidthChanged
-    BorderColorChanged
-    OpacityChanged
     TransformChanged
     SublayerTransformChanged
+    ShapeRoundedRectChanged
+    ChildrenChanged
+    AnimationsChanged
+    PositionChanged
+    AnchorPointChanged
+    BoundsChanged
+    ContentsRectChanged
+    BackingStoreChanged
+    FiltersChanged
+    ShapePathChanged
+    MaskLayerChanged
+    ClonedContentsChanged
+    TimeOffsetChanged
+    SpeedChanged
+    ContentsScaleChanged
+    CornerRadiusChanged
+    BorderWidthChanged
+    OpacityChanged
+    BackgroundColorChanged
+    BorderColorChanged
+    CustomAppearanceChanged
+    MinificationFilterChanged
+    MagnificationFilterChanged
+    BlendModeChanged
+    WindRuleChanged
+    VideoGravityChanged
+    AntialiasesEdgesChanged
     HiddenChanged
+    BackingStoreAttachmentChanged
     GeometryFlippedChanged
     DoubleSidedChanged
     MasksToBoundsChanged
     OpaqueChanged
     ContentsHiddenChanged
-    MaskLayerChanged
-    ClonedContentsChanged
-    ContentsRectChanged
-    ContentsScaleChanged
-    CornerRadiusChanged
-    ShapeRoundedRectChanged
-    ShapePathChanged
-    MinificationFilterChanged
-    MagnificationFilterChanged
-    BlendModeChanged
-    WindRuleChanged
-    SpeedChanged
-    TimeOffsetChanged
-    BackingStoreChanged
-    BackingStoreAttachmentChanged
-    FiltersChanged
-    AnimationsChanged
-    AntialiasesEdgesChanged
-    CustomAppearanceChanged
     UserInteractionEnabledChanged
     EventRegionChanged
+#if ENABLE(SCROLLING_THREAD)
+    ScrollingNodeIDChanged
+#endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     SeparatedChanged
-#endif
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS) && HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
+#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
     SeparatedPortalChanged
     DescendentOfSeparatedPortalChanged
 #endif
-    ScrollingNodeIDChanged
-    VideoGravityChanged
+#endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     CoverageRectChanged
 #endif
@@ -168,5 +170,80 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
 #endif
 #if !ENABLE(MODEL_ELEMENT)
     std::variant<WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::NoAdditionalData, WebKit::RemoteLayerTreeTransaction::LayerCreationProperties::CustomData, WebCore::LayerHostingContextIdentifier> additionalData;
+#endif
+};
+
+[Nested] struct WebKit::LayerProperties::AnimationChanges {
+    Vector<std::pair<String, WebKit::PlatformCAAnimationRemote::Properties>> addedAnimations;
+    HashSet<String> keysOfAnimationsToRemove;
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+    Vector<Ref<WebCore::AcceleratedEffect>> effects;
+    WebCore::AcceleratedEffectValues baseValues;
+#endif
+};
+
+[CustomEncoder, CustomHeader] struct WebKit::RemoteLayerBackingStoreOrProperties {
+    [NotSerialized] std::unique_ptr<RemoteLayerBackingStore> backingStore;
+    std::unique_ptr<WebKit::RemoteLayerBackingStoreProperties> properties;
+};
+
+struct WebKit::LayerProperties {
+    [OptionalTupleBits] OptionSet<WebKit::LayerChange> changedProperties;
+    [NotSerialized] OptionSet<WebKit::LayerChange> everChangedProperties;
+
+    [OptionalTupleBit=WebKit::LayerChange::NameChanged] String name;
+    [OptionalTupleBit=WebKit::LayerChange::TransformChanged] std::unique_ptr<WebCore::TransformationMatrix> transform;
+    [OptionalTupleBit=WebKit::LayerChange::SublayerTransformChanged] std::unique_ptr<WebCore::TransformationMatrix> sublayerTransform;
+    [OptionalTupleBit=WebKit::LayerChange::ShapeRoundedRectChanged] std::unique_ptr<WebCore::FloatRoundedRect> shapeRoundedRect;
+
+    [OptionalTupleBit=WebKit::LayerChange::ChildrenChanged] Vector<WebCore::PlatformLayerIdentifier> children;
+
+    [OptionalTupleBit=WebKit::LayerChange::AnimationsChanged] WebKit::LayerProperties::AnimationChanges animationChanges;
+
+    [OptionalTupleBit=WebKit::LayerChange::PositionChanged] WebCore::FloatPoint3D position;
+    [OptionalTupleBit=WebKit::LayerChange::AnchorPointChanged] WebCore::FloatPoint3D anchorPoint;
+    [OptionalTupleBit=WebKit::LayerChange::BoundsChanged] WebCore::FloatRect bounds;
+    [OptionalTupleBit=WebKit::LayerChange::ContentsRectChanged] WebCore::FloatRect contentsRect;
+    [OptionalTupleBit=WebKit::LayerChange::BackingStoreChanged] WebKit::RemoteLayerBackingStoreOrProperties backingStoreOrProperties;
+    [OptionalTupleBit=WebKit::LayerChange::FiltersChanged] std::unique_ptr<WebCore::FilterOperations> filters;
+    [OptionalTupleBit=WebKit::LayerChange::ShapePathChanged] WebCore::Path shapePath;
+    [OptionalTupleBit=WebKit::LayerChange::MaskLayerChanged] Markable<WebCore::PlatformLayerIdentifier> maskLayerID;
+    [OptionalTupleBit=WebKit::LayerChange::ClonedContentsChanged] Markable<WebCore::PlatformLayerIdentifier> clonedLayerID;
+    [OptionalTupleBit=WebKit::LayerChange::TimeOffsetChanged] double timeOffset;
+    [OptionalTupleBit=WebKit::LayerChange::SpeedChanged] float speed;
+    [OptionalTupleBit=WebKit::LayerChange::ContentsScaleChanged] float contentsScale;
+    [OptionalTupleBit=WebKit::LayerChange::CornerRadiusChanged] float cornerRadius;
+    [OptionalTupleBit=WebKit::LayerChange::BorderWidthChanged] float borderWidth;
+    [OptionalTupleBit=WebKit::LayerChange::OpacityChanged] float opacity;
+    [OptionalTupleBit=WebKit::LayerChange::BackgroundColorChanged] WebCore::Color backgroundColor;
+    [OptionalTupleBit=WebKit::LayerChange::BorderColorChanged] WebCore::Color borderColor;
+    [OptionalTupleBit=WebKit::LayerChange::CustomAppearanceChanged] WebCore::GraphicsLayer::CustomAppearance customAppearance;
+    [OptionalTupleBit=WebKit::LayerChange::MinificationFilterChanged] WebCore::PlatformCALayer::FilterType minificationFilter;
+    [OptionalTupleBit=WebKit::LayerChange::MagnificationFilterChanged] WebCore::PlatformCALayer::FilterType magnificationFilter;
+    [OptionalTupleBit=WebKit::LayerChange::BlendModeChanged] WebCore::BlendMode blendMode;
+    [OptionalTupleBit=WebKit::LayerChange::WindRuleChanged] WebCore::WindRule windRule;
+    [OptionalTupleBit=WebKit::LayerChange::VideoGravityChanged] WebCore::MediaPlayerVideoGravity videoGravity;
+    [OptionalTupleBit=WebKit::LayerChange::AntialiasesEdgesChanged] bool antialiasesEdges;
+    [OptionalTupleBit=WebKit::LayerChange::HiddenChanged] bool hidden;
+    [OptionalTupleBit=WebKit::LayerChange::BackingStoreAttachmentChanged] bool backingStoreAttached;
+    [OptionalTupleBit=WebKit::LayerChange::GeometryFlippedChanged] bool geometryFlipped;
+    [OptionalTupleBit=WebKit::LayerChange::DoubleSidedChanged] bool doubleSided;
+    [OptionalTupleBit=WebKit::LayerChange::MasksToBoundsChanged] bool masksToBounds;
+    [OptionalTupleBit=WebKit::LayerChange::OpaqueChanged] bool opaque;
+    [OptionalTupleBit=WebKit::LayerChange::ContentsHiddenChanged] bool contentsHidden;
+    [OptionalTupleBit=WebKit::LayerChange::UserInteractionEnabledChanged] bool userInteractionEnabled;
+    [OptionalTupleBit=WebKit::LayerChange::EventRegionChanged] WebCore::EventRegion eventRegion;
+#if ENABLE(SCROLLING_THREAD)
+    [OptionalTupleBit=WebKit::LayerChange::ScrollingNodeIDChanged] WebCore::ScrollingNodeID scrollingNodeID;
+#endif
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    [OptionalTupleBit=WebKit::LayerChange::CoverageRectChanged] WebCore::FloatRect coverageRect;
+#endif
+#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+    [OptionalTupleBit=WebKit::LayerChange::SeparatedChanged] bool isSeparated;
+#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
+    [OptionalTupleBit=WebKit::LayerChange::SeparatedPortalChanged] bool isSeparatedPortal;
+    [OptionalTupleBit=WebKit::LayerChange::DescendentOfSeparatedPortalChanged] bool isDescendentOfSeparatedPortal;
+#endif
 #endif
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -257,7 +257,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & LayerChange::BackingStoreChanged
         || properties.changedProperties & LayerChange::BackingStoreAttachmentChanged)
     {
-        auto* backingStore = properties.backingStoreProperties.get();
+        auto* backingStore = properties.backingStoreOrProperties.properties.get();
         if (backingStore && properties.backingStoreAttached) {
             std::optional<WebCore::RenderingResourceIdentifier> asyncContentsIdentifier;
             if (layerTreeNode) {
@@ -274,7 +274,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
         PlatformCAFilters::setFiltersOnLayer(layer, properties.filters ? *properties.filters : FilterOperations());
 
     if (properties.changedProperties & LayerChange::AnimationsChanged)
-        PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.addedAnimations, properties.keysOfAnimationsToRemove);
+        PlatformCAAnimationRemote::updateLayerAnimations(layer, layerTreeHost, properties.animationChanges.addedAnimations, properties.animationChanges.keysOfAnimationsToRemove);
 
     if (properties.changedProperties & LayerChange::AntialiasesEdgesChanged)
         layer.edgeAntialiasingMask = properties.antialiasesEdges ? (kCALayerLeftEdge | kCALayerRightEdge | kCALayerBottomEdge | kCALayerTopEdge) : 0;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -41,443 +41,11 @@
 namespace WebKit {
 
 RemoteLayerTreeTransaction::RemoteLayerTreeTransaction(RemoteLayerTreeTransaction&&) = default;
+
 RemoteLayerTreeTransaction& RemoteLayerTreeTransaction::operator=(RemoteLayerTreeTransaction&&) = default;
 
-LayerProperties::LayerProperties() = default;
-
-LayerProperties::LayerProperties(LayerProperties&&) = default;
-
-void LayerProperties::encode(IPC::Encoder& encoder) const
-{
-    encoder << changedProperties;
-
-    if (changedProperties & LayerChange::NameChanged)
-        encoder << name;
-
-    if (changedProperties & LayerChange::ChildrenChanged)
-        encoder << children;
-
-    if (changedProperties & LayerChange::AnimationsChanged) {
-        encoder << addedAnimations;
-        encoder << keysOfAnimationsToRemove;
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-        encoder << effects;
-        encoder << baseValues;
-#endif
-    }
-
-    if (changedProperties & LayerChange::PositionChanged)
-        encoder << position;
-
-    if (changedProperties & LayerChange::BoundsChanged)
-        encoder << bounds;
-
-    if (changedProperties & LayerChange::BackgroundColorChanged)
-        encoder << backgroundColor;
-
-    if (changedProperties & LayerChange::AnchorPointChanged)
-        encoder << anchorPoint;
-
-    if (changedProperties & LayerChange::BorderWidthChanged)
-        encoder << borderWidth;
-
-    if (changedProperties & LayerChange::BorderColorChanged)
-        encoder << borderColor;
-
-    if (changedProperties & LayerChange::OpacityChanged)
-        encoder << opacity;
-
-    if (changedProperties & LayerChange::TransformChanged)
-        encoder << *transform;
-
-    if (changedProperties & LayerChange::SublayerTransformChanged)
-        encoder << *sublayerTransform;
-
-    if (changedProperties & LayerChange::AntialiasesEdgesChanged)
-        encoder << antialiasesEdges;
-
-    if (changedProperties & LayerChange::HiddenChanged)
-        encoder << hidden;
-
-    if (changedProperties & LayerChange::GeometryFlippedChanged)
-        encoder << geometryFlipped;
-
-    if (changedProperties & LayerChange::DoubleSidedChanged)
-        encoder << doubleSided;
-
-    if (changedProperties & LayerChange::MasksToBoundsChanged)
-        encoder << masksToBounds;
-
-    if (changedProperties & LayerChange::OpaqueChanged)
-        encoder << opaque;
-
-    if (changedProperties & LayerChange::ContentsHiddenChanged)
-        encoder << contentsHidden;
-
-    if (changedProperties & LayerChange::MaskLayerChanged)
-        encoder << maskLayerID;
-
-    if (changedProperties & LayerChange::ClonedContentsChanged)
-        encoder << clonedLayerID;
-
-#if ENABLE(SCROLLING_THREAD)
-    if (changedProperties & LayerChange::ScrollingNodeIDChanged)
-        encoder << scrollingNodeID;
-#endif
-
-    if (changedProperties & LayerChange::ContentsRectChanged)
-        encoder << contentsRect;
-
-    if (changedProperties & LayerChange::ContentsScaleChanged)
-        encoder << contentsScale;
-
-    if (changedProperties & LayerChange::CornerRadiusChanged)
-        encoder << cornerRadius;
-
-    if (changedProperties & LayerChange::ShapeRoundedRectChanged)
-        encoder << *shapeRoundedRect;
-
-    if (changedProperties & LayerChange::ShapePathChanged)
-        encoder << shapePath;
-
-    if (changedProperties & LayerChange::MinificationFilterChanged)
-        encoder << minificationFilter;
-
-    if (changedProperties & LayerChange::MagnificationFilterChanged)
-        encoder << magnificationFilter;
-
-    if (changedProperties & LayerChange::BlendModeChanged)
-        encoder << blendMode;
-
-    if (changedProperties & LayerChange::WindRuleChanged)
-        encoder << windRule;
-
-    if (changedProperties & LayerChange::SpeedChanged)
-        encoder << speed;
-
-    if (changedProperties & LayerChange::TimeOffsetChanged)
-        encoder << timeOffset;
-
-    if (changedProperties & LayerChange::BackingStoreChanged) {
-        bool hasFrontBuffer = backingStore && backingStore->hasFrontBuffer();
-        encoder << hasFrontBuffer;
-        if (hasFrontBuffer)
-            encoder << *backingStore;
-    }
-
-    if (changedProperties & LayerChange::BackingStoreAttachmentChanged)
-        encoder << backingStoreAttached;
-
-    if (changedProperties & LayerChange::FiltersChanged)
-        encoder << *filters;
-
-    if (changedProperties & LayerChange::CustomAppearanceChanged)
-        encoder << customAppearance;
-
-    if (changedProperties & LayerChange::UserInteractionEnabledChanged)
-        encoder << userInteractionEnabled;
-
-    if (changedProperties & LayerChange::EventRegionChanged)
-        encoder << eventRegion;
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (changedProperties & LayerChange::CoverageRectChanged)
-        encoder << coverageRect;
-#endif
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    if (changedProperties & LayerChange::SeparatedChanged)
-        encoder << isSeparated;
-
-#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    if (changedProperties & LayerChange::SeparatedPortalChanged)
-        encoder << isSeparatedPortal;
-
-    if (changedProperties & LayerChange::DescendentOfSeparatedPortalChanged)
-        encoder << isDescendentOfSeparatedPortal;
-#endif
-#endif
-
-    if (changedProperties & LayerChange::VideoGravityChanged)
-        encoder << videoGravity;
-}
-
-bool LayerProperties::decode(IPC::Decoder& decoder, LayerProperties& result)
-{
-    if (!decoder.decode(result.changedProperties))
-        return false;
-
-    if (result.changedProperties & LayerChange::NameChanged) {
-        if (!decoder.decode(result.name))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::ChildrenChanged) {
-        if (!decoder.decode(result.children))
-            return false;
-
-        for (auto& layerID : result.children) {
-            if (!layerID)
-                return false;
-        }
-    }
-
-    if (result.changedProperties & LayerChange::AnimationsChanged) {
-        if (!decoder.decode(result.addedAnimations))
-            return false;
-
-        if (!decoder.decode(result.keysOfAnimationsToRemove))
-            return false;
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-        if (!decoder.decode(result.effects))
-            return false;
-
-        if (!decoder.decode(result.baseValues))
-            return false;
-#endif
-    }
-
-    if (result.changedProperties & LayerChange::PositionChanged) {
-        if (!decoder.decode(result.position))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BoundsChanged) {
-        if (!decoder.decode(result.bounds))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BackgroundColorChanged) {
-        if (!decoder.decode(result.backgroundColor))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::AnchorPointChanged) {
-        if (!decoder.decode(result.anchorPoint))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BorderWidthChanged) {
-        if (!decoder.decode(result.borderWidth))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BorderColorChanged) {
-        if (!decoder.decode(result.borderColor))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::OpacityChanged) {
-        if (!decoder.decode(result.opacity))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::TransformChanged) {
-        WebCore::TransformationMatrix transform;
-        if (!decoder.decode(transform))
-            return false;
-        
-        result.transform = makeUnique<WebCore::TransformationMatrix>(transform);
-    }
-
-    if (result.changedProperties & LayerChange::SublayerTransformChanged) {
-        WebCore::TransformationMatrix transform;
-        if (!decoder.decode(transform))
-            return false;
-
-        result.sublayerTransform = makeUnique<WebCore::TransformationMatrix>(transform);
-    }
-
-    if (result.changedProperties & LayerChange::AntialiasesEdgesChanged) {
-        if (!decoder.decode(result.antialiasesEdges))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::HiddenChanged) {
-        if (!decoder.decode(result.hidden))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::GeometryFlippedChanged) {
-        if (!decoder.decode(result.geometryFlipped))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::DoubleSidedChanged) {
-        if (!decoder.decode(result.doubleSided))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::MasksToBoundsChanged) {
-        if (!decoder.decode(result.masksToBounds))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::OpaqueChanged) {
-        if (!decoder.decode(result.opaque))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::ContentsHiddenChanged) {
-        if (!decoder.decode(result.contentsHidden))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::MaskLayerChanged) {
-        if (!decoder.decode(result.maskLayerID))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::ClonedContentsChanged) {
-        if (!decoder.decode(result.clonedLayerID))
-            return false;
-    }
-
-#if ENABLE(SCROLLING_THREAD)
-    if (result.changedProperties & LayerChange::ScrollingNodeIDChanged) {
-        if (!decoder.decode(result.scrollingNodeID))
-            return false;
-    }
-#endif
-
-    if (result.changedProperties & LayerChange::ContentsRectChanged) {
-        if (!decoder.decode(result.contentsRect))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::ContentsScaleChanged) {
-        if (!decoder.decode(result.contentsScale))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::CornerRadiusChanged) {
-        if (!decoder.decode(result.cornerRadius))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::ShapeRoundedRectChanged) {
-        WebCore::FloatRoundedRect roundedRect;
-        if (!decoder.decode(roundedRect))
-            return false;
-        
-        result.shapeRoundedRect = makeUnique<WebCore::FloatRoundedRect>(roundedRect);
-    }
-
-    if (result.changedProperties & LayerChange::ShapePathChanged) {
-        WebCore::Path path;
-        if (!decoder.decode(path))
-            return false;
-        
-        result.shapePath = WTFMove(path);
-    }
-
-    if (result.changedProperties & LayerChange::MinificationFilterChanged) {
-        if (!decoder.decode(result.minificationFilter))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::MagnificationFilterChanged) {
-        if (!decoder.decode(result.magnificationFilter))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BlendModeChanged) {
-        if (!decoder.decode(result.blendMode))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::WindRuleChanged) {
-        if (!decoder.decode(result.windRule))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::SpeedChanged) {
-        if (!decoder.decode(result.speed))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::TimeOffsetChanged) {
-        if (!decoder.decode(result.timeOffset))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::BackingStoreChanged) {
-        bool hasFrontBuffer = false;
-        if (!decoder.decode(hasFrontBuffer))
-            return false;
-        if (hasFrontBuffer) {
-            auto backingStore = makeUnique<RemoteLayerBackingStoreProperties>();
-            if (!decoder.decode(*backingStore))
-                return false;
-            
-            result.backingStoreProperties = WTFMove(backingStore);
-        } else
-            result.backingStoreProperties = nullptr;
-    }
-
-    if (result.changedProperties & LayerChange::BackingStoreAttachmentChanged) {
-        if (!decoder.decode(result.backingStoreAttached))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::FiltersChanged) {
-        auto filters = makeUnique<WebCore::FilterOperations>();
-        if (!decoder.decode(*filters))
-            return false;
-        result.filters = WTFMove(filters);
-    }
-
-    if (result.changedProperties & LayerChange::CustomAppearanceChanged) {
-        if (!decoder.decode(result.customAppearance))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::UserInteractionEnabledChanged) {
-        if (!decoder.decode(result.userInteractionEnabled))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::EventRegionChanged) {
-        std::optional<WebCore::EventRegion> eventRegion;
-        decoder >> eventRegion;
-        if (!eventRegion)
-            return false;
-        result.eventRegion = WTFMove(*eventRegion);
-    }
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (result.changedProperties & LayerChange::CoverageRectChanged) {
-        if (!decoder.decode(result.coverageRect))
-            return false;
-    }
-#endif
-#if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    if (result.changedProperties & LayerChange::SeparatedChanged) {
-        if (!decoder.decode(result.isSeparated))
-            return false;
-    }
-
-#if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    if (result.changedProperties & LayerChange::SeparatedPortalChanged) {
-        if (!decoder.decode(result.isSeparatedPortal))
-            return false;
-    }
-
-    if (result.changedProperties & LayerChange::DescendentOfSeparatedPortalChanged) {
-        if (!decoder.decode(result.isDescendentOfSeparatedPortal))
-            return false;
-    }
-#endif
-#endif
-
-    if (result.changedProperties & LayerChange::VideoGravityChanged) {
-        if (!decoder.decode(result.videoGravity))
-            return false;
-    }
-
-    return true;
-}
-
 RemoteLayerTreeTransaction::RemoteLayerTreeTransaction() = default;
+
 RemoteLayerTreeTransaction::~RemoteLayerTreeTransaction() = default;
 
 void RemoteLayerTreeTransaction::setRootLayerID(WebCore::PlatformLayerIdentifier rootLayerID)
@@ -618,7 +186,7 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
             ts.dumpProperty("timeOffset", layerProperties.timeOffset);
 
         if (layerProperties.changedProperties & LayerChange::BackingStoreChanged) {
-            if (auto* backingStoreProperties = layerProperties.backingStoreProperties.get())
+            if (auto* backingStoreProperties = layerProperties.backingStoreOrProperties.properties.get())
                 ts.dumpProperty("backingStore", *backingStoreProperties);
             else
                 ts.dumpProperty("backingStore", "removed");
@@ -631,10 +199,10 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
             ts.dumpProperty("filters", layerProperties.filters ? *layerProperties.filters : WebCore::FilterOperations());
 
         if (layerProperties.changedProperties & LayerChange::AnimationsChanged) {
-            for (const auto& keyAnimationPair : layerProperties.addedAnimations)
+            for (const auto& keyAnimationPair : layerProperties.animationChanges.addedAnimations)
                 ts.dumpProperty("animation " +  keyAnimationPair.first, keyAnimationPair.second);
 
-            for (const auto& name : layerProperties.keysOfAnimationsToRemove)
+            for (const auto& name : layerProperties.animationChanges.keysOfAnimationsToRemove)
                 ts.dumpProperty("removed animation", name);
         }
 
@@ -802,6 +370,8 @@ RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties(Lay
 
 auto RemoteLayerTreeTransaction::LayerCreationProperties::operator=(LayerCreationProperties&&) -> LayerCreationProperties& = default;
 
+RemoteLayerBackingStoreOrProperties::~RemoteLayerBackingStoreOrProperties() = default;
+
 RemoteLayerTreeTransaction::LayerCreationProperties::LayerCreationProperties(WebCore::PlatformLayerIdentifier layerID, WebCore::PlatformCALayer::LayerType type, std::optional<RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData>&& videoElementData, RemoteLayerTreeTransaction::LayerCreationProperties::AdditionalData&& additionalData)
     : layerID(layerID)
     , type(type)
@@ -850,6 +420,17 @@ void ArgumentCoder<WebKit::ChangedLayers>::encode(Encoder& encoder, const WebKit
         encoder << layer->layerID();
         encoder << layer->properties();
     }
+}
+
+void ArgumentCoder<WebKit::RemoteLayerBackingStoreOrProperties>::encode(Encoder& encoder, const WebKit::RemoteLayerBackingStoreOrProperties& instance)
+{
+    // The web content process has a std::unique_ptr<RemoteLayerBackingStore> but we want it to decode
+    // in the UI process as a std::unique_ptr<RemoteLayerBackingStoreProperties>.
+    ASSERT(WebCore::isInWebProcess());
+    bool hasFrontBuffer = instance.store && instance.store->hasFrontBuffer();
+    encoder << hasFrontBuffer;
+    if (hasFrontBuffer)
+        encoder << *instance.store;
 }
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -165,7 +165,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
     for (auto& transaction : transactions) {
         // commitLayerTreeTransaction consumes the incoming buffers, so we need to grab them first.
         for (auto& [layerID, properties] : transaction.first.changedLayerProperties()) {
-            const auto backingStoreProperties = properties->backingStoreProperties.get();
+            const auto* backingStoreProperties = properties->backingStoreOrProperties.properties.get();
             if (!backingStoreProperties)
                 continue;
             if (const auto& backendHandle = backingStoreProperties->bufferHandle()) {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -185,16 +185,16 @@ void PlatformCALayerRemote::updateClonedLayerProperties(PlatformCALayerRemote& c
 
 void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& context, RemoteLayerTreeTransaction& transaction)
 {
-    ASSERT(!m_properties.backingStore || owner());
+    ASSERT(!m_properties.backingStoreOrProperties.store || owner());
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&context == m_context);
     
     bool usesBackingStore = owner() && (owner()->platformCALayerDrawsContent() || owner()->platformCALayerDelegatesDisplay(this));
-    if (m_properties.backingStore && !usesBackingStore) {
-        m_properties.backingStore = nullptr;
+    if (m_properties.backingStoreOrProperties.store && !usesBackingStore) {
+        m_properties.backingStoreOrProperties.store = nullptr;
         m_properties.notePropertiesChanged(LayerChange::BackingStoreChanged);
     }
 
-    if (m_properties.backingStore && m_properties.backingStoreAttached && m_properties.backingStore->layerWillBeDisplayed())
+    if (m_properties.backingStoreOrProperties.store && m_properties.backingStoreAttached && m_properties.backingStoreOrProperties.store->layerWillBeDisplayed())
         m_properties.notePropertiesChanged(LayerChange::BackingStoreChanged);
 
     if (m_properties.changedProperties) {
@@ -228,8 +228,8 @@ void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& co
 
 void PlatformCALayerRemote::didCommit()
 {
-    m_properties.addedAnimations.clear();
-    m_properties.keysOfAnimationsToRemove.clear();
+    m_properties.animationChanges.addedAnimations.clear();
+    m_properties.animationChanges.keysOfAnimationsToRemove.clear();
     m_properties.resetChangedProperties();
 }
 
@@ -239,8 +239,8 @@ void PlatformCALayerRemote::ensureBackingStore()
 
     ASSERT(m_properties.backingStoreAttached);
 
-    if (!m_properties.backingStore)
-        m_properties.backingStore = makeUnique<RemoteLayerBackingStore>(this);
+    if (!m_properties.backingStoreOrProperties.store)
+        m_properties.backingStoreOrProperties.store = makeUnique<RemoteLayerBackingStore>(this);
 
     updateBackingStore();
 }
@@ -258,7 +258,7 @@ RemoteLayerBackingStore::IncludeDisplayList PlatformCALayerRemote::shouldInclude
 
 void PlatformCALayerRemote::updateBackingStore()
 {
-    if (!m_properties.backingStore)
+    if (!m_properties.backingStoreOrProperties.store)
         return;
 
     ASSERT(m_properties.backingStoreAttached);
@@ -284,7 +284,7 @@ void PlatformCALayerRemote::updateBackingStore()
         parameters.useCGDisplayListImageCache = UseCGDisplayListImageCache::Yes;
 #endif
 
-    m_properties.backingStore->ensureBackingStore(parameters);
+    m_properties.backingStoreOrProperties.store->ensureBackingStore(parameters);
 }
 
 void PlatformCALayerRemote::setNeedsDisplayInRect(const FloatRect& rect)
@@ -295,7 +295,7 @@ void PlatformCALayerRemote::setNeedsDisplayInRect(const FloatRect& rect)
     ensureBackingStore();
 
     // FIXME: Need to map this through contentsRect/etc.
-    m_properties.backingStore->setNeedsDisplay(enclosingIntRect(rect));
+    m_properties.backingStoreOrProperties.store->setNeedsDisplay(enclosingIntRect(rect));
 }
 
 void PlatformCALayerRemote::setNeedsDisplay()
@@ -305,7 +305,7 @@ void PlatformCALayerRemote::setNeedsDisplay()
 
     ensureBackingStore();
 
-    m_properties.backingStore->setNeedsDisplay();
+    m_properties.backingStoreOrProperties.store->setNeedsDisplay();
 }
 
 void PlatformCALayerRemote::copyContentsFromLayer(PlatformCALayer* layer)
@@ -422,7 +422,7 @@ void PlatformCALayerRemote::addAnimationForKey(const String& key, PlatformCAAnim
         // process yet, we update the key properties before it happens. Otherwise, we just append it
         // to the list of animations to be added: PlatformCAAnimationRemote::updateLayerAnimations
         // will actually take care of replacing the existing animation.
-        for (auto& keyAnimationPair : m_properties.addedAnimations) {
+        for (auto& keyAnimationPair : m_properties.animationChanges.addedAnimations) {
             if (keyAnimationPair.first == key) {
                 keyAnimationPair.second = downcast<PlatformCAAnimationRemote>(animation).properties();
                 appendToAddedAnimations = false;
@@ -431,7 +431,7 @@ void PlatformCALayerRemote::addAnimationForKey(const String& key, PlatformCAAnim
         }
     }
     if (appendToAddedAnimations)
-        m_properties.addedAnimations.append(std::pair<String, PlatformCAAnimationRemote::Properties>(key, downcast<PlatformCAAnimationRemote>(animation).properties()));
+        m_properties.animationChanges.addedAnimations.append(std::pair<String, PlatformCAAnimationRemote::Properties>(key, downcast<PlatformCAAnimationRemote>(animation).properties()));
     
     m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
 
@@ -442,11 +442,11 @@ void PlatformCALayerRemote::addAnimationForKey(const String& key, PlatformCAAnim
 void PlatformCALayerRemote::removeAnimationForKey(const String& key)
 {
     if (m_animations.remove(key)) {
-        m_properties.addedAnimations.removeFirstMatching([&key](auto& pair) {
+        m_properties.animationChanges.addedAnimations.removeFirstMatching([&key](auto& pair) {
             return pair.first == key;
         });
     }
-    m_properties.keysOfAnimationsToRemove.add(key);
+    m_properties.animationChanges.keysOfAnimationsToRemove.add(key);
     m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
 }
 
@@ -640,7 +640,7 @@ void PlatformCALayerRemote::setBackingStoreAttached(bool attached)
     if (attached)
         setNeedsDisplay();
     else
-        m_properties.backingStore = nullptr;
+        m_properties.backingStoreOrProperties.store = nullptr;
 }
 
 bool PlatformCALayerRemote::backingStoreAttached() const
@@ -716,7 +716,7 @@ void PlatformCALayerRemote::setWantsDeepColorBackingStore(bool wantsDeepColorBac
 
 bool PlatformCALayerRemote::hasContents() const
 {
-    return !!m_properties.backingStore;
+    return !!m_properties.backingStoreOrProperties.store;
 }
 
 CFTypeRef PlatformCALayerRemote::contents() const
@@ -726,17 +726,17 @@ CFTypeRef PlatformCALayerRemote::contents() const
 
 void PlatformCALayerRemote::setContents(CFTypeRef value)
 {
-    if (!m_properties.backingStore)
+    if (!m_properties.backingStoreOrProperties.store)
         return;
     if (!value)
-        m_properties.backingStore->clearBackingStore();
+        m_properties.backingStoreOrProperties.store->clearBackingStore();
 }
 
 void PlatformCALayerRemote::setDelegatedContents(const PlatformCALayerDelegatedContents& contents)
 {
     ASSERT(m_acceleratesDrawing);
     ensureBackingStore();
-    m_properties.backingStore->setDelegatedContents(contents);
+    m_properties.backingStoreOrProperties.store->setDelegatedContents(contents);
 }
 
 void PlatformCALayerRemote::setContentsRect(const FloatRect& value)
@@ -1037,7 +1037,7 @@ Ref<PlatformCALayer> PlatformCALayerRemote::createCompatibleLayer(PlatformCALaye
 
 void PlatformCALayerRemote::enumerateRectsBeingDrawn(WebCore::GraphicsContext& context, void (^block)(WebCore::FloatRect))
 {
-    m_properties.backingStore->enumerateRectsBeingDrawn(context, block);
+    m_properties.backingStoreOrProperties.store->enumerateRectsBeingDrawn(context, block);
 }
 
 uint32_t PlatformCALayerRemote::hostingContextID()
@@ -1048,10 +1048,10 @@ uint32_t PlatformCALayerRemote::hostingContextID()
 
 unsigned PlatformCALayerRemote::backingStoreBytesPerPixel() const
 {
-    if (!m_properties.backingStore)
+    if (!m_properties.backingStoreOrProperties.store)
         return 4;
 
-    return m_properties.backingStore->bytesPerPixel();
+    return m_properties.backingStoreOrProperties.store->bytesPerPixel();
 }
 
 LayerPool& PlatformCALayerRemote::layerPool()
@@ -1062,16 +1062,16 @@ LayerPool& PlatformCALayerRemote::layerPool()
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 void PlatformCALayerRemote::clearAcceleratedEffectsAndBaseValues()
 {
-    m_properties.effects = { };
-    m_properties.baseValues = { };
+    m_properties.animationChanges.effects = { };
+    m_properties.animationChanges.baseValues = { };
 
     m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
 }
 
 void PlatformCALayerRemote::setAcceleratedEffectsAndBaseValues(const AcceleratedEffects& effects, AcceleratedEffectValues& baseValues)
 {
-    m_properties.effects = effects;
-    m_properties.baseValues = baseValues;
+    m_properties.animationChanges.effects = effects;
+    m_properties.animationChanges.baseValues = baseValues;
 
     m_properties.notePropertiesChanged(LayerChange::AnimationsChanged);
 }


### PR DESCRIPTION
#### dfde447bae87cf7742a1d28613646004d33f4d86
<pre>
Generate serialization for LayerProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=259626">https://bugs.webkit.org/show_bug.cgi?id=259626</a>

Reviewed by Brady Eidson.

LayerProperties is basically a bunch of std::optionals, but efficiently packed
with all their bools stored as a bit in an OptionSet.  So it&apos;s a tuple of optionals.

This introduces a new primitive, an OptionalTuple that is serialized by sending
a uint64_t of all the bools followed by the tuple members if the bit is 1.
This can also be used for RemoteScrollingCoordinatorTransaction.

I think OptionalTuple is a monad.  It&apos;s never been completely clear to me
what is and what is not a monad.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.has_optional_tuple_bits):
(MemberVariable.optional_tuple_bit):
(encode_optional_tuple):
(decode_optional_tuple):
(generate_impl):
(generate_optional_tuple_type_info):
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;WebKit::LayerProperties&gt;::encode):
(IPC::ArgumentCoder&lt;WebKit::LayerProperties&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
(WebKit::RemoteLayerBackingStoreOrProperties::RemoteLayerBackingStoreOrProperties):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::didFlushLayers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::dumpChangedLayers):
(IPC::ArgumentCoder&lt;WebKit::RemoteLayerBackingStoreOrProperties&gt;::encode):
(WebKit::LayerProperties::encode const): Deleted.
(WebKit::LayerProperties::decode): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::recursiveBuildTransaction):
(WebKit::PlatformCALayerRemote::didCommit):
(WebKit::PlatformCALayerRemote::ensureBackingStore):
(WebKit::PlatformCALayerRemote::updateBackingStore):
(WebKit::PlatformCALayerRemote::setNeedsDisplayInRect):
(WebKit::PlatformCALayerRemote::setNeedsDisplay):
(WebKit::PlatformCALayerRemote::addAnimationForKey):
(WebKit::PlatformCALayerRemote::removeAnimationForKey):
(WebKit::PlatformCALayerRemote::setBackingStoreAttached):
(WebKit::PlatformCALayerRemote::hasContents const):
(WebKit::PlatformCALayerRemote::setContents):
(WebKit::PlatformCALayerRemote::setDelegatedContents):
(WebKit::PlatformCALayerRemote::enumerateRectsBeingDrawn):
(WebKit::PlatformCALayerRemote::backingStoreBytesPerPixel const):
(WebKit::PlatformCALayerRemote::clearAcceleratedEffectsAndBaseValues):
(WebKit::PlatformCALayerRemote::setAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/266533@main">https://commits.webkit.org/266533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a92279cd9bd44b82536231fbbee3ceada956ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13093 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14181 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16224 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13876 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11860 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19477 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15821 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11006 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12398 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16731 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1666 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->