### PR TITLE
[WebRTC] webrtc/video-remote-mute.html can be potentially flaky

### DIFF
--- a/LayoutTests/webrtc/video-remote-mute.html
+++ b/LayoutTests/webrtc/video-remote-mute.html
@@ -14,21 +14,6 @@
 video = document.getElementById("video");
 canvas = document.getElementById("canvas");
 
-function isVideoBlack()
-{
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
-
-    imageData = canvas.getContext('2d').getImageData(10, 325, 250, 1);
-    data = imageData.data;
-    for (var cptr = 0; cptr < canvas.width * canvas.height; ++cptr) {
-        if (data[4 * cptr] || data[4 * cptr + 1] || data[4 * cptr + 2])
-            return false;
-    }
-    return true;
-}
-
 var track;
 promise_test((test) => {
     if (window.testRunner)
@@ -48,16 +33,13 @@ promise_test((test) => {
         track = remoteStream.getVideoTracks()[0];
         return video.play();
     }).then(() => {
-         assert_false(isVideoBlack());
+        return checkVideoBlack(false, canvas, video, "enabled track is black");
     }).then(() => {
         track.enabled = false;
-        return waitFor(500);
+        return checkVideoBlack(true, canvas, video, "disabled track is not black");
     }).then(() => {
-        assert_true(isVideoBlack());
         track.enabled = true;
-        return waitFor(500);
-    }).then(() => {
-        assert_false(isVideoBlack());
+        return checkVideoBlack(false, canvas, video, "enabled track is black");
     });
 }, "Incoming muted/unmuted video track");
         </script>


### PR DESCRIPTION
#### 0902da843aeaea21f1c4fa9618d27a64bc122a77
<pre>
[WebRTC] webrtc/video-remote-mute.html can be potentially flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=259654">https://bugs.webkit.org/show_bug.cgi?id=259654</a>

Reviewed by Eric Carlson.

* LayoutTests/webrtc/video-remote-mute.html: Re-use the isVideoBlack() from routines.js because it
is more reliable and thus we no longer need to hard-code waitFor() calls in this test.

Canonical link: <a href="https://commits.webkit.org/266681@main">https://commits.webkit.org/266681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb7278d30b59ad647c5d717566befdbcaa9ec3bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13159 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14248 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15831 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11737 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16294 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19536 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12997 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15885 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12358 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3496 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16799 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->