### PR TITLE
Media Controls: Volume slider should always show if we have enough room

### DIFF
--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -705,6 +705,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-media-controls.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-media-controls.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-slider.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-slider.js
+$(PROJECT_DIR)/Modules/modern-media-controls/controls/vision-volume-container.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/watchos-activity-indicator.css
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/watchos-activity-indicator.js
 $(PROJECT_DIR)/Modules/modern-media-controls/controls/watchos-layout-traits.js

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1984,6 +1984,7 @@ MODERN_MEDIA_CONTROLS_SCRIPTS = \
     $(WebCore)/Modules/modern-media-controls/controls/invalid-placard.js \
     $(WebCore)/Modules/modern-media-controls/controls/pip-placard.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-slider.js \
+    $(WebCore)/Modules/modern-media-controls/controls/vision-volume-container.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-media-controls.js \
     $(WebCore)/Modules/modern-media-controls/controls/vision-layout-traits.js \
     $(WebCore)/Modules/modern-media-controls/controls/watchos-activity-indicator.js \

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css
@@ -76,15 +76,6 @@
     --inline-controls-bar-margin: 12px;
 }
 
-.media-controls.vision.fullscreen > .controls-bar.top-right,
-.media-controls.vision.fullscreen > .controls-bar.top-right * {
-    --inline-controls-bar-margin: 2px;
-}
-
-.media-controls.vision.fullscreen > .controls-bar.top-right {
-    padding: 0 0 0 11px;
-}
-
 /* Captions */
 
 :host(video[controls]) .visible-controls-bar:has(+ .vision) {
@@ -112,11 +103,21 @@
 
 /* Simple layout controls bar */
 
+.media-controls.vision > .controls-bar.top-right,
+.media-controls.vision > .controls-bar.top-right * {
+    --inline-controls-bar-margin: 2px;
+}
+
+.media-controls.vision > .controls-bar.top-right {
+    padding: 0 0 0 11px;
+}
+
 .media-controls.vision .controls-bar.simple-layout {
     display: flex;
     align-items: center;
 }
 
+.media-controls.vision .controls-bar.simple-layout .volume-container > .slider.vision.volume,
 .media-controls.vision .controls-bar.simple-layout > *:not(.background-tint) {
     position: relative;
     margin-right: var(--inline-controls-bar-margin);
@@ -124,6 +125,24 @@
 
 .media-controls.vision .controls-bar.simple-layout > *:last-child {
     margin-right: 0 !important;
+}
+
+.media-controls.vision .controls-bar.simple-layout.top-right > .overflow {
+    margin: 0 0 0 5px;
+}
+
+.media-controls.vision .volume-container {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    padding: 0 0 0 11px;
+}
+
+.media-controls.vision .volume-container > .mute.bar {
+    position: relative;
+    width: auto !important;
+    aspect-ratio: 1;
+    border-radius: 50%;
 }
 
 /* Background tint */
@@ -137,6 +156,7 @@
     display: none;
 }
 
+.media-controls.vision:not(.audio) .volume-container > .background-tint > .blur,
 .media-controls.vision:not(.audio) button > .background-tint > .blur {
     background-color: rgba(255, 255, 255, 0.15);
     -webkit-backdrop-filter: saturate(20%) blur(50px);

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js
@@ -27,6 +27,7 @@ const MinSizeToShowLargeProminentControl = 292;
 
 const MinWidthToShowTopCornerControlsBars = 262;
 const MinWidthToShowBottomBar = 390;
+const MinWidthToShowVolumeSlider = 390;
 const MinWidthToShowSeekingControls = 520;
 const MinWidthToShowOverflowButton = 520;
 const MinWidthToShowLargeCentralControls = 640;
@@ -172,7 +173,7 @@ class VisionMediaControls extends MediaControls
 
         this.timeControl.scrubber = new VisionSlider(this.layoutDelegate, "scrubber");
 
-        // Controls Bars
+        // Controls Bars.
 
         this._topLeftControlsBar = new ControlsBar("simple-layout top-left");
         this._topLeftControlsBar.hasBackgroundTint = false;
@@ -185,6 +186,12 @@ class VisionMediaControls extends MediaControls
 
         this._bottomBarLeftContainer = new ButtonsContainer({ cssClassName: "left" });
         this._bottomBarRightContainer = new ButtonsContainer({ cssClassName: "right" });
+
+        this.volumeSlider = new VisionSlider(this, "volume");
+        this.volumeSlider.width = 150;
+        this.volumeSlider.recessed = true;
+
+        this.volumeContainer = new VolumeContainer("volume-container");
     }
 
     _performLayout()
@@ -193,6 +200,11 @@ class VisionMediaControls extends MediaControls
     }
 
     _topRightControlsBarChildren()
+    {
+        throw "Derived class must implement this function.";
+    }
+
+    _performVolumeContainerLayout()
     {
         throw "Derived class must implement this function.";
     }
@@ -207,6 +219,8 @@ class VisionMediaControls extends MediaControls
 
     _performTopRightControlsBarLayout()
     {
+        this._performVolumeContainerLayout();
+
         this._topRightControlsBar.children = this._topRightControlsBarChildren();
     }
 
@@ -243,8 +257,6 @@ class VisionInlineMediaControls extends VisionMediaControls
     {
         super._createControls();
 
-        this.muteButton.style = Button.Styles.Rounded;
-        this.muteButton.circular = true;
         this.overflowButton.style = Button.Styles.Rounded;
         this.overflowButton.circular = true;
 
@@ -277,7 +289,7 @@ class VisionInlineMediaControls extends VisionMediaControls
             children.push(this._topLeftControlsBar);
             children.push(this._topRightControlsBar);
         }
-    
+
         this._performCentralContainerLayout();
         children.push(this._centerControlsBar);
     
