### PR TITLE
[WGSL] Empty programs should be valid

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -66,8 +66,11 @@ auto Builder::saveCurrentState() -> State
     State state;
     state.m_arena = m_arena;
 #if ASSERT_ENABLED
-    state.m_arenaStart = arena();
     state.m_arenaEnd = m_arenaEnd;
+    if (m_arenaEnd)
+        state.m_arenaStart = arena();
+    else
+        state.m_arenaStart = nullptr;
 #endif
     state.m_numberOfArenas = m_arenas.size();
     state.m_numberOfNodes = m_nodes.size();
@@ -82,11 +85,15 @@ void Builder::restore(State&& state)
     m_nodes.shrink(state.m_numberOfNodes);
     m_arena = state.m_arena;
     m_arenas.shrink(state.m_numberOfArenas);
-    m_arenaEnd = m_arenas.last().get() + arenaSize;
+    if (m_arenas.isEmpty())
+        m_arenaEnd = nullptr;
+    else {
+        m_arenaEnd = m_arenas.last().get() + arenaSize;
 #if ASSERT_ENABLED
-    ASSERT(state.m_arenaStart == m_arenas.last().get());
-    ASSERT(state.m_arenaEnd == m_arenaEnd);
+        ASSERT(state.m_arenaStart == m_arenas.last().get());
+        ASSERT(state.m_arenaEnd == m_arenaEnd);
 #endif
+    }
 }
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/tests/valid/empty.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/empty.wgsl
@@ -1,0 +1,1 @@
+// RUN: %wgslc


### PR DESCRIPTION
#### 119aaa4e834c77d5bc560cd415d0628b619c8a49
<pre>
[WGSL] Empty programs should be valid
<a href="https://bugs.webkit.org/show_bug.cgi?id=259655">https://bugs.webkit.org/show_bug.cgi?id=259655</a>
rdar://113153864

Reviewed by Dan Glastonbury.

This fixes two bugs related to evaluating an empty program:
1) The wgslc executable uses FileSystem::readEntireFile to read the input file,
   which returns nullopt if the file is empty, which is indistinguishable from
   when it fails to open the file. To fix that we check if the file exists first
   and then treat nullopt as an empty file.
2) The ASTBuilder assumed that we would always have had an allocation when saving
   and restoring its state. This caused a crash with empty programs, since no nodes
   are allocated. The fix is simply to check if we actually have an arena before
   trying to read it.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::saveCurrentState):
(WGSL::AST::Builder::restore):
* Source/WebGPU/WGSL/tests/valid/empty.wgsl: Added.
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/266469@main">https://commits.webkit.org/266469@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c26e7fa9cdcd891f3b8e6f2207b25b1aa427264e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13166 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15841 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16302 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11931 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19547 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13204 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12475 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3375 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16807 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->