### PR TITLE
[GTK] The inspector web view should follow the hardware acceleration setting of inspected web view

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 
+#include "HardwareAccelerationManager.h"
 #include "RemoteWebInspectorUIMessages.h"
 #include "WebInspectorUIProxy.h"
 #include "WebKitInspectorWindow.h"
@@ -62,6 +63,13 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     preferences->setDeveloperExtrasEnabled(true);
     preferences->setLogsPageMessagesToSystemConsoleEnabled(true);
 #endif
+
+    // If hardware acceleration is available and not forced already, force it always for the remote inspector view.
+    const auto& hardwareAccelerationManager = HardwareAccelerationManager::singleton();
+    if (hardwareAccelerationManager.canUseHardwareAcceleration() && !hardwareAccelerationManager.forceHardwareAcceleration()) {
+        preferences->setForceCompositingMode(true);
+        preferences->setThreadedScrollingEnabled(true);
+    }
     auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(nullptr));
 
     auto pageConfiguration = API::PageConfiguration::create();

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -165,6 +165,10 @@ WebPageProxy* WebInspectorUIProxy::platformCreateFrontendPage()
     });
     if (m_underTest)
         preferences->setHiddenPageDOMTimerThrottlingEnabled(false);
+    const auto& inspectedPagePreferences = inspectedPage()->preferences();
+    preferences->setAcceleratedCompositingEnabled(inspectedPagePreferences.acceleratedCompositingEnabled());
+    preferences->setForceCompositingMode(inspectedPagePreferences.forceCompositingMode());
+    preferences->setThreadedScrollingEnabled(inspectedPagePreferences.threadedScrollingEnabled());
     auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(inspectedPage()));
     auto websiteDataStore = inspectorWebsiteDataStore();
     auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());


### PR DESCRIPTION
#### 47e81828463dad7ad664fc7ad92ccdf60cb2e1e0
<pre>
[GTK] The inspector web view should follow the hardware acceleration setting of inspected web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=259688">https://bugs.webkit.org/show_bug.cgi?id=259688</a>

Reviewed by Michael Catanzaro.

For the local inspector we use the same settings as the inspected web
view. For remote inspector we just default to forcing accelerated
compositing mode unless explicitly disabled or already forced by
envorionment variables.

* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):

Canonical link: <a href="https://commits.webkit.org/266507@main">https://commits.webkit.org/266507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a470bd576cb9ff731aa41781518433fda6b66976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16775 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14349 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15914 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16393 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12003 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19616 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15958 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11154 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16896 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->