### PR TITLE
[CSS Math Functions] round() is incorrect when number is a multiple of step

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt
@@ -5,10 +5,38 @@ PASS rem(1,1) should be used-value-equivalent to 0
 PASS calc(round(100,10)) should be used-value-equivalent to 100
 PASS calc(round(up, 101,10)) should be used-value-equivalent to 110
 PASS calc(round(down, 106,10)) should be used-value-equivalent to 100
-PASS calc(round(to-zero,105, 10)) should be used-value-equivalent to 100
-PASS calc(round(to-zero,-105, 10)) should be used-value-equivalent to -100
-PASS calc(round(-100,10)) should be used-value-equivalent to -100
-PASS calc(round(up, -103,10)) should be used-value-equivalent to -100
+PASS calc(round(to-zero, 105, 10)) should be used-value-equivalent to 100
+PASS calc(round(to-zero, -105, 10)) should be used-value-equivalent to -100
+PASS calc(round(-100, 10)) should be used-value-equivalent to -100
+PASS calc(round(up, -103, 10)) should be used-value-equivalent to -100
+PASS round(up, 0, 5) should be used-value-equivalent to 0
+PASS round(down, 0, 5) should be used-value-equivalent to 0
+PASS round(nearest, 0, 5) should be used-value-equivalent to 0
+PASS round(to-zero, 0, 5) should be used-value-equivalent to 0
+PASS round(up, 5, 5) should be used-value-equivalent to 5
+PASS round(down, 5, 5) should be used-value-equivalent to 5
+PASS round(nearest, 5, 5) should be used-value-equivalent to 5
+PASS round(to-zero, 5, 5) should be used-value-equivalent to 5
+PASS round(up, -5, 5) should be used-value-equivalent to -5
+PASS round(down, -5, 5) should be used-value-equivalent to -5
+PASS round(nearest, -5, 5) should be used-value-equivalent to -5
+PASS round(to-zero, -5, 5) should be used-value-equivalent to -5
+PASS round(up, 10, 5) should be used-value-equivalent to 10
+PASS round(down, 10, 5) should be used-value-equivalent to 10
+PASS round(nearest, 10, 5) should be used-value-equivalent to 10
+PASS round(to-zero, 10, 5) should be used-value-equivalent to 10
+PASS round(up, -10, 5) should be used-value-equivalent to -10
+PASS round(down, -10, 5) should be used-value-equivalent to -10
+PASS round(nearest, -10, 5) should be used-value-equivalent to -10
+PASS round(to-zero, -10, 5) should be used-value-equivalent to -10
+PASS round(up, 20, 5) should be used-value-equivalent to 20
+PASS round(down, 20, 5) should be used-value-equivalent to 20
+PASS round(nearest, 20, 5) should be used-value-equivalent to 20
+PASS round(to-zero, 20, 5) should be used-value-equivalent to 20
+PASS round(up, -20, 5) should be used-value-equivalent to -20
+PASS round(down, -20, 5) should be used-value-equivalent to -20
+PASS round(nearest, -20, 5) should be used-value-equivalent to -20
+PASS round(to-zero, -20, 5) should be used-value-equivalent to -20
 PASS mod(18,5) should be used-value-equivalent to 3
 PASS rem(18,5) should be used-value-equivalent to 3
 PASS mod(-140,-90) should be used-value-equivalent to -50
@@ -119,4 +147,82 @@ PASS rem(-18vw,5vw) should be used-value-equivalent to -3vw
 PASS calc(round(1px + 0%, 1px + 0%)) should be used-value-equivalent to 1px
 PASS calc(mod(3px + 0%, 2px + 0%)) should be used-value-equivalent to 1px
 PASS calc(rem(3px + 0%, 2px + 0%)) should be used-value-equivalent to 1px
