### PR TITLE
[WGSL] Assertion failure when declarations have no type nor initializer

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -674,10 +674,26 @@ Result<AST::Variable::Ref> Parser<Lexer>::parseVariableWithAttributes(AST::Attri
     }
 
     AST::Expression::Ptr maybeInitializer = nullptr;
-    if (current().type == TokenType::Equal) {
-        consume();
+    if (varFlavor == AST::VariableFlavor::Const || varFlavor == AST::VariableFlavor::Let || current().type == TokenType::Equal) {
+        CONSUME_TYPE(Equal);
         PARSE(initializerExpr, Expression);
         maybeInitializer = &initializerExpr.get();
+    }
+
+    if (!maybeType && !maybeInitializer) {
+        ASCIILiteral flavor = [&] {
+            switch (varFlavor) {
+            case AST::VariableFlavor::Const:
+                RELEASE_ASSERT_NOT_REACHED();
+            case AST::VariableFlavor::Let:
+                RELEASE_ASSERT_NOT_REACHED();
+            case AST::VariableFlavor::Override:
+                return "override"_s;
+            case AST::VariableFlavor::Var:
+                return "var"_s;
+            }
+        }();
+        FAIL(makeString(flavor, " declaration requires a type or initializer"_s));
     }
 
     RETURN_ARENA_NODE(Variable, varFlavor, WTFMove(name), WTFMove(maybeQualifier), WTFMove(maybeType), WTFMove(maybeInitializer), WTFMove(attributes));

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -37,6 +37,7 @@
 #include "WGSLShaderModule.h"
 
 #include <wtf/Assertions.h>
+#include <wtf/DataLog.h>
 
 static void checkBuiltin(WGSL::AST::Attribute& attr, ASCIILiteral attrName)
 {
@@ -1112,6 +1113,84 @@ TEST(WGSLParserTests, RedFrag)
     EXPECT_TRUE(shader->structures().isEmpty());
     EXPECT_TRUE(shader->variables().isEmpty());
     EXPECT_EQ(shader->functions().size(), 1u);
+}
+
+TEST(WGSLParserTests, GlobalVarWithoutTypeOrInitializer)
+{
+    auto shader = parse("var x;"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "var declaration requires a type or initializer"_s);
+}
+
+TEST(WGSLParserTests, GlobalConstWithoutTypeOrInitializer)
+{
+    auto shader = parse("const x;"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+}
+
+TEST(WGSLParserTests, GlobalConstWithoutInitializer)
+{
+    auto shader = parse("const x: i32;"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+}
+
+TEST(WGSLParserTests, GlobalOverrideWithoutTypeOrInitializer)
+{
+    auto shader = parse("override x;"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "override declaration requires a type or initializer"_s);
+}
+
+TEST(WGSLParserTests, LocalVarWithoutTypeOrInitializer)
+{
+    auto shader = parse(
+        "fn f() {\n"
+        "   var x;\n"
+        "}"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "var declaration requires a type or initializer"_s);
+}
+
+TEST(WGSLParserTests, LocalLetWithoutTypeOrInitializer)
+{
+    auto shader = parse(
+        "fn f() {\n"
+        "   let x;\n"
+        "}"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+}
+
+TEST(WGSLParserTests, LocalLetWithoutInitializer)
+{
+    auto shader = parse(
+        "fn f() {\n"
+        "   let x: i32;\n"
+        "}"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+}
+
+TEST(WGSLParserTests, LocalConstWithoutTypeOrInitializer)
+{
+    auto shader = parse(
+        "fn f() {\n"
+        "   const x;\n"
+        "}"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
+}
+
+TEST(WGSLParserTests, LocalConstWithoutInitializer)
+{
+    auto shader = parse(
+        "fn f() {\n"
+        "   const x: i32;\n"
+        "}"_s);
+    EXPECT_FALSE(shader.has_value());
+    EXPECT_EQ(shader.error().message(), "Expected a =, but got a ;"_s);
 }
 
 }


### PR DESCRIPTION
#### 51cdfa635552c4c3e0fc3c4449af399b790ffc7f
<pre>
[WGSL] Assertion failure when declarations have no type nor initializer
<a href="https://bugs.webkit.org/show_bug.cgi?id=259728">https://bugs.webkit.org/show_bug.cgi?id=259728</a>
rdar://113258649

Reviewed by Dan Glastonbury.

We (correctly) assert that every variable declaration should (at least) have either
a type annotation or an initializer expression. However, that is currently not
handled by the parser, so invalid programs result in an assertion failure. This
patch updates the parser according to the spec:
- const and let: optional type annotation and require an initializer
- override and var: optional type annotation and optional initializer, but at least
  one of the two must be present.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:
(TEST):

Canonical link: <a href="https://commits.webkit.org/266633@main">https://commits.webkit.org/266633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f038ed5d28933b9ae7c3c08946a44a0b78f6f776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15966 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16454 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19662 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16004 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13343 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12618 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->