### PR TITLE
[WGSL] Unterminated block comments crash the lexer

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -35,7 +35,8 @@ namespace WGSL {
 template <typename T>
 Token Lexer<T>::lex()
 {
-    skipWhitespaceAndComments();
+    if (!skipWhitespaceAndComments())
+        return makeToken(TokenType::Invalid);
 
     m_tokenStartingPosition = m_currentPosition;
 
@@ -394,6 +395,8 @@ Token Lexer<T>::lex()
 template <typename T>
 T Lexer<T>::shift(unsigned i)
 {
+    ASSERT(m_code + i <= m_codeEnd);
+
     T last = m_current;
     // At one point timing showed that setting m_current to 0 unconditionally was faster than an if-else sequence.
     m_current = 0;
@@ -421,7 +424,7 @@ void Lexer<T>::newLine()
 }
 
 template <typename T>
-void Lexer<T>::skipBlockComments()
+bool Lexer<T>::skipBlockComments()
 {
     ASSERT(peek(0) == '/' && peek(1) == '*');
     shift(2);
@@ -429,7 +432,7 @@ void Lexer<T>::skipBlockComments()
     T ch = 0;
     unsigned depth = 1u;
 
-    while ((ch = shift())) {
+    while (!isAtEndOfFile() && (ch = shift())) {
         if (ch == '/' && peek() == '*') {
             shift();
             depth += 1;
@@ -440,13 +443,14 @@ void Lexer<T>::skipBlockComments()
                 // This block comment is closed, so for a construction like "/* */ */"
                 // there will be a successfully parsed block comment "/* */"
                 // and " */" will be processed separately.
-                return;
+                return true;
             }
         } else if (ch == '\n')
             newLine();
     }
 
     // FIXME: Report unbalanced block comments, such as "/* this is an unbalanced comment."
+    return false;
 }
 
 template <typename T>
@@ -460,7 +464,7 @@ void Lexer<T>::skipLineComment()
 }
 
 template <typename T>
-void Lexer<T>::skipWhitespaceAndComments()
+bool Lexer<T>::skipWhitespaceAndComments()
 {
     while (!isAtEndOfFile()) {
         if (isUnicodeCompatibleASCIIWhitespace(m_current)) {
@@ -469,13 +473,15 @@ void Lexer<T>::skipWhitespaceAndComments()
         } else if (peek(0) == '/') {
             if (peek(1) == '/')
                 skipLineComment();
-            else if (peek(1) == '*')
-                skipBlockComments();
-            else
+            else if (peek(1) == '*') {
+                if (!skipBlockComments())
+                    return false;
+            } else
                 break;
         } else
             break;
     }
+    return true;
 }
 
 template <typename T>

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -74,9 +74,9 @@ private:
     T shift(unsigned = 1);
     T peek(unsigned = 0);
     void newLine();
-    void skipBlockComments();
+    bool skipBlockComments();
     void skipLineComment();
-    void skipWhitespaceAndComments();
+    bool skipWhitespaceAndComments();
 
     // Reads [0-9]+
     std::optional<uint64_t> parseDecimalInteger();

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -348,7 +348,7 @@ Result<void> Parser<Lexer>::parseShader()
 {
     // FIXME: parse directives here.
 
-    while (!m_lexer.isAtEndOfFile()) {
+    while (current().type != TokenType::EndOfFile) {
         auto globalExpected = parseGlobalDecl();
         if (!globalExpected)
             return makeUnexpected(globalExpected.error());

--- a/Source/WebGPU/WGSL/tests/invalid/unterminated-comment.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/unterminated-comment.wgsl
@@ -1,0 +1,3 @@
+// RUN: %not %wgslc
+
+/*


### PR DESCRIPTION
#### 65d409260e7651b06c4a66b438b80b75dd00cd33
<pre>
[WGSL] Unterminated block comments crash the lexer
<a href="https://bugs.webkit.org/show_bug.cgi?id=259661">https://bugs.webkit.org/show_bug.cgi?id=259661</a>
rdar://113161516

Reviewed by Dan Glastonbury.

In Lexer::skipBlockComments, we need to check if we are at the end of the file
before we shift. I also had to tweak the parser since it would ignore the first
token if it&apos;s the only token. This happens because we call `lex()` when constructing
the parser and then check if the lexer is at the end of the file, instead of the
checking the token produced by `lex()`.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::skipBlockComments):
(WGSL::Lexer&lt;T&gt;::skipWhitespaceAndComments):
* Source/WebGPU/WGSL/Lexer.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseShader):
* Source/WebGPU/WGSL/tests/invalid/unterminated-comment.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/266476@main">https://commits.webkit.org/266476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/236bc5fe53e7ba1d031cab3863ff66aaf6885af2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13178 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11942 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19553 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15893 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11093 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12490 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3378 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13061 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->