### PR TITLE
[JSC] Make speculationFromValue cheap

### DIFF
--- a/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.cpp
@@ -515,12 +515,8 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
     if (classInfo->isSubClassOf(JSArray::info()))
         return SpecArray | SpecDerivedArray;
 
-    static_assert(std::is_final_v<JSBoundFunction>);
-    if (classInfo == JSBoundFunction::info())
-        return SpecFunctionWithNonDefaultHasInstance;
-
     if (classInfo->isSubClassOf(JSFunction::info()))
-        return SpecFunctionWithDefaultHasInstance;
+        return SpecFunction;
 
     if (classInfo->isSubClassOf(JSPromise::info()))
         return SpecPromiseObject;
@@ -538,92 +534,20 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo* classInfo)
     return SpecCellOther;
 }
 
+using SpeculationMapping = std::array<SpeculatedType, static_cast<unsigned>(UINT8_MAX) + 1>;
+static constexpr SpeculationMapping speculatedTypeMapping = ([]() -> SpeculationMapping {
+    SpeculationMapping result { };
+    result.fill(SpecObjectOther);
+#define JSC_DEFINE_JS_TYPE(type, speculatedType) result[type] = speculatedType;
+    FOR_EACH_JS_TYPE(JSC_DEFINE_JS_TYPE)
+#undef JSC_DEFINE_JS_TYPE
+    return result;
+})();
+
 SpeculatedType speculationFromStructure(Structure* structure)
 {
-    SpeculatedType filteredResult = SpecNone;
     JSType type = structure->typeInfo().type();
-    switch (type) {
-    case StringType:
-        filteredResult = SpecString;
-        break;
-    case SymbolType:
-        filteredResult = SpecSymbol;
-        break;
-    case HeapBigIntType:
-        filteredResult = SpecHeapBigInt;
-        break;
-    case FinalObjectType:
-        filteredResult = SpecFinalObject;
-        break;
-    case DirectArgumentsType:
-        filteredResult = SpecDirectArguments;
-        break;
-    case ScopedArgumentsType:
-        filteredResult = SpecScopedArguments;
-        break;
-    case RegExpObjectType:
-        filteredResult = SpecRegExpObject;
-        break;
-    case JSDateType:
-        filteredResult = SpecDateObject;
-        break;
-    case JSMapType:
-        filteredResult = SpecMapObject;
-        break;
-    case JSSetType:
-        filteredResult = SpecSetObject;
-        break;
-    case JSWeakMapType:
-        filteredResult = SpecWeakMapObject;
-        break;
-    case JSWeakSetType:
-        filteredResult = SpecWeakSetObject;
-        break;
-    case ProxyObjectType:
-        filteredResult = SpecProxyObject;
-        break;
-    case DataViewType:
-        filteredResult = SpecDataViewObject;
-        break;
-    case DerivedArrayType:
-        filteredResult = SpecDerivedArray;
-        break;
-    case ArrayType:
-        filteredResult = SpecArray;
-        break;
-    case StringObjectType:
-        filteredResult = SpecStringObject;
-        break;
-    // We do not want to accept String.prototype in StringObjectUse, so that we do not include it as SpecStringObject.
-    case DerivedStringObjectType:
-        filteredResult = SpecObjectOther;
-        break;
-    case JSPromiseType:
-        filteredResult = SpecPromiseObject;
-        break;
-    case JSFunctionType:
-        static_assert(std::is_final_v<JSBoundFunction>);
-        if (structure->classInfoForCells() == JSBoundFunction::info())
-            filteredResult = SpecFunctionWithNonDefaultHasInstance;
-        else
-            filteredResult = SpecFunctionWithDefaultHasInstance;
-        break;
-
-#define JSC_TYPED_ARRAY_CHECK(type) \
-    case type##ArrayType: \
-        filteredResult = Spec ## type ## Array; \
-        break;
-    FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_CHECK)
-#undef JSC_TYPED_ARRAY_CHECK
-
-    default:
-        if (!isObjectType(type))
-            return SpecCellOther;
-        return speculationFromClassInfoInheritance(structure->classInfoForCells());
-    }
-    ASSERT(filteredResult);
-    ASSERT(isSubtypeSpeculation(filteredResult, speculationFromClassInfoInheritance(structure->classInfoForCells())));
-    return filteredResult;
+    return speculatedTypeMapping[type];
 }
 
 SpeculatedType speculationFromCell(JSCell* cell)
