### PR TITLE
[CSS] Serialize invalid selectors inside <forgiving-selector-list>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6265,8 +6265,6 @@ imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noop
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_parent [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_top [ Skip ]
 
-imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html [ ImageOnlyFailure ]
-
 # Needs non-zero line gap in 'Arial'
 fast/text/text-box-edge-no-half-leading-simple.html [ Skip ]
 fast/text/text-box-edge-no-half-leading-with-line-height-simple.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -10,5 +10,5 @@ PASS Simple CSSOM manipulation of subrules 7
 PASS Simple CSSOM manipulation of subrules 8
 PASS Simple CSSOM manipulation of subrules 9
 PASS Simple CSSOM manipulation of subrules 10
-FAIL Simple CSSOM manipulation of subrules 11 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
+PASS Simple CSSOM manipulation of subrules 11
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html
@@ -15,4 +15,5 @@
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html
@@ -15,4 +15,5 @@
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html
@@ -17,6 +17,12 @@
     }
   }
 
+  .does-not-exist {
+    :is(.test-2, :unknown(div,&)) {
+      background-color: green;
+    }
+  }
+
   body * + * {
     margin-top: 8px;
   }
@@ -24,4 +30,5 @@
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
   <div class="test test-1"></div>
+  <div class="test test-2"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html
@@ -28,12 +28,12 @@
   test_valid_selector("::slotted(:not(.a))");
 
   test_valid_selector("::slotted(*):is()");
-  test_valid_selector("::slotted(*):is(:hover)", "::slotted(*):is()");
-  test_valid_selector("::slotted(*):is(#id)", "::slotted(*):is()");
+  test_valid_selector("::slotted(*):is(:hover)");
+  test_valid_selector("::slotted(*):is(#id)");
 
   test_valid_selector("::slotted(*):where()");
-  test_valid_selector("::slotted(*):where(:hover)", "::slotted(*):where()");
-  test_valid_selector("::slotted(*):where(#id)", "::slotted(*):where()");
+  test_valid_selector("::slotted(*):where(:hover)");
+  test_valid_selector("::slotted(*):where(#id)");
 
   // Allow tree-abiding pseudo elements after ::slotted
   test_valid_selector("::slotted(*)::before");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-error-recovery.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-error-recovery.html
@@ -23,18 +23,12 @@
         "random-selector",
         "Should've parsed",
       );
-      assert_not_equals(
-        rule.selectorText,
-        invalidSelector,
-        "Should not be considered valid and parsed as-is",
-      );
-      let emptyList = `:${pseudo}()`;
       assert_equals(
         rule.selectorText,
-        emptyList,
-        "Should be serialized as an empty selector-list",
+        invalidSelector,
+        "Should be parsed as-is (but not be considered valid)",
       );
