### PR TITLE
Restrict further top-frame navigations by a third-party iframe

### DIFF
--- a/LayoutTests/fast/files/null-origin-string-expected.txt
+++ b/LayoutTests/fast/files/null-origin-string-expected.txt
@@ -1,2 +1,7 @@
 CONSOLE MESSAGE: Started reading...
-PASS if no crash.
+
+Test that using FileReader from a document with unique origin doesn't cause a crash.
+
+If testing manually, please drop a file on an input above.
+
+PASS if not crash.

--- a/LayoutTests/fast/files/null-origin-string.html
+++ b/LayoutTests/fast/files/null-origin-string.html
@@ -16,7 +16,7 @@ function onInputFileChange()
     reader.readAsText(file);
     console.log('Started reading...');
 
-    top.location = 'data:text/html,<p>PASS if no crash.</p><script>testRunner.notifyDone()</scr' + 'ipt>';
+    top.postMessage('finish', '*');
 }
 </script>
 
@@ -25,10 +25,16 @@ if (window.eventSender) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
+addEventListener('message', (e) => {
+    if (e.data == 'finish')
+        testRunner.notifyDone();
+});
+
 document.write('<iframe src="data:text/html,<input type=file id=file onchange=\'onInputFileChange()\'><script>' + document.getElementsByTagName("script")[0].innerText + 'runTest()</scr' + 'ipt>" style="left:0px;top:0px"></iframe>');
 </script>
 
 <p>Test that using FileReader from a document with unique origin doesn't cause a crash.</p>
 <p>If testing manually, please drop a file on an input above.</p>
