### PR TITLE
[GStreamer] Rework playback rates handling

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1293,6 +1293,9 @@ media/video-supports-fullscreen.html [ Skip ]
 # Support for VP9 encoded videos with transparency is only available on ports that use GStreamer.
 media/video-with-alpha.html [ Skip ]
 
+# Support to pause with 0 rate playback seems to work only in GStreamer ports
+media/media-source/media-source-play-zero-playbackrate.html [ Skip ]
+
 # accent-color is currently only supported on Cocoa platforms
 fast/css/accent-color/button.html [ ImageOnlyFailure ]
 fast/css/accent-color/checkbox.html [ ImageOnlyFailure ]

--- a/LayoutTests/media/media-source/media-source-play-zero-playbackrate-expected.txt
+++ b/LayoutTests/media/media-source/media-source-play-zero-playbackrate-expected.txt
@@ -1,0 +1,39 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+
+Append all media segments
+
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+RUN(video.pause())
+EXPECTED (video.paused == 'true') OK
+RUN(video.playbackRate = 0)
+EXPECTED (video.playbackRate == '0') OK
+RUN(video.play())
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.currentTime == oldPosition == 'true') OK
+
+RUN(video.playbackRate = 1)
+EXPECTED (video.playbackRate == '1') OK
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.currentTime > oldPosition == 'true') OK
+RUN(video.playbackRate = 0)
+EXPECTED (video.playbackRate == '0') OK
+RUN(video.pause())
+EXPECTED (video.currentTime == oldPosition == 'true') OK
+RUN(video.playbackRate = 1)
+EXPECTED (video.playbackRate == '1') OK
+RUN(video.play())
+EXPECTED (video.currentTime > oldPosition == 'true') OK
+
+RUN(video.currentTime = 5)
+EXPECTED (video.currentTime >= '5') OK
+RUN(video.playbackRate = 0)
+EXPECTED (video.playbackRate == '0') OK
+EXPECTED (video.currentTime == oldPosition == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-play-zero-playbackrate.html
+++ b/LayoutTests/media/media-source/media-source-play-zero-playbackrate.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-play-zero-playbackrate</title>
+    <meta name="timeout" content="long">
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var oldPosition;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('<br>Append all media segments')
+        for (i = 0; i < loader.mediaSegmentsLength(); i++) {
+            sourceBuffer.appendBuffer(loader.mediaSegment(i));
+            await waitFor(sourceBuffer, 'update', true);
+        }
+
+        consoleWrite('<br>RUN(video.play())')
+        await video.play();
+        testExpected('video.paused', false);
+        run('video.pause()');
+        testExpected('video.paused', true);
+        run('video.playbackRate = 0');
+        testExpected('video.playbackRate', 0);
+        consoleWrite('RUN(video.play())')
+        await video.play();
+        testExpected('video.paused', false);
+        // To deal with cached position shaenanigans.
+        await sleepFor(500);
+        oldPosition = video.currentTime;
+        await sleepFor(500);
+        testExpected('video.currentTime == oldPosition', true);
+
+        consoleWrite('')
+        run('video.playbackRate = 1');
+        testExpected('video.playbackRate', 1);
+        testExpected('video.paused', false);
+        await sleepFor(500);
+        testExpected('video.currentTime > oldPosition', true);
+        oldPosition = video.currentTime;
+        run('video.playbackRate = 0');
+        testExpected('video.playbackRate', 0);
+        run('video.pause()');
+        await sleepFor(500);
+        testExpected('video.currentTime == oldPosition', true);
+        run('video.playbackRate = 1');
+        testExpected('video.playbackRate', 1);
+        consoleWrite('RUN(video.play())')
+        await video.play();
+        await sleepFor(500);
+        testExpected('video.currentTime > oldPosition', true);
+
+        consoleWrite('')
+        run('video.currentTime = 5');
+        testExpected('video.currentTime', 5, '>=');
+        await sleepFor(5);
+        run('video.playbackRate = 0');
+        testExpected('video.playbackRate', 0);
+        await sleepFor(500);
+        oldPosition = video.currentTime;
+        await sleepFor(500);
+        testExpected('video.currentTime == oldPosition', true);
+
+        endTest();
+    });
+
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -311,8 +311,13 @@ fast/css/accent-color/text.html [ Pass ]
 
 # Only GStreamer is honoring the CodecDelay field
 webkit.org/b/254222 media/media-source/media-webm-opus-codecdelay.html [ Pass ]
