### PR TITLE
Use thread safe weak pointers in RemoteMediaResourceManager

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h
+++ b/Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h
@@ -75,7 +75,7 @@ protected:
     PlatformMediaResourceLoader() = default;
 };
 
-class PlatformMediaResource : public ThreadSafeRefCounted<PlatformMediaResource, WTF::DestructionThread::Main> {
+class PlatformMediaResource : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PlatformMediaResource, WTF::DestructionThread::Main> {
     WTF_MAKE_NONCOPYABLE(PlatformMediaResource); WTF_MAKE_FAST_ALLOCATED;
 public:
     PlatformMediaResource() = default;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp
@@ -51,7 +51,7 @@ RemoteMediaResourceManager::~RemoteMediaResourceManager()
 void RemoteMediaResourceManager::addMediaResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier, RemoteMediaResource& remoteMediaResource)
 {
     ASSERT(!m_remoteMediaResources.contains(remoteMediaResourceIdentifier));
-    m_remoteMediaResources.add(remoteMediaResourceIdentifier, &remoteMediaResource);
+    m_remoteMediaResources.add(remoteMediaResourceIdentifier, ThreadSafeWeakPtr { remoteMediaResource });
 }
 
 void RemoteMediaResourceManager::removeMediaResource(RemoteMediaResourceIdentifier remoteMediaResourceIdentifier)
@@ -62,7 +62,7 @@ void RemoteMediaResourceManager::removeMediaResource(RemoteMediaResourceIdentifi
 
 void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier identifier, const ResourceResponse& response, bool didPassAccessControlCheck, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource) {
         completionHandler(ShouldContinuePolicyCheck::No);
         return;
@@ -73,7 +73,7 @@ void RemoteMediaResourceManager::responseReceived(RemoteMediaResourceIdentifier 
 
 void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier identifier, ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource) {
         completionHandler({ });
         return;
@@ -84,7 +84,7 @@ void RemoteMediaResourceManager::redirectReceived(RemoteMediaResourceIdentifier 
 
 void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifier, uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource)
         return;
 
@@ -93,7 +93,7 @@ void RemoteMediaResourceManager::dataSent(RemoteMediaResourceIdentifier identifi
 
 void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier identifier, IPC::SharedBufferReference&& buffer, CompletionHandler<void(std::optional<SharedMemory::Handle>&&)>&& completionHandler)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource)
         return completionHandler(std::nullopt);
 
@@ -111,7 +111,7 @@ void RemoteMediaResourceManager::dataReceived(RemoteMediaResourceIdentifier iden
 
 void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource)
         return;
 
@@ -120,7 +120,7 @@ void RemoteMediaResourceManager::accessControlCheckFailed(RemoteMediaResourceIde
 
 void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identifier, const ResourceError& error)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource)
         return;
 
@@ -129,7 +129,7 @@ void RemoteMediaResourceManager::loadFailed(RemoteMediaResourceIdentifier identi
 
 void RemoteMediaResourceManager::loadFinished(RemoteMediaResourceIdentifier identifier, const NetworkLoadMetrics& metrics)
 {
-    auto* resource = m_remoteMediaResources.get(identifier);
+    auto resource = m_remoteMediaResources.get(identifier).get();
     if (!resource)
         return;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h
@@ -72,7 +72,7 @@ private:
     void loadFailed(RemoteMediaResourceIdentifier, const WebCore::ResourceError&);
     void loadFinished(RemoteMediaResourceIdentifier, const WebCore::NetworkLoadMetrics&);
 
-    HashMap<RemoteMediaResourceIdentifier, RemoteMediaResource*> m_remoteMediaResources;
+    HashMap<RemoteMediaResourceIdentifier, ThreadSafeWeakPtr<RemoteMediaResource>> m_remoteMediaResources;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### bae62859f40c46e938384495d367c6938be79b9f
<pre>
Use thread safe weak pointers in RemoteMediaResourceManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=259716">https://bugs.webkit.org/show_bug.cgi?id=259716</a>

Reviewed by Andy Estes.

Use ThreadSafeWeakPtr in RemoteMediaResourceManager.

* Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.cpp:
(WebKit::RemoteMediaResourceManager::addMediaResource):
(WebKit::RemoteMediaResourceManager::responseReceived):
(WebKit::RemoteMediaResourceManager::redirectReceived):
(WebKit::RemoteMediaResourceManager::dataSent):
(WebKit::RemoteMediaResourceManager::dataReceived):
(WebKit::RemoteMediaResourceManager::accessControlCheckFailed):
(WebKit::RemoteMediaResourceManager::loadFailed):
(WebKit::RemoteMediaResourceManager::loadFinished):
* Source/WebKit/GPUProcess/media/RemoteMediaResourceManager.h:

Canonical link: <a href="https://commits.webkit.org/266600@main">https://commits.webkit.org/266600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/588b955aaff3c41cccaf025c80cfccd4ecc169ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15938 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14741 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16427 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19635 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15978 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11180 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12592 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16925 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1694 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->