### PR TITLE
Skip style recalc scheduling during rendering update

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1918,6 +1918,8 @@ private:
 
     bool isObservingContentVisibilityTargets() const;
 
+    void styleRecalcTimerFired();
+
     const Ref<const Settings> m_settings;
 
     UniqueRef<Quirks> m_quirks;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1059,6 +1059,8 @@ public:
 
     void performOpportunisticallyScheduledTasks(MonotonicTime deadline);
 
+    bool isInRenderingUpdate() const { return !m_renderingUpdateRemainingSteps.isEmpty(); }
+
 private:
     struct Navigation {
         RegistrableDomain domain;


### PR DESCRIPTION
#### b4d3bce152b5ca1e60b1f2b0f26ceccd18fb3a12
<pre>
Skip style recalc scheduling during rendering update
<a href="https://bugs.webkit.org/show_bug.cgi?id=208780">https://bugs.webkit.org/show_bug.cgi?id=208780</a>

Reviewed by NOBODY (OOPS!).

There is no need to schedule style recalcs during
a rendering update.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::Document):
(WebCore::Document::styleRecalcTimerFired):
(WebCore::Document::scheduleStyleRecalc):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::isInRenderingUpdate const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d3bce152b5ca1e60b1f2b0f26ceccd18fb3a12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16299 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19540 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11078 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->