@@ -633,6 +557,7 @@ SpeculatedType speculationFromCell(JSCell* cell)
         ASSERT_NOT_REACHED();
         return SpecNone;
     }
+
     if (cell->isString()) {
         JSString* string = jsCast<JSString*>(cell);
         if (const StringImpl* impl = string->tryGetValueImpl()) {
@@ -645,13 +570,9 @@ SpeculatedType speculationFromCell(JSCell* cell)
         }
         return SpecString;
     }
-    // FIXME: rdar://69036888: undo this when no longer needed.
-    auto* structure = cell->structureID().tryDecode();
-    if (UNLIKELY(!Integrity::isSanePointer(structure))) {
-        ASSERT_NOT_REACHED();
-        return SpecNone;
-    }
-    return speculationFromStructure(structure);
+
+    JSType type = cell->type();
+    return speculatedTypeMapping[type];
 }
 
 SpeculatedType speculationFromValue(JSValue value)

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -41,9 +41,7 @@ typedef uint64_t SpeculatedType;
 static constexpr SpeculatedType SpecNone                              = 0; // We don't know anything yet.
 static constexpr SpeculatedType SpecFinalObject                       = 1ull << 0; // It's definitely a JSFinalObject.
 static constexpr SpeculatedType SpecArray                             = 1ull << 1; // It's definitely a JSArray.
-static constexpr SpeculatedType SpecFunctionWithDefaultHasInstance    = 1ull << 2; // It's definitely a JSFunction that has its ImplementsDefaultHasInstance type info flags bit set.
-static constexpr SpeculatedType SpecFunctionWithNonDefaultHasInstance = 1ull << 3; // It's definitely a JSFunction that does not have its ImplementsDefaultHasInstance type info flags bit set.
-static constexpr SpeculatedType SpecFunction                          = SpecFunctionWithDefaultHasInstance | SpecFunctionWithNonDefaultHasInstance; // It's definitely a JSFunction.
+static constexpr SpeculatedType SpecFunction                          = 1ull << 2; // It's definitely a JSFunction.
 static constexpr SpeculatedType SpecInt8Array                         = 1ull << 4; // It's definitely an Int8Array or one of its subclasses.
 static constexpr SpeculatedType SpecInt16Array                        = 1ull << 5; // It's definitely an Int16Array or one of its subclasses.
 static constexpr SpeculatedType SpecInt32Array                        = 1ull << 6; // It's definitely an Int32Array or one of its subclasses.
@@ -521,7 +519,7 @@ SpeculatedType speculationFromClassInfoInheritance(const ClassInfo*);
 
 SpeculatedType speculationFromStructure(Structure*);
 SpeculatedType speculationFromCell(JSCell*);
-JS_EXPORT_PRIVATE SpeculatedType speculationFromValue(JSValue);
+SpeculatedType speculationFromValue(JSValue);
 // If it's an anyInt(), it'll return speculated types from the Int52 lattice.
 // Otherwise, it'll return types from the JSValue lattice.
 JS_EXPORT_PRIVATE SpeculatedType int52AwareSpeculationFromValue(JSValue);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4946,12 +4946,6 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         const AbstractValue& abstractValue = forNode(node->child1());
         unsigned bits = node->typeInfoOperand();
         ASSERT(bits);
