### PR TITLE
[fullscreen] Remove hierarchy requirement from fullscreen ready check

### DIFF
--- a/LayoutTests/fullscreen/full-screen-restrictions-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-restrictions-expected.txt
@@ -4,10 +4,6 @@ This tests the restrictions to entering full screen mode laid out in section 4.1
 EVENT(webkitfullscreenerror)
 "The context object's node document, or an ancestor browsing context's document does not have the fullscreen enabled flag set."
 EVENT(webkitfullscreenerror)
-"The context object's node document fullscreen element stack is not empty and its top element is not an ancestor of the context object."
-EVENT(webkitfullscreenchange)
-EVENT(webkitfullscreenerror)
-EVENT(webkitfullscreenchange)
 "A descendant browsing context's document has a non-empty fullscreen element stack."
 EVENT(webkitfullscreenchange)
 EVENT(webkitfullscreenerror)
@@ -15,6 +11,5 @@ EVENT(webkitfullscreenchange)
 "This algorithm is not allowed to show a pop-up."
 EVENT(webkitfullscreenerror)
 END OF TEST
-
 
 

--- a/LayoutTests/fullscreen/full-screen-restrictions.html
+++ b/LayoutTests/fullscreen/full-screen-restrictions.html
@@ -26,20 +26,6 @@
         };
 
         var step3 = function() {
-            consoleWrite('"The context object\'s node document fullscreen element stack is not empty and its top element is not an ancestor of the context object."');
-            var div = document.documentElement.appendChild(document.createElement('div'));
-            var div2 = document.documentElement.appendChild(document.createElement('div'));
-            waitForEventOnce(document, 'webkitfullscreenchange', function() {
-                waitForEventOnce(document, 'webkitfullscreenerror', function() {
-                   waitForEventOnce(document, 'webkitfullscreenchange', step4);
-                   document.webkitExitFullscreen(); 
-                });
-                runWithKeyDown(function(){div2.webkitRequestFullscreen()});
-            });
-            runWithKeyDown(function(){div.webkitRequestFullscreen()});
-        };
-
-        var step4 = function() {
             consoleWrite('"A descendant browsing context\'s document has a non-empty fullscreen element stack."');
             var iframe = document.documentElement.appendChild(document.createElement('iframe'));
             iframe.setAttribute('webkitallowfullscreen', 'true');
@@ -47,7 +33,7 @@
             var div2 = document.documentElement.appendChild(document.createElement('div'));
             waitForEventOnce(iframe.contentDocument, 'webkitfullscreenchange', function() {
                 waitForEventOnce(document, 'webkitfullscreenerror', function(){
-                    waitForEventOnce(iframe.contentDocument, 'webkitfullscreenchange', step5);
+                    waitForEventOnce(iframe.contentDocument, 'webkitfullscreenchange', step4);
                     iframe.contentDocument.webkitExitFullscreen(); 
                 });
                 runWithKeyDown(function(){div2.webkitRequestFullscreen()});
@@ -55,7 +41,7 @@
             runWithKeyDown(function(){div.webkitRequestFullscreen()});
         };
 
-        var step5 = function() {
+        var step4 = function() {
             consoleWrite('"This algorithm is not allowed to show a pop-up."');
             var div = document.documentElement.appendChild(document.createElement('div'));
             waitForEventOnce(document, 'webkitfullscreenerror', endTest);

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-fullscreen-element-sibling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-fullscreen-element-sibling-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element ready check for sibling of fullscreen element promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Element ready check for sibling of fullscreen element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-non-top-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-non-top-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL
+PASS
     Element#requestFullscreen() for non-top element in fullscreen element stack
- promise_test: Unhandled rejection with value: object "TypeError: Type error"
+
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-two-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-two-elements-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element#requestFullscreen() on two elements in the same document promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Element#requestFullscreen() on two elements in the same document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering-expected.txt
@@ -1,0 +1,5 @@
+Element A
+Element B
+
+PASS Requesting fullscreen on A, then B, then A
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<title>Re-requesting fullscreen doesn't fail but doesn't change order</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../../html/semantics/popovers/resources/popover-utils.js"></script>
+
+<div class="elements">
+  <div id="A">Element A</div>
+  <div id="B">Element B</div>
+</div>
+
+<style>
+  .elements > div {
+    width: 200px;
+    height: 200px;
+  }
+  #A { background: blue; }
+  #B { background: green; }
+</style>
+
+<script>
+promise_test(async (t) => {
+  t.add_cleanup(async () => {
+    while (document.fullscreenElement)
+      await document.exitFullscreen();
+  });
+  document.onfullscreenerror = () => assert_unreached('fullscreenerror should not happen');
+  const A = document.getElementById('A');
+  const B = document.getElementById('B');
+  assert_true(!isTopLayer(A) && !isTopLayer(B));
+  await blessTopLayer(document.body);
+  await A.requestFullscreen();
+  assert_equals(document.fullscreenElement, A, 'first A request');
+  assert_true(isTopLayer(A), 'A top layer');
+  await blessTopLayer(A);
+  try {
+    await B.requestFullscreen();
+  } catch (error) {
+    assert_unreached('The second call to requestFullscreen rejected - it should be possible to put siblings into fullscreen together');
+  }
+  assert_equals(document.fullscreenElement, B, 'B request');
+  assert_true(isTopLayer(B), 'B top layer');
+  assert_true(isTopLayer(A), 'A still top layer');
+  await blessTopLayer(B);
+  await A.requestFullscreen();
+  assert_true(isTopLayer(A), 'A is still top layer');
+  assert_true(isTopLayer(B), 'B is still top layer');
+  assert_equals(document.fullscreenElement, A, 'A is moved back to the top of the top layer stack');
+  assert_equals(document.elementFromPoint(10, 10), A, 'A should be topmost');
+
+  await document.exitFullscreen();
+  assert_equals(document.fullscreenElement, B, 'B goes back to being the fullscreen element');
+  assert_true(isTopLayer(B), 'B is still top layer');
+  assert_false(isTopLayer(A), 'A is no longer top layer');
+  await document.exitFullscreen();
+  assert_equals(document.fullscreenElement, null, 'Both closed');
+  assert_false(isTopLayer(A), 'A is no longer top layer');
+  assert_false(isTopLayer(B), 'B is no longer top layer');
+}, 'Requesting fullscreen on A, then B, then A');
+</script>

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt
@@ -1,3 +1,6 @@
+This is a Fullscreen Element
+
+Harness Error (FAIL), message = Test named 'A Fullscreen Element should *not* close a Fullscreen Element.' specified 1 'cleanup' function, and 1 failed.
 
 PASS A Popover should close a Popover.
 PASS A Modal Dialog should close a Popover.

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -216,14 +216,6 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
             return;
         }
 
-        // The context object's node document fullscreen element stack is not empty and its top element
-        // is not an ancestor of the context object.
-        if (auto* currentFullscreenElement = fullscreenElement(); currentFullscreenElement && !currentFullscreenElement->contains(element.get())) {
-            ERROR_LOG(identifier, "task - fullscreen stack not empty; failing.");
-            failedPreflights(WTFMove(element), WTFMove(promise));
-            return;
-        }
-
         // A descendant browsing context's document has a non-empty fullscreen element stack.
         bool descendentHasNonEmptyStack = false;
         for (auto* descendant = frame() ? frame()->tree().traverseNext() : nullptr; descendant; descendant = descendant->tree().traverseNext()) {
@@ -402,9 +394,13 @@ void FullscreenManager::exitFullscreen(RefPtr<DeferredPromise>&& promise)
         else {
             finishExitFullscreen(document(), ExitMode::NoResize);
 
-            INFO_LOG(identifier, "task - New fullscreen element.");
             m_pendingFullscreenElement = fullscreenElement();
-            page->chrome().client().enterFullScreenForElement(*m_pendingFullscreenElement);
+            if (m_pendingFullscreenElement)
+                page->chrome().client().enterFullScreenForElement(*m_pendingFullscreenElement);
+            else if (m_pendingPromise) {
+                m_pendingPromise->resolve();
+                m_pendingPromise = nullptr;
+            }
         }
     });
 }


### PR DESCRIPTION
#### 675766f7450526b44c5f863da3d42ddd3aa9a13d
<pre>
[fullscreen] Remove hierarchy requirement from fullscreen ready check
<a href="https://bugs.webkit.org/show_bug.cgi?id=257199">https://bugs.webkit.org/show_bug.cgi?id=257199</a>
rdar://110004138

Reviewed by Darin Adler.

The hierarchy requirement was part of the old W3C spec, but is no longer part of the current WHATWG spec. It has also been removed from Blink &amp; Gecko.

Also fix a nullptr deref to make popover-top-layer-interactions.html pass, by adding step 11 of exit fullscreen algorithm to both ExitMode codepaths.

* LayoutTests/fullscreen/full-screen-restrictions-expected.txt:
* LayoutTests/fullscreen/full-screen-restrictions.html:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-fullscreen-element-sibling-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-non-top-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-two-elements-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-interactions-expected.txt.
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::exitFullscreen): Fix nullptr deref in the edge case where 2 exit fullscreen event loop tasks are queued next to each other.

Canonical link: <a href="https://commits.webkit.org/266426@main">https://commits.webkit.org/266426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d46c717a2819813ff01b5f6ad8fee71365ee0e47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14484 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15819 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16277 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11910 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19524 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12986 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11060 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12345 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/3359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16782 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1596 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->