### PR TITLE
Remove the extra string allocation in RemoteLayerTreeDrawingArea::addRootFrame()

### DIFF
--- a/Source/WebCore/platform/ProcessQualified.h
+++ b/Source/WebCore/platform/ProcessQualified.h
@@ -155,4 +155,32 @@ template<typename T> struct HashTraits<WebCore::ProcessQualified<T>> : SimpleCla
     static constexpr bool emptyValueIsZero = HashTraits<T>::emptyValueIsZero;
 };
 
+class ProcessQualifiedStringTypeAdapter {
+public:
+    unsigned length() const { return lengthOfIntegerAsString(m_processIdentifier) + lengthOfIntegerAsString(m_objectIdentifier) + 1; }
+    bool is8Bit() const { return true; }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const
+    {
+        auto processIdentifierLength = lengthOfIntegerAsString(m_processIdentifier);
+        writeIntegerToBuffer(m_processIdentifier, destination);
+        *(destination + processIdentifierLength) = '-';
+        writeIntegerToBuffer(m_objectIdentifier, destination + processIdentifierLength + 1);
+    }
+protected:
+    explicit ProcessQualifiedStringTypeAdapter(uint64_t processIdentifier, uint64_t objectIdentifier)
+        : m_processIdentifier(processIdentifier)
+        , m_objectIdentifier(objectIdentifier)
+        { }
+private:
+    uint64_t m_processIdentifier;
+    uint64_t m_objectIdentifier;
+};
+
+template<typename T>
+class StringTypeAdapter<WebCore::ProcessQualified<T>, void> : public ProcessQualifiedStringTypeAdapter {
+public:
+    explicit StringTypeAdapter(const WebCore::ProcessQualified<T>& processQualified)
+        : ProcessQualifiedStringTypeAdapter(processQualified.processIdentifier().toUInt64(), processQualified.object().toUInt64()) { }
+};
+
 } // namespace WTF

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -130,8 +130,7 @@ void RemoteLayerTreeDrawingArea::attachViewOverlayGraphicsLayer(WebCore::FrameId
 void RemoteLayerTreeDrawingArea::addRootFrame(WebCore::FrameIdentifier frameID)
 {
     auto layer = GraphicsLayer::create(graphicsLayerFactory(), *this);
-    // FIXME: This has an unnecessary string allocation. Adding a StringTypeAdapter for FrameIdentifier or ProcessQualified would remove that.
-    layer->setName(makeString("drawing area root "_s, frameID.toString()));
+    layer->setName(makeString("drawing area root "_s, frameID));
     m_rootLayers.append(RootLayerInfo {
         WTFMove(layer),
         nullptr,


### PR DESCRIPTION
#### ea2dd1db499db3e958418d462bc62b51aa1c1ba4
<pre>
Remove the extra string allocation in RemoteLayerTreeDrawingArea::addRootFrame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259652">https://bugs.webkit.org/show_bug.cgi?id=259652</a>
rdar://113145706

Reviewed by Alex Christensen.

Introduce StringTypeAdapter to WebCore::ProcessQualified to remove the extra allocation.

* Source/WebCore/platform/ProcessQualified.h:
(WTF::ProcessQualifiedStringTypeAdapter::length const):
(WTF::ProcessQualifiedStringTypeAdapter::is8Bit const):
(WTF::ProcessQualifiedStringTypeAdapter::writeTo const):
(WTF::ProcessQualifiedStringTypeAdapter::ProcessQualifiedStringTypeAdapter):

Canonical link: <a href="https://commits.webkit.org/266467@main">https://commits.webkit.org/266467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8cae1a83e5d1f27a2ea83f8cd9230bd62c190b63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15879 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14680 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16352 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19584 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15927 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11117 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12524 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->