### PR TITLE
[Apple Pay] Deprecate `enabled` in favor of `available` in ApplePayShippingContactEditingMode

### DIFF
--- a/LayoutTests/http/tests/paymentrequest/paymentrequest-shippingContactEditingMode.https.html
+++ b/LayoutTests/http/tests/paymentrequest/paymentrequest-shippingContactEditingMode.https.html
@@ -35,7 +35,7 @@ user_activation_test(async (test) => {
 
 user_activation_test(async (test) => {
     const method = validPaymentMethod();
-    method.data.shippingContactEditingMode = "enabled";
+    method.data.shippingContactEditingMode = "available";
 
     let request = new PaymentRequest([method], validPaymentDetails());
     request.addEventListener("merchantvalidation", (event) => {

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h
@@ -27,13 +27,29 @@
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
 
+#include <wtf/EnumTraits.h>
+
 namespace WebCore {
 
-enum class ApplePayShippingContactEditingMode : bool {
-    Enabled,
+enum class ApplePayShippingContactEditingMode : uint8_t {
+    Available,
+    Enabled, // Deprecated in favor of `Available`.
     StorePickup,
 };
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<> struct EnumTraits<WebCore::ApplePayShippingContactEditingMode> {
+    using values = EnumValues<
+        WebCore::ApplePayShippingContactEditingMode,
+        WebCore::ApplePayShippingContactEditingMode::Available,
+        WebCore::ApplePayShippingContactEditingMode::Enabled,
+        WebCore::ApplePayShippingContactEditingMode::StorePickup
+    >;
+};
+
+} // namespace WTF
 
 #endif // ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.idl
@@ -27,6 +27,7 @@
     Conditional=APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE,
     ExportMacro=WEBCORE_EXPORT,
 ] enum ApplePayShippingContactEditingMode {
+    "available",
     "enabled",
     "storePickup"
 };

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -107,6 +107,11 @@ bool PaymentCoordinator::beginPaymentSession(Document& document, PaymentSession&
     if (!showPaymentUI)
         return false;
 
+#if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
+    if (paymentRequest.shippingContactEditingMode() == ApplePayShippingContactEditingMode::Enabled)
+        document.addConsoleMessage(MessageSource::PaymentRequest, MessageLevel::Warning, "`enabled` is a deprecated value for `shippingContactEditingMode`. Please use `available` instead."_s);
+#endif
+
     m_activeSession = &paymentSession;
     return true;
 }

--- a/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm
+++ b/Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm
@@ -78,6 +78,6 @@ PaymentSetupConfiguration::PaymentSetupConfiguration(const WebCore::ApplePaySetu
 {
 }
 
-} // namespace WebKitAdditions
+} // namespace WebKit
 
 #endif // ENABLE(APPLE_PAY)

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -216,6 +216,7 @@ PKShippingMethods *toPKShippingMethods(const Vector<WebCore::ApplePayShippingMet
 static PKShippingContactEditingMode toPKShippingContactEditingMode(WebCore::ApplePayShippingContactEditingMode shippingContactEditingMode)
 {
     switch (shippingContactEditingMode) {
+    case WebCore::ApplePayShippingContactEditingMode::Available:
     case WebCore::ApplePayShippingContactEditingMode::Enabled:
 #if USE(PKSHIPPINGCONTACTEDITINGMODEENABLED)
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN


### PR DESCRIPTION
#### 07b5559f651ee6ed1e95391fea5bf353ea3b9a72
<pre>
[Apple Pay] Deprecate `enabled` in favor of `available` in ApplePayShippingContactEditingMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=259659">https://bugs.webkit.org/show_bug.cgi?id=259659</a>
rdar://113159800

Reviewed by Wenson Hsieh.

In iOS 17, PassKit is deprecating PKShippingContactEditingModeEnabled in
favor of PKShippingContactEditingModeAvailable in the
PKShippingContactEditingMode  enumeration. Reference: <a href="https://developer.apple.com/documentation/passkit/pkshippingcontacteditingmode/pkshippingcontacteditingmodeenabled?language=objc">https://developer.apple.com/documentation/passkit/pkshippingcontacteditingmode/pkshippingcontacteditingmodeenabled?language=objc</a>

Given our intention to reflect the PassKit public API in the Apple Pay
JS API, we should follow suit and perform a similar deprecation. We do
so by introducing `available`, the preferred enumeration value, and
logging a console warning whenever a PaymentSession is inititated with a
PaymentRequest containing the deprecated `shippingContactEditingMode`
value.

* LayoutTests/http/tests/paymentrequest/paymentrequest-shippingContactEditingMode.https.html:
* Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.h:
* Source/WebCore/Modules/applepay/ApplePayShippingContactEditingMode.idl:
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginPaymentSession):
* Source/WebKit/Shared/ApplePay/PaymentSetupConfiguration.mm:

Drive-by fix of a mismatched namespace.

* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKShippingContactEditingMode):

Canonical link: <a href="https://commits.webkit.org/266493@main">https://commits.webkit.org/266493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c78ff5c1270e6244769c3d64063a94274958a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19613 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13289 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11153 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12438 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16895 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->