### PR TITLE
WebPage::mainFrameView() should return a FrameView

### DIFF
--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -75,13 +75,14 @@ public:
     virtual void changeLocation(FrameLoadRequest&&) = 0;
     virtual void broadcastFrameRemovalToOtherProcesses() = 0;
 
+    virtual FrameView* virtualView() const = 0;
+
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);
     void resetWindowProxy();
 
 private:
     virtual DOMWindow* virtualWindow() const = 0;
-    virtual FrameView* virtualView() const = 0;
 
     WeakPtr<Page> m_page;
     const FrameIdentifier m_frameID;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -897,7 +897,7 @@ void WebAutomationSessionProxy::setFilesForInputFileUpload(WebCore::PageIdentifi
 
 static WebCore::IntRect snapshotElementRectForScreenshot(WebPage& page, WebCore::Element* element, bool clipToViewport)
 {
-    auto* frameView = page.mainFrameView();
+    auto* frameView = page.localMainFrameView();
     if (!frameView)
         return { };
 
@@ -913,7 +913,7 @@ static WebCore::IntRect snapshotElementRectForScreenshot(WebPage& page, WebCore:
         return elementRect;
     }
 
-    if (auto* frameView = page.mainFrameView())
+    if (auto* frameView = page.localMainFrameView())
         return clipToViewport ? frameView->visibleContentRect() : WebCore::IntRect(WebCore::IntPoint(0, 0), frameView->contentsSize());
 
     return { };

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -635,7 +635,7 @@ void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
 
     m_page.pageDidScroll();
 #if USE(COORDINATED_GRAPHICS)
-    auto* frameView = m_page.mainFrameView();
+    auto* frameView = m_page.localMainFrameView();
     if (frameView && frameView->delegatesScrolling()) {
         m_page.drawingArea()->scroll(rect, IntSize());
         return;
@@ -1518,7 +1518,10 @@ void WebChromeClient::removePlaybackTargetPickerClient(PlaybackTargetClientConte
 
 void WebChromeClient::showPlaybackTargetPicker(PlaybackTargetClientContextIdentifier contextId, const IntPoint& position, bool isVideo)
 {
-    auto* frameView = m_page.mainFrameView();
+    auto* frameView = m_page.localMainFrameView();
+    if (!frameView)
+        return;
+
     FloatRect rect(frameView->contentsToRootView(frameView->windowToContents(position)), FloatSize());
     m_page.send(Messages::WebPageProxy::ShowPlaybackTargetPicker(contextId, rect, isVideo));
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -463,8 +463,11 @@ void DrawingAreaCoordinatedGraphics::displayDidRefresh()
 void DrawingAreaCoordinatedGraphics::adjustTransientZoom(double scale, FloatPoint origin)
 {
     if (!m_transientZoom) {
-        auto& frameView = *m_webPage.mainFrameView();
-        FloatRect unobscuredContentRect = frameView.unobscuredContentRectIncludingScrollbars();
+        auto* frameView = m_webPage.localMainFrameView();
+        if (!frameView)
+            return;
+
+        FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
 
         m_transientZoom = true;
         m_transientZoomInitialOrigin = unobscuredContentRect.location();

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -161,14 +161,17 @@ bool DrawingArea::supportsGPUProcessRendering(DrawingAreaType type)
 
 WebCore::TiledBacking* DrawingArea::mainFrameTiledBacking() const
 {
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
     return frameView ? frameView->tiledBacking() : nullptr;
 }
 
 void DrawingArea::prepopulateRectForZoom(double scale, WebCore::FloatPoint origin)
 {
     double currentPageScale = m_webPage.totalScaleFactor();
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
+    if (!frameView)
+        return;
+
     FloatRect tileCoverageRect = frameView->visibleContentRectIncludingScrollbars();
     tileCoverageRect.moveBy(-origin);
     tileCoverageRect.scale(currentPageScale / scale);
@@ -188,11 +191,11 @@ void DrawingArea::scaleViewToFitDocumentIfNeeded()
     LOG(Resize, "DrawingArea %p scaleViewToFitDocumentIfNeeded", this);
     m_webPage.layoutIfNeeded();
 
-    if (!m_webPage.mainFrameView() || !m_webPage.mainFrameView()->renderView())
+    if (!m_webPage.localMainFrameView() || !m_webPage.localMainFrameView()->renderView())
         return;
 
     int viewWidth = m_webPage.size().width();
-    int documentWidth = m_webPage.mainFrameView()->renderView()->unscaledDocumentRect().width();
+    int documentWidth = m_webPage.localMainFrameView()->renderView()->unscaledDocumentRect().width();
 
     bool documentWidthChanged = m_lastDocumentSizeForScaleToFit.width() != documentWidth;
     bool viewWidthChanged = m_lastViewSizeForScaleToFit.width() != viewWidth;
@@ -237,10 +240,10 @@ void DrawingArea::scaleViewToFitDocumentIfNeeded()
     m_webPage.setUseFixedLayout(false);
     m_webPage.layoutIfNeeded();
 
-    if (!m_webPage.mainFrameView() || !m_webPage.mainFrameView()->renderView())
+    if (!m_webPage.localMainFrameView() || !m_webPage.localMainFrameView()->renderView())
         return;
 
-    IntSize documentSize = m_webPage.mainFrameView()->renderView()->unscaledDocumentRect().size();
+    IntSize documentSize = m_webPage.localMainFrameView()->renderView()->unscaledDocumentRect().size();
     m_lastViewSizeForScaleToFit = m_webPage.size();
     m_lastDocumentSizeForScaleToFit = documentSize;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -158,7 +158,7 @@ void RemoteLayerTreeDrawingArea::updateGeometry(const IntSize& viewSize, bool fl
     if (!m_webPage.minimumSizeForAutoLayout().width() || m_webPage.autoSizingShouldExpandToViewHeight() || (!m_webPage.sizeToContentAutoSizeMaximumSize().width() && !m_webPage.sizeToContentAutoSizeMaximumSize().height()))
         m_webPage.setSize(size);
 
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
 
     if (m_webPage.autoSizingShouldExpandToViewHeight() && frameView)
         frameView->setAutoSizeFixedMinimumHeight(viewSize.height());
@@ -251,13 +251,13 @@ void RemoteLayerTreeDrawingArea::setViewExposedRect(std::optional<WebCore::Float
 {
     m_viewExposedRect = viewExposedRect;
 
-    if (auto* frameView = m_webPage.mainFrameView())
+    if (auto* frameView = m_webPage.localMainFrameView())
         frameView->setViewExposedRect(m_viewExposedRect);
 }
 
 WebCore::FloatRect RemoteLayerTreeDrawingArea::exposedContentRect() const
 {
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
     if (!frameView)
         return FloatRect();
 
@@ -266,7 +266,7 @@ WebCore::FloatRect RemoteLayerTreeDrawingArea::exposedContentRect() const
 
 void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedContentRect)
 {
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
     if (!frameView)
         return;
     if (frameView->exposedContentRect() == exposedContentRect)
@@ -325,7 +325,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     auto size = m_webPage.size();
     FloatRect visibleRect(FloatPoint(), size);
-    if (auto* mainFrameView = m_webPage.mainFrameView()) {
+    if (auto* mainFrameView = m_webPage.localMainFrameView()) {
         if (auto exposedRect = mainFrameView->viewExposedRect())
             visibleRect.intersect(*exposedRect);
     }

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -83,7 +83,11 @@ void ViewGestureGeometryCollector::dispatchDidCollectGeometryForSmartMagnificati
 
 void ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture(FloatPoint origin)
 {
-    FloatRect visibleContentRect = m_webPage.mainFrameView()->unobscuredContentRectIncludingScrollbars();
+    auto* frameView = m_webPage.localMainFrameView();
+    if (!frameView)
+        return;
+
+    FloatRect visibleContentRect = frameView->unobscuredContentRectIncludingScrollbars();
 
     if (m_webPage.handlesPageScaleGesture())
         return;
@@ -114,7 +118,7 @@ void ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture(F
     }
 #endif // PLATFORM(IOS_FAMILY)
 
-    IntPoint originInContentsSpace = m_webPage.mainFrameView()->windowToContents(roundedIntPoint(origin));
+    IntPoint originInContentsSpace = frameView->windowToContents(roundedIntPoint(origin));
     HitTestResult hitTestResult = HitTestResult(originInContentsSpace);
 
     if (auto* mainFrame = dynamicDowncast<WebCore::LocalFrame>(m_webPage.mainFrame()))
@@ -251,7 +255,11 @@ void ViewGestureGeometryCollector::computeMinimumAndMaximumViewportScales(double
 #if !PLATFORM(IOS_FAMILY)
 void ViewGestureGeometryCollector::collectGeometryForMagnificationGesture()
 {
-    FloatRect visibleContentRect = m_webPage.mainFrameView()->unobscuredContentRectIncludingScrollbars();
+    auto* frameView = m_webPage.localMainFrameView();
+    if (!frameView)
+        return;
+
+    FloatRect visibleContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     bool frameHandlesMagnificationGesture = m_webPage.handlesPageScaleGesture();
     m_webPage.send(Messages::ViewGestureController::DidCollectGeometryForMagnificationGesture(visibleContentRect, frameHandlesMagnificationGesture));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -598,7 +598,8 @@ public:
     WebFrame& mainWebFrame() const { return m_mainFrame; }
 
     WebCore::Frame* mainFrame() const; // May return nullptr.
-    WebCore::LocalFrameView* mainFrameView() const; // May return nullptr.
+    WebCore::FrameView* mainFrameView() const; // May return nullptr.
+    WebCore::LocalFrameView* localMainFrameView() const; // May return nullptr.
 
     void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID);
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4208,7 +4208,7 @@ void WebPage::viewportConfigurationChanged(ZoomToInitialScale zoomToInitialScale
     updateSizeForCSSSmallViewportUnits();
     updateSizeForCSSLargeViewportUnits();
 
-    auto* mainFrameView = this->mainFrameView();
+    auto* mainFrameView = this->localMainFrameView();
     if (!mainFrameView) {
         // FIXME: This is hit in some site isolation tests on iOS. Investigate and fix.
         return;

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -129,7 +129,7 @@ bool PageBanner::mouseEvent(const WebMouseEvent& mouseEvent)
     if (m_isHidden)
         return false;
 
-    auto* frameView = m_webPage->mainFrameView();
+    auto* frameView = m_webPage->localMainFrameView();
     if (!frameView)
         return false;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -71,10 +71,12 @@ void RemoteLayerTreeDrawingAreaMac::mainFrameContentSizeChanged(WebCore::FrameId
 
 void RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage(double scale, FloatPoint origin)
 {
-    auto& frameView = *m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
+    if (!frameView)
+        return;
 
     auto unscrolledOrigin = origin;
-    FloatRect unobscuredContentRect = frameView.unobscuredContentRectIncludingScrollbars();
+    FloatRect unobscuredContentRect = frameView->unobscuredContentRectIncludingScrollbars();
     unscrolledOrigin.moveBy(-unobscuredContentRect.location());
     m_webPage.scalePage(scale / m_webPage.viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
     updateRendering();
@@ -103,7 +105,7 @@ void RemoteLayerTreeDrawingAreaMac::commitTransientZoom(double scale, WebCore::F
 void RemoteLayerTreeDrawingAreaMac::willCommitLayerTree(RemoteLayerTreeTransaction& transaction)
 {
     // FIXME: Probably need something here for PDF.
-    auto* frameView = m_webPage.mainFrameView();
+    auto* frameView = m_webPage.localMainFrameView();
     if (!frameView)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -288,7 +288,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (protectedSelf->m_page->mainFramePlugIn())
             return convertedPoint;
 
-        if (auto* frameView = protectedSelf->m_page->mainFrameView())
+        if (auto* frameView = protectedSelf->m_page->localMainFrameView())
             convertedPoint.moveBy(frameView->scrollPosition());
         if (auto* page = protectedSelf->m_page->corePage())
             convertedPoint.move(0, -page->topContentInset());

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -1414,7 +1414,7 @@ void WebProcess::updatePageScreenProperties()
     }
 
     bool allPagesAreOnHDRScreens = allOf(m_pageMap.values(), [] (auto& page) {
-        return page && screenSupportsHighDynamicRange(page->mainFrameView());
+        return page && screenSupportsHighDynamicRange(page->localMainFrameView());
     });
     setShouldOverrideScreenSupportsHighDynamicRange(true, allPagesAreOnHDRScreens);
 #endif


### PR DESCRIPTION
#### 37a31aff7bcbc1d180255f5b16be3def142ed5b4
<pre>
WebPage::mainFrameView() should return a FrameView
<a href="https://bugs.webkit.org/show_bug.cgi?id=259651">https://bugs.webkit.org/show_bug.cgi?id=259651</a>
rdar://113145893

Reviewed by Alex Christensen.

Make WebPage::mainFrameView() return a FrameView and introduce WebPage::localMainFrameView().

* Source/WebCore/page/Frame.h:
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::snapshotElementRectForScreenshot):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::showPlaybackTargetPicker):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::adjustTransientZoom):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::scrollNonCompositedContents):
(WebKit::LayerTreeHost::constrainTransientZoomOrigin const):
(WebKit::LayerTreeHost::layerForTransientZoom const):
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::mainFrameTiledBacking const):
(WebKit::DrawingArea::prepopulateRectForZoom):
(WebKit::DrawingArea::scaleViewToFitDocumentIfNeeded):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateGeometry):
(WebKit::RemoteLayerTreeDrawingArea::setViewExposedRect):
(WebKit::RemoteLayerTreeDrawingArea::exposedContentRect const):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
(WebKit::ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture):
(WebKit::ViewGestureGeometryCollector::collectGeometryForMagnificationGesture):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setTracksRepaints):
(WebKit::WebPage::isTrackingRepaints const):
(WebKit::WebPage::resetTrackedRepaints):
(WebKit::WebPage::trackedRepaintRects):
(WebKit::WebPage::scalePageInViewCoordinates):
(WebKit::WebPage::setUseFixedLayout):
(WebKit::WebPage::setFixedLayoutSize):
(WebKit::WebPage::fixedLayoutSize const):
(WebKit::WebPage::updateSizeForCSSDefaultViewportUnits):
(WebKit::WebPage::updateSizeForCSSSmallViewportUnits):
(WebKit::WebPage::updateSizeForCSSLargeViewportUnits):
(WebKit::WebPage::setBackgroundColor):
(WebKit::WebPage::updateMainFrameScrollOffsetPinning):
(WebKit::WebPage::mainFrameDidLayout):
(WebKit::WebPage::mainFrameView const):
(WebKit::WebPage::localMainFrameView const):
(WebKit::WebPage::updateIntrinsicContentSizeIfNeeded):
(WebKit::WebPage::scheduleIntrinsicContentSizeUpdate):
(WebKit::WebPage::dispatchDidReachLayoutMilestone):
(WebKit::WebPage::scrollToRect):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::viewportConfigurationChanged):
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::mouseEvent):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::applyTransientZoomToPage):
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitLayerTree):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::updateRendering):
(WebKit::TiledCoreAnimationDrawingArea::setViewExposedRect):
(WebKit::TiledCoreAnimationDrawingArea::updateGeometry):
(WebKit::TiledCoreAnimationDrawingArea::layerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom const):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToLayers):
(WebKit::TiledCoreAnimationDrawingArea::commitTransientZoom):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToPage):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::updatePageScreenProperties):

Canonical link: <a href="https://commits.webkit.org/266456@main">https://commits.webkit.org/266456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e10cd546a3d93425f8728c83ef0cdf87c89ecb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15835 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14022 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16296 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12500 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12664 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11076 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12469 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3365 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16801 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->