### PR TITLE
[

### DIFF
--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
@@ -1,0 +1,9 @@
+No crash when property 'x' is assigned
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("No crash when property 'x' is assigned");
+
+// This structure has a non-reified static property "isTrusted".
+const EVENT = new Event('a');
+
+
+function opt(use_event, proxy) {
+    let tmp = Object.create(null);
+    if (use_event)
+        tmp = Object.create(EVENT);
+
+    tmp.isTrusted = 1;  // Here the compiler expects that it'll transition but at runtime it'll fail due to the setter from EVENT.
+
+    tmp.a0 = 0x1111;
+    tmp.a1 = 0x2222;
+    tmp.a2 = 0x3333;
+    tmp.a3 = 0x4444;
+    tmp.a4 = 0x5555;
+    tmp.a5 = 0x6666;
+    
+    proxy.set_getter_on = tmp;
+
+    const value = tmp.a5;
+
+    return value;
+}
+
+
+function initialize() {
+    {
+        const object = Object.create(EVENT);
+        Object.defineProperty(object, 'isTrusted', {value: 1, writable: true, enumerable: true, configurable: true});
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+
+    {
+        const object = Object.create(EVENT);
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+}
+
+
+function main() {
+    const proxy = new Proxy({}, {
+        set: (object, property, value) => {
+            const tmp = {};
+            tmp[26] = 2.3023e-320;
+            value[26] = 1.1;
+
+            return true;
+        }
+    });
+
+    initialize();
+
+    for (let i = 0; i < 1000; i++) {
+        opt(/* use_event */ false, /* proxy */ 1.1);
+        opt(/* use_event */ true, /* proxy */ 1.1);
+    }
+    
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    setTimeout(() => {
+        const value = opt(/* use_event */ true, proxy);
+
+        // Should crash here.
+        value.x = 1234;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+}
+
+main();
+
+</script>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2514,6 +2514,9 @@ imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ WontFix 
 # Per-process limit is only for WK2
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 
+# IPC is for WK2
+ipc/shared-video-frame-size.html [ Skip ]
+
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]
 

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -190,6 +190,10 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
             if (PropertyConditionInternal::verbose)
                 dataLog("Invalid because its put() override may treat ", uid(), " property as special non-structure one.\n");
             return false;
+        } else if (structure->hasNonReifiedStaticProperties() && structure->classInfoForCells()->hasStaticReadOnlyOrGetterSetterProperty(uid())) {
+            if (PropertyConditionInternal::verbose)
+                dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
+            return false;
         }
 
         if (structure->hasPolyProto()) {

--- a/Source/JavaScriptCore/runtime/ClassInfo.h
+++ b/Source/JavaScriptCore/runtime/ClassInfo.h
@@ -209,6 +209,8 @@ struct CLASS_INFO_ALIGNMENT ClassInfo {
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
 
     JS_EXPORT_PRIVATE bool hasStaticPropertyWithAnyOfAttributes(uint8_t attributes) const;
+    JS_EXPORT_PRIVATE bool hasStaticSetterOrReadonlyProperties() const;
+    JS_EXPORT_PRIVATE bool hasStaticReadOnlyOrGetterSetterProperty(UniquedStringImpl*) const;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1456,6 +1456,19 @@ bool ClassInfo::hasStaticPropertyWithAnyOfAttributes(uint8_t attributes) const
     return false;
 }
 
+bool ClassInfo::hasStaticReadOnlyOrGetterSetterProperty(UniquedStringImpl* uid) const
+{
+    for (const ClassInfo* ci = this; ci; ci = ci->parentClass) {
+        if (const HashTable* table = ci->staticPropHashTable) {
+            if (!table->hasSetterOrReadonlyProperties)
+                continue;
+            if (const HashTableValue* entry = table->entry(uid))
+                return entry->attributes() & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue;
+        }
+    }
+    return false;
+}
+
 void Structure::setCachedPropertyNameEnumerator(VM& vm, JSPropertyNameEnumerator* enumerator, StructureChain* chain)
 {
     ASSERT(typeInfo().isObject());

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -73,8 +73,8 @@ private:
     uint32_t m_bytesPerRow { 0 };
     uint32_t m_widthPlaneB { 0 };
     uint32_t m_heightPlaneB { 0 };
-    uint32_t m_bytesPerRowPlaneB { 0 };
-    uint32_t m_bytesPerRowPlaneAlpha { 0 };
+    uint32_t m_bytesPerRowPlaneB { 0 };uint32_t m_bytesPerRowPlaneAlpha { 0 };
+    size_t m_storageSize { 0 };
 };
 
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -73,7 +73,8 @@ private:
     uint32_t m_bytesPerRow { 0 };
     uint32_t m_widthPlaneB { 0 };
     uint32_t m_heightPlaneB { 0 };
-    uint32_t m_bytesPerRowPlaneB { 0 };uint32_t m_bytesPerRowPlaneAlpha { 0 };
+    uint32_t m_bytesPerRowPlaneB { 0 };
+    uint32_t m_bytesPerRowPlaneAlpha { 0 };
     size_t m_storageSize { 0 };
 };
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -76,6 +76,9 @@ bool SharedVideoFrameInfo::isReadWriteSupported() const
 
 size_t SharedVideoFrameInfo::storageSize() const
 {
+    if (m_storageSize)
+        return m_storageSize;
+
     size_t sizePlaneA;
     if (!WTF::safeMultiply(m_bytesPerRow, m_height, sizePlaneA))
         return 0;
@@ -92,6 +95,9 @@ size_t SharedVideoFrameInfo::storageSize() const
         return 0;
 
     return size;
+
+    const_cast<SharedVideoFrameInfo*>(this)->m_storageSize = size;
+    return m_storageSize;
 }
 
 void SharedVideoFrameInfo::encode(uint8_t* destination)


### PR DESCRIPTION
#### 0952d54732a53c3f67b6d9a2780ed17842c3de92
<pre>
[JSC] PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() should take non-reified static properties into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=255952">https://bugs.webkit.org/show_bug.cgi?id=255952</a>
&lt;rdar://108334411&gt;

Reviewed by Yusuke Suzuki.

Currently, PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() is not checking the
structure&apos;s non-reified static properties against the condition. This can lead to incorrect analysis
of side effects: AbsenceOfSetEffect condition with a non-reified static setter is considered pure
even though a setter with arbitrary code can be invoked.

This patch fixes AbsenceOfSetEffect validity check for structures with non-reified static properties
while takes extra care to make the fix as precise as possible to avoid unnecessary slowdowns.

* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt: Added.
* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html: Added.
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):
* Source/JavaScriptCore/runtime/ClassInfo.h:
* Source/JavaScriptCore/runtime/PropertySlot.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::ClassInfo::hasStaticReadOnlyOrGetterSetterProperty const):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:

Originally-landed-as: 259548.775@safari-7615-branch (ffe32d106cb2). rdar://104290899
</pre>
----------------------------------------------------------------------
#### 7a56af858e9b77e5fd49939737557a9f3d286d0a
<pre>
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read
rdar://107023292

Reviewed by Eric Carlson.

Compute with safeMultitply/safeAdd the total size of the frame.
If there is an overflow, we now fail the decoding of SharedVideoFrameInfo.
We store the size of the frame in SharedVideoFrameInfo to not recompute it a second time.

Covered by provided IPC test.

* LayoutTests/ipc/shared-video-frame-size-expected.txt: Added.
* LayoutTests/ipc/shared-video-frame-size.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::storageSize const):
(WebCore::SharedVideoFrameInfo::decode):

Originally-landed-as: 259548.590@safari-7615-branch (dd4ad7b0b286). rdar://104290899
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0952d54732a53c3f67b6d9a2780ed17842c3de92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13865 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14180 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14515 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15603 "Failed to compile WebKit") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13948 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16688 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14262 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15603 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14034 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16688 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14515 "Failed to compile WebKit") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16688 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14515 "Failed to compile WebKit") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/16307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/11841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16688 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14515 "Failed to compile WebKit") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13136 "Failed to compile JSC") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13209 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14262 "Failed to compile WebKit") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13909 "Failed to compile JSC") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/12480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14515 "Failed to compile WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/13909 "Failed to compile JSC") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16812 "Failed to compile WebKit") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14295 "Failed to compile JSC") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13052 "Failed to compile WebKit") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/14295 "Failed to compile JSC") | 
<!--EWS-Status-Bubble-End-->