### PR TITLE
[WGSL] Variable redeclaration should not assert

### DIFF
--- a/Source/WebGPU/WGSL/ContextProvider.h
+++ b/Source/WebGPU/WGSL/ContextProvider.h
@@ -53,7 +53,7 @@ protected:
 
     ContextProvider();
 
-    const ContextValue& introduceVariable(const String&, const ContextValue&);
+    const ContextValue* introduceVariable(const String&, const ContextValue&);
     const ContextValue* readVariable(const String&) const;
 
 private:
@@ -62,7 +62,7 @@ private:
         Context(const Context *const parent);
 
         const ContextValue* lookup(const String&) const;
-        const ContextValue& add(const String&, const ContextValue&);
+        const ContextValue* add(const String&, const ContextValue&);
 
     private:
         const Context* m_parent { nullptr };

--- a/Source/WebGPU/WGSL/ContextProviderInlines.h
+++ b/Source/WebGPU/WGSL/ContextProviderInlines.h
@@ -48,11 +48,12 @@ const Value* ContextProvider<Value>::Context::lookup(const String& name) const
 }
 
 template<typename Value>
-const Value& ContextProvider<Value>::Context::add(const String& name, const Value& value)
+const Value* ContextProvider<Value>::Context::add(const String& name, const Value& value)
 {
     auto result = m_map.add(name, value);
-    ASSERT(result.isNewEntry);
-    return result.iterator->value;
+    if (UNLIKELY(!result.isNewEntry))
+        return nullptr;
+    return &result.iterator->value;
 }
 
 template<typename Value>
@@ -80,7 +81,7 @@ ContextProvider<Value>::ContextProvider()
 }
 
 template<typename Value>
-auto ContextProvider<Value>::introduceVariable(const String& name, const Value& value) -> const Value&
+auto ContextProvider<Value>::introduceVariable(const String& name, const Value& value) -> const Value*
 {
     return m_context->add(name, value);
 }

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -226,8 +226,9 @@ void NameManglerVisitor::visit(AST::NamedTypeName& type)
 
 void NameManglerVisitor::introduceVariable(AST::Identifier& name, MangledName::Kind kind)
 {
-    const auto& mangledName = ContextProvider::introduceVariable(name, makeMangledName(name, kind));
-    m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName.toString()));
+    const auto* mangledName = ContextProvider::introduceVariable(name, makeMangledName(name, kind));
+    ASSERT(mangledName);
+    m_callGraph.ast().replace(&name, AST::Identifier::makeWithSpan(name.span(), mangledName->toString()));
 }
 
 MangledName NameManglerVisitor::makeMangledName(const String& name, MangledName::Kind kind)

--- a/Source/WebGPU/WGSL/tests/invalid/redeclaration.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/redeclaration.wgsl
@@ -1,0 +1,16 @@
+// RUN: %not %wgslc | %check
+
+struct f {
+}
+
+// CHECK-L: redeclaration of 'f'
+override f = 1;
+
+// CHECK-L: redeclaration of 'f'
+fn f() {
+    let x = 1;
+    // CHECK-L: redeclaration of 'x'
+    var x = 2;
+    // CHECK-L: redeclaration of 'x'
+    const x = 2;
+}


### PR DESCRIPTION
#### 0db7d09bde23910e479e714aff930fc453b5e926
<pre>
[WGSL] Variable redeclaration should not assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=259727">https://bugs.webkit.org/show_bug.cgi?id=259727</a>
rdar://113257297

Reviewed by Dan Glastonbury.

Currently, when inserting a new value or type into the type checker context we
assert that the context doesn&apos;t already have another entry with the same name.
Instead, we should report an error informing that it&apos;s invalid to redeclare
that value/type.

* Source/WebGPU/WGSL/ContextProvider.h:
* Source/WebGPU/WGSL/ContextProviderInlines.h:
(WGSL::ContextProvider&lt;Value&gt;::Context::add):
(WGSL::ContextProvider&lt;Value&gt;::introduceVariable const):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::introduceVariable):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
(WGSL::TypeChecker::introduceType):
(WGSL::TypeChecker::introduceValue):
* Source/WebGPU/WGSL/tests/invalid/redeclaration.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/266635@main">https://commits.webkit.org/266635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a92aab643c341bf571207385a76ad41992f6d2a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13294 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15964 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16453 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12053 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19660 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13129 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16002 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13342 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11205 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12617 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3463 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->