### PR TITLE
REGRESSION(263118@main): [GTK] Web inspector does not paint reliably

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -75,8 +75,11 @@ void DrawingAreaProxyCoordinatedGraphics::paint(BackingStore::PlatformGraphicsCo
     if (isInAcceleratedCompositingMode())
         return;
 
-    if (!m_backingStore)
+    if (!m_backingStore) {
+        if (!m_isWaitingForDidUpdateGeometry)
+            m_webPageProxy.send(Messages::DrawingArea::ForceUpdate(), m_identifier);
         return;
+    }
 
     m_backingStore->paint(context, rect);
     unpaintedRegion.subtract(IntRect(IntPoint(), m_backingStore->size()));
@@ -260,7 +263,7 @@ void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 
     // We'll wait this many seconds after the last paint before throwing away our backing store to save memory.
     // FIXME: It would be smarter to make this delay based on how expensive painting is. See <http://webkit.org/b/55733>.
-    static const Seconds discardBackingStoreDelay = 2_s;
+    static const Seconds discardBackingStoreDelay = 10_s;
 
     m_discardBackingStoreTimer.startOneShot(discardBackingStoreDelay);
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -815,4 +815,13 @@ void DrawingAreaCoordinatedGraphics::display(UpdateInfo& updateInfo)
     m_displayTimer.stop();
 }
 
+void DrawingAreaCoordinatedGraphics::forceUpdate()
+{
+    if (m_isWaitingForDidUpdate || m_layerTreeHost)
+        return;
+
+    m_dirtyRegion = m_webPage.bounds();
+    display();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -87,6 +87,7 @@ private:
     void targetRefreshRateDidChange(unsigned rate) override;
     void displayDidRefresh() override;
     void setDeviceScaleFactor(float) override;
+    void forceUpdate();
 
 #if PLATFORM(GTK)
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -206,6 +206,7 @@ private:
                                          const WebCore::IntSize& /*scrollOffset*/) { }
     virtual void targetRefreshRateDidChange(unsigned /*rate*/) { }
     virtual void setDeviceScaleFactor(float) { }
+    virtual void forceUpdate() { }
 #endif
     virtual void displayDidRefresh() { }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -25,6 +25,7 @@ messages -> DrawingArea NotRefCounted {
     UpdateGeometry(WebCore::IntSize size) -> ()
     TargetRefreshRateDidChange(unsigned rate)
     SetDeviceScaleFactor(float deviceScaleFactor)
+    ForceUpdate()
 #endif
 
     DisplayDidRefresh()


### PR DESCRIPTION
#### 184eb796664e115922abffd641c09c3994501b47
<pre>
REGRESSION(263118@main): [GTK] Web inspector does not paint reliably
<a href="https://bugs.webkit.org/show_bug.cgi?id=259449">https://bugs.webkit.org/show_bug.cgi?id=259449</a>

Reviewed by Michael Catanzaro.

This happens with the inspector because the inspector view doesn&apos;t
follow the hardware accelerated settings, and always runs in
non-accelerated compositing mode. This is actually a bug in
non-accelerated compositing mode implementation, it happens with any web
view when disabling hardware acceleration. The problem is that when the
view is no longer in the active window (it loses the focus) we discard
the backing store after 2 seconds and we don&apos;t notify the web process
nor ask for an update when a new paint is requested (when the web view
is redraw), as we did before 263118@main. After the resize
simplification we can simplify this part too, and just add a message to
request an update when the web view is redrawn after the backing store
has been discarded. I&apos;m also increasing the delay to discard the backing
store, because with 2 seconds we usually end up creating a new one after
losing the focus due to the repaint requested by the overlay scrollbars
fade out animation. Using 10 seconds we ensure we always discard the
backing store after the scrollbar animation finished and no more repaints
are expected.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::paint):
(WebKit::DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::forceUpdate):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::forceUpdate):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:

Canonical link: <a href="https://commits.webkit.org/266511@main">https://commits.webkit.org/266511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cf9f504bbe9d0c319109c6d56c0ec9d33cd2662

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13235 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15908 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11999 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19607 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15950 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11149 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12556 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16888 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1651 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->