### PR TITLE
Compute the correct overflow-x and overflow-y values for table elements

### DIFF
--- a/LayoutTests/fast/table/overflowScroll-display-block-expected.html
+++ b/LayoutTests/fast/table/overflowScroll-display-block-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+div
+{
+    margin-bottom: 35px;
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+</style>
+<div style="overflow: scroll;">
+</div>
+<div style="overflow: scroll;">
+</div>
+<div style="overflow: scroll;">
+</div>
+<p> crbug.com/368699: When table elements have display: block, they should be allowed to have overflow:scroll. The exception is the table element, which doesn't permit anything other than visible per http://dev.w3.org/csswg/css2/visufx.html#overflow.</p>

--- a/LayoutTests/fast/table/overflowScroll-display-block.html
+++ b/LayoutTests/fast/table/overflowScroll-display-block.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    overflow: scroll;
+    display: block;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td></td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td></td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td></td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: When table elements have display: block, they should be allowed to have overflow:scroll. The exception is the table element, which doesn't permit anything other than visible per http://dev.w3.org/csswg/css2/visufx.html#overflow.</p>

--- a/LayoutTests/fast/table/overflowScroll-expected.html
+++ b/LayoutTests/fast/table/overflowScroll-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td>text text text text</td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: Tables, table rows and table sections don't have scrollbars when they have overflow:scroll. </p>

--- a/LayoutTests/fast/table/overflowScroll.html
+++ b/LayoutTests/fast/table/overflowScroll.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+.scrollingElement
+{
+    width: 100px;
+    height: 100px;
+    background-color: green;
+}
+table
+{
+    margin-bottom: 35px;
+}
+</style>
+<table class="scrollingElement" cellspacing=0>
+    <tbody>
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody class="scrollingElement">
+        <tr><td> text text text text</td></tr>
+    </tbody>
+</table>
+<table cellspacing=0>
+    <tbody>
+        <tr class="scrollingElement"><td>text text text text</td></tr>
+    </tbody>
+</table>
+<p> crbug.com/368699: Tables, table rows and table sections don't have scrollbars when they have overflow:scroll. </p>

--- a/LayoutTests/fast/table/table-different-overflow-values-2-expected.txt
+++ b/LayoutTests/fast/table/table-different-overflow-values-2-expected.txt
@@ -1,0 +1,22 @@
+This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS table1: overflow-x is either not visible or both overflow values are visible.
+PASS table2: overflow-x is either not visible or both overflow values are visible.
+PASS table3: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table1: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table2: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table3: overflow-x is either not visible or both overflow values are visible.
+PASS tbody1: overflow-x is either not visible or both overflow values are visible.
+PASS tbody2: overflow-x is either not visible or both overflow values are visible.
+PASS tbody3: overflow-x is either not visible or both overflow values are visible.
+PASS tr1: overflow-x is either not visible or both overflow values are visible.
+PASS tr2: overflow-x is either not visible or both overflow values are visible.
+PASS tr3: overflow-x is either not visible or both overflow values are visible.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/table/table-different-overflow-values-2.html
+++ b/LayoutTests/fast/table/table-different-overflow-values-2.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<!-- For tables. -->
+<table id="table1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+<table id="table2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+<table id="table3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+<!-- For inline tables. -->
+<table id="inline_table1" class="test" style="overflow-y: visible; overflow-x: auto; display: inline-table;"/>
+<table id="inline_table2" class="test" style="overflow-y: visible; overflow-x: scroll; display: inline-table;"/>
+<table id="inline_table3" class="test" style="overflow-y: visible; overflow-x: hidden; display: inline-table;"/>
+<!-- For table row groups. -->
+<table>
+    <tbody id="tbody1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+    <tbody id="tbody2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+    <tbody id="tbody3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+</table>
+<!-- For table rows. -->
+<table>
+    <tr id="tr1" class="test" style="overflow-y: visible; overflow-x: auto"/>
+    <tr id="tr2" class="test" style="overflow-y: visible; overflow-x: scroll"/>
+    <tr id="tr3" class="test" style="overflow-y: visible; overflow-x: hidden"/>
+</table>
+<script>
+description("This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.");
+var elements = document.getElementsByClassName("test");
+for (i = 0; i < elements.length; ++i)
+{
+    computedStyle = getComputedStyle(elements[i]);
+    overflowX = computedStyle.getPropertyValue('overflow-x');
+    overflowY = computedStyle.getPropertyValue('overflow-y');
+    if (overflowX == "visible" && overflowX != overflowY)
+        testFailed(elements[i].id + ": overflow-y should be visible. Was " + overflowY + ".");
+    else
+        testPassed(elements[i].id + ": overflow-x is either not visible or both overflow values are visible.");
+}
+</script>

--- a/LayoutTests/fast/table/table-different-overflow-values-expected.txt
+++ b/LayoutTests/fast/table/table-different-overflow-values-expected.txt
@@ -1,0 +1,22 @@
+This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS table1: overflow-x is either not visible or both overflow values are visible.
+PASS table2: overflow-x is either not visible or both overflow values are visible.
+PASS table3: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table1: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table2: overflow-x is either not visible or both overflow values are visible.
+PASS inline_table3: overflow-x is either not visible or both overflow values are visible.
+PASS tbody1: overflow-x is either not visible or both overflow values are visible.
+PASS tbody2: overflow-x is either not visible or both overflow values are visible.
+PASS tbody3: overflow-x is either not visible or both overflow values are visible.
+PASS tr1: overflow-x is either not visible or both overflow values are visible.
+PASS tr2: overflow-x is either not visible or both overflow values are visible.
+PASS tr3: overflow-x is either not visible or both overflow values are visible.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/table/table-different-overflow-values.html
+++ b/LayoutTests/fast/table/table-different-overflow-values.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<!-- For tables. -->
+<table id="table1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+<table id="table2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+<table id="table3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+<!-- For inline tables. -->
+<table id="inline_table1" class="test" style="overflow-x: visible; overflow-y: auto; display: inline-table;"/>
+<table id="inline_table2" class="test" style="overflow-x: visible; overflow-y: scroll; display: inline-table;"/>
+<table id="inline_table3" class="test" style="overflow-x: visible; overflow-y: hidden; display: inline-table;"/>
+<!-- For table row groups. -->
+<table>
+    <tbody id="tbody1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+    <tbody id="tbody2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+    <tbody id="tbody3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+</table>
+<!-- For table rows. -->
+<table>
+    <tr id="tr1" class="test" style="overflow-x: visible; overflow-y: auto"/>
+    <tr id="tr2" class="test" style="overflow-x: visible; overflow-y: scroll"/>
+    <tr id="tr3" class="test" style="overflow-x: visible; overflow-y: hidden"/>
+</table>
+<script>
+description("This test checks for overflow equality. If overflow-x is visible then overflow-y should be visible as well.");
+var elements = document.getElementsByClassName("test");
+for (i = 0; i < elements.length; ++i)
+{
+    computedStyle = getComputedStyle(elements[i]);
+    overflowX = computedStyle.getPropertyValue('overflow-x');
+    overflowY = computedStyle.getPropertyValue('overflow-y');
+    if (overflowX == "visible" && overflowX != overflowY)
+        testFailed(elements[i].id + ": overflow-y should be visible. Was " + overflowY + ".");
+    else
+        testPassed(elements[i].id + ": overflow-x is either not visible or both overflow values are visible.");
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/overflow/computed-value-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/overflow/computed-value-001-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL overflow on MathML elements assert_equals: overflow on mtr expected "scroll" but got "visible"
+PASS overflow on MathML elements
 
 
 


### PR DESCRIPTION
#### e6264aebbca8560834e3cf399543ab4dbbbc4855
<pre>
Compute the correct overflow-x and overflow-y values for table elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=252422">https://bugs.webkit.org/show_bug.cgi?id=252422</a>
rdar://problem/105850323

Reviewed by Antti Koivisto.

This patch is to align WebKit with Chromium / Blink and Firefox / Gecko.

Inspired &amp; Test Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=199640

This patch is to align WebKit to respect web-specification[1] &amp; [2], which tells us that
display:table must treat anything other than hidden as visible and if overflow-x and
overflow-y are different, how they must be resolved. This latter part is already taken care
of, we&apos;re just allowing it to be applied to tables and table parts now.
Additionally, it allows us to have consolidated logic and simplify our code.

[1] <a href="https://drafts.csswg.org/css2/#overflow">https://drafts.csswg.org/css2/#overflow</a>
[2] <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a>

* Source/WebCore/style/StyleAdjuster.cpp:
(isOverflowClipOrVisible): New static &apos;bool&apos; helper function
(Adjuster::adjust): Update handling of &quot;overflow-x&quot; and &quot;overflow-y&quot; align with spec and
interop with other engines and simplify code with comments
* LayoutTests/fast/table/table-different-overflow-values.html: Add Test Case
* LayoutTests/fast/table/table-different-overflow-values-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/table-different-overflow-values-2.html: Add Test Case
* LayoutTests/fast/table/table-different-overflow-values-2-expected.txt: Add Test Case Expectation
* LayoutTests/fast/table/overflowScroll.html: Add Test Case
* LayoutTests/fast/table/overflowScroll-expected.html: Add Test Case Expectation
* LayoutTests/fast/table/overflowScroll-display-block.html: Add Test Case
* LayoutTests/fast/table/overflowScroll-display-block-expected.html: Add Test Case Expectation
* LayoutTests/imported/w3c/web-platform-tests/mathml/relations/css-styling/overflow/computed-value-001-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/266560@main">https://commits.webkit.org/266560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e4dbbc2798d897a9be5642aad15c430dc0600a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15903 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14560 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14342 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16622 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/12771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16140 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12763 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/12631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1680 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->