### PR TITLE
unionRect(const Vector<LayoutRect>&) behaves incorrectly with empty rects

### DIFF
--- a/Source/WebCore/platform/graphics/LayoutRect.cpp
+++ b/Source/WebCore/platform/graphics/LayoutRect.cpp
@@ -180,10 +180,12 @@ void LayoutRect::expandToInfiniteX()
 
 LayoutRect unionRect(const Vector<LayoutRect>& rects)
 {
-    LayoutRect result;
+    if (rects.isEmpty())
+        return { };
 
+    LayoutRect result = rects[0];
     size_t count = rects.size();
-    for (size_t i = 0; i < count; ++i)
+    for (size_t i = 1; i < count; ++i)
         result.unite(rects[i]);
 
     return result;


### PR DESCRIPTION
#### 0ab8911857862b8a5bada65ec96d83eb9eafefdc
<pre>
unionRect(const Vector&lt;LayoutRect&gt;&amp;) behaves incorrectly with empty rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=259674">https://bugs.webkit.org/show_bug.cgi?id=259674</a>
rdar://113183595

Reviewed by Alan Baradlay.

unionRect(const Vector&lt;LayoutRect&gt;&amp;) behaves incorrectly if the input vector contains
a single zero-size rect with a non-zero location; it will union with the empty rect,
and therefore return the empty rect.

This is not known to change any behavior, but a future change in bug 259672
will exercise this code.

* Source/WebCore/platform/graphics/LayoutRect.cpp:
(WebCore::unionRect):

Canonical link: <a href="https://commits.webkit.org/266479@main">https://commits.webkit.org/266479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe27f2b2975f901d1d77ca1a037cdf89c6814197

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15885 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16362 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19588 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15931 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11125 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12534 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->