### PR TITLE
[GTK] Implement the Ed25519 algorithm

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1977,10 +1977,6 @@ webkit.org/b/177226 imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapK
 webkit.org/b/213678 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html [ Failure Timeout ]
 webkit.org/b/213678 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.worker.html [ Failure Timeout ]
 # Needs rebasing.
-imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/failures_Ed25519.https.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/generateKey/successes_Ed25519.https.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues-bigint.tentative.any.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/getRandomValues-bigint.tentative.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/historical.any.sharedworker.html [ Failure ]
@@ -1989,12 +1985,6 @@ imported/w3c/web-platform-tests/WebCryptoAPI/import_export/ec_importKey.https.an
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/import_export/rsa_importKey.https.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/WebCryptoAPI/wrapKey_unwrapKey/wrapKey_unwrapKey.https.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey.https.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/import_export/okp_importKey_failures_Ed25519.https.any.worker.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.html [ Failure ]
-imported/w3c/web-platform-tests/WebCryptoAPI/sign_verify/eddsa.https.any.worker.html [ Failure ]
 
 # TODO: This failure exists in the general TestExpectations, I got in a GTK run.
 # I think marking the whole folder as 'Slow' makes the expected result for this test 'Pass'.

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7391,13 +7391,13 @@ WebCryptoSafeCurvesEnabled:
   humanReadableDescription: "Enable Web Crypto Safe Curves"
   defaultValue:
     WebKitLegacy:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebKit:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
-      "PLATFORM(COCOA)": true
+      "PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 WebGLDraftExtensionsEnabled:

--- a/Source/WebCore/PAL/pal/crypto/tasn1/Utilities.cpp
+++ b/Source/WebCore/PAL/pal/crypto/tasn1/Utilities.cpp
@@ -57,6 +57,7 @@ static asn1_node asn1Definitions()
         { "Version", 1073741827, nullptr },
         { "PrivateKeyAlgorithmIdentifier", 1073741826, "AlgorithmIdentifier"},
         { "PrivateKey", 1073741831, nullptr },
+        { "CurvePrivateKey", 1073741831, nullptr },
         { "Attributes", 1610612751, nullptr },
         { nullptr, 2, "Attribute"},
         { "Attribute", 1610612741, nullptr },

--- a/Source/WebCore/PAL/pal/crypto/tasn1/WebCrypto.asn
+++ b/Source/WebCore/PAL/pal/crypto/tasn1/WebCrypto.asn
@@ -31,6 +31,8 @@ PrivateKeyAlgorithmIdentifier ::= AlgorithmIdentifier
 
 PrivateKey ::= OCTET STRING
 
