### PR TITLE
Prevent SVG filters from leaking visited hyperlinks

### DIFF
--- a/LayoutTests/css3/filters/filter-visited-links-expected.html
+++ b/LayoutTests/css3/filters/filter-visited-links-expected.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        margin: 10px;
+        width: 400px;
+        height: 140px;
+        padding: 10px;
+        border: 1px solid black;
+        font-size: 20pt;
+        text-align: center;
+    }
+    h1 {
+        font-size: 20pt;
+    }
+    .no-op-css-filter {
+        filter: blur(0px);
+    }
+    .no-op-svg-filter {
+        filter: url(#svg-no-op-blur);
+    }
+    .css-filter {
+        filter: blur(2px);
+    }
+    .svg-filter {
+        filter: url(#svg-blur);
+    }
+    a {
+        color: blue;
+        text-decoration: none;
+    }
+    a:visited {
+        color: purple;
+    }
+</style>
+<body>
+    <div class="container">
+        <h1>No filter</h1>
+        <a href="">Visited link</a>
+    </div>
+    <div class="container">
+        <h1>No-op filter</h1>
+        <a class="no-op-css-filter" href="">Visited link (CSS filter)</a>
+        <br>
+        <a class="no-op-svg-filter" href="unvisited">Visited link (SVG filter)</a>
+    </div>
+    <div class="container">
+        <h1>Blur filter</h1>
+        <a class="css-filter" href="unvisited">Visited link (CSS filter)</a>
+        <br>
+        <a class="svg-filter" href="unvisited">Visited link (SVG filter)</a>
+    </div>
+    <svg style="position: absolute; top: -99999px">
+        <filter id="svg-no-op-blur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="0"/>
+        </filter>
+        <filter id="svg-blur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="2"/>
+        </filter>
+    </svg>
+</body>

--- a/LayoutTests/css3/filters/filter-visited-links.html
+++ b/LayoutTests/css3/filters/filter-visited-links.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<style>
+    .container {
+        margin: 10px;
+        width: 400px;
+        height: 140px;
+        padding: 10px;
+        border: 1px solid black;
+        font-size: 20pt;
+        text-align: center;
+    }
+    h1 {
+        font-size: 20pt;
+    }
+    .no-op-css-filter {
+        filter: blur(0px);
+    }
+    .no-op-svg-filter {
+        filter: url(#svg-no-op-blur);
+    }
+    .css-filter {
+        filter: blur(2px);
+    }
+    .svg-filter {
+        filter: url(#svg-blur);
+    }
+    a {
+        color: blue;
+        text-decoration: none;
+    }
+    a:visited {
+        color: purple;
+    }
+</style>
+<body>
+    <div class="container">
+        <h1>No filter</h1>
+        <a href="">Visited link</a>
+    </div>
+    <div class="container">
+        <h1>No-op filter</h1>
+        <a class="no-op-css-filter" href="">Visited link (CSS filter)</a>
+        <br>
+        <a class="no-op-svg-filter" href="">Visited link (SVG filter)</a>
+    </div>
+    <div class="container">
+        <h1>Blur filter</h1>
+        <a class="css-filter" href="">Visited link (CSS filter)</a>
+        <br>
+        <a class="svg-filter" href="">Visited link (SVG filter)</a>
+    </div>
+    <svg style="position: absolute; top: -99999px">
+        <filter id="svg-no-op-blur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="0"/>
+        </filter>
+        <filter id="svg-blur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="2"/>
+        </filter>
+    </svg>
+</body>

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -73,6 +73,8 @@ enum class PaintBehavior : uint32_t {
     EventRegionIncludeForeground        = 1 << 14, // FIXME: Event region painting should use paint phases.
     EventRegionIncludeBackground        = 1 << 15,
     Snapshotting                        = 1 << 16, // Paint is updating external backing store and visits all content, including composited content and always completes image decoding of painted images. FIXME: Will be removed.
+    DontShowVisitedLinks                = 1 << 16,
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3295,6 +3295,9 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         }
         GraphicsContext& currentContext = filterContext ? *filterContext : context;
 
+        if (filterContext)
+            localPaintingInfo.paintBehavior.add(PaintBehavior::DontShowVisitedLinks);
+
         // If this layer's renderer is a child of the subtreePaintRoot, we render unconditionally, which
         // is done by passing a nil subtreePaintRoot down to our renderer (as if no subtreePaintRoot was ever set).
         // Otherwise, our renderer tree may or may not contain the subtreePaintRoot root, so we pass that root along
@@ -3727,6 +3730,9 @@ void RenderLayer::paintForegroundForFragments(const LayerFragments& layerFragmen
     // FIXME: It's unclear if this flag copying is necessary.
     constexpr OptionSet<PaintBehavior> flagsToCopy { PaintBehavior::ExcludeSelection, PaintBehavior::Snapshotting, PaintBehavior::DefaultAsynchronousImageDecode, PaintBehavior::CompositedOverflowScrollContent, PaintBehavior::ForceSynchronousImageDecode };
     localPaintBehavior.add(localPaintingInfo.paintBehavior & flagsToCopy);
+
+    if (localPaintingInfo.paintBehavior & PaintBehavior::DontShowVisitedLinks)
+        localPaintBehavior.add(PaintBehavior::DontShowVisitedLinks);
 
     GraphicsContextStateSaver stateSaver(context, false);
     RegionContextStateSaver regionContextStateSaver(localPaintingInfo.regionContext);
@@ -5811,6 +5817,7 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::EventRegionIncludeForeground: ts << "EventRegionIncludeForeground"; break;
     case PaintBehavior::EventRegionIncludeBackground: ts << "EventRegionIncludeBackground"; break;
     case PaintBehavior::Snapshotting: ts << "Snapshotting"; break;
+    case PaintBehavior::DontShowVisitedLinks: ts << "DontShowVisitedLinks"; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -56,7 +56,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
             style.textStyles.strokeColor = renderStyle->computedStrokeColor();
             style.textStyles.hasExplicitlySetFillColor = renderStyle->hasExplicitlySetColor();
 
-            auto color = TextDecorationPainter::decorationColor(*renderStyle.get());
+            auto color = TextDecorationPainter::decorationColor(*renderStyle.get(), paintInfo.paintBehavior);
             auto decorationStyle = renderStyle->textDecorationStyle();
             auto decorations = renderStyle->textDecorationsInEffect();
 
@@ -116,7 +116,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
 StyledMarkedText::Style StyledMarkedText::computeStyleForUnmarkedMarkedText(const RenderText& renderer, const RenderStyle& lineStyle, bool isFirstLine, const PaintInfo& paintInfo)
 {
     StyledMarkedText::Style style;
-    style.textDecorationStyles = TextDecorationPainter::stylesForRenderer(renderer, lineStyle.textDecorationsInEffect(), isFirstLine);
+    style.textDecorationStyles = TextDecorationPainter::stylesForRenderer(renderer, lineStyle.textDecorationsInEffect(), isFirstLine, paintInfo.paintBehavior);
     style.textStyles = computeTextPaintStyle(renderer.frame(), lineStyle, paintInfo);
     style.textShadow = ShadowData::clone(paintInfo.forceTextColor() ? nullptr : lineStyle.textShadow());
     return style;

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -319,13 +319,13 @@ void TextDecorationPainter::paintLineThrough(const ForegroundDecorationGeometry&
         m_context.drawLineForText(rect, m_isPrinting, style == TextDecorationStyle::Double, strokeStyle);
 }
 
-static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, PseudoId pseudoId)
+static void collectStylesForRenderer(TextDecorationPainter::Styles& result, const RenderObject& renderer, OptionSet<TextDecorationLine> remainingDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId)
 {
     auto extractDecorations = [&] (const RenderStyle& style, OptionSet<TextDecorationLine> decorations) {
         if (decorations.isEmpty())
             return;
 
-        auto color = TextDecorationPainter::decorationColor(style);
+        auto color = TextDecorationPainter::decorationColor(style, paintBehavior);
         auto decorationStyle = style.textDecorationStyle();
 
         if (decorations.contains(TextDecorationLine::Underline)) {
@@ -376,20 +376,20 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
         extractDecorations(styleForRenderer(*current), remainingDecorations);
 }
 
-Color TextDecorationPainter::decorationColor(const RenderStyle& style)
+Color TextDecorationPainter::decorationColor(const RenderStyle& style, OptionSet<PaintBehavior> paintBehavior)
 {
-    return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor);
+    return style.visitedDependentColorWithColorFilter(CSSPropertyTextDecorationColor, paintBehavior);
 }
 
-auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, PseudoId pseudoId) -> Styles
+auto TextDecorationPainter::stylesForRenderer(const RenderObject& renderer, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle, OptionSet<PaintBehavior> paintBehavior, PseudoId pseudoId) -> Styles
 {
     if (requestedDecorations.isEmpty())
         return { };
 
     Styles result;
-    collectStylesForRenderer(result, renderer, requestedDecorations, false, pseudoId);
+    collectStylesForRenderer(result, renderer, requestedDecorations, false, paintBehavior, pseudoId);
     if (firstLineStyle)
-        collectStylesForRenderer(result, renderer, requestedDecorations, true, pseudoId);
+        collectStylesForRenderer(result, renderer, requestedDecorations, true, paintBehavior, pseudoId);
     result.skipInk = renderer.style().textDecorationSkipInk();
     return result;
 }

--- a/Source/WebCore/rendering/TextDecorationPainter.h
+++ b/Source/WebCore/rendering/TextDecorationPainter.h
@@ -77,8 +77,8 @@ public:
     };
     void paintForegroundDecorations(const ForegroundDecorationGeometry&, const Styles&);
 
-    static Color decorationColor(const RenderStyle&);
-    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, PseudoId = PseudoId::None);
+    static Color decorationColor(const RenderStyle&, OptionSet<PaintBehavior> paintBehavior = { });
+    static Styles stylesForRenderer(const RenderObject&, OptionSet<TextDecorationLine> requestedDecorations, bool firstLineStyle = false, OptionSet<PaintBehavior> paintBehavior = { }, PseudoId = PseudoId::None);
     static OptionSet<TextDecorationLine> textDecorationsInEffectForStyle(const TextDecorationPainter::Styles&);
 
 private:

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -106,7 +106,7 @@ TextPaintStyle computeTextPaintStyle(const LocalFrame& frame, const RenderStyle&
         }
     }
 
-    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor);
+    paintStyle.fillColor = lineStyle.visitedDependentColorWithColorFilter(CSSPropertyWebkitTextFillColor, paintInfo.paintBehavior);
 
     bool forceBackgroundToWhite = false;
     if (frame.document() && frame.document()->printing()) {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2412,17 +2412,20 @@ Color RenderStyle::colorResolvingCurrentColor(const StyleColor& color) const
     return color.resolveColor(this->color());
 }
 
-Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty) const
+Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const
 {
     Color unvisitedColor = colorResolvingCurrentColor(colorProperty, false);
     if (insideLink() != InsideLink::InsideVisited)
+        return unvisitedColor;
+
+    if (paintBehavior.contains(PaintBehavior::DontShowVisitedLinks))
         return unvisitedColor;
 
 #if ENABLE(CSS_COMPOSITING)
     if (isInSubtreeWithBlendMode())
         return unvisitedColor;
 #endif
-    
+
     Color visitedColor = colorResolvingCurrentColor(colorProperty, true);
 
     // FIXME: Technically someone could explicitly specify the color transparent, but for now we'll just
@@ -2437,12 +2440,12 @@ Color RenderStyle::visitedDependentColor(CSSPropertyID colorProperty) const
     return visitedColor.colorWithAlpha(unvisitedColor.alphaAsFloat());
 }
 
