### PR TITLE
[JSC] Use jsSubstring with JSString

### DIFF
--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -587,8 +587,10 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
 
                 if (matchStart < 0)
                     patternValue = jsUndefined();
-                else
-                    patternValue = jsSubstring(vm, source, matchStart, matchLen);
+                else {
+                    patternValue = jsSubstring(vm, globalObject, string, matchStart, matchLen);
+                    RETURN_IF_EXCEPTION(scope, nullptr);
+                }
 
                 cachedCall.appendArgument(patternValue);
 
@@ -605,8 +607,10 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
                             JSValue captureValue;
                             if (captureStart < 0)
                                 captureValue = jsUndefined();
-                            else
-                                captureValue = jsSubstring(vm, source, captureStart, captureLen);
+                            else {
+                                captureValue = jsSubstring(vm, globalObject, string, captureStart, captureLen);
+                                RETURN_IF_EXCEPTION(scope, nullptr);
+                            }
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
                         } else
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), jsUndefined());
@@ -669,7 +673,7 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
                     if (matchStart < 0)
                         patternValue = jsUndefined();
                     else {
-                        patternValue = jsSubstring(vm, source, matchStart, matchLen);
+                        patternValue = jsSubstring(vm, globalObject, string, matchStart, matchLen);
                         RETURN_IF_EXCEPTION(scope, nullptr);
                     }
 
@@ -689,7 +693,7 @@ static ALWAYS_INLINE JSString* replaceUsingRegExpSearch(
                                 if (captureStart < 0)
                                     captureValue = jsUndefined();
                                 else {
-                                    captureValue = jsSubstring(vm, source, captureStart, captureLen);
+                                    captureValue = jsSubstring(vm, globalObject, string, captureStart, captureLen);
                                     RETURN_IF_EXCEPTION(scope, nullptr);
                                 }
                                 groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -270,7 +270,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
         if (callData.type != CallData::Type::None) {
             JSValue replacement;
             if (cachedCall) {
-                auto* substring = jsSubstring(vm, string, matchStart, searchStringLength);
+                auto* substring = jsSubstring(vm, globalObject, jsString, matchStart, searchStringLength);
                 RETURN_IF_EXCEPTION(scope, nullptr);
                 cachedCall->clearArguments();
                 cachedCall->appendArgument(substring);
@@ -280,7 +280,7 @@ inline JSString* replaceUsingStringSearch(VM& vm, JSGlobalObject* globalObject, 
                 replacement = cachedCall->call();
             } else {
                 MarkedArgumentBuffer args;
-                auto* substring = jsSubstring(vm, string, matchStart, searchString.impl()->length());
+                auto* substring = jsSubstring(vm, globalObject, jsString, matchStart, searchString.impl()->length());
                 RETURN_IF_EXCEPTION(scope, nullptr);
                 args.append(substring);
                 args.append(jsNumber(matchStart));


### PR DESCRIPTION
#### 2d05c14c15115713fb374d74ae4d956e09b38e6f
<pre>
[JSC] Use jsSubstring with JSString
<a href="https://bugs.webkit.org/show_bug.cgi?id=259678">https://bugs.webkit.org/show_bug.cgi?id=259678</a>
rdar://113191047

Reviewed by Mark Lam.

This patch uses more jsSubstring + JSString* form instead of jsSubstring + WTF::String form
since it can have more opportunities for optimizations including 2-characters atomizations.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::replaceUsingStringSearch):

Canonical link: <a href="https://commits.webkit.org/266481@main">https://commits.webkit.org/266481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/191aaad5a75b68dfbe20faadf0cd0ad5478331e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13224 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15894 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16373 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19597 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/11898 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13060 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15940 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11135 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/13976 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12544 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3630 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16876 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14362 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1640 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13112 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3442 "Passed tests") | 
<!--EWS-Status-Bubble-End-->