+CurvePrivateKey ::= OCTET STRING
+
 Attributes ::= SET OF Attribute
 
 Attribute ::= SEQUENCE {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && !USE(GCRYPT)
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&)
 {
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "CryptoAlgorithmEd25519.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoKeyOKP.h"
+#include "GCryptUtilities.h"
+
+namespace WebCore {
+
+static bool extractEDDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t signatureSexp, const char* integerName, size_t keySizeInBytes)
+{
+    // Retrieve byte data of the specified integer.
+    PAL::GCrypt::Handle<gcry_sexp_t> integerSexp(gcry_sexp_find_token(signatureSexp, integerName, 0));
+    if (!integerSexp)
+        return false;
+
+    auto integerData = mpiData(integerSexp);
+    if (!integerData)
+        return false;
+
+    size_t dataSize = integerData->size();
+    if (dataSize >= keySizeInBytes) {
+        // Append the last `keySizeInBytes` bytes of the data Vector, if available.
+        signature.append(&integerData->at(dataSize - keySizeInBytes), keySizeInBytes);
+    } else {
+        // If not, prefix the binary data with zero bytes.
+        for (size_t paddingSize = keySizeInBytes - dataSize; paddingSize > 0; --paddingSize)
+            signature.uncheckedAppend(0x00);
+        signature.appendVector(*integerData);
+    }
+
+    return true;
+}
+
+static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, size_t keySizeInBytes, const Vector<uint8_t>& data)
+{
+    ASSERT(keySizeInBytes == 32);
+
+    // Construct the data s-expression that contains raw hashed data.
+    PAL::GCrypt::Handle<gcry_sexp_t> dataSexp;
+    {
+        gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags eddsa)(hash-algo sha512) (value %b))",
+            data.size(), data.data());
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return Exception { OperationError };
+        }
+    }
+
+    // Construct the `private-key` expression that will also be used for the EC context.
+    PAL::GCrypt::Handle<gcry_sexp_t> keySexp;
+    gcry_error_t error = gcry_sexp_build(&keySexp, nullptr, "(private-key(ecc(curve Ed25519)(flags eddsa)(d %b)))",
+        sk.size(), sk.data());
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return Exception { OperationError };
+    }
+
+    // Perform the PK signing, retrieving a sig-val s-expression of the following form:
+    // (sig-val
+    //   (dsa
+    //     (r r-mpi)
+    //     (s s-mpi)))
+    PAL::GCrypt::Handle<gcry_sexp_t> signatureSexp;
+    error = gcry_pk_sign(&signatureSexp, dataSexp, keySexp);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return Exception { OperationError };
+    }
+
+    // Retrieve MPI data of the resulting r and s integers. They are concatenated into
+    // a single buffer, properly accounting for integers that don't match the key in size.
+    Vector<uint8_t> signature;
+    signature.reserveInitialCapacity(64);
+
+    if (!extractEDDSASignatureInteger(signature, signatureSexp, "r", keySizeInBytes)
+        || !extractEDDSASignatureInteger(signature, signatureSexp, "s", keySizeInBytes))
+        return Exception { OperationError };
+
+    return signature;
+}
+
+static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    if (signature.size() != keyLengthInBytes * 2)
+        return false;
+
+    // Construct the sig-val s-expression, extracting the r and s components from the signature vector.
+    PAL::GCrypt::Handle<gcry_sexp_t> signatureSexp;
+    gcry_error_t error = gcry_sexp_build(&signatureSexp, nullptr, "(sig-val(eddsa(r %b)(s %b)))",
+        keyLengthInBytes, signature.data(), keyLengthInBytes, signature.data() + keyLengthInBytes);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return false;
+    }
+
+    // Construct the data s-expression that contains raw hashed data.
+    PAL::GCrypt::Handle<gcry_sexp_t> dataSexp;
+    {
+        gcry_error_t error = gcry_sexp_build(&dataSexp, nullptr, "(data(flags eddsa)(hash-algo sha512) (value %b))",
+            data.size(), data.data());
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return false;
+        }
+    }
+
+    // Construct the `public-key` expression to be used for generating the MPI structure.
+    PAL::GCrypt::Handle<gcry_sexp_t> keySexp;
+    error = gcry_sexp_build(&keySexp, nullptr, "(public-key(ecc(curve Ed25519)(q %b)))",
+        key.size(), key.data());
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return false;
+    }
+
+    // Perform the PK verification. We report success if there's no error returned, or
+    // a failure in any other case. OperationError should not be returned at this point,
+    // avoiding spilling information about the exact cause of verification failure.
+    error = gcry_pk_verify(signatureSexp, dataSexp, keySexp);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return false;
+    }
+    return { error == GPG_ERR_NO_ERROR };
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmEd25519::platformSign(const CryptoKeyOKP& key, const Vector<uint8_t>& data)
+{
+    return signEd25519(key.platformKey(), key.keySizeInBytes(), data);
+}
+
+ExceptionOr<bool> CryptoAlgorithmEd25519::platformVerify(const CryptoKeyOKP& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+{
+    return verifyEd25519(key.platformKey(), key.keySizeInBytes(), signature, data);
+}
+
+}
+#endif

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
@@ -34,6 +34,7 @@
 #include "CryptoAlgorithmAES_KW.h"
 #include "CryptoAlgorithmECDH.h"
 #include "CryptoAlgorithmECDSA.h"
+#include "CryptoAlgorithmEd25519.h"
 #include "CryptoAlgorithmHKDF.h"
 #include "CryptoAlgorithmHMAC.h"
 #include "CryptoAlgorithmPBKDF2.h"
@@ -57,6 +58,7 @@ void CryptoAlgorithmRegistry::platformRegisterAlgorithms()
     registerAlgorithm<CryptoAlgorithmAES_KW>();
     registerAlgorithm<CryptoAlgorithmECDH>();
     registerAlgorithm<CryptoAlgorithmECDSA>();
