### PR TITLE
[JSC] Atomize 2-character substrings

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -587,10 +587,10 @@ void Heap::releaseDelayedReleasedObjects()
 #endif
 }
 
-void Heap::reportExtraMemoryAllocatedSlowCase(size_t size)
+void Heap::reportExtraMemoryAllocatedSlowCase(GCDeferralContext* deferralContext, size_t size)
 {
     didAllocate(size);
-    collectIfNecessaryOrDefer();
+    collectIfNecessaryOrDefer(deferralContext);
 }
 
 void Heap::deprecatedReportExtraMemorySlowCase(size_t size)
@@ -600,7 +600,7 @@ void Heap::deprecatedReportExtraMemorySlowCase(size_t size)
     CheckedSize checkedNewSize = m_deprecatedExtraMemorySize;
     checkedNewSize += size;
     m_deprecatedExtraMemorySize = UNLIKELY(checkedNewSize.hasOverflowed()) ? std::numeric_limits<size_t>::max() : checkedNewSize.value();
-    reportExtraMemoryAllocatedSlowCase(size);
+    reportExtraMemoryAllocatedSlowCase(nullptr, size);
 }
 
 bool Heap::overCriticalMemoryThreshold(MemoryThresholdCallType memoryThresholdCallType)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -388,6 +388,7 @@ public:
     // call both of these functions: Calling only one may trigger catastropic
     // memory growth.
     void reportExtraMemoryAllocated(size_t);
+    void reportExtraMemoryAllocated(GCDeferralContext*, size_t);
     JS_EXPORT_PRIVATE void reportExtraMemoryVisited(size_t);
 
 #if ENABLE(RESOURCE_USAGE)
@@ -612,7 +613,7 @@ private:
 
     Lock& lock() { return m_lock; }
 
-    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(size_t);
+    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, size_t);
     JS_EXPORT_PRIVATE void deprecatedReportExtraMemorySlowCase(size_t);
     
     bool shouldCollectInCollectorThread(const AbstractLocker&);

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -212,8 +212,14 @@ inline HashSet<MarkedVectorBase*>& Heap::markListSet()
 
 inline void Heap::reportExtraMemoryAllocated(size_t size)
 {
-    if (size > minExtraMemory) 
-        reportExtraMemoryAllocatedSlowCase(size);
+    if (size > minExtraMemory)
+        reportExtraMemoryAllocatedSlowCase(nullptr, size);
+}
+
+inline void Heap::reportExtraMemoryAllocated(GCDeferralContext* deferralContext, size_t size)
+{
+    if (size > minExtraMemory)
+        reportExtraMemoryAllocatedSlowCase(deferralContext, size);
 }
 
 inline void Heap::deprecatedReportExtraMemory(size_t size)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -175,6 +175,14 @@ private:
         vm.heap.reportExtraMemoryAllocated(cost);
     }
 
+    void finishCreation(VM& vm, GCDeferralContext* deferralContext, unsigned length, size_t cost)
+    {
+        ASSERT_UNUSED(length, length > 0);
+        ASSERT(!valueInternal().isNull());
+        Base::finishCreation(vm);
+        vm.heap.reportExtraMemoryAllocated(deferralContext, cost);
+    }
+
     static JSString* createEmptyString(VM&);
 
     static JSString* create(VM& vm, Ref<StringImpl>&& value)
@@ -184,6 +192,16 @@ private:
         size_t cost = value->cost();
         JSString* newString = new (NotNull, allocateCell<JSString>(vm)) JSString(vm, WTFMove(value));
         newString->finishCreation(vm, length, cost);
+        return newString;
+    }
+
+    static JSString* create(VM& vm, GCDeferralContext* deferralContext, Ref<StringImpl>&& value)
+    {
+        unsigned length = value->length();
+        ASSERT(length > 0);
+        size_t cost = value->cost();
+        JSString* newString = new (NotNull, allocateCell<JSString>(vm, deferralContext)) JSString(vm, WTFMove(value));
+        newString->finishCreation(vm, deferralContext, length, cost);
         return newString;
     }
     static JSString* createHasOtherOwner(VM& vm, Ref<StringImpl>&& value)
