### PR TITLE
REGRESSION(227811@main): run-webkit-tests reports "perl: warning: Setting locale failed." on Windows

### DIFF
--- a/Tools/Scripts/webkitpy/common/host.py
+++ b/Tools/Scripts/webkitpy/common/host.py
@@ -76,6 +76,8 @@ class Host(SystemHost):
     # We call this from the Host constructor, as it's one of the
     # earliest calls made for all webkitpy-based programs.
     def _engage_awesome_locale_hacks(self):
+        if sys.platform.startswith('win'):
+            return
         # To make life easier on our non-english users, we override
         # the locale environment variables inside webkitpy.
         # If we don't do this, programs like SVN will output localized


### PR DESCRIPTION
#### 42fcbb07f8be92bcf0b6171f114e39aded2d10f4
<pre>
REGRESSION(227811@main): run-webkit-tests reports &quot;perl: warning: Setting locale failed.&quot; on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=259640">https://bugs.webkit.org/show_bug.cgi?id=259640</a>

Reviewed by Don Olmstead.

After 227811@main set a environment vairable &apos;LC_ALL&apos; to
&apos;en_US.UTF-8&apos;, run-webkit-tests reports &quot;perl: warning: Setting locale
failed.&quot; on Windows.

&gt; perl: warning: Setting locale failed.
&gt; perl: warning: Please check that your locale settings:
&gt;       LC_ALL = &quot;en_US.UTF-8&quot;,
&gt;       LC_MESSAGES = &quot;en_US.UTF-8&quot;,
&gt;       LANG = &quot;en_US.UTF-8&quot;
&gt;     are supported and installed on your system.
&gt; perl: warning: Falling back to the standard locale (&quot;C&quot;).

* Tools/Scripts/webkitpy/common/host.py:
(Host._engage_awesome_locale_hacks):
Do nothing on Windows.

Canonical link: <a href="https://commits.webkit.org/266671@main">https://commits.webkit.org/266671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/813a1fe43505f0c7974e61fd857b3aca525b8c7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15556 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15801 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16259 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/13911 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12466 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19503 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15848 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12433 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3490 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->