-      assert_equals(document.querySelector(emptyList), null, "Should never match, but should parse");
+      assert_equals(document.querySelector(rule.selectorText), null, "Should never match, but should parse");
       for (let mixedList of [
         `:${pseudo}(:total-nonsense, #test-div)`,
         `:${pseudo}(:total-nonsense and-more-stuff, #test-div)`,
@@ -43,8 +37,8 @@
         rule.selectorText = mixedList;
         assert_equals(
           rule.selectorText,
-          `:${pseudo}(#test-div)`,
-          `${mixedList}: Should ignore invalid selectors`,
+          mixedList,
+          `${mixedList}: Should parse invalid selectors`,
         );
         let testDiv = document.getElementById("test-div");
         assert_equals(document.querySelector(mixedList), testDiv, "Should correctly match");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-parsing.html
@@ -10,7 +10,7 @@
 </style>
 <script>
   let rule = document.getElementById("test-sheet").sheet.cssRules[0];
-  function assert_valid(expected_valid, pattern, expected_pattern, description) {
+  function assert_valid(expected_parseable, pattern, expected_pattern, description) {
     test(function() {
       for (let pseudo of ["is", "where"]) {
         let selector = pattern.replace("{}", ":" + pseudo);
@@ -19,7 +19,7 @@
           expected_selector = expected_pattern.replace("{}", ":" + pseudo);
         rule.selectorText = "random-selector";
         rule.selectorText = selector;
-        (expected_valid ? assert_equals : assert_not_equals)(
+        (expected_parseable ? assert_equals : assert_not_equals)(
           rule.selectorText,
           expected_selector,
           `${description}: ${selector}`
@@ -42,7 +42,8 @@
   assert_valid(true, "{}(:hover, :active)", null, "Pseudo-classes inside");
   assert_valid(true, "{}(div):hover", null, "Pseudo-classes after");
   assert_valid(true, "{}(div)::before", null, "Pseudo-elements after");
-  assert_valid(false, "{}(::before)", null, "Pseudo-elements inside");
+  // Should ask clarification from CSSWG
+  assert_valid(true, "{}(::before)", null, "Pseudo-elements inside");
 
   assert_valid(true, "{}(div) + bar", null, "Combinators after");
   assert_valid(true, "::part(foo):is(:hover)", null, "After part with simple pseudo-class");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html
@@ -8,6 +8,6 @@
 <script src="/css/support/parsing-testcommon.js"></script>
 <script>
   test_invalid_selector('.a:has(.b:has(.c))');
-  test_valid_selector('.a:has(:is(.b:has(.c)))', '.a:has(:is())');
-  test_valid_selector('.a:has(:is(.b:has(.c), .d))', '.a:has(:is(.d))');
+  test_valid_selector('.a:has(:is(.b:has(.c)))');
+  test_valid_selector('.a:has(:is(.b:has(.c), .d))');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html
@@ -37,5 +37,5 @@
   test_invalid_selector(':has()');
   test_invalid_selector(':has(123)');
   test_invalid_selector(':has(.a, 123)');
-  test_valid_selector(':has(:is(.a, 123))', ':has(:is(.a))');
+  test_valid_selector(':has(:is(.a, 123))');
 </script>

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -83,7 +83,9 @@ struct PossiblyQuotedIdentifier {
             Begin, // css3: E[foo^="bar"]
             End, // css3: E[foo$="bar"]
             PagePseudoClass,
-            NestingParent // &
+            NestingParent, // &
+            ForgivingUnknown,
+            ForgivingUnknownNestContaining
         };
 
         enum class RelationType : uint8_t {
@@ -325,8 +327,9 @@ struct PossiblyQuotedIdentifier {
 
     private:
         unsigned m_relation : 4 { static_cast<unsigned>(RelationType::DescendantSpace) }; // enum RelationType.
-        mutable unsigned m_match : 4 { static_cast<unsigned>(Match::Unknown) }; // enum Match.
+        mutable unsigned m_match : 5 { static_cast<unsigned>(Match::Unknown) }; // enum Match.
         mutable unsigned m_pseudoType : 8 { 0 }; // PseudoType.
+        // 17 bits
         unsigned m_isLastInSelectorList : 1 { false };
         unsigned m_isFirstInTagHistory : 1 { true };
         unsigned m_isLastInTagHistory : 1 { true };
@@ -334,6 +337,7 @@ struct PossiblyQuotedIdentifier {
         unsigned m_isForPage : 1 { false };
         unsigned m_tagIsForNamespaceRule : 1 { false };
         unsigned m_caseInsensitiveAttributeValueMatching : 1 { false };
+        // 24 bits
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
         unsigned m_destructorHasBeenCalled : 1 { false };
 #endif

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -629,6 +629,8 @@ static bool canMatchHoverOrActiveInQuirksMode(const SelectorChecker::LocalContex
             return true;
         case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::Unknown:
+        case CSSSelector::Match::ForgivingUnknown:
+        case CSSSelector::Match::ForgivingUnknownNestContaining:
             ASSERT_NOT_REACHED();
             break;
         }
@@ -694,6 +696,14 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             caseSensitive = false;
 
         return anyAttributeMatches(element, selector, attr, caseSensitive);
+    }
+
+    if (selector.match() == CSSSelector::Match::ForgivingUnknown || selector.match() == CSSSelector::Match::ForgivingUnknownNestContaining)
+        return false;
+
+    if (selector.match() == CSSSelector::Match::NestingParent) {
+        ASSERT_NOT_REACHED();
+        return false;
     }
 
     if (selector.match() == CSSSelector::Match::PseudoClass) {

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -111,7 +111,10 @@ private:
     const CSSSelectorParserContext m_context;
     const RefPtr<StyleSheetContents> m_styleSheet;
     CSSParserEnum::IsNestedContext m_isNestedContext { CSSParserEnum::IsNestedContext::No };
+
+    // FIXME: This m_failedParsing is ugly and confusing, we should look into removing it (the return value of each function already convey this information).
     bool m_failedParsing { false };
+
     bool m_disallowPseudoElements { false };
     bool m_disallowHasPseudoClass { false };
     bool m_resistDefaultNamespace { false };

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1545,6 +1545,9 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
         case CSSSelector::Match::Unknown:
             ASSERT_NOT_REACHED();
             return FunctionType::CannotMatchAnything;
+        case CSSSelector::Match::ForgivingUnknown:
+        case CSSSelector::Match::ForgivingUnknownNestContaining:
+            return FunctionType::CannotMatchAnything;
         }
 
         auto relation = selector->relation();

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -215,6 +215,8 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             }
             break;
         case CSSSelector::Match::Unknown:
+        case CSSSelector::Match::ForgivingUnknown:
+        case CSSSelector::Match::ForgivingUnknownNestContaining:
         case CSSSelector::Match::NestingParent:
         case CSSSelector::Match::PagePseudoClass:
             break;

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -227,7 +227,6 @@ void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
         return;
 
     auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.originalSelectorList(), parentResolvedSelectorList);
-    ASSERT(!resolvedSelectorList.hasExplicitNestingParent());
     rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));    
 }
 


### PR DESCRIPTION
#### 7f6950788ad1839fe563ce11c29b6b396d74bdac
<pre>
[CSS] Serialize invalid selectors inside &lt;forgiving-selector-list&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=258688">https://bugs.webkit.org/show_bug.cgi?id=258688</a>
rdar://111861948

Reviewed by Antti Koivisto and Darin Adler.

For the serialization round-trip to work with the presence of invalid
selectors containing a nesting selector, the spec mandates that
invalid selectors inside forgiving selector list (such as :is(..) or :where(...))
should be kept in serialization (and be considered when deciding whether a selector
is &quot;nest-containing&quot; or not).

<a href="https://github.com/w3c/csswg-drafts/issues/8356#issuecomment-1642840607">https://github.com/w3c/csswg-drafts/issues/8356#issuecomment-1642840607</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nest-containing-forgiving.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-error-recovery.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/is-where-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has-disallow-nesting-has-inside-has.html:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/parsing/parse-has.html:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::simpleSelectorSpecificity):
(WebCore::CSSSelector::selectorText const):
(WebCore::CSSSelector::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::canMatchHoverOrActiveInQuirksMode):
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeForgivingSelectorList):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):

Canonical link: <a href="https://commits.webkit.org/266762@main">https://commits.webkit.org/266762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/076c1a1efe0dca88e343c36b1934c0624f919c34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13878 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15123 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16525 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17200 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13442 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16685 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13986 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17623 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->