-        if (bits == ImplementsDefaultHasInstance) {
-            if (abstractValue.m_type == SpecFunctionWithDefaultHasInstance) {
-                m_state.setShouldTryConstantFolding(true);
-                break;
-            }
-        }
 
         if (JSValue value = abstractValue.value()) {
             if (value.isCell()) {

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -544,6 +544,63 @@ void AbstractValue::fastForwardToSlow(AbstractValueClobberEpoch newEpoch)
     checkConsistency();
 }
 
+bool AbstractValue::validateOSREntryValue(JSValue value, FlushFormat format) const
+{
+    if (isBytecodeTop())
+        return true;
+
+    if (format == FlushedInt52) {
+        if (!isInt52Any())
+            return false;
+
+        if (!validateTypeAcceptingBoxedInt52(value))
+            return false;
+
+        if (!!m_value) {
+            ASSERT(m_value.isAnyInt());
+            ASSERT(value.isAnyInt());
+            if (jsDoubleNumber(m_value.asAnyInt()) != jsDoubleNumber(value.asAnyInt()))
+                return false;
+        }
+    } else {
+        if (!!m_value && m_value != value)
+            return false;
+
+        if (mergeSpeculations(m_type, speculationFromValue(value)) != m_type)
+            return false;
+
+        if (value.isEmpty()) {
+            ASSERT(m_type & SpecEmpty);
+            return true;
+        }
+    }
+
+    if (!!value && value.isCell()) {
+        ASSERT(m_type & SpecCell);
+        Structure* structure = value.asCell()->structure();
+        return m_structure.contains(structure)
+            && (m_arrayModes & arrayModesFromStructure(structure));
+    }
+
+    return true;
+}
+
+bool AbstractValue::validateTypeAcceptingBoxedInt52(JSValue value) const
+{
+    if (isBytecodeTop())
+        return true;
+
+    if (m_type & SpecInt52Any) {
+        if (mergeSpeculations(m_type, int52AwareSpeculationFromValue(value)) == m_type)
+            return true;
+    }
+
+    if (mergeSpeculations(m_type, speculationFromValue(value)) != m_type)
+        return false;
+
+    return true;
+}
+
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.h
@@ -380,47 +380,8 @@ struct AbstractValue {
     
     bool contains(RegisteredStructure) const;
 
-    bool validateOSREntryValue(JSValue value, FlushFormat format) const
-    {
-        if (isBytecodeTop())
-            return true;
-        
-        if (format == FlushedInt52) {
-            if (!isInt52Any())
-                return false;
+    JS_EXPORT_PRIVATE bool validateOSREntryValue(JSValue, FlushFormat) const;
 
-            if (!validateTypeAcceptingBoxedInt52(value))
-                return false;
-
-            if (!!m_value) {
-                ASSERT(m_value.isAnyInt());
-                ASSERT(value.isAnyInt());
-                if (jsDoubleNumber(m_value.asAnyInt()) != jsDoubleNumber(value.asAnyInt()))
-                    return false;
-            }
-        } else {
-            if (!!m_value && m_value != value)
-                return false;
-        
-            if (mergeSpeculations(m_type, speculationFromValue(value)) != m_type)
-                return false;
-            
-            if (value.isEmpty()) {
-                ASSERT(m_type & SpecEmpty);
-                return true;
-            }
-        }
-        
-        if (!!value && value.isCell()) {
-            ASSERT(m_type & SpecCell);
-            Structure* structure = value.asCell()->structure();
-            return m_structure.contains(structure)
-                && (m_arrayModes & arrayModesFromStructure(structure));
-        }
-        
-        return true;
-    }
-    
     bool hasClobberableState() const
     {
         return m_structure.isNeitherClearNorTop()
@@ -515,23 +476,9 @@ private:
         if (m_arrayModes & from)
             m_arrayModes |= to;
     }
-    
-    bool validateTypeAcceptingBoxedInt52(JSValue value) const
-    {
-        if (isBytecodeTop())
-            return true;
-        
-        if (m_type & SpecInt52Any) {
-            if (mergeSpeculations(m_type, int52AwareSpeculationFromValue(value)) == m_type)
-                return true;
-        }
 
-        if (mergeSpeculations(m_type, speculationFromValue(value)) != m_type)
-            return false;
-        
-        return true;
-    }
-    
+    bool validateTypeAcceptingBoxedInt52(JSValue) const;
+
     void makeTop(SpeculatedType top)
     {
         m_type = top;

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1157,13 +1157,6 @@ private:
                 const AbstractValue& abstractValue = m_state.forNode(node->child1());
                 unsigned bits = node->typeInfoOperand();
                 ASSERT(bits);
-                if (bits == ImplementsDefaultHasInstance) {
-                    if (abstractValue.m_type == SpecFunctionWithDefaultHasInstance) {
-                        eliminated = true;
-                        node->remove(m_graph);
-                        break;
-                    }
-                }
 
                 if (JSValue value = abstractValue.value()) {
                     if (value.isCell()) {

--- a/Source/JavaScriptCore/dfg/DFGInsertionSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInsertionSet.cpp
@@ -52,6 +52,11 @@ size_t InsertionSet::execute(BasicBlock* block)
     return executeInsertions(*block, m_insertions);
 }
 
+Node* InsertionSet::insertConstant(size_t index, NodeOrigin origin, FrozenValue* value, NodeType op)
+{
+    return insertNode(index, speculationFromValue(value->value()), op, origin, OpInfo(value));
+}
+
 } } // namespace JSC::DFG
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGInsertionSet.h
+++ b/Source/JavaScriptCore/dfg/DFGInsertionSet.h
@@ -68,14 +68,8 @@ public:
         return insert(index, m_graph.addNode(type, params...));
     }
     
-    Node* insertConstant(
-        size_t index, NodeOrigin origin, FrozenValue* value,
-        NodeType op = JSConstant)
-    {
-        return insertNode(
-            index, speculationFromValue(value->value()), op, origin, OpInfo(value));
-    }
-    
+    Node* insertConstant(size_t index, NodeOrigin, FrozenValue*, NodeType op = JSConstant);
+
     Edge insertConstantForUse(
         size_t index, NodeOrigin origin, FrozenValue* value, UseKind useKind)
     {

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -2190,7 +2190,7 @@ macro llintJumpTrueOrFalseOp(opcodeName, opcodeStruct, miscConditionOp, truthyCe
 
     .maybeCell:
         btqnz t0, notCellMask, .slow
-        bbbeq JSCell::m_type[t0], constexpr JSType::LastMaybeFalsyCellPrimitive, .slow
+        bbbeq JSCell::m_type[t0], constexpr LastMaybeFalsyCellPrimitive, .slow
         btbnz JSCell::m_flags[t0], constexpr MasqueradesAsUndefined, .slow
         truthyCellConditionOp(dispatch)
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -22,120 +22,128 @@
 
 namespace JSC {
 
+// macro(JSType, DirectSpeculatedType)
+#define FOR_EACH_JS_TYPE(macro) \
+    /* The CellType value must come before any JSType that is a JSCell. */ \
+    macro(CellType, SpecCellOther) \
+    macro(StructureType, SpecCellOther) \
+    macro(StringType, SpecString) \
+    macro(HeapBigIntType, SpecHeapBigInt) \
+    macro(SymbolType, SpecSymbol) \
+    \
+    macro(GetterSetterType, SpecCellOther) \
+    macro(CustomGetterSetterType, SpecCellOther) \
+    macro(APIValueWrapperType, SpecCellOther) \
+    \
+    macro(NativeExecutableType, SpecCellOther) \
+    \
+    macro(ProgramExecutableType, SpecCellOther) \
+    macro(ModuleProgramExecutableType, SpecCellOther) \
+    macro(EvalExecutableType, SpecCellOther) \
+    macro(FunctionExecutableType, SpecCellOther) \
+    \
+    macro(UnlinkedFunctionExecutableType, SpecCellOther) \
+    \
+    macro(UnlinkedProgramCodeBlockType, SpecCellOther) \
+    macro(UnlinkedModuleProgramCodeBlockType, SpecCellOther) \
+    macro(UnlinkedEvalCodeBlockType, SpecCellOther) \
+    macro(UnlinkedFunctionCodeBlockType, SpecCellOther) \
+    \
+    macro(CodeBlockType, SpecCellOther) \
+    \
+    macro(JSImmutableButterflyType, SpecCellOther) \
+    macro(JSSourceCodeType, SpecCellOther) \
+    macro(JSScriptFetcherType, SpecCellOther) \
+    macro(JSScriptFetchParametersType, SpecCellOther) \
+    \
+    /* The ObjectType value must come before any JSType that is a subclass of JSObject. */ \
+    macro(ObjectType, SpecObjectOther) \
+    macro(FinalObjectType, SpecFinalObject) \
+    macro(JSCalleeType, SpecObjectOther) \
+    macro(JSFunctionType, SpecFunction) \
+    macro(InternalFunctionType, SpecObjectOther) \
+    macro(NullSetterFunctionType, SpecObjectOther) \
+    macro(BooleanObjectType, SpecObjectOther) \
+    macro(NumberObjectType, SpecObjectOther) \
+    macro(ErrorInstanceType, SpecObjectOther) \
+    macro(GlobalProxyType, SpecObjectOther) \
+    macro(DirectArgumentsType, SpecDirectArguments) \
+    macro(ScopedArgumentsType, SpecScopedArguments) \
+    macro(ClonedArgumentsType, SpecObjectOther) \
+    \
+    /* Start JSArray types. */ \
+    macro(ArrayType, SpecArray) \
+    macro(DerivedArrayType, SpecDerivedArray) \
+    /* End JSArray types. */ \
+    \
+    macro(ArrayBufferType, SpecObjectOther) \
+    \
+    /* Start JSArrayBufferView types. Keep in sync with the order of FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW. */ \
+    macro(Int8ArrayType, SpecInt8Array) \
+    macro(Uint8ArrayType,SpecUint8Array) \
+    macro(Uint8ClampedArrayType, SpecUint8ClampedArray) \
+    macro(Int16ArrayType, SpecInt16Array) \
+    macro(Uint16ArrayType, SpecUint16Array) \
+    macro(Int32ArrayType, SpecInt32Array) \
+    macro(Uint32ArrayType, SpecUint32Array) \
+    macro(Float32ArrayType, SpecFloat32Array) \
+    macro(Float64ArrayType, SpecFloat64Array) \
+    macro(BigInt64ArrayType, SpecBigInt64Array) \
+    macro(BigUint64ArrayType, SpecBigUint64Array) \
+    macro(DataViewType, SpecDataViewObject) \
+    /* End JSArrayBufferView types. */ \
+    \
+    /* JSScope <- JSWithScope */ \
+    /*         <- StrictEvalActivation */ \
+    /*         <- JSSymbolTableObject  <- JSLexicalEnvironment      <- JSModuleEnvironment */ \
+    /*                                 <- JSSegmentedVariableObject <- JSGlobalLexicalEnvironment */ \
+    /*                                                              <- JSGlobalObject */ \
+    /* Start JSScope types. */ \
+    /* Start environment record types. */ \
+    macro(GlobalObjectType, SpecObjectOther) \
+    macro(GlobalLexicalEnvironmentType, SpecObjectOther) \
+    macro(LexicalEnvironmentType, SpecObjectOther) \
+    macro(ModuleEnvironmentType, SpecObjectOther) \
+    macro(StrictEvalActivationType, SpecObjectOther) \
+    /* End environment record types. */ \
+    macro(WithScopeType, SpecObjectOther) \
+    /* End JSScope types. */ \
+    \
+    macro(ModuleNamespaceObjectType, SpecObjectOther) \
+    macro(ShadowRealmType, SpecObjectOther) \
+    macro(RegExpObjectType, SpecRegExpObject) \
+    macro(JSDateType, SpecDateObject) \
+    macro(ProxyObjectType, SpecProxyObject) \
+    macro(JSGeneratorType, SpecObjectOther) \
+    macro(JSAsyncGeneratorType, SpecObjectOther) \
+    macro(JSArrayIteratorType, SpecObjectOther) \
+    macro(JSMapIteratorType, SpecObjectOther) \
+    macro(JSSetIteratorType, SpecObjectOther) \
+    macro(JSStringIteratorType, SpecObjectOther) \
+    macro(JSPromiseType, SpecPromiseObject) \
+    macro(JSMapType, SpecMapObject) \
+    macro(JSSetType, SpecSetObject) \
+    macro(JSWeakMapType, SpecWeakMapObject) \
+    macro(JSWeakSetType, SpecWeakSetObject) \
+    macro(WebAssemblyModuleType, SpecObjectOther) \
+    macro(WebAssemblyInstanceType, SpecObjectOther) \
+    macro(WebAssemblyGCObjectType, SpecObjectOther) \
+    /* Start StringObjectType types. */ \
+    macro(StringObjectType, SpecStringObject) \
+    /* We do not want to accept String.prototype in StringObjectUse, so that we do not include it as SpecStringObject. */ \
+    macro(DerivedStringObjectType, SpecObjectOther) \
+    /* End StringObjectType types. */ \
+
+
 enum JSType : uint8_t {
-    // The CellType value must come before any JSType that is a JSCell.
-    CellType,
-    StructureType,
-    StringType,
-    HeapBigIntType,
-    LastMaybeFalsyCellPrimitive = HeapBigIntType,
-    SymbolType,
-
-    GetterSetterType,
-    CustomGetterSetterType,
-    APIValueWrapperType,
-
-    NativeExecutableType,
-
-    ProgramExecutableType,
-    ModuleProgramExecutableType,
-    EvalExecutableType,
-    FunctionExecutableType,
-
-    UnlinkedFunctionExecutableType,
-
-    UnlinkedProgramCodeBlockType,
-    UnlinkedModuleProgramCodeBlockType,
-    UnlinkedEvalCodeBlockType,
-    UnlinkedFunctionCodeBlockType,
-        
-    CodeBlockType,
-
-    JSImmutableButterflyType,
-    JSSourceCodeType,
-    JSScriptFetcherType,
-    JSScriptFetchParametersType,
-
-    // The ObjectType value must come before any JSType that is a subclass of JSObject.
-    ObjectType,
-    FinalObjectType,
-    JSCalleeType,
-    JSFunctionType,
-    InternalFunctionType,
-    NullSetterFunctionType,
-    BooleanObjectType,
-    NumberObjectType,
-    ErrorInstanceType,
-    GlobalProxyType,
-    DirectArgumentsType,
-    ScopedArgumentsType,
-    ClonedArgumentsType,
-
-    // Start JSArray types.
-    ArrayType,
-    DerivedArrayType,
-    // End JSArray types.
-
-    ArrayBufferType,
-
-    // Start JSArrayBufferView types. Keep in sync with the order of FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW.
-    Int8ArrayType,
-    Uint8ArrayType,
-    Uint8ClampedArrayType,
-    Int16ArrayType,
-    Uint16ArrayType,
-    Int32ArrayType,
-    Uint32ArrayType,
-    Float32ArrayType,
-    Float64ArrayType,
-    BigInt64ArrayType,
-    BigUint64ArrayType,
-    DataViewType,
-    // End JSArrayBufferView types.
-
-    // JSScope <- JSWithScope
-    //         <- StrictEvalActivation
-    //         <- JSSymbolTableObject  <- JSLexicalEnvironment      <- JSModuleEnvironment
-    //                                 <- JSSegmentedVariableObject <- JSGlobalLexicalEnvironment
-    //                                                              <- JSGlobalObject
-    // Start JSScope types.
-    // Start environment record types.
-    GlobalObjectType,
-    GlobalLexicalEnvironmentType,
-    LexicalEnvironmentType,
-    ModuleEnvironmentType,
-    StrictEvalActivationType,
-    // End environment record types.
-    WithScopeType,
-    // End JSScope types.
-
-    ModuleNamespaceObjectType,
-    ShadowRealmType,
-    RegExpObjectType,
-    JSDateType,
-    ProxyObjectType,
-    JSGeneratorType,
-    JSAsyncGeneratorType,
-    JSArrayIteratorType,
-    JSMapIteratorType,
-    JSSetIteratorType,
-    JSStringIteratorType,
-    JSPromiseType,
-    JSMapType,
-    JSSetType,
-    JSWeakMapType,
-    JSWeakSetType,
-    WebAssemblyModuleType,
-    WebAssemblyInstanceType,
-    WebAssemblyGCObjectType,
-    // Start StringObjectType types.
-    StringObjectType,
-    DerivedStringObjectType,
-    // End StringObjectType types.
-
+#define JSC_DEFINE_JS_TYPE(type, speculatedType) type,
+    FOR_EACH_JS_TYPE(JSC_DEFINE_JS_TYPE)
+#undef JSC_DEFINE_JS_TYPE
     LastJSCObjectType = DerivedStringObjectType, // This is the last "JSC" Object type. After this, we have embedder's (e.g., WebCore) extended object types.
     MaxJSType = 0b11111111,
 };
+
+static constexpr uint32_t LastMaybeFalsyCellPrimitive = HeapBigIntType;
 
 static constexpr uint32_t FirstTypedArrayType = Int8ArrayType;
 static constexpr uint32_t LastTypedArrayType = DataViewType;


### PR DESCRIPTION
#### ea191c94955ddd2f015f7a677b138109987620b2
<pre>
[JSC] Make speculationFromValue cheap
<a href="https://bugs.webkit.org/show_bug.cgi?id=259633">https://bugs.webkit.org/show_bug.cgi?id=259633</a>
rdar://113098188

Reviewed by Mark Lam.

This patch makes speculationFromValue extremely cheap by using JSType based SpeculatedType lookup.
This function can be called from operationOptimize &amp; GC End phase. And this sometimes takes very long
time due to huge size of functions. Thus making this function extremely cheap is particularly important
to make startup time faster. In particular, we observed massive sampling points for speculationFromValue
in startup times in Speedometer2.1, Speedometer3.0, JetStream2.1, and JetStream3.0.

1. This patch removes SpecFunctionWithDefaultHasInstance and SpecFunctionWithNonDefaultHasInstance.
   We can just use existing Structure iteration and that can cover almost all possible cases. These
   type makes speculationFromValue costly for JSFunction and derived classes, so rather not so great.
2. This patch makes some functions JS_EXPORT_PRIVATE to make speculationFromValue non-JS_EXPORT_PRIVATE.
   So we can allow LTO / PGO to inline this if it is useful.
3. We define JSType via macro, and we list up corresponding SpeculatedType at that time. This allows us
   to construct a mapping between them easily, and this makes speculationFromValue just array lookup,
   which becomes extremely fast.

* Source/JavaScriptCore/bytecode/SpeculatedType.cpp:
(JSC::=):
(JSC::speculationFromStructure):
(JSC::speculationFromCell):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp:
(JSC::DFG::AbstractValue::validateOSREntryValue const):
(JSC::DFG::AbstractValue::validateTypeAcceptingBoxedInt52 const):
* Source/JavaScriptCore/dfg/DFGAbstractValue.h:
(JSC::DFG::AbstractValue::observeIndexingTypeTransition):
(JSC::DFG::AbstractValue::validateOSREntryValue const): Deleted.
(JSC::DFG::AbstractValue::validateTypeAcceptingBoxedInt52 const): Deleted.
* Source/JavaScriptCore/dfg/DFGInsertionSet.cpp:
(JSC::DFG::InsertionSet::insertConstant):
* Source/JavaScriptCore/dfg/DFGInsertionSet.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/266422@main">https://commits.webkit.org/266422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b4342d57c02a961d9d89c14999f87bc2cbe6ec2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13819 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13127 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13986 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/11707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16258 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/11891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/12465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11795 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/12967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13087 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13162 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12432 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16765 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1595 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13005 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->