+    registerAlgorithm<CryptoAlgorithmEd25519>();
     registerAlgorithm<CryptoAlgorithmHKDF>();
     registerAlgorithm<CryptoAlgorithmHMAC>();
     registerAlgorithm<CryptoAlgorithmPBKDF2>();

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
@@ -1,0 +1,402 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "CryptoKeyOKP.h"
+
+#if ENABLE(WEB_CRYPTO)
+
+#include "CryptoKeyPair.h"
+#include "GCryptUtilities.h"
+#include "JsonWebKey.h"
+#include <pal/crypto/gcrypt/Utilities.h>
+#include <pal/crypto/tasn1/Utilities.h>
+#include <wtf/text/Base64.h>
+
+namespace WebCore {
+
+bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve namedCurve)
+{
+    return namedCurve == NamedCurve::Ed25519;
+}
+
+namespace CryptoKeyOKPImpl {
+
+static bool supportedAlgorithmIdentifier(CryptoAlgorithmIdentifier keyIdentifier, const Vector<uint8_t>& identifier)
+{
+    auto* data = identifier.data();
+    auto size = identifier.size();
+
+    switch (keyIdentifier) {
+    case CryptoAlgorithmIdentifier::Ed25519:
+        // Ed25519 only supports id-Ed25519 idenfitied for imported keys.
+        if (CryptoConstants::matches(data, size, CryptoConstants::s_ed25519Identifier))
+            return true;
+        return false;
+    default:
+        ASSERT_NOT_REACHED();
+        break;
+    }
+
+    return false;
+}
+
+}
+
+std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmIdentifier identifier, NamedCurve namedCurve, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    if (namedCurve != NamedCurve::Ed25519)
+        return { };
+
+    PAL::GCrypt::Handle<gcry_sexp_t> genkeySexp;
+    gcry_error_t error = gcry_sexp_build(&genkeySexp, nullptr, "(genkey (ecdsa (curve \"Ed25519\") (flags eddsa)))");
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return std::nullopt;
+    }
+
+    PAL::GCrypt::Handle<gcry_sexp_t> keyPairSexp;
+    error = gcry_pk_genkey(&keyPairSexp, genkeySexp);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return std::nullopt;
+    }
+
+    PAL::GCrypt::Handle<gcry_mpi_t> qMpi, dMpi;
+    error = gcry_sexp_extract_param(keyPairSexp, "private-key", "qd", &qMpi, &dMpi, nullptr);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return std::nullopt;
+    }
+
+    auto publicKeyData = mpiData(qMpi);
+    auto privateKeyData = mpiData(dMpi);
+    if (!publicKeyData || publicKeyData->size() != 32 || !privateKeyData || privateKeyData->size() != 32)
+        return std::nullopt;
+
+    bool isPublicKeyExtractable = true;
+    auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, Vector<uint8_t>(*publicKeyData), isPublicKeyExtractable, usages);
+    ASSERT(publicKey);
+    auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, Vector<uint8_t>(*privateKeyData), extractable, usages);
+    ASSERT(privateKey);
+    return CryptoKeyPair { WTFMove(publicKey), WTFMove(privateKey) };
+}
+
+// Per https://www.ietf.org/rfc/rfc5280.txt
+// SubjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
+// AlgorithmIdentifier  ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY DEFINED BY algorithm OPTIONAL }
+// Per https://www.rfc-editor.org/rfc/rfc8410
+// id-X25519    OBJECT IDENTIFIER ::= { 1 3 101 110 }
+// id-X448      OBJECT IDENTIFIER ::= { 1 3 101 111 }
+// id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
+// id-Ed448     OBJECT IDENTIFIER ::= { 1 3 101 113 }
+// For all of the OIDs, the parameters MUST be absent.
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importSpki(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    // Decode the `SubjectPublicKeyInfo` structure using the provided key data.
+    PAL::TASN1::Structure spki;
+    if (!PAL::TASN1::decodeStructure(&spki, "WebCrypto.SubjectPublicKeyInfo", keyData))
+        return nullptr;
+
+    // Validate `algorithm.algorithm`.
+    {
+        auto algorithm = PAL::TASN1::elementData(spki, "algorithm.algorithm");
+        if (!algorithm)
+            return nullptr;
+
+        if (!CryptoKeyOKPImpl::supportedAlgorithmIdentifier(identifier, *algorithm))
+            return nullptr;
+    }
+
+    // Retrieve the `subjectPublicKey` data and embed it into the `public-key` s-expression.
+    PAL::GCrypt::Handle<gcry_sexp_t> platformKey;
+    {
+        auto subjectPublicKey = PAL::TASN1::elementData(spki, "subjectPublicKey");
+        if (!subjectPublicKey)
+            return nullptr;
+
+        // If the parameters field of the algorithm AlgorithmIdentifier field of spki is present, then throw a DataError.
+        auto parameters = PAL::TASN1::elementData(spki, "algorithm.parameters");
+        if (parameters)
+            return nullptr;
+
+        // Construct the `public-key` expression to be used for generating the MPI structure.
+        gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(public-key(ecc(curve Ed25519)(q %b)))",
+            subjectPublicKey->size(), subjectPublicKey->data());
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return nullptr;
+        }
+    }
+
+    // Exrtact the 'q' parameter to get the raw public key.
+    PAL::GCrypt::Handle<gcry_mpi_t> mpi;
+    gcry_error_t error = gcry_sexp_extract_param(platformKey, "public-key", "q", &mpi, nullptr);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return nullptr;
+    }
+
+    auto rawKey = mpiData(mpi);
+    if (!rawKey)
+        return nullptr;
+
+    return create(identifier, curve, CryptoKeyType::Public, Vector<uint8_t>(*rawKey), extractable, usages);
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
+{
+    if (type() != CryptoKeyType::Public)
+        return Exception { InvalidAccessError };
+
+    PAL::TASN1::Structure spki;
+    {
+        // Create the `SubjectPublicKeyInfo` structure.
+        if (!PAL::TASN1::createStructure("WebCrypto.SubjectPublicKeyInfo", &spki))
+            return Exception { OperationError };
+
+        // Write out the id-edPublicKey identifier under `algorithm.algorithm`.
+        if (!PAL::TASN1::writeElement(spki, "algorithm.algorithm", CryptoConstants::s_ed25519Identifier.data(), 1))
+            return Exception { OperationError };
+
+        // The 'paramaters' element should not be present
+        if (!PAL::TASN1::writeElement(spki, "algorithm.parameters", nullptr, 0))
+            return Exception { OperationError };
+
+        // Write out the public key data under `subjectPublicKey`. Because this is a
+        // bit string parameter, the data size has to be multiplied by 8.
+        if (!PAL::TASN1::writeElement(spki, "subjectPublicKey", m_data.data(), m_data.size() * 8))
+            return Exception { OperationError };
+    }
+
+    // Retrieve the encoded `SubjectPublicKeyInfo` data and return it.
+    auto result = PAL::TASN1::encodedData(spki, "");
+    if (!result)
+        return Exception { OperationError };
+
+    return WTFMove(result.value());
+}
+
+// Per https://www.ietf.org/rfc/rfc5280.txt
+// PrivateKeyInfo ::= SEQUENCE { version INTEGER, privateKeyAlgorithm AlgorithmIdentifier, privateKey OCTET STRING }
+// AlgorithmIdentifier  ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters ANY DEFINED BY algorithm OPTIONAL }
+// Per https://www.rfc-editor.org/rfc/rfc8410
+// id-X25519    OBJECT IDENTIFIER ::= { 1 3 101 110 }
+// id-X448      OBJECT IDENTIFIER ::= { 1 3 101 111 }
+// id-Ed25519   OBJECT IDENTIFIER ::= { 1 3 101 112 }
+// id-Ed448     OBJECT IDENTIFIER ::= { 1 3 101 113 }
+// For all of the OIDs, the parameters MUST be absent.
+RefPtr<CryptoKeyOKP> CryptoKeyOKP::importPkcs8(CryptoAlgorithmIdentifier identifier, NamedCurve curve, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+{
+    // Decode the `PrivateKeyInfo` structure using the provided key data.
+    PAL::TASN1::Structure pkcs8;
+    if (!PAL::TASN1::decodeStructure(&pkcs8, "WebCrypto.PrivateKeyInfo", keyData))
+        return nullptr;
+
+    // Validate `version`.
+    {
+        auto version = PAL::TASN1::elementData(pkcs8, "version");
+        if (!version)
+            return nullptr;
+
+        if (!CryptoConstants::matches(version->data(), version->size(), CryptoConstants::s_asn1Version0))
+            return nullptr;
+    }
+
+    // Validate `privateKeyAlgorithm.algorithm`.
+    {
+        auto algorithm = PAL::TASN1::elementData(pkcs8, "privateKeyAlgorithm.algorithm");
+        if (!algorithm)
+            return nullptr;
+
+        if (!CryptoKeyOKPImpl::supportedAlgorithmIdentifier(identifier, *algorithm))
+            return nullptr;
+    }
+
+    // If the parameters field of the algorithm AlgorithmIdentifier field of pkcs8 is present, then throw a DataError.
+    auto parameters = PAL::TASN1::elementData(pkcs8, "privateKeyAlgorithm.parameters");
+    if (parameters)
+        return nullptr;
+
+    // Decode the `CurvePrivateKey` structure using the `privateKey` data.
+    PAL::TASN1::Structure ecPrivateKey;
+    {
+        auto privateKey = PAL::TASN1::elementData(pkcs8, "privateKey");
+        if (!privateKey)
+            return nullptr;
+
+        if (!PAL::TASN1::decodeStructure(&ecPrivateKey, "WebCrypto.CurvePrivateKey", *privateKey))
+            return nullptr;
+    }
+
+    // Retrieve the `privateKey.privateKey` data and embed it into the `private-key` s-expression.
+    PAL::GCrypt::Handle<gcry_sexp_t> platformKey;
+    {
+        auto privateKey = PAL::TASN1::elementData(ecPrivateKey, "");
+        if (!privateKey)
+            return nullptr;
+
+        // Validate the size of `privateKey`, making sure it fits the byte-size of the specified EC curve.
+        if (privateKey->size() != 32)
+            return nullptr;
+
+        // Construct the `private-key` expression that will also be used for the EC context.
+        gcry_error_t error = gcry_sexp_build(&platformKey, nullptr, "(private-key(ecc(curve Ed25519)(flags eddsa)(d %b)))",
+            privateKey->size(), privateKey->data());
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return nullptr;
+        }
+
+        // Create an EC context for the specified curve.
+        PAL::GCrypt::Handle<gcry_ctx_t> context;
+        error = gcry_mpi_ec_new(&context, platformKey, nullptr);
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return nullptr;
+        }
+
+        // Retrieve the `q` point. If the public key was provided through the PKCS#8 import, that
+        // key value will be retrieved as an gcry_mpi_point_t. Otherwise, the `q` point value will
+        // be computed on-the-fly by libgcrypt for the specified elliptic curve.
+        PAL::GCrypt::Handle<gcry_mpi_point_t> point(gcry_mpi_ec_get_point("q", context, 1));
+        if (!point)
+            return nullptr;
+
+        // Bail if the retrieved `q` MPI point is not on the specified EC curve.
+        if (!gcry_mpi_ec_curve_point(point, context))
+            return nullptr;
+
+        PAL::GCrypt::Handle<gcry_mpi_t> mpi;
+        error = gcry_sexp_extract_param(platformKey, "private-key", "d", &mpi, nullptr);
+        if (error != GPG_ERR_NO_ERROR) {
+            PAL::GCrypt::logError(error);
+            return nullptr;
+        }
+
+        auto rawKey = mpiData(mpi);
+        if (!rawKey)
+            return nullptr;
+
+        return create(identifier, curve, CryptoKeyType::Private, Vector<uint8_t>(*rawKey), extractable, usages);
+    }
+}
+
+ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const
+{
+    if (type() != CryptoKeyType::Private)
+        return Exception { InvalidAccessError };
+
+    PAL::TASN1::Structure ecPrivateKey;
+    {
+        // Create the `ECPrivateKey` structure.
+        if (!PAL::TASN1::createStructure("WebCrypto.CurvePrivateKey", &ecPrivateKey))
+            return Exception { OperationError };
+
+        // Write out the data under `privateKey`.
+        if (!PAL::TASN1::writeElement(ecPrivateKey, "", m_data.data(), m_data.size()))
+            return Exception { OperationError };
+    }
+
+    PAL::TASN1::Structure pkcs8;
+    {
+        // Create the `PrivateKeyInfo` structure.
+        if (!PAL::TASN1::createStructure("WebCrypto.PrivateKeyInfo", &pkcs8))
+            return Exception { OperationError };
+
+        // Write out '0' under `version`.
+        if (!PAL::TASN1::writeElement(pkcs8, "version", "0", 0))
+            return Exception { OperationError };
+
+        // Write out the id-Ed25519 identifier under `privateKeyAlgorithm.algorithm`.
+        if (!PAL::TASN1::writeElement(pkcs8, "privateKeyAlgorithm.algorithm", CryptoConstants::s_ed25519Identifier.data(), 1))
+            return Exception { OperationError };
+
+        // The 'paramaters' element should not be present
+        if (!PAL::TASN1::writeElement(pkcs8, "privateKeyAlgorithm.parameters", nullptr, 0))
+            return Exception { OperationError };
+
+        // Write out the `CurvePrivateKey` data under `privateKey`.
+        {
+            auto data = PAL::TASN1::encodedData(ecPrivateKey, "");
+            if (!data || !PAL::TASN1::writeElement(pkcs8, "privateKey", data->data(), data->size()))
+                return Exception { OperationError };
+        }
+
+        // Eliminate the optional `attributes` element.
+        if (!PAL::TASN1::writeElement(pkcs8, "attributes", nullptr, 0))
+            return Exception { OperationError };
+    }
+
+    // Retrieve the encoded `PrivateKeyInfo` data and return it.
+    auto result = PAL::TASN1::encodedData(pkcs8, "");
+    if (!result)
+        return Exception { OperationError };
+
+    return WTFMove(result.value());
+}
+
+String CryptoKeyOKP::generateJwkD() const
+{
+    ASSERT(type() == CryptoKeyType::Private);
+    return base64URLEncodeToString(m_data);
+}
+
+String CryptoKeyOKP::generateJwkX() const
+{
+    if (type() == CryptoKeyType::Public)
+        return base64URLEncodeToString(m_data);
+
+    ASSERT(type() == CryptoKeyType::Private);
+
+    // We get an sexp of the private-key so that we could later extract the public-key associated to it.
+    PAL::GCrypt::Handle<gcry_sexp_t> privKey;
+    gcry_error_t error = gcry_sexp_build(&privKey, nullptr, "(private-key(ecc(curve Ed25519)(flags eddsa)(d %b)))", m_data.size(), m_data.data());
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return { };
+    }
+
+    // Create a context based on the private-key sexp.
+    PAL::GCrypt::Handle<gcry_ctx_t> context;
+    error = gcry_mpi_ec_new(&context, privKey, nullptr);
+    if (error != GPG_ERR_NO_ERROR) {
+        PAL::GCrypt::logError(error);
+        return { };
+    }
+
+    // Return an EdDSA style compressed point. This is only supported for Twisted Edwards curves.
+    PAL::GCrypt::Handle<gcry_mpi_t> qMPI(gcry_mpi_ec_get_mpi("q@eddsa", context, 0));
+    if (qMPI) {
+        auto q = mpiData(qMPI);
+        if (q && q->size() == 32)
+            return base64URLEncodeToString(*q);
+    }
+
+    return { };
+}
+
+Vector<uint8_t> CryptoKeyOKP::platformExportRaw() const
+{
+    return m_data;
+}
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_CRYPTO)

