### PR TITLE
Add CookieChangeListener base class and make WebCookieCache a CookieChangeListener

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1325,6 +1325,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     loader/CORPViolationReportBody.h
     loader/CanvasActivityRecord.h
     loader/ContentFilterClient.h
+    loader/CookieChangeListener.h
     loader/CookieJar.h
     loader/CrossOriginAccessControl.h
     loader/CrossOriginEmbedderPolicy.h

--- a/Source/WebCore/loader/CookieChangeListener.h
+++ b/Source/WebCore/loader/CookieChangeListener.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+struct Cookie;
+
+class CookieChangeListener : public CanMakeWeakPtr<CookieChangeListener> {
+public:
+    virtual void cookiesAdded(const String& host, const Vector<Cookie>&) = 0;
+    virtual void cookiesDeleted(const String& host, const Vector<Cookie>&) = 0;
+
+    virtual ~CookieChangeListener() { }
+};
+
+}

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -200,4 +200,14 @@ void CookieJar::setCookieAsync(Document&, const URL&, const Cookie&, CompletionH
     completionHandler(false);
 }
 
+#if HAVE(COOKIE_CHANGE_LISTENER_API)
+void CookieJar::addChangeListener(const String&, const CookieChangeListener&)
+{
 }
+
+void CookieJar::removeChangeListener(const String&, const CookieChangeListener&)
+{
+}
+#endif
+
+} // namespace WebCore

--- a/Source/WebCore/loader/CookieJar.h
+++ b/Source/WebCore/loader/CookieJar.h
@@ -30,7 +30,6 @@
 #include "SameSiteInfo.h"
 #include <optional>
 #include <wtf/Forward.h>
-#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
@@ -40,6 +39,7 @@ enum class SecureCookiesAccessed : bool { No, Yes };
 
 class Document;
 struct Cookie;
+class CookieChangeListener;
 struct CookieRequestHeaderFieldProxy;
 struct CookieStoreGetOptions;
 class NetworkStorageSession;
@@ -66,6 +66,11 @@ public:
 
     virtual void getCookiesAsync(Document&, const URL&, const CookieStoreGetOptions&, CompletionHandler<void(std::optional<Vector<Cookie>>&&)>&&) const;
     virtual void setCookieAsync(Document&, const URL&, const Cookie&, CompletionHandler<void(bool)>&&) const;
+
+#if HAVE(COOKIE_CHANGE_LISTENER_API)
+    virtual void addChangeListener(const String& host, const CookieChangeListener&);
+    virtual void removeChangeListener(const String& host, const CookieChangeListener&);
+#endif
 
     // Cookie Cache.
     virtual void clearCache() { }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -344,10 +344,11 @@ private:
 
     uint64_t nextMessageBatchIdentifier(CompletionHandler<void()>&&);
 
-    void domCookiesForHost(const URL& host, bool subscribeToCookieChangeNotifications, CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);
+    void domCookiesForHost(const URL& host, CompletionHandler<void(const Vector<WebCore::Cookie>&)>&&);
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    void unsubscribeFromCookieChangeNotifications(const HashSet<String>& hosts);
+    void subscribeToCookieChangeNotifications(const String& host);
+    void unsubscribeFromCookieChangeNotifications(const String& host);
 
     // WebCore::CookieChangeObserver.
     void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&) final;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -43,14 +43,15 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     GetRawCookies(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) -> (Vector<WebCore::Cookie> cookies) Synchronous
     SetRawCookie(struct WebCore::Cookie cookie)
     DeleteCookie(URL url, String cookieName) -> ()
-    DomCookiesForHost(URL host, bool subscribeToCookieChangeNotifications) -> (Vector<WebCore::Cookie> cookies) Synchronous
+    DomCookiesForHost(URL host) -> (Vector<WebCore::Cookie> cookies) Synchronous
 
     CookiesForDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::IncludeSecureCookies includeSecureCookies, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::CookieStoreGetOptions options) -> (std::optional<Vector<WebCore::Cookie>> cookies)
 
     SetCookieFromDOMAsync(URL firstParty, struct WebCore::SameSiteInfo sameSiteInfo, URL url, WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID, enum:bool WebCore::ApplyTrackingPrevention applyTrackingPrevention, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, struct WebCore::Cookie cookie) -> (bool setSuccessfully)
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    UnsubscribeFromCookieChangeNotifications(HashSet<String> hosts)
+    SubscribeToCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply
+    UnsubscribeFromCookieChangeNotifications(String host) AllowedWhenWaitingForSyncReply
 #endif
 
     RegisterInternalFileBlobURL(URL url, String path, String replacementPath, WebKit::SandboxExtension::Handle extensionHandle, String contentType)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -259,14 +259,14 @@ void NetworkProcessConnection::cookieAcceptPolicyChanged(HTTPCookieAcceptPolicy 
 }
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-void NetworkProcessConnection::cookiesAdded(const String& host, const Vector<WebCore::Cookie>& cookies)
+void NetworkProcessConnection::cookiesAdded(const String& host, Vector<WebCore::Cookie>&& cookies)
 {
-    WebProcess::singleton().cookieJar().cookiesAdded(host, cookies);
+    WebProcess::singleton().cookieJar().cookiesAdded(host, WTFMove(cookies));
 }
 
