### PR TITLE
Ignore willCommitLayerTree and commitLayerTreeNotTriggered when reordered after a commitLayerTree

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -113,7 +113,7 @@ private:
     // Message handlers
     virtual void setPreferredFramesPerSecond(WebCore::FramesPerSecond) { }
     void willCommitLayerTree(TransactionID);
-    void commitLayerTreeNotTriggered();
+    void commitLayerTreeNotTriggered(TransactionID);
     void commitLayerTree(IPC::Connection&, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>&);
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
@@ -141,6 +141,7 @@ private:
     RetainPtr<CALayer> m_exposedRectIndicatorLayer;
 
     TransactionID m_pendingLayerTreeTransactionID;
+    TransactionID m_lastLayerTreeTransactionID;
 #if ASSERT_ENABLED
     TransactionID m_lastVisibleTransactionID;
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -23,7 +23,7 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy NotRefCounted {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void WillCommitLayerTree(WebKit::TransactionID transactionID)
-    void CommitLayerTreeNotTriggered()
+    void CommitLayerTreeNotTriggered(WebKit::TransactionID nextCommitTransactionID)
     void CommitLayerTree(Vector<std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>> transactions)
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::ImageBufferBackendHandle handle, WebCore::RenderingResourceIdentifier identifier)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -137,8 +137,13 @@ void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
     }, m_identifier);
 }
 
-void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered()
+void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered(TransactionID nextCommitTransactionID)
 {
+    if (nextCommitTransactionID <= m_lastLayerTreeTransactionID) {
+        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered nextCommitTransactionID=" << nextCommitTransactionID << ") already obsoleted by m_lastLayerTreeTransactionID=" << m_lastLayerTreeTransactionID);
+        return;
+    }
+
     m_commitLayerTreeMessageState = Idle;
     pauseDisplayRefreshCallbacks();
 #if ENABLE(ASYNC_SCROLLING)
@@ -148,6 +153,9 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered()
 
 void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(TransactionID transactionID)
 {
+    if (transactionID <= m_lastLayerTreeTransactionID)
+        return;
+
     m_pendingLayerTreeTransactionID = transactionID;
 }
 
@@ -180,6 +188,10 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
 
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree transaction:" << layerTreeTransaction.description());
     LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree scrolling tree:" << scrollingTreeTransaction.description());
+
+    m_lastLayerTreeTransactionID = layerTreeTransaction.transactionID();
+    if (m_pendingLayerTreeTransactionID < m_lastLayerTreeTransactionID)
+        m_pendingLayerTreeTransactionID = m_lastLayerTreeTransactionID;
 
     bool didUpdateEditorState { false };
     if (layerTreeTransaction.isMainFrameProcessTransaction()) {

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -438,7 +438,7 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh()
     } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else
-        send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered());
+        send(Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTreeNotTriggered(nextTransactionID()));
 }
 
 auto RemoteLayerTreeDrawingArea::rootLayerInfoWithFrameIdentifier(WebCore::FrameIdentifier frameID) -> RootLayerInfo*


### PR DESCRIPTION
#### 3fe5ba4547a3ece6a1ab059a583e183b06e6da54
<pre>
Ignore willCommitLayerTree and commitLayerTreeNotTriggered when reordered after a commitLayerTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=259632">https://bugs.webkit.org/show_bug.cgi?id=259632</a>
rdar://110498860

Reviewed by Matt Woodrow.

The normal sequence of RemoteLayerTreeDrawingAreaProxy messages should normally be:
willCommit(1) commit(1) notTriggered(next commit 2) willCommit(2) commit(2) ...

However this could be disrupted by RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState, which
waits for the first commit message and runs it immediately! This could lead to handling them in this order:
willCommit(1) commit(1) **commit(2)** notTriggered(next commit 2) willCommit(2) ...
The main issue is that the notTriggered(next commit 2) handler pauses further display refresh callbacks,
which would normally have been restarted by the later-sent commit(2), so the rendering doesn&apos;t get updated
anymore. In some applications like Mail, this may result in blank email bodies.

The solution here is to detect such re-orderings, and produce the same effects as if they had run in the
expected order. Details below:

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
Add `nextCommitTransactionID` to CommitLayerTreeNotTriggered, to know which commit they should
precede (and hence which commit should come after).

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
Send the next commit transaction ID with CommitLayerTreeNotTriggered.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
Record the last processed CommitLayerTree transaction ID.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeNotTriggered):
If this message&apos;s next-to-commit transaction ID is lower than or equal to the last-received committed
transaction ID, this means that the commit was reordered and handled before this not-triggered, so nothing
should be done here; especially, display-refresh callbacks should not be paused, and the scrolling update
should happen in the upcoming not-triggered that corresponds to the last-received commit.
This should be rare, so a log message is appropriate to expose this event.

(WebKit::RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree):
Similar to the message above, if the will-commit transaction ID is not smaller than the last-received
committed transaction ID, it means that this message was reordered and can be ignored. Its effect would
have already been handled by the commit message (see below.)

(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
Update the last processed transaction ID.
Also, if the pending transaction ID is lower than this commit&apos;s transaction ID, it means this message is
being preemptively handled sooner, so the will-commit effect is simulated by updating the pending
transaction ID now -- the already sent will-commit will be ignored later on.

Canonical link: <a href="https://commits.webkit.org/266421@main">https://commits.webkit.org/266421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/769cf4d7d8cafe08b00f92935b16f37cfc20e12b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14127 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13121 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15795 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16252 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11885 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19497 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15842 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11033 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12426 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3355 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->