### PR TITLE
[Win][MiniBrowser] Don't show the download dialog for subframes.

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
@@ -43,3 +43,9 @@ WKURLResponseRef WKNavigationResponseCopyResponse(WKNavigationResponseRef respon
 {
     return WebKit::toAPI(API::URLResponse::create(WebKit::toImpl(response)->response()).leakRef());
 }
+
+WKFrameInfoRef WKNavigationResponseCopyFrameInfo(WKNavigationResponseRef response)
+{
+    Ref frame = WebKit::toImpl(response)->frame();
+    return WebKit::toAPI(&frame.leakRef());
+}

--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h
@@ -36,6 +36,7 @@ WK_EXPORT WKTypeID WKNavigationResponseGetTypeID();
     
 WK_EXPORT bool WKNavigationResponseCanShowMIMEType(WKNavigationResponseRef);
 WK_EXPORT WKURLResponseRef WKNavigationResponseCopyResponse(WKNavigationResponseRef);
+WK_EXPORT WKFrameInfoRef WKNavigationResponseCopyFrameInfo(WKNavigationResponseRef);
 
 #ifdef __cplusplus
 }

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.cpp
@@ -36,6 +36,7 @@
 #include <WebKit/WKCredential.h>
 #include <WebKit/WKDownloadClient.h>
 #include <WebKit/WKDownloadRef.h>
+#include <WebKit/WKFrameInfoRef.h>
 #include <WebKit/WKHTTPCookieStoreRef.h>
 #include <WebKit/WKInspector.h>
 #include <WebKit/WKNavigationResponseRef.h>
@@ -511,7 +512,8 @@ void WebKitBrowserWindow::decidePolicyForNavigationResponse(WKPageRef page, WKNa
         MessageBox(thisWindow.m_hMainWnd, text.str().c_str(), L"No Content", MB_OK | MB_ICONWARNING);
     }
 
-    if (WKNavigationResponseCanShowMIMEType(navigationResponse))
+    auto isMainFrame = WKFrameInfoGetIsMainFrame(adoptWK(WKNavigationResponseCopyFrameInfo(navigationResponse)).get());
+    if (WKNavigationResponseCanShowMIMEType(navigationResponse) || !isMainFrame)
         WKFramePolicyListenerUse(listener);
     else {
         std::wstringstream text;


### PR DESCRIPTION
#### b6570992dff1c1d29ccca397f0dd24f016a2edc9
<pre>
[Win][MiniBrowser] Don&apos;t show the download dialog for subframes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259639">https://bugs.webkit.org/show_bug.cgi?id=259639</a>

Reviewed by Fujii Hironori.

On some pages, a download dialog is displayed even though the content
is not for download since 266320@main. Refer to the SOUP port and
we modify it so that it does not download if it is a subframe.

* Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp:
(WKNavigationResponseCopyFrameInfo):
* Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.h:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
(WebKitBrowserWindow::decidePolicyForNavigationResponse):

Canonical link: <a href="https://commits.webkit.org/266471@main">https://commits.webkit.org/266471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34ffec175adcdf6b192dd70ab7fb1b40cf738069

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15890 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16368 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19594 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15937 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12540 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3376 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13107 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->