-Color RenderStyle::visitedDependentColorWithColorFilter(CSSPropertyID colorProperty) const
+Color RenderStyle::visitedDependentColorWithColorFilter(CSSPropertyID colorProperty, OptionSet<PaintBehavior> paintBehavior) const
 {
     if (!hasAppleColorFilter())
-        return visitedDependentColor(colorProperty);
+        return visitedDependentColor(colorProperty, paintBehavior);
 
-    return colorByApplyingColorFilter(visitedDependentColor(colorProperty));
+    return colorByApplyingColorFilter(visitedDependentColor(colorProperty, paintBehavior));
 }
 
 Color RenderStyle::colorByApplyingColorFilter(const Color& color) const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -242,6 +242,8 @@ struct MasonryAutoFlow;
 struct NamedGridAreaMap;
 struct NamedGridLinesMap;
 struct OrderedNamedGridLinesMap;
+enum class PaintBehavior : uint32_t;
+
 struct ScrollSnapAlign;
 struct ScrollSnapType;
 struct ScrollbarGutter;
@@ -1730,8 +1732,8 @@ public:
     // Resolves the currentColor keyword, but must not be used for the "color" property which has a different semantic.
     WEBCORE_EXPORT Color colorResolvingCurrentColor(const StyleColor&) const;
 
