### PR TITLE
[JSC] Make less conservative on isCanonicalNumericIndexString

### DIFF
--- a/JSTests/stress/typed-array-canonical.js
+++ b/JSTests/stress/typed-array-canonical.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+Object.prototype["Infinity"] = 42;
+Object.prototype["infinity"] = 42;
+Object.prototype["NaN"] = 42;
+Object.prototype["nan"] = 42;
+Object.prototype["-Infinity"] = 42;
+Object.prototype["-infinity"] = 42;
+Object.prototype["-NaN"] = 42;
+Object.prototype["-nan"] = 42;
+var array = new Uint8Array(42);
+shouldBe(array["Infinity"], undefined);
+shouldBe(array["infinity"], 42);
+shouldBe(array["NaN"], undefined);
+shouldBe(array["nan"], 42);
+shouldBe(array["-Infinity"], undefined);
+shouldBe(array["-infinity"], 42);
+shouldBe(array["-NaN"], 42);
+shouldBe(array["-nan"], 42);

--- a/Source/JavaScriptCore/runtime/PropertyName.h
+++ b/Source/JavaScriptCore/runtime/PropertyName.h
@@ -140,7 +140,7 @@ ALWAYS_INLINE bool isCanonicalNumericIndexString(UniquedStringImpl* propertyName
             return true;
     } else if (!isASCIIDigit(first)) {
         // Infinity and NaN should go to the slow path.
-        if (!(length == strlen("Infinity") || first == 'I') && !(length == strlen("NaN") || first == 'N'))
+        if (!(length == strlen("Infinity") && first == 'I') && !(length == strlen("NaN") && first == 'N'))
             return false;
     }
 


### PR DESCRIPTION
#### d7f086248b902e1169a89efd78525b07b2481e54
<pre>
[JSC] Make less conservative on isCanonicalNumericIndexString
<a href="https://bugs.webkit.org/show_bug.cgi?id=259664">https://bugs.webkit.org/show_bug.cgi?id=259664</a>
rdar://113162575

Reviewed by Mark Lam.

This makes less conservative on isCanonicalNumericIndexString. We only care &quot;Infinity&quot; and &quot;NaN&quot; cases here.

* JSTests/stress/typed-array-canonical.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/PropertyName.h:
(JSC::isCanonicalNumericIndexString):

Canonical link: <a href="https://commits.webkit.org/266460@main">https://commits.webkit.org/266460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42be07554fb5b7c746fe8e42df9ed0b0f23c2e8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13180 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15854 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14047 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16320 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12520 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12684 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13149 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11094 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13922 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12492 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3618 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16823 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14308 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1630 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13063 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3429 "Passed tests") | 
<!--EWS-Status-Bubble-End-->