### PR TITLE
[run-benchmarks] Use `ktrace artrace` for profiling browser benchmarks

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py
@@ -23,7 +23,7 @@ _log = logging.getLogger(__name__)
 class BenchmarkRunner(object):
     name = 'benchmark_runner'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, profiling_interval=None, browser_args=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None):
         self._plan_name, self._plan = BenchmarkRunner._load_plan_data(plan_file)
         if 'options' not in self._plan:
             self._plan['options'] = {}
@@ -49,6 +49,7 @@ class BenchmarkRunner(object):
         if self._profile_output_dir:
             os.makedirs(self._profile_output_dir, exist_ok=True)
             _log.info('Collecting profiles to {}'.format(self._profile_output_dir))
+        self._trace_type = trace_type
         self._profiling_interval = profiling_interval
         self._output_file = output_file
         self._scale_unit = scale_unit

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -56,7 +56,7 @@ class BrowserDriver(object):
         yield
 
     @contextmanager
-    def profile(self, output_path, profile_filename, profiling_interval, timeout=300):
+    def profile(self, output_path, profile_filename, profiling_interval, trace_type='profile', timeout=300):
         _log.error('The --profile option was specified, but an empty context was called. This run will not be profiled.')
         yield
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
@@ -7,6 +7,7 @@ import time
 
 from contextlib import contextmanager
 
+from webkitcorepy import Timeout
 from webkitpy.benchmark_runner.browser_driver.browser_driver import BrowserDriver
 from webkitpy.benchmark_runner.utils import write_defaults
 
@@ -40,6 +41,43 @@ class OSXBrowserDriver(BrowserDriver):
 
     def close_browsers(self):
         self._terminate_processes(self.process_name, self.bundle_id)
+
+    @contextmanager
+    def profile(self, output_path, profile_filename, profiling_interval, trace_type='profile', timeout=300):
+        trace_process = None
+        additional_trace_arguments = {
+            'full': ['--type=full'],
+            'profile': ['--type=profile'],
+        }
+        if trace_type not in additional_trace_arguments:
+            _log.error('`{}` is not a valid type of trace. Defaulting to `profile`.'.format(trace_type))
+            trace_type = 'profile'
+        try:
+            _log.info('Gathering traces')
+            _log.info('If passwordless sudo is not enabled, you may see a prompt for your host machine\'s admin password.')
+            trace_command = ['sudo', 'ktrace', 'artrace', '-o', os.path.join(output_path, profile_filename + '.ktrace')]
+            trace_command += additional_trace_arguments[trace_type]
+            if profiling_interval:
+                trace_command += ['-i', profiling_interval]
+            _log.info('Running ktrace command: {}'.format(trace_command))
+            trace_process = subprocess.Popen(trace_command)
+            time.sleep(5)  # Wait a few seconds for `ktrace` process to start
+            yield
+        except Exception as error:
+            raise Exception('Failed to start ktrace. Error: {}'.format(error))
+        finally:
+            if not trace_process:
+                return
+            try:
+                subprocess.call(['sudo', 'pkill', '-2', 'ktrace'])
+                _log.info('Stopping ktrace task.')
+                with Timeout(timeout):
+                    trace_process.wait()
+            except Exception as error:
+                _log.error('Failed to quit ktrace.')
+            finally:
+                _log.info('Killing ktrace task.')
+                subprocess.call(['sudo', 'pkill', '-9', 'ktrace'])
 
     def _save_screenshot_to_path(self, output_directory, filename):
         jpg_image_path = os.path.join(output_directory, filename)

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -59,7 +59,7 @@ def config_argument_parser():
     parser.add_argument('--no-adjust-unit', dest='scale_unit', action='store_false', help="Don't convert to scientific notation.")
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
     parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
-    parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
+    parser.add_argument('--profile', dest='trace_type', default=None, help="Collect profiling traces, and copy them to the diagnostic directory. Requires a valid TRACE_TYPE - options are `full` and `profile`.")
     parser.add_argument('--profiling-interval', default=None, help="Specify the profiling sampling rate.")
 
     group = parser.add_mutually_exclusive_group()
@@ -84,7 +84,7 @@ def parse_args(parser=None):
     _log.debug('\tbuild directory\t: %s' % args.build_dir)
     _log.debug('\tplan name\t: %s', args.plan)
 
