### PR TITLE
Use WeakPtr in VisitedLinkTableController

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
@@ -36,21 +36,21 @@
 namespace WebKit {
 using namespace WebCore;
 
-static HashMap<uint64_t, VisitedLinkTableController*>& visitedLinkTableControllers()
+static HashMap<uint64_t, WeakPtr<VisitedLinkTableController>>& visitedLinkTableControllers()
 {
-    static NeverDestroyed<HashMap<uint64_t, VisitedLinkTableController*>> visitedLinkTableControllers;
-
+    static NeverDestroyed<HashMap<uint64_t, WeakPtr<VisitedLinkTableController>>> visitedLinkTableControllers;
+    RELEASE_ASSERT(isMainRunLoop());
     return visitedLinkTableControllers;
 }
 
 Ref<VisitedLinkTableController> VisitedLinkTableController::getOrCreate(uint64_t identifier)
 {
     auto& visitedLinkTableControllerPtr = visitedLinkTableControllers().add(identifier, nullptr).iterator->value;
-    if (visitedLinkTableControllerPtr)
-        return *visitedLinkTableControllerPtr;
+    if (RefPtr ptr = visitedLinkTableControllerPtr.get())
+        return *ptr;
 
     auto visitedLinkTableController = adoptRef(*new VisitedLinkTableController(identifier));
-    visitedLinkTableControllerPtr = visitedLinkTableController.ptr();
+    visitedLinkTableControllerPtr = visitedLinkTableController.get();
 
     return visitedLinkTableController;
 }

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h
@@ -32,7 +32,7 @@
 
 namespace WebKit {
 
-class VisitedLinkTableController final : public WebCore::VisitedLinkStore , private IPC::MessageReceiver {
+class VisitedLinkTableController final : public WebCore::VisitedLinkStore, public IPC::MessageReceiver {
 public:
     static Ref<VisitedLinkTableController> getOrCreate(uint64_t identifier);
     virtual ~VisitedLinkTableController();


### PR DESCRIPTION
#### 7fef3d7581017a8c627ed62167d8e2621f8d3188
<pre>
Use WeakPtr in VisitedLinkTableController
<a href="https://bugs.webkit.org/show_bug.cgi?id=259711">https://bugs.webkit.org/show_bug.cgi?id=259711</a>

Reviewed by Chris Dumez.

Use WeakPtr instead of raw pointers to keep track of all VisitedLinkTableControllers.

* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp:
(WebKit::visitedLinkTableControllers):
(WebKit::VisitedLinkTableController::getOrCreate):
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.h:

Canonical link: <a href="https://commits.webkit.org/266500@main">https://commits.webkit.org/266500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fa701c2805d29c4d30e2e10e06685047adafda7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13267 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16801 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15937 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16423 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12025 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19633 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15976 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11177 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16921 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1647 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->