### PR TITLE
Process Isolation Bypass via navigating to about:* context

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5462,6 +5462,8 @@ void WebPageProxy::didExplicitOpenForFrame(FrameIdentifier frameID, URL&& url, S
 
     m_hasCommittedAnyProvisionalLoads = true;
     m_process->didCommitProvisionalLoad();
+    if (!url.protocolIsAbout())
+        m_process->didCommitMeaningfulProvisionalLoad();
 
     internals().pageLoadState.commitChanges();
 }
@@ -5703,6 +5705,8 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
 
     m_hasCommittedAnyProvisionalLoads = true;
     m_process->didCommitProvisionalLoad();
+    if (!request.url().protocolIsAbout())
+        m_process->didCommitMeaningfulProvisionalLoad();
 
     if (frame->isMainFrame()) {
         m_hasUpdatedRenderingAfterDidCommitLoad = false;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1999,8 +1999,8 @@ std::tuple<Ref<WebProcessProxy>, SuspendedPageProxy*, ASCIILiteral> WebProcessPo
     if (!m_configuration->processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol() && !sourceURL.protocolIsInHTTPFamily() && sourceURL.protocol() == targetURL.protocol())
         return { WTFMove(sourceProcess), nullptr, "Navigation within the same non-HTTP(s) protocol"_s };
 
-    if (!sourceURL.isValid() || !targetURL.isValid() || sourceURL.isEmpty() || sourceURL.protocolIsAbout() || targetRegistrableDomain.matches(sourceURL))
-        return { WTFMove(sourceProcess), nullptr, "Navigation is same-site"_s };
+    if (!sourceURL.isValid() || !targetURL.isValid() || sourceURL.isEmpty() || (sourceURL.protocolIsAbout() && (!sourceProcess->hasCommittedAnyMeaningfulProvisionalLoads() || sourceProcess->registrableDomain().matches(targetURL))) || targetRegistrableDomain.matches(sourceURL))
+        return completionHandler(WTFMove(sourceProcess), nullptr, "Navigation is same-site"_s);
 
     auto reason = "Navigation is cross-site"_s;
     

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -322,6 +322,9 @@ public:
     void didCommitProvisionalLoad() { m_hasCommittedAnyProvisionalLoads = true; }
     bool hasCommittedAnyProvisionalLoads() const { return m_hasCommittedAnyProvisionalLoads; }
 
+    void didCommitMeaningfulProvisionalLoad() { m_hasCommittedAnyMeaningfulProvisionalLoads = true; }
+    bool hasCommittedAnyMeaningfulProvisionalLoads() const { return m_hasCommittedAnyMeaningfulProvisionalLoads; }
+
 #if PLATFORM(WATCHOS)
     void startBackgroundActivityForFullscreenInput();
     void endBackgroundActivityForFullscreenInput();
@@ -706,6 +709,7 @@ private:
 #endif
 
     bool m_hasCommittedAnyProvisionalLoads { false };
+    bool m_hasCommittedAnyMeaningfulProvisionalLoads { false }; // True if the process has committed a provisional load to a URL that was not about:*.
     bool m_isPrewarmed;
     LockdownMode m_lockdownMode { LockdownMode::Disabled };
     WebCore::CrossOriginMode m_crossOriginMode { WebCore::CrossOriginMode::Shared };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -8748,6 +8748,70 @@ TEST(ProcessSwap, ChangeViewSizeDuringNavigationActionPolicyDecision)
 
 #endif // PLATFORM(IOS_FAMILY)
 
+TEST(ProcessSwap, NewProcessAfterNavigatingToCrossOriginThroughAboutPage)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/source.html"_s, { ""_s } },
+        { "/destination.html"_s, { ""_s } },
+    });
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+    [webView synchronouslyLoadRequest:server.request("/source.html"_s)];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+
+    auto pid1 = [webView _webProcessIdentifier];
+
+    [webView synchronouslyLoadRequest:server.requestWithLocalhost("/destination.html"_s)];
+
+    auto pid2 = [webView _webProcessIdentifier];
+    EXPECT_NE(pid1, pid2);
+}
+
+TEST(ProcessSwap, ReuseProcessAfterNavigatingToSameOriginThroughAboutPage)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/source.html"_s, { ""_s } },
+        { "/destination.html"_s, { ""_s } },
+    });
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+    [webView synchronouslyLoadRequest:server.request("/source.html"_s)];
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+
+    auto pid1 = [webView _webProcessIdentifier];
+
+    [webView synchronouslyLoadRequest:server.request("/destination.html"_s)];
+
+    auto pid2 = [webView _webProcessIdentifier];
+    EXPECT_EQ(pid1, pid2);
+}
+
+TEST(ProcessSwap, ReuseProcessAfterNavigatingFromAboutPage)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/destination.html"_s, { ""_s } },
+    });
+
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+
+    auto pid1 = [webView _webProcessIdentifier];
+
+    [webView synchronouslyLoadRequest:server.request("/destination.html"_s)];
+
+    auto pid2 = [webView _webProcessIdentifier];
+    EXPECT_EQ(pid1, pid2);
+}
+
 // The WebProcess cache cannot be enabled on devices with too little RAM so we need to disable
 // tests relying on it on iOS. The WebProcess cache is disabled by default on iOS anyway.
 #if !PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 4e77aea509fbd600e1cd3c1dddd0a6e782c3e096
<pre>
Process Isolation Bypass via navigating to about:* context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257348">https://bugs.webkit.org/show_bug.cgi?id=257348</a>
rdar://109853048

Reviewed by Chris Dumez and J Pascoe.

This patch fixes an issue where we will never swap processes when navigating from an
about:* page. A compromised WebContent process could leverage this behavior to avoid
swapping processes when navigating to a cross-origin domain.

This is fixed by checking the following when navigating from an about:* page.
- The page has not committed a provisional load to a URL that isn&apos;t about:*.
- The source process last loaded a domain from the same origin as the domain we are navigating to.

If neither of these two conditions are met, we won’t reuse the process.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didExplicitOpenForFrame):
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(WebKit::WebProcessProxy::didCommitMeaningfulProvisionalLoad):
(WebKit::WebProcessProxy::hasCommittedAnyMeaningfulProvisionalLoads const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Originally-landed-as: 259548.792@safari-7615-branch (f52bc7e18a7c). rdar://113174653
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e77aea509fbd600e1cd3c1dddd0a6e782c3e096

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13913 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14228 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14562 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15650 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13206 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13996 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16736 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14310 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15650 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14082 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16736 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14562 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16354 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16736 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14562 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16354 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16736 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14562 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16354 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13251 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14310 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12526 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14562 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16857 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13093 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->