-    if (args.generate_pgo_profiles or args.profile) and not args.diagnose_dir:
+    if (args.generate_pgo_profiles or args.trace_type) and not args.diagnose_dir:
         raise Exception('Collecting profiles requires a diagnostic directory (--diagnose-directory) to be set.')
 
     if args.generate_pgo_profiles and args.platform != 'osx':
@@ -100,8 +100,8 @@ def run_benchmark_plan(args, plan):
                                     args.platform, args.browser, args.browser_path, args.subtests, args.scale_unit,
                                     args.show_iteration_values, args.device_id, args.diagnose_dir,
                                     args.diagnose_dir if args.generate_pgo_profiles else None,
-                                    args.diagnose_dir if args.profile else None,
-                                    args.profiling_interval,
+                                    args.diagnose_dir if args.trace_type else None,
+                                    args.trace_type, args.profiling_interval,
                                     args.browser_args)
     runner.execute()
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -23,10 +23,10 @@ _log = logging.getLogger(__name__)
 class WebServerBenchmarkRunner(BenchmarkRunner):
     name = 'webserver'
 
-    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, profiling_interval=None, browser_args=None):
+    def __init__(self, plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests=None, scale_unit=True, show_iteration_values=False, device_id=None, diagnose_dir=None, pgo_profile_output_dir=None, profile_output_dir=None, trace_type=None, profiling_interval=None, browser_args=None):
         self._http_server_driver = HTTPServerDriverFactory.create(platform)
         self._http_server_driver.set_device_id(device_id)
-        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, profiling_interval, browser_args)
+        super(WebServerBenchmarkRunner, self).__init__(plan_file, local_copy, count_override, timeout_override, build_dir, output_file, platform, browser, browser_path, subtests, scale_unit, show_iteration_values, device_id, diagnose_dir, pgo_profile_output_dir, profile_output_dir, trace_type, profiling_interval, browser_args)
         if self._diagnose_dir:
             self._http_server_driver.set_http_log(os.path.join(self._diagnose_dir, 'run-benchmark-http.log'))
 
@@ -57,7 +57,7 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         return subtest_url
 
     def _run_one_test(self, web_root, test_file, iteration):
-        enable_profiling = True if self._profile_output_dir else False
+        enable_profiling = self._profile_output_dir and self._trace_type
         profile_filename = '{}-{}'.format(self._plan_name, iteration)
         try:
             self._http_server_driver.serve(web_root)
@@ -65,7 +65,7 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
             if '?' not in url:
                 url = url.replace('&', '?', 1)
             if enable_profiling:
-                context = self._browser_driver.profile(self._profile_output_dir, profile_filename, self._profiling_interval)
+                context = self._browser_driver.profile(self._profile_output_dir, profile_filename, self._profiling_interval, trace_type=self._trace_type)
             else:
                 context = NullContext()
             with context:


### PR DESCRIPTION
#### 4b03459ba7f6a33a8e4b610ca229901d64e07eb7
<pre>
[run-benchmarks] Use `ktrace artrace` for profiling browser benchmarks
<a href="https://bugs.webkit.org/show_bug.cgi?id=259669">https://bugs.webkit.org/show_bug.cgi?id=259669</a>
rdar://113167762

Reviewed by Dewei Zhu.

Up until now, the `--profile` argument in run-benchmarks hasn&apos;t done anything. This patch implements profiling using the `ktrace artrace` command.

The --profile argument has been modified to require a TRACE_TYPE argument, this can be either `full` or `profile`. It&apos;ll start profiling when the test starts, and save the resulting files to the directory specified in --diagnose-directory (or /tmp/ by default).

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.profile):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py:
(OSXBrowserDriver):
(OSXBrowserDriver.profile):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(config_argument_parser):
(parse_args):
(run_benchmark_plan):
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner.__init__):
(WebServerBenchmarkRunner):

Canonical link: <a href="https://commits.webkit.org/266492@main">https://commits.webkit.org/266492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4be872f3576650075e34282bf5c408871fe86bee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15697 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13250 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11825 "Passed tests") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16404 "An unexpected error occured. Recent messages:Failed to print configuration") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14054 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12586 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16404 "An unexpected error occured. Recent messages:Failed to print configuration") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12750 "Passed tests") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16404 "An unexpected error occured. Recent messages:Failed to print configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13297 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12571 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3383 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->