+PASS round(0, 0) should be used-value-equivalent to calc(NaN)
+PASS round(-0, 0) should be used-value-equivalent to calc(NaN)
+PASS round(Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS round(-Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS round(-4, 0) should be used-value-equivalent to calc(NaN)
+PASS round(4, 0) should be used-value-equivalent to calc(NaN)
+PASS round(Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS round(-Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS round(Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS round(-Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(0, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(-0, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(-Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(-4, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(4, 0) should be used-value-equivalent to calc(NaN)
+PASS mod(Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(-Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(-Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS rem(0, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(-0, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(-Infinity, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(-4, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(4, 0) should be used-value-equivalent to calc(NaN)
+PASS rem(Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS rem(-Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS rem(Infinity, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS rem(-Infinity, Infinity) should be used-value-equivalent to calc(NaN)
+PASS round(up, Infinity, 4) should be used-value-equivalent to calc(Infinity)
+PASS round(up, -Infinity, 4) should be used-value-equivalent to calc(-Infinity)
+PASS round(up, Infinity, -4) should be used-value-equivalent to calc(Infinity)
+PASS round(up, -Infinity, -4) should be used-value-equivalent to calc(-Infinity)
+PASS round(down, Infinity, 4) should be used-value-equivalent to calc(Infinity)
+PASS round(down, -Infinity, 4) should be used-value-equivalent to calc(-Infinity)
+PASS round(down, Infinity, -4) should be used-value-equivalent to calc(Infinity)
+PASS round(down, -Infinity, -4) should be used-value-equivalent to calc(-Infinity)
+PASS round(nearest, Infinity, 4) should be used-value-equivalent to calc(Infinity)
+PASS round(nearest, -Infinity, 4) should be used-value-equivalent to calc(-Infinity)
+PASS round(nearest, Infinity, -4) should be used-value-equivalent to calc(Infinity)
+PASS round(nearest, -Infinity, -4) should be used-value-equivalent to calc(-Infinity)
+PASS round(to-zero, Infinity, 4) should be used-value-equivalent to calc(Infinity)
+PASS round(to-zero, -Infinity, 4) should be used-value-equivalent to calc(-Infinity)
+PASS round(to-zero, Infinity, -4) should be used-value-equivalent to calc(Infinity)
+PASS round(to-zero, -Infinity, -4) should be used-value-equivalent to calc(-Infinity)
+PASS round(nearest, 0, Infinity) should be used-value-equivalent to 0
+PASS round(nearest, 4, Infinity) should be used-value-equivalent to 0
+PASS round(nearest, -0, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(nearest, -4, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(nearest, 0, -Infinity) should be used-value-equivalent to 0
+PASS round(nearest, 4, -Infinity) should be used-value-equivalent to 0
+PASS round(nearest, -0, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(nearest, -4, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(to-zero, 0, Infinity) should be used-value-equivalent to 0
+PASS round(to-zero, 4, Infinity) should be used-value-equivalent to 0
+PASS round(to-zero, -0, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(to-zero, -4, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(to-zero, 0, -Infinity) should be used-value-equivalent to 0
+PASS round(to-zero, 4, -Infinity) should be used-value-equivalent to 0
+PASS round(to-zero, -0, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(to-zero, -4, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(up, 1, Infinity) should be used-value-equivalent to calc(Infinity)
+PASS round(up, 0, Infinity) should be used-value-equivalent to 0
+PASS round(up, -1, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(up, 1, -Infinity) should be used-value-equivalent to calc(Infinity)
+PASS round(up, 0, -Infinity) should be used-value-equivalent to 0
+PASS round(up, -1, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(down, 1, Infinity) should be used-value-equivalent to calc(-0)
+PASS round(down, 0, Infinity) should be used-value-equivalent to 0
+PASS round(down, -1, Infinity) should be used-value-equivalent to calc(-Infinity)
+PASS round(down, 1, -Infinity) should be used-value-equivalent to calc(-0)
+PASS round(down, 0, -Infinity) should be used-value-equivalent to 0
+PASS round(down, -1, -Infinity) should be used-value-equivalent to calc(-Infinity)
+PASS mod(-0, Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(0, -Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(-4, Infinity) should be used-value-equivalent to calc(NaN)
+PASS mod(4, -Infinity) should be used-value-equivalent to calc(NaN)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed.html
@@ -15,16 +15,24 @@ test_math_used('round(10,10)', '10', {type:'number'});
 test_math_used('mod(1,1)', '0', {type:'number'});
 test_math_used('rem(1,1)', '0', {type:'number'});
 
-//Test basic round
+// Test basic round
 test_math_used('calc(round(100,10))', '100', {type:'number'});
 test_math_used('calc(round(up, 101,10))', '110', {type:'number'});
 test_math_used('calc(round(down, 106,10))', '100', {type:'number'});
-test_math_used('calc(round(to-zero,105, 10))', '100', {type:'number'});
-test_math_used('calc(round(to-zero,-105, 10))', '-100', {type:'number'});
-test_math_used('calc(round(-100,10))', '-100', {type:'number'});
-test_math_used('calc(round(up, -103,10))', '-100', {type:'number'});
+test_math_used('calc(round(to-zero, 105, 10))', '100', {type:'number'});
+test_math_used('calc(round(to-zero, -105, 10))', '-100', {type:'number'});
+test_math_used('calc(round(-100, 10))', '-100', {type:'number'});
+test_math_used('calc(round(up, -103, 10))', '-100', {type:'number'});
 
-//Test basic mod/rem
+// Test round when first number is a multiple of the second number.
+for (let number of [0, 5, -5, 10, -10, 20, -20]) {
+    test_math_used(`round(up, ${number}, 5)`, `${number}`, {type:'number'});
+    test_math_used(`round(down, ${number}, 5)`, `${number}`, {type:'number'});
+    test_math_used(`round(nearest, ${number}, 5)`, `${number}`, {type:'number'});
+    test_math_used(`round(to-zero, ${number}, 5)`, `${number}`, {type:'number'});
+}
+
+// Test basic mod/rem
 test_math_used('mod(18,5)', '3', {type:'number'});
 test_math_used('rem(18,5)', '3', {type:'number'});
 test_math_used('mod(-140,-90)', '-50', {type:'number'});
@@ -33,7 +41,7 @@ test_math_used('rem(-18,5)', '-3', {type:'number'});
 test_math_used('mod(140,-90)', '-40', {type:'number'});
 test_math_used('rem(140,-90)', '50', {type:'number'});
 
-//Test basic calculations
+// Test basic calculations
 test_math_used('calc(round(round(100,10), 10))', '100', {type:'number'});
 test_math_used('calc(round(up, round(100,10) + 1,10))', '110', {type:'number'});
 test_math_used('calc(round(down, round(100,10) + 2 * 3,10))', '100', {type:'number'});
@@ -147,4 +155,60 @@ test_math_used('calc(round(1px + 0%, 1px + 0%))', '1px');
 test_math_used('calc(mod(3px + 0%, 2px + 0%))', '1px');
 test_math_used('calc(rem(3px + 0%, 2px + 0%))', '1px');
 
+// In round(A, B), if B is 0, the result is NaN. If A and B are both infinite, the result is NaN.
+// In mod(A, B) or rem(A, B), if B is 0, the result is NaN. If A is infinite, the result is NaN.
+for (let operator of ['round', 'mod', 'rem']) {
+    test_math_used(`${operator}(0, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(-0, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(Infinity, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(-Infinity, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(-4, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(4, 0)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(Infinity, Infinity)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(-Infinity, -Infinity)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(Infinity, -Infinity)`, 'calc(NaN)', {type: 'number'});
+    test_math_used(`${operator}(-Infinity, Infinity)`, 'calc(NaN)', {type: 'number'});
+}
+
+// In round(A, B), if A is infinite but B is finite, the result is the same infinity.
+for (let roundingStrategy of ['up', 'down', 'nearest', 'to-zero']) {
+    test_math_used(`round(${roundingStrategy}, Infinity, 4)`, 'calc(Infinity)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -Infinity, 4)`, 'calc(-Infinity)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, Infinity, -4)`, 'calc(Infinity)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -Infinity, -4)`, 'calc(-Infinity)', {type: 'number'});
+}
+
+// If A is finite but B is infinite, the result depends on the <rounding-strategy> and the sign of A:
+// nearest & to-zero: If A is positive or 0⁺, return 0⁺. Otherwise, return 0⁻.
+for (let roundingStrategy of ['nearest', 'to-zero']) {
+    test_math_used(`round(${roundingStrategy}, 0, Infinity)`, '0', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, 4, Infinity)`, '0', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -0, Infinity)`, 'calc(-0)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -4, Infinity)`, 'calc(-0)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, 0, -Infinity)`, '0', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, 4, -Infinity)`, '0', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -0, -Infinity)`, 'calc(-0)', {type: 'number'});
+    test_math_used(`round(${roundingStrategy}, -4, -Infinity)`, 'calc(-0)', {type: 'number'});
+}
+
+// up: If A is positive (not zero), return +∞. If A is 0⁺, return 0⁺. Otherwise, return 0⁻.
+test_math_used('round(up, 1, Infinity)', 'calc(Infinity)', {type: 'number'});
+test_math_used('round(up, 0, Infinity)', '0', {type: 'number'});
+test_math_used('round(up, -1, Infinity)', 'calc(-0)', {type: 'number'});
+test_math_used('round(up, 1, -Infinity)', 'calc(Infinity)', {type: 'number'});
+test_math_used('round(up, 0, -Infinity)', '0', {type: 'number'});
+test_math_used('round(up, -1, -Infinity)', 'calc(-0)', {type: 'number'});
+// down: If A is negative (not zero), return −∞. If A is 0⁻, return 0⁻. Otherwise, return 0⁺.
+test_math_used('round(down, 1, Infinity)', 'calc(-0)', {type: 'number'});
+test_math_used('round(down, 0, Infinity)', '0', {type: 'number'});
+test_math_used('round(down, -1, Infinity)', 'calc(-Infinity)', {type: 'number'});
+test_math_used('round(down, 1, -Infinity)', 'calc(-0)', {type: 'number'});
+test_math_used('round(down, 0, -Infinity)', '0', {type: 'number'});
+test_math_used('round(down, -1, -Infinity)', 'calc(-Infinity)', {type: 'number'});
+
+// In mod(A, B) only, if B is infinite and A has opposite sign to B (including an oppositely-signed zero), the result is NaN.
+test_math_used('mod(-0, Infinity)', 'calc(NaN)', {type: 'number'});
+test_math_used('mod(0, -Infinity)', 'calc(NaN)', {type: 'number'});
+test_math_used('mod(-4, Infinity)', 'calc(NaN)', {type: 'number'});
+test_math_used('mod(4, -Infinity)', 'calc(NaN)', {type: 'number'});
 </script>

--- a/Source/WebCore/platform/calc/CalcOperator.h
+++ b/Source/WebCore/platform/calc/CalcOperator.h
@@ -68,6 +68,8 @@ template <typename T, typename Function>
 double evaluateCalcExpression(CalcOperator calcOperator, const Vector<T>& children, Function&& evaluate)
 {
     auto getNearestMultiples = [](double a, double b) -> std::pair<double, double> {
+        if (!std::fmod(a, b))
+            return { a, a };
         double lower = std::floor(a / std::abs(b)) * std::abs(b);
         double upper = lower + std::abs(b);
         return { lower, upper };


### PR DESCRIPTION
#### 58d1ff825f4e6920efe7fe6a8762d8c84cedf76e
<pre>
[CSS Math Functions] round() is incorrect when number is a multiple of step
<a href="https://bugs.webkit.org/show_bug.cgi?id=259702">https://bugs.webkit.org/show_bug.cgi?id=259702</a>
rdar://113233588

Reviewed by Simon Fraser.

In Safari 16.6, round(up, 10px, 5px) resolves to 15px instead of 10px as it should.

From <a href="https://drafts.csswg.org/css-values-4/#round-func">https://drafts.csswg.org/css-values-4/#round-func</a>:
&gt; If A is exactly equal to an integer multiple of B, round() resolves to A exactly

Also add WPT for <a href="https://drafts.csswg.org/css-values/#round-infinities">https://drafts.csswg.org/css-values/#round-infinities</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/round-mod-rem-computed.html:
* Source/WebCore/platform/calc/CalcOperator.h:
(WebCore::evaluateCalcExpression):

Canonical link: <a href="https://commits.webkit.org/266504@main">https://commits.webkit.org/266504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d413776108f30ae9aee71ef4ec74d287a8167614

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14392 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15950 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16439 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19646 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13115 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15989 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11193 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12476 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3393 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->