### PR TITLE
Handle potential overflow of gamepadEventListenerCount.

### DIFF
--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -63,6 +63,93 @@ protected:
 
 private:
     GlobalWindowIdentifier m_identifier;
+    explicit DOMWindow(Document&);
+
+    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+
+    bool isLocalDOMWindow() const final { return true; }
+    bool isRemoteDOMWindow() const final { return false; }
+    void eventListenersDidChange() final;
+
+    bool allowedToChangeWindowGeometry() const;
+
+    static ExceptionOr<RefPtr<Frame>> createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures&, DOMWindow& activeWindow, Frame& firstFrame, Frame& openerFrame, const Function<void(DOMWindow&)>& prepareDialogFunction = nullptr);
+    bool isInsecureScriptAccess(DOMWindow& activeWindow, const String& urlString);
+
+#if ENABLE(DEVICE_ORIENTATION)
+    bool isAllowedToUseDeviceMotionOrOrientation(String& message) const;
+    bool hasPermissionToReceiveDeviceMotionOrOrientationEvents(String& message) const;
+    void failedToRegisterDeviceMotionEventListener();
+#endif
+
+    bool isSameSecurityOriginAsMainFrame() const;
+
+#if ENABLE(GAMEPAD)
+    void incrementGamepadEventListenerCount();
+    void decrementGamepadEventListenerCount();
+#endif
+
+    bool m_shouldPrintWhenFinishedLoading { false };
+    bool m_suspendedForDocumentSuspension { false };
+    bool m_isSuspendingObservers { false };
+    std::optional<bool> m_canShowModalDialogOverride;
+
+    HashSet<Observer*> m_observers;
+
+    mutable RefPtr<Crypto> m_crypto;
+    mutable RefPtr<History> m_history;
+    mutable RefPtr<BarProp> m_locationbar;
+    mutable RefPtr<StyleMedia> m_media;
+    mutable RefPtr<BarProp> m_menubar;
+    mutable RefPtr<Navigator> m_navigator;
+    mutable RefPtr<BarProp> m_personalbar;
+    mutable RefPtr<Screen> m_screen;
+    mutable RefPtr<BarProp> m_scrollbars;
+    mutable RefPtr<DOMSelection> m_selection;
+    mutable RefPtr<BarProp> m_statusbar;
+    mutable RefPtr<BarProp> m_toolbar;
+    mutable RefPtr<Location> m_location;
+    mutable RefPtr<VisualViewport> m_visualViewport;
+
+    String m_status;
+    String m_defaultStatus;
+
+    enum class PageStatus { None, Shown, Hidden };
+    PageStatus m_lastPageStatus { PageStatus::None };
+
+#if PLATFORM(IOS_FAMILY)
+    unsigned m_scrollEventListenerCount { 0 };
+#endif
+
+#if ENABLE(IOS_TOUCH_EVENTS) || ENABLE(IOS_GESTURE_EVENTS)
+    unsigned m_touchAndGestureEventListenerCount { 0 };
+#endif
+
+#if ENABLE(GAMEPAD)
+    uint64_t m_gamepadEventListenerCount { 0 };
+#endif
+
+    mutable RefPtr<Storage> m_sessionStorage;
+    mutable RefPtr<Storage> m_localStorage;
+    mutable RefPtr<DOMApplicationCache> m_applicationCache;
+
+    RefPtr<CustomElementRegistry> m_customElementRegistry;
+
+    mutable RefPtr<Performance> m_performance;
+
+    std::optional<ReducedResolutionSeconds> m_frozenNowTimestamp;
+
+    // For the purpose of tracking user activation, each Window W has a last activation timestamp. This is a number indicating the last time W got
+    // an activation notification. It corresponds to a DOMHighResTimeStamp value except for two cases: positive infinity indicates that W has never
+    // been activated, while negative infinity indicates that a user activation-gated API has consumed the last user activation of W. The initial
+    // value is positive infinity.
+    MonotonicTime m_lastActivationTimestamp { MonotonicTime::infinity() };
+
+    bool m_wasWrappedWithoutInitializedSecurityOrigin { false };
+    bool m_mayReuseForNavigation { true };
+#if ENABLE(USER_MESSAGE_HANDLERS)
+    mutable RefPtr<WebKitNamespace> m_webkitNamespace;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ea19ce1401a271fe935c5c8bb1007e0616eb2bfe
<pre>
Handle potential overflow of gamepadEventListenerCount.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256205.">https://bugs.webkit.org/show_bug.cgi?id=256205.</a>
rdar://80838189.

Reviewed by Ryosuke Niwa.

m_gamepadEventListenerCount can overflow if addEventListener() is called UINT_MAX+1 times.
Once the window is freed, we will be left with a dangling pointer in the GamepadManager.
This change adds a flag to check for overflow and keep the behavior same in the event of overflow..

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::~DOMWindow):
(WebCore::DOMWindow::incrementGamepadEventListenerCount):
(WebCore::DOMWindow::decrementGamepadEventListenerCount):
* Source/WebCore/page/DOMWindow.h:

Originally-landed-as: 259548.729@safari-7615-branch (5cc2ead4986a). rdar://113169820
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea19ce1401a271fe935c5c8bb1007e0616eb2bfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13903 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14218 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14552 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15640 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13197 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13986 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16726 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14300 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15640 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14072 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16726 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14552 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16344 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16726 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14552 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16344 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16726 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14552 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16344 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13242 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14300 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12516 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14552 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16847 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13084 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->