-void NetworkProcessConnection::cookiesDeleted(const String& host, const Vector<WebCore::Cookie>& cookies)
+void NetworkProcessConnection::cookiesDeleted(const String& host, Vector<WebCore::Cookie>&& cookies)
 {
-    WebProcess::singleton().cookieJar().cookiesDeleted(host, cookies);
+    WebProcess::singleton().cookieJar().cookiesDeleted(host, WTFMove(cookies));
 }
 
 void NetworkProcessConnection::allCookiesDeleted()

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -88,8 +88,8 @@ public:
     bool cookiesEnabled() const;
 
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&);
-    void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&);
+    void cookiesAdded(const String& host, Vector<WebCore::Cookie>&&);
+    void cookiesDeleted(const String& host, Vector<WebCore::Cookie>&&);
     void allCookiesDeleted();
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -25,18 +25,21 @@
 
 #pragma once
 
+#include <WebCore/CookieChangeListener.h>
 #include <WebCore/CookieJar.h>
 #include <WebCore/SameSiteInfo.h>
+#include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 
 namespace WebCore {
+struct Cookie;
 class NetworkStorageSession;
 enum class ShouldRelaxThirdPartyCookieBlocking : bool;
 }
 
 namespace WebKit {
 
-class WebCookieCache {
+class WebCookieCache : public WebCore::CookieChangeListener {
 public:
     WebCookieCache() = default;
 
@@ -45,8 +48,6 @@ public:
     String cookiesForDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, WebCore::IncludeSecureCookies);
     void setCookiesFromDOM(const URL& firstParty, const WebCore::SameSiteInfo&, const URL&, WebCore::FrameIdentifier, WebCore::PageIdentifier, const String& cookieString, WebCore::ShouldRelaxThirdPartyCookieBlocking);
 
-    void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&);
-    void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&);
     void allCookiesDeleted();
 
     void clear();
@@ -55,6 +56,10 @@ public:
 private:
     WebCore::NetworkStorageSession& inMemoryStorageSession();
     void pruneCacheIfNecessary();
+
+    // CookieChangeListener
+    void cookiesAdded(const String& host, const Vector<WebCore::Cookie>&) final;
+    void cookiesDeleted(const String& host, const Vector<WebCore::Cookie>&) final;
 
     HashSet<String> m_hostsWithInMemoryStorage;
     std::unique_ptr<WebCore::NetworkStorageSession> m_inMemoryStorageSession;


### PR DESCRIPTION
#### 08f56b30694ca5a973f159ad51c86a6b294fcbce
<pre>
Add CookieChangeListener base class and make WebCookieCache a CookieChangeListener
<a href="https://bugs.webkit.org/show_bug.cgi?id=259710">https://bugs.webkit.org/show_bug.cgi?id=259710</a>

Reviewed by Chris Dumez.

This patch is a step towards implementing the notifications upon
changes in cookies part of the new Cookie Store API. We would like
the CookieStore to listen for changes in cookies. So we add a
CookieChangeListener abstract base class which requires subclasses
to define what should happen when a cookie is added or deleted.

Currently, we have a WebCookieCache in the Web Process which listens
to updates in cookies (per host) from the Network Process. It sends
an IPC to NetworkConnectionToWebProcess to subscribe to cookie-update
notifications. When a change happends, NetworkConnectionToWebProcess
sends an IPC with the update to WebCookieaJar, which notifies the
WebCookieCache.

The new design is that: WebCookieCache is a subclass of
CookieChangeListener (so it specifies what to do on cookie add/delete).
As before, when it receives a request to obtain cookies for a host and
it&apos;s the first request for this host, WebCookieCache will subscribe to
listen to updates. Except, instead of directly sending an IPC to the
NetworkProcess, it will register itself as a listener with the
WebCookieJar. The WebCookieJar will maintain a map from hosts to their
listeners. The WebCookieJar will send an IPC to the Network Process
to subscribe the listener. On updates, the WebCookieJar will be sent
an IPC and it will notify the relevant listeners for that host. When
the WebCookieCache wants to unsubscribe to notifications for a certain
host, it will tell the WebCookieJar, which will send the IPC to the
Network Process to unsubscribe the listener. It will also update it&apos;s
map accordingly.

A future patch will make the CookieStore a CookieChangeListener too.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/CookieChangeListener.h: Copied from Source/WebKit/WebProcess/WebPage/WebCookieCache.h.
(WebCore::CookieChangeListener::~CookieChangeListener):
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::CookieJar::addChangeListener):
(WebCore::CookieJar::removeChangeListener):
* Source/WebCore/loader/CookieJar.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::domCookiesForHost):
(WebKit::NetworkConnectionToWebProcess::subscribeToCookieChangeNotifications):
(WebKit::NetworkConnectionToWebProcess::unsubscribeFromCookieChangeNotifications):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::cookiesAdded):
(WebKit::NetworkProcessConnection::cookiesDeleted):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
(WebKit::WebCookieCache::cookiesAdded):
(WebKit::WebCookieCache::clear):
(WebKit::WebCookieCache::clearForHost):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookiesAdded):
(WebKit::WebCookieJar::cookiesDeleted):
(WebKit::WebCookieJar::addChangeListener):
(WebKit::WebCookieJar::removeChangeListener):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.h:

Canonical link: <a href="https://commits.webkit.org/266570@main">https://commits.webkit.org/266570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b767c7ad3d425b24a18a21574dfbed02bfc44524

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16955 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14528 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16584 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19762 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16110 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11314 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12730 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3432 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->