### PR TITLE
[ macOS Debug WK2 ] ASSERT call in RenderVTTCue.cpp causing flaky crash (media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html)

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1826,8 +1826,6 @@ webkit.org/b/259496 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/tempora
 
 webkit.org/b/238033 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-050.html [ Pass Failure ]
 
-webkit.org/b/259544 [ Debug ] media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html [ Pass Crash ]
-
 webkit.org/b/259183 fast/attachment/mac/wide-attachment-image-controls-basic.html [ Pass Failure ]
 
 webkit.org/b/259699 media/media-source/media-source-duplicate-seeked.html [ Pass Failure ]

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -346,7 +346,6 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
     if (!initializeLayoutParameters(step, position))
         return;
 
-    ASSERT(firstChild());
     if (!firstChild())
         return;
 
@@ -377,7 +376,6 @@ void RenderVTTCue::repositionCueSnapToLinesSet()
 
 void RenderVTTCue::repositionGenericCue()
 {
-    ASSERT(firstChild());
     if (!firstChild())
         return;
 


### PR DESCRIPTION
#### 83a6562ec0c7855fbbeb1f50ea2f16034c504317
<pre>
[ macOS Debug WK2 ] ASSERT call in RenderVTTCue.cpp causing flaky crash (media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html)
<a href="https://bugs.webkit.org/show_bug.cgi?id=259544">https://bugs.webkit.org/show_bug.cgi?id=259544</a>
rdar://112951082

Reviewed by Jer Noble.

Remove two unneeded asserts. Both checked a condition that is commonly encountered and which
is not dangerous or harmful.

* LayoutTests/platform/mac-wk2/TestExpectations: Unskip test.

* Source/WebCore/rendering/RenderVTTCue.cpp:
(WebCore::RenderVTTCue::repositionCueSnapToLinesSet): Remove assert.
(WebCore::RenderVTTCue::repositionGenericCue): Ditto.

Canonical link: <a href="https://commits.webkit.org/266513@main">https://commits.webkit.org/266513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93be53a1135ce8b8ffbbb64b8ca329b6fcbe937

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16467 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12642 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19673 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13142 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16017 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12630 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3396 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->