### PR TITLE
WebGLRenderingContexts should initialize all context state in initializeNewContext()

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -521,7 +521,6 @@ protected:
 
     virtual void initializeNewContext();
     virtual void initializeVertexArrayObjects() = 0;
-    void setupFlags();
 
     // ActiveDOMObject
     void stop() override;
@@ -549,10 +548,6 @@ protected:
     void addActivityStateChangeObserverIfNecessary();
     void removeActivityStateChangeObserver();
 
-    // Query whether it is built on top of compliant GLES2 implementation.
-    bool isGLES2Compliant() { return m_isGLES2Compliant; }
-    // Query if the GL implementation is NPOT strict.
-    bool isGLES2NPOTStrict() { return m_isGLES2NPOTStrict; }
     // Query if depth_stencil buffer is supported.
     bool isDepthStencilSupported() { return m_isDepthStencilSupported; }
 
@@ -717,9 +712,7 @@ protected:
     bool m_rasterizerDiscardEnabled { false };
 
     bool m_isGLES2Compliant;
-    bool m_isGLES2NPOTStrict;
     bool m_isDepthStencilSupported;
-    bool m_isRobustnessEXTSupported;
 
     bool m_synthesizedErrorsToConsole { true };
     int m_numGLErrorsToConsoleAllowed;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1585,8 +1585,6 @@ public:
 
     WEBCORE_EXPORT virtual void setDrawingBufferColorSpace(const DestinationColorSpace&);
 
-    virtual bool isGLES2Compliant() const = 0;
-
     virtual void prepareForDisplay() = 0;
 
     // FIXME: should be removed, caller should keep track of changed state.

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3177,11 +3177,6 @@ void GraphicsContextGLANGLE::simulateEventForTesting(SimulatedEventForTesting ev
     }
 }
 
-bool GraphicsContextGLANGLE::isGLES2Compliant() const
-{
-    return m_isForWebGL2;
-}
-
 void GraphicsContextGLANGLE::paintRenderingResultsToCanvas(ImageBuffer& imageBuffer)
 {
     withDrawingBufferAsNativeImage([&](NativeImage& image) {

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -60,7 +60,6 @@ public:
     static bool releaseThreadResources(ReleaseThreadResourceBehavior);
 
     // GraphicsContextGL overrides.
-    bool isGLES2Compliant() const final;
     void activeTexture(GCGLenum texture) final;
     void attachShader(PlatformGLObject program, PlatformGLObject shader) final;
     void bindAttribLocation(PlatformGLObject, GCGLuint index, const String& name) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -127,11 +127,6 @@ void RemoteGraphicsContextGLProxy::setContextVisibility(bool)
     notImplemented();
 }
 
-bool RemoteGraphicsContextGLProxy::isGLES2Compliant() const
-{
-    return contextAttributes().webGLVersion == GraphicsContextGLWebGLVersion::WebGL2;
-}
-
 void RemoteGraphicsContextGLProxy::markContextChanged()
 {
     // FIXME: The caller should track this state.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -76,7 +76,6 @@ public:
     std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
     void reshape(int width, int height) final;
     void setContextVisibility(bool) final;
-    bool isGLES2Compliant() const final;
     void markContextChanged() final;
     bool supportsExtension(const String&) final;
     void ensureExtensionEnabled(const String&) final;


### PR DESCRIPTION
#### 2aadd417b2ceeb22999ab366a12e1e55815be786
<pre>
WebGLRenderingContexts should initialize all context state in initializeNewContext()
<a href="https://bugs.webkit.org/show_bug.cgi?id=259731">https://bugs.webkit.org/show_bug.cgi?id=259731</a>
rdar://113261547

Reviewed by Dan Glastonbury.

Move initialization of m_maxViewportDims, m_isDepthStencilSupported
to WebGLRenderingContextBase::initializeNewContext(). m_maxViewportDims
was not reinitialized consistently on context restore.

Removes isGLES2Compliant, it corresponds to isForWebGL2 flag.
Removes unused robustness flag query, robustness is always provided by
ANGLE.
Removes unused isGLES2NPOTStrict.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
(WebCore::WebGLRenderingContextBase::checkForContextLossHandling):
(WebCore::WebGLRenderingContextBase::registerWithWebGLStateTracker):
(WebCore::WebGLRenderingContextBase::initializeNewContext):
(WebCore::WebGLRenderingContextBase::setupFlags):
(WebCore::WebGLRenderingContextBase::getActiveUniform):
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
(WebCore::WebGLRenderingContextBase::maybeRestoreContext):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::isGLES2Compliant): Deleted.
(WebCore::WebGLRenderingContextBase::isGLES2NPOTStrict): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::isGLES2Compliant const): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::isGLES2Compliant const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:

Canonical link: <a href="https://commits.webkit.org/266579@main">https://commits.webkit.org/266579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f1ecfcad56d4258956b9118b39b57e4de615a68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16048 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11959 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19746 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16094 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12708 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3437 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->