+<p>PASS if not crash.</p>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes-expected.txt
@@ -1,0 +1,16 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+
+CONSOLE MESSAGE: SecurityError: The operation is insecure.
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+
+CONSOLE MESSAGE: SecurityError: The operation is insecure.
+Test blocking of suspicious top-level navigations by a third-party iframe (same-site but different scheme)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS All navigations by subframes have been blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-to-different-scheme-by-third-party-iframes.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test blocking of suspicious top-level navigations by a third-party iframe (same-site but different scheme)");
+jsTestIsAsync = true;
+onload = () => {
+    setTimeout(() => {
+        document.getElementById('testFrame').src = "http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html";
+        setTimeout(() => {
+            testPassed("All navigations by subframes have been blocked");
+            finishJSTest();
+        }, 100);
+    }, 10);
+}
+</script>
+<iframe src="http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html"></iframe>
+<iframe id="testFrame"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Unsafe JavaScript attempt to initiate navigation for frame with URL 'http://127.0.0.1:8000/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html' from frame with URL 'http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.
+Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS All navigations by subframes have been blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
+++ b/LayoutTests/http/tests/security/block-top-level-navigation-via-redirect-by-third-party-iframes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Test blocking of suspicious top-level navigations by a third-party iframe (same-site but redirects to a different site)");
+jsTestIsAsync = true;
+onload = () => {
+    setTimeout(() => {
+        document.getElementById('testFrame').src = "http://localhost:8000/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html";
+        setTimeout(() => {
+            testPassed("All navigations by subframes have been blocked");
+            finishJSTest();
+        }, 100);
+    }, 10);
+}
+</script>
+<iframe id="testFrame"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html
+++ b/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-different-scheme.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+Success! The navigation was blocked
+<script>
+window.addEventListener("load", e => {
+  top.location = "https://127.0.0.1:8443/security/resources/should-not-have-loaded.html";
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html
+++ b/LayoutTests/http/tests/security/resources/navigate-top-level-frame-to-failure-page-via-redirect.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+Success! The navigation was blocked
+<script>
+window.addEventListener("load", e => {
+  // The initial navigation URL is same-site but it redirects to a different site.
+  top.location = "http://127.0.0.1:8000/resources/redirect.py?url=http://localhost:8000/security/resources/should-not-have-loaded.html";
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3925,10 +3925,13 @@ bool Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame&
 
     // Only prevent cross-site navigations.
     RefPtr targetDocument = targetFrame.document();
-    if (targetDocument && (targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL)))
-        return false;
+    if (!targetDocument)
+        return true;
 
-    return true;
+    if (targetDocument->securityOrigin().protocol() != destinationURL.protocol())
+        return true;
+
+    return !(targetDocument->securityOrigin().isSameOriginDomain(SecurityOrigin::create(destinationURL)) || areRegistrableDomainsEqual(targetDocument->url(), destinationURL));
 }
 
 void Document::didRemoveAllPendingStylesheet()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1779,9 +1779,7 @@ public:
 #endif
 
     virtual void didChangeViewSize() { }
-
-    void updateRelevancyOfContentVisibilityElements();
-    void scheduleContentRelevancyUpdate(ContentRelevancyStatus);
+    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(Frame& targetFrame, const URL& destinationURL);
 
 protected:
     enum class ConstructionFlag : uint8_t {
@@ -1885,8 +1883,7 @@ private:
     void invalidateDOMCookieCache();
     void didLoadResourceSynchronously(const URL&) final;
 
-    bool canNavigateInternal(LocalFrame& targetFrame);
-    bool isNavigationBlockedByThirdPartyIFrameRedirectBlocking(LocalFrame& targetFrame, const URL& destinationURL);
+    bool canNavigateInternal(Frame& targetFrame);
 
 #if USE(QUICK_LOOK)
     bool shouldEnforceQuickLookSandbox() const;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -664,6 +664,24 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         return completionHandler(WTFMove(newRequest));
     }
 
+    if (auto requester = m_triggeringAction.requester(); requester && requester->documentIdentifier) {
+        if (RefPtr requestingDocument = Document::allDocumentsMap().get(requester->documentIdentifier); requestingDocument && requestingDocument->frame()) {
+            if (m_frame && requestingDocument->isNavigationBlockedByThirdPartyIFrameRedirectBlocking(*m_frame, newRequest.url())) {
+                DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - cross-site redirect of top frame triggered by third-party iframe");
+                if (m_frame->document()) {
+                    auto message = makeString("Unsafe JavaScript attempt to initiate navigation for frame with URL '"
+                        , m_frame->document()->url().string()
+                        , "' from frame with URL '"
+                        , requestingDocument->url().string()
+                        , "'. The frame attempting navigation of the top-level window is cross-origin or untrusted and the user has never interacted with the frame.");
+                    m_frame->document()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
+                }
+                cancelMainResourceLoad(frameLoader()->blockedError(newRequest));
+                return completionHandler(WTFMove(newRequest));
+            }
+        }
+    }
+
     ASSERT(timing().startTime());
     if (didReceiveRedirectResponse) {
         if (newRequest.url().protocolIsAbout() || newRequest.url().protocolIsData()) {

--- a/Source/WebCore/loader/NavigationRequester.cpp
+++ b/Source/WebCore/loader/NavigationRequester.cpp
@@ -54,6 +54,7 @@ NavigationRequester NavigationRequester::from(Document& document)
         document.securityOrigin(),
         document.topOrigin(),
         document.policyContainer(),
+        document.identifier(),
         createGlobalFrameIdentifier(document)
     };
 }

--- a/Source/WebCore/loader/NavigationRequester.h
+++ b/Source/WebCore/loader/NavigationRequester.h
@@ -40,7 +40,50 @@ struct NavigationRequester {
     Ref<SecurityOrigin> securityOrigin;
     Ref<SecurityOrigin> topOrigin;
     PolicyContainer policyContainer;
+    ScriptExecutionContextIdentifier documentIdentifier;
     std::optional<GlobalFrameIdentifier> globalFrameIdentifier;
 };
+
+template<class Encoder>
+void NavigationRequester::encode(Encoder& encoder) const
+{
+    encoder << url << securityOrigin.get() << topOrigin.get() << policyContainer << documentIdentifier << globalFrameIdentifier;
+}
+
+template<class Decoder>
+std::optional<NavigationRequester> NavigationRequester::decode(Decoder& decoder)
+{
+    std::optional<URL> url;
+    decoder >> url;
+    if (!url)
+        return std::nullopt;
+
+    std::optional<Ref<SecurityOrigin>> securityOrigin;
+    decoder >> securityOrigin;
+    if (!securityOrigin)
+        return std::nullopt;
+
+    std::optional<Ref<SecurityOrigin>> topOrigin;
+    decoder >> topOrigin;
+    if (!topOrigin)
+        return std::nullopt;
+
+    std::optional<PolicyContainer> policyContainer;
+    decoder >> policyContainer;
+    if (!policyContainer)
+        return std::nullopt;
+
+    std::optional<ScriptExecutionContextIdentifier> documentIdentifier;
+    decoder >> documentIdentifier;
+    if (!documentIdentifier)
+        return std::nullopt;
+
+    std::optional<std::optional<GlobalFrameIdentifier>> globalFrameIdentifier;
+    decoder >> globalFrameIdentifier;
+    if (!globalFrameIdentifier)
+        return std::nullopt;
+
+    return NavigationRequester { WTFMove(*url), WTFMove(*securityOrigin), WTFMove(*topOrigin), WTFMove(*policyContainer), *documentIdentifier, *globalFrameIdentifier };
+}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 30b9cef3be89d7f057b14aea8f6f231209a1980b
<pre>
Restrict further top-frame navigations by a third-party iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=256549">https://bugs.webkit.org/show_bug.cgi?id=256549</a>
rdar://108794051

Reviewed by Geoffrey Garen.

Restrict further top-frame navigations by a third-party iframe:
- Block navigations to a different scheme
- Block navigations that start off same-site but redirect to a different site

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
* Source/WebCore/dom/Document.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/NavigationRequester.cpp:
(WebCore::NavigationRequester::from):
* Source/WebCore/loader/NavigationRequester.h:
(WebCore::NavigationRequester::encode const):
(WebCore::NavigationRequester::decode):

Originally-landed-as: 259548.752@safari-7615-branch (a0fa94d1a572). rdar://113170544
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b9cef3be89d7f057b14aea8f6f231209a1980b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13904 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14219 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14553 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15641 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13198 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13987 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16727 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14301 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15641 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14073 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16727 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14553 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16345 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16727 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14553 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16345 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16727 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14553 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16345 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13243 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14301 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12517 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14553 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16848 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13085 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->