### PR TITLE
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2514,6 +2514,9 @@ imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ WontFix 
 # Per-process limit is only for WK2
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 
+# IPC is for WK2
+ipc/shared-video-frame-size.html [ Skip ]
+
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -75,6 +75,7 @@ private:
     uint32_t m_heightPlaneB { 0 };
     uint32_t m_bytesPerRowPlaneB { 0 };
     uint32_t m_bytesPerRowPlaneAlpha { 0 };
+    size_t m_storageSize { 0 };
 };
 
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -76,6 +76,9 @@ bool SharedVideoFrameInfo::isReadWriteSupported() const
 
 size_t SharedVideoFrameInfo::storageSize() const
 {
+    if (m_storageSize)
+        return m_storageSize;
+
     size_t sizePlaneA;
     if (!WTF::safeMultiply(m_bytesPerRow, m_height, sizePlaneA))
         return 0;
@@ -91,7 +94,8 @@ size_t SharedVideoFrameInfo::storageSize() const
     if (m_bufferType == kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar && !WTF::safeAdd(sizePlaneA, size, size))
         return 0;
 
-    return size;
+    const_cast<SharedVideoFrameInfo*>(this)->m_storageSize = size;
+    return m_storageSize;
 }
 
 void SharedVideoFrameInfo::encode(uint8_t* destination)


### PR DESCRIPTION
#### 291058072b1786d6242ebd2e304ece4d7080ce5f
<pre>
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read
rdar://107023292

Reviewed by Eric Carlson.

Compute with safeMultitply/safeAdd the total size of the frame.
If there is an overflow, we now fail the decoding of SharedVideoFrameInfo.
We store the size of the frame in SharedVideoFrameInfo to not recompute it a second time.

Covered by provided IPC test.

* LayoutTests/ipc/shared-video-frame-size-expected.txt: Added.
* LayoutTests/ipc/shared-video-frame-size.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::storageSize const):
(WebCore::SharedVideoFrameInfo::decode):

Originally-landed-as: 259548.590@safari-7615-branch (dd4ad7b0b286). rdar://113166244
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/291058072b1786d6242ebd2e304ece4d7080ce5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15626 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15859 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16330 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19570 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13228 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11145 "Exiting early after 60 failures. 67206 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->