--- a/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
+++ b/Source/WebCore/crypto/gcrypt/GCryptUtilities.h
@@ -39,6 +39,9 @@ namespace WebCore {
 
 namespace CryptoConstants {
 
+static const std::array<uint8_t, 12> s_ed25519Identifier { { "1.3.101.112" } };
+static const std::array<uint8_t, 12> s_x25519Identifier { { "1.3.101.110" } };
+
 static const std::array<uint8_t, 18> s_ecPublicKeyIdentifier { { "1.2.840.10045.2.1" } };
 static const std::array<uint8_t, 13> s_ecDHIdentifier { { "1.3.132.1.12" } };
 

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.cpp
@@ -88,6 +88,7 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
 
     switch (namedCurve) {
     case NamedCurve::Ed25519:
+        // FIXME: this is already done in the Algorithm's importKey method for each format, so it seems we can remoev this duplicated code.
         if (!keyData.d.isEmpty()) {
             if (usages & (CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt | CryptoKeyUsageVerify | CryptoKeyUsageDeriveKey | CryptoKeyUsageDeriveBits | CryptoKeyUsageWrapKey | CryptoKeyUsageUnwrapKey))
                 return nullptr;
@@ -197,7 +198,7 @@ auto CryptoKeyOKP::algorithm() const -> KeyAlgorithm
     return CryptoKeyAlgorithm { CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier()) };
 }
 
-#if !PLATFORM(COCOA)
+#if !PLATFORM(COCOA) && !USE(GCRYPT)
 bool CryptoKeyOKP::isPlatformSupportedCurve(NamedCurve)
 {
     return false;

--- a/Source/WebCore/platform/SourcesGCrypt.txt
+++ b/Source/WebCore/platform/SourcesGCrypt.txt
@@ -28,6 +28,7 @@ crypto/gcrypt/CryptoAlgorithmAES_GCMGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmAES_KWGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmHKDFGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmHMACGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmPBKDF2GCrypt.cpp
@@ -37,6 +38,7 @@ crypto/gcrypt/CryptoAlgorithmRSA_OAEPGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
 crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp
 crypto/gcrypt/CryptoKeyECGCrypt.cpp
+crypto/gcrypt/CryptoKeyOKPGCrypt.cpp
 crypto/gcrypt/CryptoKeyRSAGCrypt.cpp
 crypto/gcrypt/GCryptUtilities.cpp
 crypto/gcrypt/SerializedCryptoKeyWrapGCrypt.cpp


### PR DESCRIPTION
#### bdf80b88c96dac5fb3603260a5ca57d87eee401f
<pre>
[GTK] Implement the Ed25519 algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=259663">https://bugs.webkit.org/show_bug.cgi?id=259663</a>

Reviewed by Žan Doberšek.

This change implements all the Ed25519&apos;s operations defined in the
WebCrypto Secure Curves specification. These operations include the
key generation, import/export in spki, pkcs8 and jwk formats and the
sign and verify methods that are the key operations of this algorithm.

It&apos;s worth mentioning that the basic support for the OKP key format
has been already introduced by the Cocoa implementation of this
algorithm (see bug 246145 for details).

The implementation of the Ed25519 algorithm for the GTK+ port is done
with the Libgcrypt primitives, as it&apos;s the case of the post&apos;s most
complete  and mature implementation of the WebCrypto APIs. There is an
ongoing effort to implement it in OpenSSL (see bug 248980 for details)
but it won&apos;t be an option for the GTK+ port in the short term.

* LayoutTests/platform/glib/TestExpectations: All the Ed25519 tests should pass now.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Feature enabled for GTK and WPE ports
* Source/WebCore/PAL/pal/crypto/tasn1/Utilities.cpp:
(PAL::TASN1::asn1Definitions):
* Source/WebCore/PAL/pal/crypto/tasn1/WebCrypto.asn:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp: Added.
(WebCore::extractEDDSASignatureInteger): Extract the &apos;r&apos; and &apos;s&apos; integers of the Elliptic curve
(WebCore::signEd25519): Gcrypt sign operation
(WebCore::verifyEd25519): Gcrypt verify operation
(WebCore::CryptoAlgorithmEd25519::platformSign): Generic implementation of the abstract method.
(WebCore::CryptoAlgorithmEd25519::platformVerify): Generic implementation of the abstract method.
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRegistryGCrypt.cpp: Registration of the Ed25519 alg
(WebCore::CryptoAlgorithmRegistry::platformRegisterAlgorithms): Generci implementation of the abstract method
* Source/WebCore/crypto/gcrypt/CryptoKeyOKPGCrypt.cpp: Added.
(WebCore::CryptoKeyOKP::isPlatformSupportedCurve):
(WebCore::CryptoKeyOKPImpl::supportedAlgorithmIdentifier):
(WebCore::CryptoKeyOKP::platformGeneratePair):
(WebCore::CryptoKeyOKP::importSpki):
(WebCore::CryptoKeyOKP::exportSpki const):
(WebCore::CryptoKeyOKP::importPkcs8):
(WebCore::CryptoKeyOKP::exportPkcs8 const):
(WebCore::CryptoKeyOKP::generateJwkD const):
(WebCore::CryptoKeyOKP::generateJwkX const):
(WebCore::CryptoKeyOKP::platformExportRaw const):
* Source/WebCore/crypto/gcrypt/GCryptUtilities.h:
* Source/WebCore/crypto/keys/CryptoKeyOKP.cpp:
(WebCore::CryptoKeyOKP::importJwk):
* Source/WebCore/platform/SourcesGCrypt.txt:

Canonical link: <a href="https://commits.webkit.org/266599@main">https://commits.webkit.org/266599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f465527eb08db1f132f078a62e0623a66d41d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14051 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16324 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19559 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11857 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15911 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13153 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13224 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11097 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13926 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12496 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3446 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16827 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14312 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13067 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3430 "Passed tests") | 
<!--EWS-Status-Bubble-End-->