### PR TITLE
Fix crash when HTMLMediaElement::exitFullscreen is called on a video

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6552,3 +6552,4 @@ webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
 
 # Only some OSes have support for auto word breaking.
 imported/w3c/web-platform-tests/css/css-text/word-break/auto [ Pass Failure ImageOnlyFailure ]
+webkit.org/b/255970 [ Debug ] fullscreen/exit-full-screen-video-crash.html [ Crash ]

--- a/LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt
+++ b/LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fullscreen/exit-full-screen-video-crash.html
+++ b/LayoutTests/fullscreen/exit-full-screen-video-crash.html
@@ -1,0 +1,17 @@
+<script>
+  onload = async () => {
+    if (window.testRunner)
+      testRunner.dumpAsText();
+    internals.withUserGesture(() => {});
+    let video0 = document.createElement('video');
+    video0.src = 'data:video/mp4;';
+    document.body.append(video0);
+    $vm.print(await video0.requestFullscreen());
+    navigator.mediaSession.callActionHandler({action: 'play'});
+    let div0 = document.createElement('div');
+    video0.append(div0);
+    $vm.print(await div0.requestFullscreen());
+    video0.webkitSetPresentationMode('inline');
+    document.body.innerHTML = 'PASS if no crash';
+  };
+</script>

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -409,10 +409,17 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
 void VideoFullscreenManager::exitVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, CompletionHandler<void(bool)>&& completionHandler)
 {
     INFO_LOG(LOGIDENTIFIER);
+    LOG(Fullscreen, "VideoFullscreenManager::exitVideoFullscreenForVideoElement(%p)", this);
+
     ASSERT(m_page);
     ASSERT(m_videoElements.contains(videoElement));
 
-    auto contextId = m_videoElements.get(videoElement);
+    if (!m_videoElements.contains(&videoElement)) {
+        completionHandler(false);
+        return;
+    }
+
+    auto contextId = m_videoElements.get(&videoElement);
     auto& interface = ensureInterface(contextId);
     if (interface.animationState() != VideoFullscreenInterfaceContext::AnimationType::None) {
         completionHandler(false);
@@ -441,6 +448,9 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
 
     ASSERT(m_page);
     ASSERT(m_videoElements.contains(videoElement));
+
+    if (!m_videoElements.contains(&videoElement))
+        return;
 
     if (m_videoElementInPictureInPicture == &videoElement)
         m_videoElementInPictureInPicture = nullptr;


### PR DESCRIPTION
#### d7a747e9b38a7d262b7bfac2342da260f2430705
<pre>
Fix crash when HTMLMediaElement::exitFullscreen is called on a video
element which is not currently full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255970">https://bugs.webkit.org/show_bug.cgi?id=255970</a>
rdar://108489504

Reviewed by Jer Noble.

This change fixes an issue where exitFullScreen is called on video, but
the current full screen element is div, due to which we end up
scheduling the webkitendfullscreenEvent event for video, which trips
over an assertion.

* LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt: Added.
* LayoutTests/fullscreen/exit-full-screen-video-crash.html: Added.
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):

Originally-landed-as: 259548.703@safari-7615-branch (0ffc79d64999). rdar://113167859
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7a747e9b38a7d262b7bfac2342da260f2430705

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13893 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14208 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14543 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13190 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16716 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14290 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14062 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16716 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14543 "Failed to compile WebKit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16335 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16716 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14543 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19569 "1 flakes 116 failures") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16716 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14543 "Failed to compile WebKit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15909 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13233 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14290 "Failed to compile WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12507 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14543 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16838 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13076 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->