@@ -968,24 +986,6 @@ inline JSString* jsSubstring(VM& vm, JSGlobalObject* globalObject, JSString* bas
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
     return jsSubstringOfResolved(vm, nullptr, base, offset, length);
-}
-
-inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContext, JSString* s, unsigned offset, unsigned length)
-{
-    ASSERT(offset <= s->length());
-    ASSERT(length <= s->length());
-    ASSERT(offset + length <= s->length());
-    ASSERT(!s->isRope());
-    if (!length)
-        return vm.smallStrings.emptyString();
-    if (!offset && length == s->length())
-        return s;
-    if (length == 1) {
-        auto& base = s->valueInternal();
-        if (auto c = base.characterAt(offset); c <= maxSingleCharacterString)
-            return vm.smallStrings.singleCharacterString(c);
-    }
-    return JSRopeString::createSubstringOfResolved(vm, deferralContext, s, offset, length);
 }
 
 inline JSString* jsSubstringOfResolved(VM& vm, JSString* s, unsigned offset, unsigned length)

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -468,4 +468,39 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1
     return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }
 
+inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContext, JSString* s, unsigned offset, unsigned length)
+{
+    ASSERT(offset <= s->length());
+    ASSERT(length <= s->length());
+    ASSERT(offset + length <= s->length());
+    ASSERT(!s->isRope());
+    if (!length)
+        return vm.smallStrings.emptyString();
+    if (!offset && length == s->length())
+        return s;
+    if (length == 1) {
+        auto& base = s->valueInternal();
+        if (auto c = base.characterAt(offset); c <= maxSingleCharacterString)
+            return vm.smallStrings.singleCharacterString(c);
+    } else if (length == 2) {
+        auto createFromSubstring = [&](VM& vm, auto& buffer) {
+            auto impl = AtomStringImpl::add(buffer);
+            return JSString::create(vm, deferralContext, impl.releaseNonNull());
+        };
+
+        auto& base = s->valueInternal();
+        UChar first = base.characterAt(offset);
+        UChar second = base.characterAt(offset + 1);
+        if ((first | second) > 0xff) {
+            UChar buf[] = { first, second };
+            WTF::HashTranslatorCharBuffer<UChar> buffer { buf, length };
+            return vm.keyAtomStringCache.make(vm, buffer, createFromSubstring);
+        }
+        LChar buf[] = { static_cast<LChar>(first), static_cast<LChar>(second) };
+        WTF::HashTranslatorCharBuffer<LChar> buffer { buf, length };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromSubstring);
+    }
+    return JSRopeString::createSubstringOfResolved(vm, deferralContext, s, offset, length);
+}
+
 } // namespace JSC


### PR DESCRIPTION
#### dd55eccc28f8f388c83caf287b7bd2044319b6ab
<pre>
[JSC] Atomize 2-character substrings
<a href="https://bugs.webkit.org/show_bug.cgi?id=259675">https://bugs.webkit.org/show_bug.cgi?id=259675</a>
rdar://113184158

Reviewed by Mark Lam.

This imports V8&apos;s heuristics: V8 atomize 2-character substrings because they are too
frequently used as a key of dictionary: because of code minifiers. This patch adopts
this change into our jsSubstringOfResolved.

* Source/JavaScriptCore/runtime/JSString.h:
(JSC::jsSubstringOfResolved):

Canonical link: <a href="https://commits.webkit.org/266466@main">https://commits.webkit.org/266466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0686df768b80c329040781cd5c504c64917c5a96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14325 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/15891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16369 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12558 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11894 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15936 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13198 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11132 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13972 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12541 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3629 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16872 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14358 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1633 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13108 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3441 "Passed tests") | 
<!--EWS-Status-Bubble-End-->