### PR TITLE
[WebAuthn] Do not end ceremony if plugged in U2F cannot fulfill the request.

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -54,10 +54,8 @@ U2fAuthenticator::U2fAuthenticator(std::unique_ptr<CtapDriver>&& driver)
 void U2fAuthenticator::makeCredential()
 {
     auto& creationOptions = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
-    if (!isConvertibleToU2fRegisterCommand(creationOptions)) {
-        receiveRespond(ExceptionData { NotSupportedError, "Cannot convert the request to U2F command."_s });
+    if (!isConvertibleToU2fRegisterCommand(creationOptions))
         return;
-    }
     if (!creationOptions.excludeCredentials.isEmpty()) {
         ASSERT(!m_nextListIndex);
         checkExcludeList(m_nextListIndex++);
@@ -87,10 +85,8 @@ void U2fAuthenticator::issueRegisterCommand()
 
 void U2fAuthenticator::getAssertion()
 {
-    if (!isConvertibleToU2fSignCommand(std::get<PublicKeyCredentialRequestOptions>(requestData().options))) {
-        receiveRespond(ExceptionData { NotSupportedError, "Cannot convert the request to U2F command."_s });
+    if (!isConvertibleToU2fSignCommand(std::get<PublicKeyCredentialRequestOptions>(requestData().options)))
         return;
-    }
     ASSERT(!m_nextListIndex);
     issueSignCommand(m_nextListIndex++);
 }


### PR DESCRIPTION
#### b9ff70d1e70e562a45676c604a12c79e6a65aad9
<pre>
[WebAuthn] Do not end ceremony if plugged in U2F cannot fulfill the request.
<a href="https://bugs.webkit.org/show_bug.cgi?id=259662">https://bugs.webkit.org/show_bug.cgi?id=259662</a>
rdar://112477660

Reviewed by Brent Fulgham.

These responses cause ceremonies to error out whenever an unsupported for the
operation U2F key is plugged in. We shouldn&apos;t end the ceremony just because
the plugged in U2F key is plugged in because the user could still plug in a different
key or use the platform authenticator.

* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::makeCredential):
(WebKit::U2fAuthenticator::getAssertion):

Canonical link: <a href="https://commits.webkit.org/266658@main">https://commits.webkit.org/266658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68de0bb9f4901835fdb6c1f2736119807f3f2dda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14188 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13175 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15847 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16315 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11939 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19557 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13015 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15897 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11089 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12487 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3482 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->