### PR TITLE
[GTK] Fallback to first render node returned by DRM when failing to get using EGLDevice

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -457,32 +457,54 @@ const String& PlatformDisplay::drmDeviceFile()
     return m_drmDeviceFile.value();
 }
 
-static String drmRenderNodeFromPrimaryDeviceFile(const String& primaryDeviceFile)
+static void drmForeachDevice(Function<bool(drmDevice*)>&& functor)
 {
-    if (primaryDeviceFile.isEmpty())
-        return { };
-
     drmDevicePtr devices[64];
     memset(devices, 0, sizeof(devices));
 
     int numDevices = drmGetDevices2(0, devices, std::size(devices));
     if (numDevices <= 0)
-        return { };
+        return;
+
+    for (int i = 0; i < numDevices; ++i) {
+        if (!functor(devices[i]))
+            break;
+    }
+    drmFreeDevices(devices, numDevices);
+}
+
+static String drmFirstRenderNode()
+{
+    String renderNodeDeviceFile;
+    drmForeachDevice([&](drmDevice* device) {
+        if (!(device->available_nodes & (1 << DRM_NODE_RENDER)))
+            return true;
+
+        renderNodeDeviceFile = String::fromUTF8(device->nodes[DRM_NODE_RENDER]);
+        return false;
+    });
+    return renderNodeDeviceFile;
+}
+
+static String drmRenderNodeFromPrimaryDeviceFile(const String& primaryDeviceFile)
+{
+    if (primaryDeviceFile.isEmpty())
+        return drmFirstRenderNode();
 
     String renderNodeDeviceFile;
-    for (int i = 0; i < numDevices; ++i) {
-        drmDevice* device = devices[i];
+    drmForeachDevice([&](drmDevice* device) {
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY | 1 << DRM_NODE_RENDER)))
-            continue;
+            return true;
 
         if (String::fromUTF8(device->nodes[DRM_NODE_PRIMARY]) == primaryDeviceFile) {
             renderNodeDeviceFile = String::fromUTF8(device->nodes[DRM_NODE_RENDER]);
-            break;
+            return false;
         }
-    }
-    drmFreeDevices(devices, numDevices);
 
-    return renderNodeDeviceFile;
+        return true;
+    });
+    // If we fail to find a render node for the device file, just use the device file as render node.
+    return !renderNodeDeviceFile.isEmpty() ? renderNodeDeviceFile : primaryDeviceFile;
 }
 
 const String& PlatformDisplay::drmRenderNodeFile()
@@ -502,8 +524,10 @@ const String& PlatformDisplay::drmRenderNodeFile()
 
             // If EGL_EXT_device_drm_render_node is not present, try to get the render node using DRM API.
             m_drmRenderNodeFile = drmRenderNodeFromPrimaryDeviceFile(drmDeviceFile());
-        } else
-            m_drmRenderNodeFile = String();
+        } else {
+            // If EGLDevice is not available, just get the first render node returned by DRM.
+            m_drmRenderNodeFile = drmFirstRenderNode();
+        }
     }
 
     return m_drmRenderNodeFile.value();


### PR DESCRIPTION
#### a6106792d52a53b68c8c2206e112f2edf6f659ac
<pre>
[GTK] Fallback to first render node returned by DRM when failing to get using EGLDevice
<a href="https://bugs.webkit.org/show_bug.cgi?id=259647">https://bugs.webkit.org/show_bug.cgi?id=259647</a>

Reviewed by Alejandro G. Castro.

There might be drivers that don&apos;t implement EGL_EXT_device_query or
EGL_EXT_device_drm. In those cases just fallback to get the first
render node returned by libdrm.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::drmForeachDevice):
(WebCore::drmFirstRenderNode):
(WebCore::drmRenderNodeFromPrimaryDeviceFile):
(WebCore::PlatformDisplay::drmRenderNodeFile):

Canonical link: <a href="https://commits.webkit.org/266997@main">https://commits.webkit.org/266997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa5e5db1e20dbb1052ef261de54f82c3575f947

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15734 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15514 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/15942 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/13038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17821 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/13220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/13833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/13145 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/14302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/14000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/17254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14578 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12346 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15524 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13842 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3947 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18189 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15759 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14405 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/3759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->