@@ -291,9 +303,16 @@ class VisionInlineMediaControls extends VisionMediaControls
 
     _topRightControlsBarChildren()
     {
-        const children = [this.muteButton];
+        const children = [];
+
+        if (this._widthForSizeClassDetermination >= MinWidthToShowVolumeSlider)
+            children.push(this.volumeContainer);
+        else
+            children.push(this.muteButton);
+
         if (this._widthForSizeClassDetermination >= MinWidthToShowOverflowButton)
             children.push(this.overflowButton);
+
         return children;
     }
 
@@ -317,7 +336,20 @@ class VisionInlineMediaControls extends VisionMediaControls
         }
         this._centerControlsBar.children = buttons;
     }
-    
+
+    _performVolumeContainerLayout()
+    {
+        if (this._widthForSizeClassDetermination >= MinWidthToShowVolumeSlider) {
+            this.muteButton.style = Button.Styles.Bar;
+            this.muteButton.circular = false;
+            this.volumeContainer.children = [this.volumeSlider, this.muteButton];
+        } else {
+            this.muteButton.style = Button.Styles.Rounded;
+            this.muteButton.circular = true;
+            this.volumeContainer.children = [];
+        }
+    }
+
     _performBottomBarLayout()
     {
         const margin = this.computedValueForStylePropertyInPx("--inline-controls-inside-margin");
@@ -386,13 +418,9 @@ class VisionFullscreenMediaControls extends VisionMediaControls
     {
         super._createControls();
 
-        this.volumeSlider = new VisionSlider(this, "volume");
-        this.volumeSlider.width = 150;
-        this.volumeSlider.recessed = true;
-
         this.timeControl.scrubber.recessed = true;
 
-        this._topRightControlsBar.hasBackgroundTint = true;
+        this._topRightControlsBar.hasBackgroundTint = false;
 
         this.muteButton.style = Button.Styles.Bar;
         this.overflowButton.style = Button.Styles.Bar;
@@ -419,9 +447,16 @@ class VisionFullscreenMediaControls extends VisionMediaControls
         this.children = [this._backdrop, this._topLeftControlsBar, this._topRightControlsBar, this.bottomControlsBar];
     }
 
+    _performVolumeContainerLayout()
+    {
+        this.muteButton.style = Button.Styles.Bar;
+        this.muteButton.circular = false;
+        this.volumeContainer.children = [this.volumeSlider, this.muteButton];
+    }
+
     _topRightControlsBarChildren()
     {
-        return [this.volumeSlider, this.muteButton];
+        return [this.volumeContainer];
     }
 
     _performBottomBarLayout()

--- a/Source/WebCore/Modules/modern-media-controls/controls/vision-volume-container.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/vision-volume-container.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class VolumeContainer extends LayoutNode
+{
+    constructor(cssClassName = "")
+    {
+        super(`<div role="group" class="${cssClassName}"></div>`);
+        this._backgroundTint = this.addChild(new BackgroundTint);
+    }
+
+    get children()
+    {
+        return super.children;
+    }
+
+    set children(children)
+    {
+        super.children = [this._backgroundTint].concat(children);
+    }
+}


### PR DESCRIPTION
#### e4772fad1ca24d48d3d2fd2bcfd313fd6c4dcccf
<pre>
Media Controls: Volume slider should always show if we have enough room
<a href="https://bugs.webkit.org/show_bug.cgi?id=259721">https://bugs.webkit.org/show_bug.cgi?id=259721</a>
rdar://113243353

Reviewed by Dean Jackson.

On visionOS, the volume slider should always show within inline video, if there is enough room.

* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.css:
(.media-controls.vision &gt; .controls-bar.top-right,):
(.media-controls.vision &gt; .controls-bar.top-right):
(.media-controls.vision .controls-bar.simple-layout .volume-container &gt; .slider.vision.volume,):
(.media-controls.vision .controls-bar.simple-layout.top-right &gt; .overflow):
(.media-controls.vision .volume-container):
(.media-controls.vision .volume-container &gt; .mute.bar):
(.media-controls.vision:not(.audio) .volume-container &gt; .background-tint &gt; .blur,):
(.media-controls.vision.fullscreen &gt; .controls-bar.top-right,): Deleted.
(.media-controls.vision.fullscreen &gt; .controls-bar.top-right): Deleted.
(.media-controls.vision .controls-bar.simple-layout &gt; *:not(.background-tint)): Deleted.
(.media-controls.vision:not(.audio) button &gt; .background-tint &gt; .blur): Deleted.
* Source/WebCore/Modules/modern-media-controls/controls/vision-media-controls.js:
(VisionMediaControls.prototype._createControls):
(VisionMediaControls.prototype._performVolumeContainerLayout):
(VisionMediaControls.prototype._performTopRightControlsBarLayout):
(VisionInlineMediaControls.prototype._createControls):
(VisionInlineMediaControls.prototype._performLayout):
(VisionInlineMediaControls.prototype._topRightControlsBarChildren):
(VisionInlineMediaControls.prototype._performVolumeContainerLayout):
(VisionFullscreenMediaControls.prototype._createControls):
(VisionFullscreenMediaControls.prototype._performVolumeContainerLayout):
(VisionFullscreenMediaControls.prototype._topRightControlsBarChildren):
* Source/WebCore/Modules/modern-media-controls/controls/vision-volume-container.js: Added.
(VolumeContainer.prototype.get children):
(VolumeContainer.prototype.set children):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/266566@main">https://commits.webkit.org/266566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c74967d02d22077bf3191e5388515989c22c8f4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13407 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14246 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16081 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11992 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16597 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12753 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/16597 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12917 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/16597 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13463 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11325 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12742 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17077 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->