-    WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID) const;
-    WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID) const;
+    WEBCORE_EXPORT Color visitedDependentColor(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
+    WEBCORE_EXPORT Color visitedDependentColorWithColorFilter(CSSPropertyID, OptionSet<PaintBehavior> paintBehavior = { }) const;
 
     WEBCORE_EXPORT Color colorByApplyingColorFilter(const Color&) const;
     WEBCORE_EXPORT Color colorWithColorFilter(const StyleColor&) const;


### PR DESCRIPTION
#### 105559bb1a33027f521a6e0bdef5d4107efb4c5b
<pre>
Prevent SVG filters from leaking visited hyperlinks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257822">https://bugs.webkit.org/show_bug.cgi?id=257822</a>
rdar://109749006

Reviewed by Simon Fraser.

We should prevent websites from learning which sites have been visited via SVG
filters on hyperlinks, per the attack described in <a href="https://arxiv.org/abs/2305.12784.">https://arxiv.org/abs/2305.12784.</a>

This can be acheived by ignoring the visited links color when a filter is applied
to the anchor element.

* LayoutTests/css3/filters/filter-visited-links-expected.html: Added.
* LayoutTests/css3/filters/filter-visited-links.html: Added.
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
(WebCore::StyledMarkedText::computeStyleForUnmarkedMarkedText):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):
(WebCore::TextDecorationPainter::decorationColor):
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/TextDecorationPainter.h:
(WebCore::TextDecorationPainter::decorationColor):
(WebCore::TextDecorationPainter::stylesForRenderer):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::visitedDependentColor const):
(WebCore::RenderStyle::visitedDependentColorWithColorFilter const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::visitedDependentColor):
(WebCore::RenderStyle::visitedDependentColorWithColorFilter):

Originally-landed-as: 259548.820@safari-7615-branch (89399f0f4614). rdar://113224260
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/105559bb1a33027f521a6e0bdef5d4107efb4c5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13966 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14281 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14616 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15704 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13257 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14050 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16790 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14364 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/15704 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14136 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16790 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14616 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16412 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16790 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14616 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16412 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16790 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14616 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16412 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13304 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14364 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12578 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14616 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16910 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13146 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->