### PR TITLE
Fix type confusion in BuilderConverter::applyValueContent.

### DIFF
--- a/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt
+++ b/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash.

--- a/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html
+++ b/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html
@@ -1,0 +1,9 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    d.attributeStyleMap.set('content', 'url(A)');
+  };
+</script>
+<div id="d"></div>
+<p>PASS if no crash.</p>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -1474,6 +1474,12 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
                 break;
             }
         }
+    };
+    if (is<CSSValueList>(value)) {
+        for (auto& item : downcast<CSSValueList>(value))
+            processSingleValue(item);
+    } else {
+        processSingleValue(value);
     }
     if (!didSet)
         builderState.style().clearContent();


### PR DESCRIPTION
#### 930f7d5cbe0ab89eb31dea7d8830b111b60972f8
<pre>
Fix type confusion in BuilderConverter::applyValueContent.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255955.">https://bugs.webkit.org/show_bug.cgi?id=255955.</a>
rdar://108499561.

Reviewed by Antti Koivisto.

This change fixes applyValueContent so that it can deal with single
values instead of expecting a list of values towards the end.

* LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt: Added.
* LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
  (WebCore::Style::BuilderCustom::applyValueContent):

Originally-landed-as: 259548.730@safari-7615-branch (c123784dc828). rdar://113168576
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/930f7d5cbe0ab89eb31dea7d8830b111b60972f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13899 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14214 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14549 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15637 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13194 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13982 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16722 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14296 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15637 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14068 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16722 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14549 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16341 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16722 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14549 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16341 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16722 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14549 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16341 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13239 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14296 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12513 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14549 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16844 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13081 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->