### PR TITLE
configureLoggingChannel only needs to be exposed if !RELEASE_LOG_DISABLED

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -405,9 +405,9 @@ void GPUConnectionToWebProcess::destroyVisibilityPropagationContextForPage(WebPa
 }
 #endif
 
+#if !RELEASE_LOG_DISABLED
 void GPUConnectionToWebProcess::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)
 {
-#if !RELEASE_LOG_DISABLED
     if  (auto* channel = WebCore::getLogChannel(channelName)) {
         channel->state = state;
         channel->level = level;
@@ -419,12 +419,8 @@ void GPUConnectionToWebProcess::configureLoggingChannel(const String& channelNam
 
     channel->state = state;
     channel->level = level;
-#else
-    UNUSED_PARAM(channelName);
-    UNUSED_PARAM(state);
-    UNUSED_PARAM(level);
-#endif
 }
+#endif
 
 #if USE(GRAPHICS_LAYER_WC)
 void GPUConnectionToWebProcess::createWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -297,7 +297,9 @@ private:
     void createRemoteCommandListener(RemoteRemoteCommandListenerIdentifier);
     void releaseRemoteCommandListener(RemoteRemoteCommandListenerIdentifier);
     void setMediaOverridesForTesting(MediaOverridesForTesting);
+#if !RELEASE_LOG_DISABLED
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
+#endif
 
 #if USE(GRAPHICS_LAYER_WC)
     void createWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier, uint64_t nativeWindow, bool usesOffscreenRendering);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -52,7 +52,9 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     ReleaseAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
     CreateRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
     ReleaseRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
+#if !RELEASE_LOG_DISABLED
     ConfigureLoggingChannel(String channelName, enum:uint8_t WTFLogChannelState state, enum:uint8_t WTFLogLevel level)
+#endif
 #if USE(GRAPHICS_LAYER_WC)
     CreateWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering) AllowedWhenWaitingForSyncReply
     ReleaseWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12082,21 +12082,17 @@ const void* WebPageProxy::logIdentifier() const
     return reinterpret_cast<const void*>(intHash(identifier().toUInt64()));
 }
 
+#if !RELEASE_LOG_DISABLED
 void WebPageProxy::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)
 {
-#if !RELEASE_LOG_DISABLED
     auto* channel = getLogChannel(channelName);
     if  (!channel)
         return;
 
     channel->state = state;
     channel->level = level;
-#else
-    UNUSED_PARAM(channelName);
-    UNUSED_PARAM(state);
-    UNUSED_PARAM(level);
-#endif
 }
+#endif
 
 #if HAVE(APP_SSO)
 void WebPageProxy::decidePolicyForSOAuthorizationLoad(const String& extension, CompletionHandler<void(SOAuthorizationLoadPolicy)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1940,7 +1940,9 @@ public:
     void speechSynthesisResetState();
 #endif
 
+#if !RELEASE_LOG_DISABLED
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
+#endif
 
     void addDidMoveToWindowObserver(WebViewDidMoveToWindowObserver&);
     void removeDidMoveToWindowObserver(WebViewDidMoveToWindowObserver&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -555,7 +555,9 @@ messages -> WebPageProxy {
     RemovePDFHUD(WebKit::PDFPluginIdentifier identifier)
 #endif
 
+#if !RELEASE_LOG_DISABLED
     ConfigureLoggingChannel(String channelName, enum:uint8_t WTFLogChannelState state, enum:uint8_t WTFLogLevel level)
+#endif
 
 #if PLATFORM(GTK)
     ShowEmojiPicker(WebCore::IntRect caretRect) -> (String result)


### PR DESCRIPTION
#### 8d9df7a0a85b47882d07d749b3c68b317c770641
<pre>
configureLoggingChannel only needs to be exposed if !RELEASE_LOG_DISABLED
<a href="https://bugs.webkit.org/show_bug.cgi?id=259650">https://bugs.webkit.org/show_bug.cgi?id=259650</a>
rdar://113142431

Reviewed by NOBODY (OOPS!).

configureLoggingChannel for WebPageProxy and GPUConnectionToWebProcess
only needs to be exposed if !RELEASE_LOG_DISABLED. This change moves
the macro usage to the messages.in files so that we don&apos;t have a NOP
endpoint exposed when RELEASE_LOG_DISABLED.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::configureLoggingChannel):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::configureLoggingChannel):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d9df7a0a85b47882d07d749b3c68b317c770641

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15575 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13148 "Failed to compile WebKit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15822 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16280 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11914 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19545 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15869 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13025 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->