+
 # GStreamer seeks to the wrong frame
 webkit.org/b/261335 media/media-source/media-managedmse-seek.html [ Failure ]
+
+# Support to pause with 0 rate playback seems to work only in GStreamer ports
+media/media-source/media-source-play-zero-playbackrate.html [ Pass ]
+
 # NOTIFICATION_EVENT tests
 http/tests/workers/service/shownotification-allowed-document.html [ Pass ]
 http/tests/workers/service/shownotification-invalid-data.html [ Pass ]

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -255,6 +255,16 @@ protected:
         StreamCollectionChanged = 1 << 7
     };
 
+    enum class PlaybackRatePausedState {
+        ManuallyPaused, // Initialization or user explicitly paused. This takes preference over RatePaused. You don't
+                        // transition from Manually to Rate Paused unless there is a play while rate == 0.
+        RatePaused, // Pipeline was playing and rate was set to zero.
+        ShouldMoveToPlaying, // Pipeline was paused because of zero rate and it should be playing. This is not a
+                             // definitive state, just an operational transition from RatePaused to Playing to keep the
+                             // pipeline state changes contained in updateStates.
+        Playing, // Pipeline is playing and it should be.
+    };
+
     static bool isAvailable();
 
     virtual void durationChanged();
@@ -352,6 +362,7 @@ protected:
     // https://bugs.webkit.org/show_bug.cgi?id=260385
     bool m_isPaused { true };
     float m_playbackRate { 1 };
+    PlaybackRatePausedState m_playbackRatePausedState { PlaybackRatePausedState::ManuallyPaused };
     GstState m_currentState { GST_STATE_NULL };
     GstState m_oldState { GST_STATE_NULL };
     GstState m_requestedState { GST_STATE_VOID_PENDING };
@@ -518,7 +529,6 @@ private:
     GRefPtr<GstElement> m_textSink;
     GUniquePtr<GstStructure> m_mediaLocations;
     int m_mediaLocationCurrentIndex { 0 };
-    bool m_isPlaybackRatePaused { false };
     MediaTime m_timeOfOverlappingSeek;
     // Last playback rate sent through a GStreamer seek.
     float m_lastPlaybackRate { 1 };


### PR DESCRIPTION
#### 86301d12f31fa6659af3ee6fc5c0ac8be73b73a7
<pre>
[GStreamer] Rework playback rates handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=259732">https://bugs.webkit.org/show_bug.cgi?id=259732</a>

Reviewed by Alicia Boya Garcia.

There were some use cases in MSE where playback rate change was not working properly and it was decided that a better
idea would be to do a rework of the playback rate handling in the base class. The idea was to not do playback rate state
changes out of the updateStates functions (both regular and MSE) because calling that function should do what is
expected at any moment. In order to do that, we needed to switch the boolean variable representing if pipeline was
paused because of rate into something more reflecting the different states we could be in. We created a self explanatory
enum class (that also was comments to make it even more clear) and set that state when needed for updateStates to move
the pipeline if needed.

A fly-by fix was to make the paused function to return true when we are also moving to paused during an async state
change because the test we are introducing here arose this flaky bug more clearly. The bug was that the media element
went bananas could not realize the player was paused (or on its way to pause) and it was skipping state changes and
playback rate changes.

* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-source-play-zero-playbackrate-expected.txt: Added.
* LayoutTests/media/media-source/media-source-play-zero-playbackrate.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::play):
(WebCore::MediaPlayerPrivateGStreamer::pause):
(WebCore::MediaPlayerPrivateGStreamer::paused const):
(WebCore::MediaPlayerPrivateGStreamer::updatePlaybackRate):
(WebCore::MediaPlayerPrivateGStreamer::setRate):
(WebCore::MediaPlayerPrivateGStreamer::updateStates):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::play):
(WebCore::MediaPlayerPrivateGStreamerMSE::pause):
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):

Canonical link: <a href="https://commits.webkit.org/268518@main">https://commits.webkit.org/268518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2395fc61ea58123ca662dfceb82d1da6b2f93e9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/19934 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/20981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/21830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20511 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22684 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18141 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/24409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18374 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18317 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/22397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/18904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/16031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18075 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/17977 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4767 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22424 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/18728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->