### PR TITLE
VisibleSelection::nonBoundaryShadowTreeRootNode should return null when its anchor is a shadow root

### DIFF
--- a/LayoutTests/fast/forms/ua-shadow-select-all-behavior-expected.txt
+++ b/LayoutTests/fast/forms/ua-shadow-select-all-behavior-expected.txt
@@ -1,0 +1,20 @@
+Tests `SelectAll` behavior with user agent shadow roots.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS s.type is "Range"
+PASS s.rangeCount is 1
+PASS s.isCollapsed is false
+PASS s.focusOffset is 8
+PASS s.focusNode is document.body
+PASS s.extentOffset is 8
+PASS s.extentNode is document.body
+PASS s.baseOffset is 0
+PASS s.baseNode is document.getElementById('description').firstChild.firstChild.firstChild
+PASS s.anchorOffset is 0
+PASS s.anchorNode is document.getElementById('description').firstChild.firstChild.firstChild
+PASS successfullyParsed is true
+
+TEST COMPLETE
+FOOO  FOO

--- a/LayoutTests/fast/forms/ua-shadow-select-all-behavior.html
+++ b/LayoutTests/fast/forms/ua-shadow-select-all-behavior.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<button type="button" id="button1">FOOO</button>
+<input type="text" id="input1">
+<script>
+description("Tests `SelectAll` behavior with user agent shadow roots.");
+var button1 = document.getElementById('button1');
+var input1 = document.getElementById('input1');
+input1.setSelectionRange(0, 0);
+input1.type = 'week';
+document.execCommand('SelectAll');
+let s = window.getSelection();
+shouldBeEqualToString("s.type", "Range");
+shouldBe("s.rangeCount", "1");
+shouldBeFalse("s.isCollapsed");
+shouldBe("s.focusOffset", "8");
+shouldBe("s.focusNode", "document.body");
+shouldBe("s.extentOffset", "8");
+shouldBe("s.extentNode", "document.body");
+shouldBe("s.baseOffset", "0");
+shouldBe("s.baseNode", "document.getElementById('description').firstChild.firstChild.firstChild");
+shouldBe("s.anchorOffset", "0");
+shouldBe("s.anchorNode", "document.getElementById('description').firstChild.firstChild.firstChild");
+</script>
+FOO
+</body>
+</html>

--- a/LayoutTests/fast/forms/ua-shadow-select-all-crash-expected.txt
+++ b/LayoutTests/fast/forms/ua-shadow-select-all-crash-expected.txt
@@ -1,0 +1,2 @@
+
+Pass if it doesn't crash

--- a/LayoutTests/fast/forms/ua-shadow-select-all-crash.html
+++ b/LayoutTests/fast/forms/ua-shadow-select-all-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<button type="button" id="button1">FOOO</button>
+<input type="text" id="input1">
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+var button1 = document.getElementById('button1');
+var input1 = document.getElementById('input1');
+input1.setSelectionRange(0, 0);
+input1.type = 'week';
+var oSelection = window.getSelection();
+document.execCommand('SelectAll');
+oSelection.deleteFromDocument();
+input1.value = 'foo';
+</script>
+<p>Pass if it doesn't crash</p>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1999,6 +1999,8 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-ste
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-weekmonth.html
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/type-change-state-weekmonth.html
 imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/valueMode-weekmonth.html
+fast/forms/ua-shadow-select-all-behavior.html
+fast/forms/ua-shadow-select-all-crash.html
 
 # New failure after update of WPT tests in bug 214278
 webkit.org/b/214291 imported/w3c/web-platform-tests/css/css-writing-modes/sizing-orthog-htb-in-vrl-013.xht [ ImageOnlyFailure ]

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -677,7 +677,7 @@ Element* VisibleSelection::rootEditableElement() const
 
 Node* VisibleSelection::nonBoundaryShadowTreeRootNode() const
 {
-    return start().deprecatedNode() ? start().deprecatedNode()->nonBoundaryShadowTreeRootNode() : nullptr;
+    return start().deprecatedNode() && !start().deprecatedNode()->isShadowRoot() ? start().deprecatedNode()->nonBoundaryShadowTreeRootNode() : nullptr;
 }
 
 bool VisibleSelection::isInPasswordField() const


### PR DESCRIPTION
#### 786e20b521453e0fc5c7ee7734aaa3a3e04e19ba
<pre>
VisibleSelection::nonBoundaryShadowTreeRootNode should return null when its anchor is a shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=249862">https://bugs.webkit.org/show_bug.cgi?id=249862</a>
rdar://103683388

Reviewed by Ryosuke Niwa.

Cherry-pick the following fix from Blink:
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=188788

While WebKit doesn&apos;t crash in release with the Blink test case, it does
hit the `ASSERT(!isShadowRoot());` assertion inside `Node::nonBoundaryShadowTreeRootNode()`
on debug builds. Also, our selection behavior was vastly different from Chrome and Firefox.
We would end up with a caret while Blink and Gecko would end up with a proper range
selection. This patch aligns our behavior with Blink.

* LayoutTests/fast/forms/ua-shadow-select-all-behavior-expected.txt: Added.
* LayoutTests/fast/forms/ua-shadow-select-all-behavior.html: Added.
* LayoutTests/fast/forms/ua-shadow-select-all-crash.html: Added.
* LayoutTests/fast/forms/ua-shadow-select-all-crash-expected.txt: Added.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::nonBoundaryShadowTreeRootNode const):

Canonical link: <a href="https://commits.webkit.org/266505@main">https://commits.webkit.org/266505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/553a60ab1f1e1ad53cc65c415bc6bfbd9604c601

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15943 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16431 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19637 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15980 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11187 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3392 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->