### PR TITLE
[content-visibility] Make c-v: auto add auto to contain-intrinsic-size

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Content Visibility: off-screen focus assert_equals: step5 height expected 10 but got 100
+PASS Content Visibility: off-screen focus
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -711,6 +711,8 @@ public:
     inline bool containIntrinsicHeightHasAuto() const;
     inline bool containIntrinsicLogicalWidthHasAuto() const;
     inline bool containIntrinsicLogicalHeightHasAuto() const;
+    inline void containIntrinsicWidthAddAuto();
+    inline void containIntrinsicHeightAddAuto();
     inline std::optional<Length> containIntrinsicWidth() const;
     inline std::optional<Length> containIntrinsicHeight() const;
     inline bool hasAutoLengthContainIntrinsicSize() const;

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -556,6 +556,22 @@ inline bool RenderStyle::setZoom(float zoomLevel)
     return true;
 }
 
+inline void RenderStyle::containIntrinsicWidthAddAuto()
+{
+    if (containIntrinsicWidthType() == ContainIntrinsicSizeType::None)
+        setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndNone);
+    else if (containIntrinsicWidthType() == ContainIntrinsicSizeType::Length)
+        setContainIntrinsicWidthType(ContainIntrinsicSizeType::AutoAndLength);
+}
+
+inline void RenderStyle::containIntrinsicHeightAddAuto()
+{
+    if (containIntrinsicHeightType() == ContainIntrinsicSizeType::None)
+        setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndNone);
+    else if (containIntrinsicHeightType() == ContainIntrinsicSizeType::Length)
+        setContainIntrinsicHeightType(ContainIntrinsicSizeType::AutoAndLength);
+}
+
 #if ENABLE(CSS_COMPOSITING)
 
 inline void RenderStyle::setBlendMode(BlendMode mode)

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -619,6 +619,11 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     if (isSkippedContentRoot(style, m_element) && m_parentStyle.contentVisibility() != ContentVisibility::Hidden)
         style.setSkippedContentReason(style.contentVisibility());
 
+    if (style.contentVisibility() == ContentVisibility::Auto) {
+        style.containIntrinsicWidthAddAuto();
+        style.containIntrinsicHeightAddAuto();
+    }
+
     adjustForSiteSpecificQuirks(style);
 }
 


### PR DESCRIPTION
#### 3c2445f3450d97ed4cd9d3400b09352f051ce241
<pre>
[content-visibility] Make c-v: auto add auto to contain-intrinsic-size
<a href="https://bugs.webkit.org/show_bug.cgi?id=259645">https://bugs.webkit.org/show_bug.cgi?id=259645</a>

Reviewed by Tim Nguyen.

This was approved here:
<a href="https://github.com/w3c/csswg-drafts/issues/8407#issuecomment-1440466558">https://github.com/w3c/csswg-drafts/issues/8407#issuecomment-1440466558</a>

Already implemented in Chromium and gecko.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-068-expected.txt:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::containIntrinsicWidthAddAuto):
(WebCore::RenderStyle::containIntrinsicHeightAddAuto):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/267180@main">https://commits.webkit.org/267180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a08e25b22bfa865193f33db1cb46d5d3ed7462c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/16096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14808 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/19095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/16192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/17303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/16440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/18295 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13687 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/21148 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13564 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17672 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/15024 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/15007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12721 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15976 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/14254 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/4006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18623 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/17171 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14829 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3801 "Passed tests") | 
<!--EWS-Status-Bubble-End-->