### PR TITLE
WebKit shouldn't be modifying the value of UIApplication.idleTimerDisabled

### DIFF
--- a/Source/WebCore/PAL/pal/Logging.cpp
+++ b/Source/WebCore/PAL/pal/Logging.cpp
@@ -48,4 +48,11 @@ void registerNotifyCallback(ASCIILiteral notifyID, Function<void()>&& callback)
 #endif
 }
 
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#define DEFINE_PAL_LOG_CHANNEL(name) DEFINE_LOG_CHANNEL(name, LOG_CHANNEL_WEBKIT_SUBSYSTEM)
+PAL_LOG_CHANNELS(DEFINE_PAL_LOG_CHANNEL)
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
 } // namespace WebCore

--- a/Source/WebCore/PAL/pal/Logging.h
+++ b/Source/WebCore/PAL/pal/Logging.h
@@ -31,5 +31,22 @@ namespace PAL {
 
 PAL_EXPORT void registerNotifyCallback(ASCIILiteral, Function<void()>&&);
 
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+#ifndef LOG_CHANNEL_PREFIX
+#define LOG_CHANNEL_PREFIX Log
+#endif
+
+#define PAL_LOG_CHANNELS(M) \
+    M(Media)
+
+#undef DECLARE_LOG_CHANNEL
+#define DECLARE_LOG_CHANNEL(name) \
+PAL_EXPORT extern WTFLogChannel JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, name);
+
+PAL_LOG_CHANNELS(DECLARE_LOG_CHANNEL)
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
 } // namespace PAL
 

--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -90,6 +90,7 @@ typedef enum {
 - (BOOL)_isClassic;
 + (UIApplicationSceneClassicMode)_classicMode;
 - (GSKeyboardRef)_hardwareKeyboard;
+- (void)_setIdleTimerDisabled:(BOOL)disabled forReason:(NSString *)reason;
 @end
 
 @interface UIColor ()

--- a/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
+++ b/Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm
@@ -27,6 +27,8 @@
 #import "SleepDisablerCocoa.h"
 
 #if PLATFORM(IOS_FAMILY)
+#import "Logging.h"
+#import <pal/spi/ios/UIKitSPI.h>
 #import <wtf/NeverDestroyed.h>
 
 #import <pal/ios/UIKitSoftLink.h>
@@ -64,10 +66,11 @@ private:
             return;
 
         bool shouldKeepScreenAwake = !!m_screenSleepDisablerCount.value();
+        RELEASE_LOG(Media, "ScreenSleepDisabler::updateState() shouldKeepScreenAwake=%d", shouldKeepScreenAwake);
         ensureOnMainRunLoop([this, shouldKeepScreenAwake] {
             if (m_screenWakeLockHandler && m_screenWakeLockHandler(shouldKeepScreenAwake))
                 return;
-            [PAL::getUIApplicationClass() sharedApplication].idleTimerDisabled = shouldKeepScreenAwake;
+            [[PAL::getUIApplicationClass() sharedApplication] _setIdleTimerDisabled:shouldKeepScreenAwake forReason:@"WebKit SleepDisabler"];
         });
     }
     ScreenSleepDisablerCounter m_screenSleepDisablerCount;


### PR DESCRIPTION
#### 9ed33f8f5890bf7acc64e10e0efe32f275a5a646
<pre>
WebKit shouldn&apos;t be modifying the value of UIApplication.idleTimerDisabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=259706">https://bugs.webkit.org/show_bug.cgi?id=259706</a>

Reviewed by Jer Noble.

WebKit shouldn&apos;t be modifying the value of UIApplication.idleTimerDisabled
because we&apos;re a framework. The hosting application can rely on this flag to
prevent screen sleep and it is not good for WebKit to be potentially overriding
a value set by the application.

To address the issue, the UIKit code indicates that frameworks are expected to
call the `_setIdleTimerDisabled:forReason:` SPI instead.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm:
(PAL::ScreenSleepDisabler::updateState):

Canonical link: <a href="https://commits.webkit.org/266499@main">https://commits.webkit.org/266499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0235ba87094595566f12003b4eb2749e91fd9a4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13973 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13263 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15933 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16419 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19630 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12762 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/15973 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11173 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12584 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3388 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->