### PR TITLE
[GLib] Use correct number of webviews for TestWebsiteData/handle-corrupted-local-storage

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp
@@ -941,7 +941,18 @@ static void testWebViewHandleCorruptedLocalStorage(WebsiteDataTest* test, gconst
     g_assert_cmpstr(fooValue.get(), ==, "");
 
     // Creating a second web view and loading a web page with the same url to read the item from localStorage.
+#if ENABLE(2022_GLIB_API)
+    auto webView = Test::adoptView(g_object_new(WEBKIT_TYPE_WEB_VIEW,
+#if PLATFORM(WPE)
+        "backend", Test::createWebViewBackend(),
+#endif
+        "web-context", webkit_web_view_get_context(test->m_webView),
+        "network-session", test->m_networkSession.get(),
+        nullptr));
+    g_assert_true(webkit_web_view_get_network_session(webView.get()) == test->m_networkSession.get());
+#else
     auto webView = Test::adoptView(Test::createWebView(test->m_webContext.get()));
+#endif
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(webView.get()));
     webkit_web_view_load_html(webView.get(), html, "http://example.com");
     test->waitUntilLoadFinished(webView.get());

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -128,9 +128,6 @@
         "subtests": {
             "/webkit/WebKitWebsiteData/cache": {
                 "expected": {"gtk": {"status": ["PASS", "FAIL"], "bug": "webkit.org/b/254002"}}
-            },
-            "/webkit/WebKitWebsiteData/handle-corrupted-local-storage": {
-                "expected": {"wpe": {"status": ["FAIL"], "bug": "webkit.org/b/256557"}}
             }
         }
     },


### PR DESCRIPTION
#### 97e6ebdc6b257b12126bf535ec5b70508b30d688
<pre>
[GLib] Use correct number of webviews for TestWebsiteData/handle-corrupted-local-storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=259701">https://bugs.webkit.org/show_bug.cgi?id=259701</a>

Reviewed by Carlos Garcia Campos.

We added a test for handling corrupted local storage when we added the
GLib feature in 259573@main a few months ago in January.

It seems that this test has never succeeded since introduced according to
WPE API test reports (`wk-bot-digest` for the last several thousand CI
runs including this commit 259573@main); note that for WPE the new GLib API
is running on the bots by default build per OptionsWPE.cmake
`SET_AND_EXPOSE_TO_BUILD(ENABLE_2022_GLIB_API ON)`.

Previously, this test did not work for the new `2022_GLIB_API`, presumably
because it used 2 different network sessions for the 2 webViews. That did
not work for the new GLib API; it only worked for the old GLib API.
`test-&gt;m_webview` (used for the first webView) uses `test-&gt;m_networkSession`
as its network session, whereas the web views created manually without
specifying a network session are going to get a default network session
(e.g. `Test::adoptView(...)`, which was used in the second webView in
this test).

This test is now fixed in the new GLib API by using our idiomatic test
patterns found in our other API tests wrt the new GLib API with
conditionally creating a webView for new API that uses `test-&gt;m_networkSession`
for the second webView in this test, hence assuring that it shares the
same network session as the _first_ webView for the new GLib API;
now the test runs in the new GLib API.

Similar work was done for Cocoa test coverage in 262161@main in February;
that PR was a followup to 259573@main.

* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebsiteData.cpp:
(testWebViewHandleCorruptedLocalStorage): See above.

* Tools/TestWebKitAPI/glib/TestExpectations.json: remove WPE API failing
expectation for this test that was added in a meta-gardening bug
b/256557 a couple of months ago in May.

Canonical link: <a href="https://commits.webkit.org/266631@main">https://commits.webkit.org/266631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/626cf5c49d62aabcd6f6d582662619578335de1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13479 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14622 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16150 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19847 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16201 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11400 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17160 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1711 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->