### PR TITLE
Don't call PAL::getWKDDActionContextClass in macOS base system

### DIFF
--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -54,7 +54,14 @@ namespace WebKit {
 
 #if PLATFORM(MAC)
 struct WebHitTestResultPlatformData {
-    RetainPtr<WKDDActionContext> detectedDataActionContext;
+    struct DetectedDataActionContext {
+        RetainPtr<WKDDActionContext> context;
+        struct MarkableTraits {
+            static bool isEmptyValue(const DetectedDataActionContext& context) { return !context.context; }
+            static DetectedDataActionContext emptyValue() { return { nullptr }; }
+        };
+    };
+    Markable<DetectedDataActionContext> detectedDataActionContext;
     WebCore::FloatRect detectedDataBoundingBox;
     RefPtr<WebCore::TextIndicator> detectedDataTextIndicator;
     WebCore::PageOverlay::PageOverlayID detectedDataOriginatingPageOverlay;

--- a/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
+++ b/Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in
@@ -24,8 +24,11 @@ headers: <WebCore/TextIndicator.h>
 
 #if PLATFORM(MAC)
 header: "WebHitTestResultData.h" <pal/mac/DataDetectorsSoftLink.h>
+[Nested] struct WebKit::WebHitTestResultPlatformData::DetectedDataActionContext {
+    [SecureCodingAllowed=[PAL::getWKDDActionContextClass()]] RetainPtr<WKDDActionContext> context;
+};
 [CustomHeader] struct WebKit::WebHitTestResultPlatformData {
-    [SecureCodingAllowed=[PAL::getWKDDActionContextClass()]] RetainPtr<WKDDActionContext> detectedDataActionContext;
+    Markable<WebKit::WebHitTestResultPlatformData::DetectedDataActionContext> detectedDataActionContext;
     WebCore::FloatRect detectedDataBoundingBox;
     RefPtr<WebCore::TextIndicator> detectedDataTextIndicator;
     WebCore::PageOverlay::PageOverlayID detectedDataOriginatingPageOverlay;

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -405,7 +405,11 @@
     if (!PAL::isDataDetectorsFrameworkAvailable())
         return nil;
 
-    WKDDActionContext *actionContext = _hitTestResultData.platformData.detectedDataActionContext.get();
+    auto& detectedContext = _hitTestResultData.platformData.detectedDataActionContext;
+    if (!detectedContext)
+        return nil;
+
+    WKDDActionContext *actionContext = detectedContext->context.get();
     if (!actionContext)
         return nil;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -912,7 +912,8 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
             continue;
 
         pageOverlayDidOverrideDataDetectors = true;
-        immediateActionResult.platformData.detectedDataActionContext = actionContext->context.get();
+        if (auto* detectedContext = actionContext->context.get())
+            immediateActionResult.platformData.detectedDataActionContext = { { detectedContext } };
         immediateActionResult.platformData.detectedDataBoundingBox = view->contentsToWindow(enclosingIntRect(unitedBoundingBoxes(RenderObject::absoluteTextQuads(actionContext->range))));
         immediateActionResult.platformData.detectedDataTextIndicator = TextIndicator::createWithRange(actionContext->range, indicatorOptions(actionContext->range), TextIndicatorPresentationTransition::FadeIn);
         immediateActionResult.platformData.detectedDataOriginatingPageOverlay = overlay->pageOverlayID();
@@ -922,7 +923,8 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FloatPoint locati
     // FIXME: Avoid scanning if we will just throw away the result (e.g. we're over a link).
     if (!pageOverlayDidOverrideDataDetectors && hitTestResult.innerNode() && (hitTestResult.innerNode()->isTextNode() || hitTestResult.isOverTextInsideFormControlElement())) {
         if (auto result = DataDetection::detectItemAroundHitTestResult(hitTestResult)) {
-            immediateActionResult.platformData.detectedDataActionContext = WTFMove(result->actionContext);
+            if (auto detectedContext = WTFMove(result->actionContext))
+                immediateActionResult.platformData.detectedDataActionContext = { { WTFMove(detectedContext) } };
             immediateActionResult.platformData.detectedDataBoundingBox = result->boundingBox;
             immediateActionResult.platformData.detectedDataTextIndicator = TextIndicator::createWithRange(result->range, indicatorOptions(result->range), TextIndicatorPresentationTransition::FadeIn);
         }


### PR DESCRIPTION
#### e3ec0669b5492d884e183bb20547c133233577be
<pre>
Don&apos;t call PAL::getWKDDActionContextClass in macOS base system
<a href="https://bugs.webkit.org/show_bug.cgi?id=259660">https://bugs.webkit.org/show_bug.cgi?id=259660</a>
rdar://113156967

Reviewed by Tim Horton and Chris Dumez.

Before 266374@main we would only call PAL::getWKDDActionContextClass if detectedDataActionContext was non-null.
Now we always call it when decoding a WebHitTestResultPlatformData, which causes a crash in the base system
where the framework doesn&apos;t exist.  Use Markable to stop the crash.

* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/mac/WebHitTestResultPlatformData.serialization.in:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

Canonical link: <a href="https://commits.webkit.org/266459@main">https://commits.webkit.org/266459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62af5b106f4151de177d40d8f12c8fbce4c8ea64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13879 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15617 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14276 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16321 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/11943 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19556 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12683 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11095 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12493 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16824 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1629 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->