### PR TITLE
[Win][MiniBrowser] Don't show the download dialog for subframes.

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
@@ -43,3 +43,8 @@ WKURLResponseRef WKNavigationResponseCopyResponse(WKNavigationResponseRef respon
 {
     return WebKit::toAPI(API::URLResponse::create(WebKit::toImpl(response)->response()).leakRef());
 }
+
+WKFrameInfoRef WKNavigationResponseGetFrameInfoRef(WKNavigationResponseRef response)
+{
+    return WebKit::toAPI(WebKit::toImpl(response)->frame());
+}

--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
@@ -36,6 +36,7 @@ WK_EXPORT WKTypeID WKNavigationResponseGetTypeID();
     
 WK_EXPORT bool WKNavigationResponseCanShowMIMEType(WKNavigationResponseRef);
 WK_EXPORT WKURLResponseRef WKNavigationResponseCopyResponse(WKNavigationResponseRef);
+WK_EXPORT WKFrameInfoRef WKNavigationResponseGetFrameInfoRef(WKNavigationResponseRef);
 
 #ifdef __cplusplus
 }

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -36,6 +36,7 @@
 #include <WebKit/WKCredential.h>
 #include <WebKit/WKDownloadClient.h>
 #include <WebKit/WKDownloadRef.h>
+#include <WebKit/WKFrameInfoRef.h>
 #include <WebKit/WKHTTPCookieStoreRef.h>
 #include <WebKit/WKInspector.h>
 #include <WebKit/WKNavigationResponseRef.h>
@@ -511,7 +512,8 @@ void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef page, WKNa
         MessageBox(thisWindow.m_hMainWnd, text.str().c_str(), L"No Content", MB_OK | MB_ICONWARNING);
     }
 
-    if (WKNavigationResponseCanShowMIMEType(navigationResponse))
+    auto isMainFrame = WKFrameInfoGetIsMainFrame(WKNavigationResponseGetFrameInfoRef(navigationResponse));
+    if (WKNavigationResponseCanShowMIMEType(navigationResponse) | !isMainFrame)
         WKFramePolicyListenerUse(listener);
     else {
         std::wstringstream text;


### PR DESCRIPTION
#### ea4731fad3f7c997c8f20d2cba67697da8a791a7
<pre>
[Win][MiniBrowser] Don&apos;t show the download dialog for subframes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259638">https://bugs.webkit.org/show_bug.cgi?id=259638</a>

Reviewed by NOBODY (OOPS!).

On some pages, a download dialog is displayed even though the content
is not for download since 266320@main. Refer to the SOUP port and
we modify it so that it does not download if it is a subframe.

* Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp:
(WKNavigationResponseGetFrameInfoRef):
* Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::decidePolicyForNavigationResponse):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea4731fad3f7c997c8f20d2cba67697da8a791a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14129 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/14462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/15551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13123 "Failed to checkout and rebase branch from PR 16222") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13896 "Failed to checkout and rebase branch from PR 16222") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/15551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/13982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/14462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/11887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/14462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/16254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/12963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/14462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13158 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12428 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/14462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->