### PR TITLE
SVG font for some SVG tests is missing.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/resources/SVGFreeSans.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/resources/SVGFreeSans.svg
@@ -1,0 +1,517 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<font horiz-adv-x="481" id="ascii">
+  <font-face font-family="SVGFreeSansASCII" units-per-em="1000" panose-1="2 11 5 4 2 2 2 2 2 4" ascent="800" descent="-200" alphabetic="0"/>
+<missing-glyph horiz-adv-x="432" d="M33 0V666H366V0H33ZM66 33H333V633H66V33Z"/>
+<glyph unicode=" " glyph-name="space" horiz-adv-x="278"/>
+<glyph unicode=" " glyph-name="nbsp" horiz-adv-x="278"/>
+<glyph unicode="!" glyph-name="exclam" horiz-adv-x="278" d="M208 729V391L186 168H147L125 391V729H208ZM208 104V0H124V104H208Z"/>
+<glyph unicode="&quot;" glyph-name="quotedbl" horiz-adv-x="355" d="M52 709H145V598L118 464H79L52 598V709ZM212 709H305V598L278 464H239L212 598V709Z"/>
+<glyph unicode="#" glyph-name="numbersign" horiz-adv-x="556" d="M485 697L449 501H542V433H436L405 259H510V191H393L354 -20H278L316 191H192L153 -20H77L115 191H14V259H128L159 433H51V501H172L208 697H284L248 501H373L408 697H485ZM360 433H236L204 259H329L360 433Z"/>
+<glyph unicode="$" glyph-name="dollar" horiz-adv-x="556" d="M243 770H302V716Q427 707 474 615Q496 574 496 520V519H417Q416 596 359 630Q339 641 315 645L302 646V397Q402 366 431 350L433 349Q517 301 518 196V195Q518 91 450 30L426 12Q377 -17 302 -23V-126H243V-23Q89 -13 46 104Q30 150 33 208H112Q119 134 133 110L137 103Q172 55 243 46V318Q150 346 117 370Q46 421 46 515V516Q46 662 186 704Q212 712 243 716V770ZM243 405V645Q147 632 130 556L127 526Q127 436 243 405ZM302 309V46Q363 53 394 83Q436 123 436 182V183Q436 244 389 274Q360 292 302 309Z"/>
+<glyph unicode="%" glyph-name="percent" horiz-adv-x="889" d="M199 685Q283 685 334 619H335Q370 573 370 513V512Q370 433 307 382Q260 343 200 343Q119 343 67 406Q29 453 29 513V514Q29 595 92 647Q139 685 199 685ZM199 615Q145 615 115 569H114Q98 544 98 515V514Q98 461 143 430Q169 413 200 413Q254 413 284 458Q301 483 301 512V513Q301 570 253 600Q229 615 199 615ZM609 709H675L280 -20H214L609 709ZM688 322Q773 322 824 256Q859 210 859 151V150Q859 71 796 20Q749 -19 689 -19Q608 -19 556 44Q518 91 518 151V152Q518 233 582 284Q629 322 688 322ZM688 252Q634 252 604 207Q587 182 587 153V152Q587 97 634 67H635V66Q636 66 636 66Q636 65 637 65Q661 51 689 51Q743 51 773 96Q790 120 790 149V150Q790 207 742 237V237L741 238Q724 248 704 251Q700 251 695 252Q693 252 690 252H688Z"/>
+<glyph unicode="&amp;" glyph-name="ampersand" horiz-adv-x="667" d="M493 334H573Q573 240 515 151L637 0H528L466 78Q417 30 389 13Q333 -23 257 -23Q141 -23 85 59Q52 108 52 175V176Q52 257 104 310Q140 346 214 389Q144 477 135 525V525Q135 527 135 530Q134 532 134 535L133 552Q133 628 197 675Q244 709 304 709Q394 709 440 643V642Q467 604 467 553V552Q467 483 412 434Q383 409 330 379L329 378L462 215Q495 272 493 334ZM285 431Q366 482 381 519Q388 534 388 553V554Q388 606 343 629Q324 639 301 639Q241 639 221 589Q215 573 215 554V553Q215 520 240 485L241 484V484L242 483L243 482V482L285 431ZM418 137L258 337Q164 277 144 227Q136 207 136 184V183Q136 118 190 80Q225 55 267 55Q334 55 402 120Q409 127 416 135Q417 135 417 136L418 137Z"/>
+<glyph unicode="'" glyph-name="quotesingle" horiz-adv-x="191" d="M48 709H142V598L115 464H75L48 598V709Z"/>
+<glyph unicode="(" glyph-name="parenleft" horiz-adv-x="333" d="M236 729H291Q167 529 155 300L154 259Q154 26 276 -187Q283 -200 291 -212H236Q123 -64 86 128Q73 196 73 258V259Q73 438 166 617Q197 678 236 729Z"/>
+<glyph unicode=")" glyph-name="parenright" horiz-adv-x="333" d="M93 -212H38Q162 -12 174 217Q175 258 175 258Q175 491 53 704L38 729H93Q206 581 243 389Q256 321 256 259V258Q256 79 163 -100Q132 -161 93 -212Z"/>
+<glyph unicode="*" glyph-name="asterisk" horiz-adv-x="389" d="M160 729H223L218 617L324 655L343 596L235 566L305 477L254 441L192 534L129 441L79 477L148 566L40 596L59 655L165 617L160 729Z"/>
+<glyph unicode="+" glyph-name="plus" horiz-adv-x="584" d="M534 267V197H327V-10H257V197H50V267H257V474H327V267H534Z"/>
+<glyph unicode="," glyph-name="comma" horiz-adv-x="278" d="M87 104H192V-16Q192 -147 87 -147V-109Q130 -107 140 -76Q147 -58 147 -19V-18V0H87V104Z"/>
+<glyph unicode="-" glyph-name="hyphen" horiz-adv-x="333" d="M284 312V240H46V312H284Z"/>
+<glyph unicode="." glyph-name="period" horiz-adv-x="278" d="M191 104V0H87V104H191Z"/>
+<glyph unicode="/" glyph-name="slash" horiz-adv-x="278" d="M229 729H284L47 -20H-8L229 729Z"/>
+<glyph unicode="0" glyph-name="zero" horiz-adv-x="556" d="M275 709Q378 709 436 634Q437 632 438 631Q507 537 507 338V337Q507 66 369 -3Q327 -23 275 -23Q99 -23 56 193Q43 258 43 342V343Q43 538 112 631Q166 702 261 709Q268 709 275 709ZM275 631Q133 631 133 344Q133 344 133 344V342Q133 50 273 50Q391 50 412 242Q417 287 417 344V345Q417 631 275 631Z"/>
+<glyph unicode="1" glyph-name="one" horiz-adv-x="556" d="M259 505H102V568Q204 581 234 604H235Q245 611 252 621Q271 645 289 709H347V0H259V505Z"/>
+<glyph unicode="2" glyph-name="two" horiz-adv-x="556" d="M506 87V0H34Q41 128 91 195Q133 250 233 307L325 359Q420 413 421 498V499Q421 571 361 610Q326 632 282 632H281Q206 632 166 575Q163 571 161 566L159 563Q142 531 138 463H50Q53 563 88 617Q148 709 284 709Q383 709 445 653Q511 594 511 502V501Q511 369 361 287L261 233Q170 180 146 131Q137 111 133 87H506Z"/>
+<glyph unicode="3" glyph-name="three" horiz-adv-x="556" d="M221 325V400Q305 401 338 415Q394 438 395 509V511Q395 596 325 623Q301 632 270 632Q192 632 157 579L156 578L151 569Q136 540 135 480H47Q51 690 237 708L269 709Q408 709 460 616Q485 573 485 515V514Q485 406 386 367Q479 335 499 259Q506 233 506 199V198Q506 75 412 15Q352 -23 266 -23Q118 -23 64 79L63 80Q37 128 32 206H120Q128 74 233 58Q250 55 269 55Q373 55 405 134Q416 161 416 196V197Q416 326 269 326L232 325H221Z"/>
+<glyph unicode="4" glyph-name="four" horiz-adv-x="556" d="M327 170H28V263L350 709H415V249H520V170H415V0H327V170ZM327 249V559L105 249H327Z"/>
+<glyph unicode="5" glyph-name="five" horiz-adv-x="556" d="M476 709V622H181L153 424Q212 467 284 467Q404 467 468 380Q513 319 513 232V231Q513 102 426 30Q362 -23 270 -23Q159 -23 94 44L78 62Q51 95 35 172V174H123Q154 55 268 55Q369 55 407 136Q423 171 423 218V219Q423 328 347 370Q313 389 268 389Q204 389 159 346L138 323H57L110 709H476Z"/>
+<glyph unicode="6" glyph-name="six" horiz-adv-x="556" d="M498 524H410Q392 611 321 628Q307 631 291 631Q180 631 146 487Q133 433 133 362Q191 441 296 441Q407 441 469 358Q513 299 513 217V216Q513 97 431 29Q369 -23 281 -23Q162 -23 103 65Q45 153 43 312Q43 317 43 322V323Q43 508 107 608Q163 692 263 707Q280 709 297 709Q412 709 467 616Q490 577 498 525V524ZM285 363Q200 363 160 297Q138 262 138 215V214Q138 128 199 82Q235 55 282 55Q358 55 398 118Q423 157 423 208V209Q423 311 352 348Q323 363 285 363Z"/>
+<glyph unicode="7" glyph-name="seven" horiz-adv-x="556" d="M520 709V635Q318 367 252 96Q240 49 232 0H138Q188 218 281 389Q336 490 429 622H46V709H520Z"/>
+<glyph unicode="8" glyph-name="eight" horiz-adv-x="556" d="M391 373Q512 315 513 197V196Q513 84 427 23Q364 -23 275 -23Q151 -23 84 59Q37 116 37 196V197Q37 315 158 373Q86 418 70 466Q62 488 62 519V520Q62 619 143 672Q198 709 275 709Q391 709 450 633Q488 586 488 521V520Q488 452 443 411Q443 410 442 410Q423 392 391 373ZM275 631Q195 631 165 573L164 572V572Q152 549 152 520V519Q152 449 213 421Q240 408 274 408H275Q355 408 385 465Q386 465 386 466Q398 488 398 516V517V518Q398 593 333 620Q308 631 275 631ZM275 334Q186 334 147 270Q127 238 127 196V195Q127 113 193 75Q227 55 273 55Q364 55 403 120Q423 152 423 194V195Q423 277 356 315Q321 334 275 334Z"/>
+<glyph unicode="9" glyph-name="nine" horiz-adv-x="556" d="M53 162H141Q159 75 230 58Q244 55 260 55Q371 55 405 199Q418 253 418 324Q354 247 262 245H256Q144 245 82 328Q38 387 38 469V470Q38 589 120 657Q182 709 270 709Q389 709 449 621Q507 533 509 374Q509 369 509 364V363Q509 178 444 78Q391 -3 294 -20L254 -23Q139 -23 84 70Q61 110 53 162ZM269 632Q193 632 153 568L152 567Q128 529 128 478V477Q128 375 199 338Q228 323 266 323Q349 323 390 388Q413 424 413 471V472Q413 559 352 605Q315 632 269 632Z"/>
+<glyph unicode=":" glyph-name="colon" horiz-adv-x="278" d="M214 104V0H110V104H214ZM214 524V420H110V524H214Z"/>
+<glyph unicode=";" glyph-name="semicolon" horiz-adv-x="278" d="M215 524V420H111V524H215ZM110 104H215V-16Q215 -147 110 -147V-109Q153 -107 163 -76Q170 -58 170 -19V-18V0H110V104Z"/>
+<glyph unicode="&lt;" glyph-name="less" horiz-adv-x="584" d="M45 198V267L534 474V395L140 234L534 70V-9L45 198Z"/>
+<glyph unicode="=" glyph-name="equal" horiz-adv-x="584" d="M534 353V283H50V353H534ZM534 181V111H50V181H534Z"/>
+<glyph unicode="&gt;" glyph-name="greater" horiz-adv-x="584" d="M539 267V198L50 -9V70L444 231L50 395V474L539 267Z"/>
+<glyph unicode="?" glyph-name="question" horiz-adv-x="556" d="M330 199H240V254Q240 304 268 341Q285 363 320 396L322 397L344 417Q418 483 419 547Q419 547 419 547Q419 547 419 548V549Q419 619 358 649H357Q328 663 291 663Q209 663 179 605Q162 571 162 508V507H77Q77 718 257 739L296 741Q422 741 478 658L479 657V657V656Q509 611 509 550V549Q509 479 458 420Q439 397 409 370Q346 312 336 285Q330 270 330 247V246V199ZM330 104V0H240V104H330Z"/>
+<glyph unicode="@" glyph-name="at" horiz-adv-x="1015" d="M665 501H748L658 221Q646 187 646 172V171Q646 144 675 131H676Q685 127 696 127Q760 127 813 199Q864 270 864 356V357Q864 477 767 566Q668 658 528 664H512Q365 664 252 562L221 531Q119 418 119 274V273Q119 132 224 35Q332 -65 493 -65H494Q573 -65 687 -33L715 -100Q603 -142 489 -142Q309 -142 178 -35Q56 65 37 212Q34 258 34 258Q34 412 129 542Q141 558 154 573Q155 574 156 575Q157 576 158 577Q172 593 188 608L192 612Q300 710 451 735Q488 741 525 741Q691 741 814 640Q930 546 948 411Q951 390 951 370V369Q951 248 867 149Q866 147 865 146Q789 57 679 57Q583 57 569 134Q503 62 428 62H427Q345 62 298 131Q264 179 264 244V245Q264 354 343 438Q420 521 519 522H521Q604 522 642 436L643 435L665 501ZM515 458Q449 458 399 387Q354 324 354 245V244Q354 177 401 143H402Q425 126 452 126H453Q511 126 555 191Q588 239 604 323L609 362Q612 417 566 444Q543 458 515 458Z"/>
+<glyph unicode="A" glyph-name="A" horiz-adv-x="667" d="M474 219H193L116 0H17L277 729H397L653 0H549L474 219ZM448 297L336 629L216 297H448Z"/>
+<glyph unicode="B" glyph-name="B" horiz-adv-x="667" d="M79 0V729H375Q478 729 533 678Q591 627 591 545V544Q591 432 490 385Q595 344 616 264Q622 244 623 221Q623 215 623 209V208Q623 120 567 61Q511 0 409 0H408H79ZM172 415H352Q424 415 458 441Q498 471 498 530V531Q498 590 458 621Q424 647 352 647H172V415ZM172 82H399Q463 82 495 116L496 117Q530 152 530 206V207Q530 262 496 298Q464 333 399 333H172V82Z"/>
+<glyph unicode="C" glyph-name="C" horiz-adv-x="722" d="M662 503H567Q552 578 514 613Q467 657 377 659H370Q242 659 181 544Q141 469 141 358V357Q141 187 236 108Q295 59 378 59Q487 59 538 136Q544 144 548 153Q570 195 581 266H677Q644 -23 377 -23Q236 -23 154 62Q48 171 48 355V356Q48 539 150 650Q232 741 380 741H381Q619 741 662 503Z"/>
+<glyph unicode="D" glyph-name="D" horiz-adv-x="722" d="M89 0V729H370Q533 729 612 597Q613 596 613 595Q667 504 667 366V365Q667 156 551 61Q478 0 370 0H89ZM182 82H354Q528 82 565 263Q574 308 574 363V364Q574 610 406 642Q381 647 354 647H182V82Z"/>
+<glyph unicode="E" glyph-name="E" horiz-adv-x="667" d="M183 332V82H613V0H90V729H595V647H183V414H580V332H183Z"/>
+<glyph unicode="F" glyph-name="F" horiz-adv-x="611" d="M183 332V0H90V729H579V647H183V414H531V332H183Z"/>
+<glyph unicode="G" glyph-name="G" horiz-adv-x="778" d="M709 385V-4H650L627 93Q523 -23 379 -23H378Q225 -23 131 91Q44 195 44 356V357Q44 533 146 643Q160 658 176 671Q261 741 393 741H394Q573 741 654 623Q687 574 699 508H604Q583 606 488 642Q446 659 393 659Q261 659 190 555Q137 477 137 363V362Q137 236 198 152L214 133Q280 61 392 59Q395 59 398 59Q512 59 578 139Q627 199 627 282V283V303H405V385H709Z"/>
+<glyph unicode="H" glyph-name="H" horiz-adv-x="722" d="M551 332H177V0H83V729H176V414H551V729H644V0H551V332Z"/>
+<glyph unicode="I" glyph-name="I" horiz-adv-x="278" d="M194 729V0H100V729H194Z"/>
+<glyph unicode="J" glyph-name="J" horiz-adv-x="500" d="M333 729H426V182Q426 58 336 5Q287 -23 220 -23Q96 -23 44 63Q17 108 17 169V170V234H112V187Q112 76 193 58L221 55Q279 55 309 98L310 100Q333 134 333 215V216V729Z"/>
+<glyph unicode="K" glyph-name="K" horiz-adv-x="667" d="M172 255V0H79V729H172V360L535 729H655L358 432L658 0H548L291 374L172 255Z"/>
+<glyph unicode="L" glyph-name="L" horiz-adv-x="556" d="M173 729V82H533V0H80V729H173Z"/>
+<glyph unicode="M" glyph-name="M" horiz-adv-x="833" d="M468 0H370L163 611V0H75V729H204L420 94L632 729H761V0H673V611L468 0Z"/>
+<glyph unicode="N" glyph-name="N" horiz-adv-x="722" d="M646 729V0H541L164 591V0H76V729H177L558 133V729H646Z"/>
+<glyph unicode="O" glyph-name="O" horiz-adv-x="778" d="M389 741Q563 741 660 618L661 617Q662 616 663 615Q723 536 738 422Q742 389 742 354V353Q742 205 660 100Q640 74 616 54Q525 -23 390 -23Q223 -23 125 94Q38 198 38 358V359Q38 543 149 650Q244 741 389 741ZM389 659Q259 659 187 557Q131 478 131 360V359Q131 201 226 118Q293 59 390 59Q519 59 591 159Q649 237 649 354V355Q649 520 551 603Q485 659 389 659Z"/>
+<glyph unicode="P" glyph-name="P" horiz-adv-x="667" d="M184 309V0H91V729H392Q553 729 600 611Q617 570 617 516V515Q617 418 554 361Q496 309 414 309H413H184ZM184 391H378Q480 391 510 465Q520 488 520 518V519Q520 609 441 637Q441 637 440 637Q413 647 378 647H184V391Z"/>
+<glyph unicode="Q" glyph-name="Q" horiz-adv-x="778" d="M733 -1L686 -59L581 28Q495 -23 390 -23Q223 -23 125 94Q38 198 38 358V359Q38 543 149 650Q245 741 390 741Q556 741 654 625Q742 522 742 362V361Q742 189 639 76L733 -1ZM481 205L570 132Q649 221 649 359V360Q649 517 555 600Q487 659 390 659Q259 659 187 557Q131 478 131 360V359Q131 200 226 117Q293 59 389 59Q449 59 509 87L435 149L481 205Z"/>
+<glyph unicode="R" glyph-name="R" horiz-adv-x="722" d="M186 314V0H93V729H429Q599 729 640 609Q651 576 651 535V534Q651 436 579 385Q560 372 536 360Q598 333 617 293Q634 256 635 170Q637 74 654 47Q663 34 679 23V0H566Q545 48 545 118V119L546 184Q546 293 466 310Q448 314 426 314H186ZM186 396H411Q532 396 550 482Q554 499 554 520V521Q554 587 516 619Q484 647 411 647H186V396Z"/>
+<glyph unicode="S" glyph-name="S" horiz-adv-x="667" d="M596 515H508Q507 626 398 655Q366 663 326 663Q222 663 181 601V601Q163 574 163 541V540Q163 484 217 456Q242 443 283 432L466 383Q586 350 614 253Q621 228 621 201V200Q621 116 563 53L541 33Q468 -23 336 -23Q167 -23 91 81Q49 138 48 232H136Q135 167 174 120Q225 59 342 59Q431 59 476 90Q520 121 527 176L528 191Q528 267 418 302Q407 306 395 309H394L213 357Q71 394 70 525V527Q70 651 174 707Q238 741 329 741Q505 741 568 630Q596 581 596 515Z"/>
+<glyph unicode="T" glyph-name="T" horiz-adv-x="611" d="M354 647V0H261V647H21V729H593V647H354Z"/>
+<glyph unicode="U" glyph-name="U" horiz-adv-x="722" d="M552 729H645V217Q645 87 541 22Q469 -23 364 -23Q199 -23 126 78Q86 135 85 215Q85 217 85 217V729H178V217Q178 138 231 97Q284 59 364 59Q487 59 532 138Q551 171 552 215Q552 215 552 216V217V729Z"/>
+<glyph unicode="V" glyph-name="V" horiz-adv-x="667" d="M392 0H292L30 729H130L344 112L546 729H645L392 0Z"/>
+<glyph unicode="W" glyph-name="W" horiz-adv-x="944" d="M744 0H642L474 599L311 0H209L22 729H126L263 137L425 729H525L691 137L825 729H929L744 0Z"/>
+<glyph unicode="X" glyph-name="X" horiz-adv-x="667" d="M391 374L649 0H534L335 304L135 0H22L280 374L38 729H151L338 443L526 729H637L391 374Z"/>
+<glyph unicode="Y" glyph-name="Y" horiz-adv-x="667" d="M387 286V0H294V286L13 729H128L342 374L550 729H661L387 286Z"/>
+<glyph unicode="Z" glyph-name="Z" horiz-adv-x="611" d="M581 729V645L145 82H583V0H28V82L466 647H56V729H581Z"/>
+<glyph unicode="[" glyph-name="bracketleft" horiz-adv-x="278" d="M250 729V657H147V-140H250V-212H64V729H250Z"/>
+<glyph unicode="\" glyph-name="backslash" horiz-adv-x="278" d="M47 729L284 -20H229L-8 729H47Z"/>
+<glyph unicode="]" glyph-name="bracketright" horiz-adv-x="278" d="M23 -212V-140H126V657H23V729H209V-212H23Z"/>
+<glyph unicode="^" glyph-name="asciicircum" horiz-adv-x="469" d="M197 709H270L425 329H356L234 629L113 329H44L197 709Z"/>
+<glyph unicode="_" glyph-name="underscore" horiz-adv-x="556" d="M578 -126V-176H-22V-126H578Z"/>
+<glyph unicode="`" glyph-name="grave" horiz-adv-x="333" d="M135 740L231 592H171L22 740H135Z"/>
+<glyph unicode="a" glyph-name="a" horiz-adv-x="556" d="M535 49V-14Q500 -23 478 -23Q407 -23 394 40Q393 47 392 54Q309 -22 218 -23H214Q104 -23 61 52Q42 86 42 131V132Q42 234 134 272Q170 287 264 299L302 304Q375 313 386 342V343V344L389 362V384Q389 448 308 460Q291 462 272 462Q169 462 152 387Q150 378 149 369H65Q68 441 101 478Q156 539 275 539Q451 539 470 423Q472 411 472 397V396V88Q472 47 517 47L535 49ZM389 165V259Q357 244 275 233Q266 232 255 230Q149 215 133 161L129 135V134Q129 69 196 54Q212 50 232 50Q304 50 356 97Q388 126 389 161Q389 162 389 162V162V163V163V165Z"/>
+<glyph unicode="b" glyph-name="b" horiz-adv-x="556" d="M54 729H137V453Q194 539 299 539Q427 539 486 431Q523 363 523 265V264Q523 103 432 26Q375 -23 295 -23Q188 -23 129 67V0H54V729ZM283 461Q200 461 161 377Q137 328 137 259V258Q137 133 206 81Q239 55 283 55Q367 55 409 134Q436 185 436 254V255Q436 382 364 435Q331 460 288 461Q285 461 283 461Z"/>
+<glyph unicode="c" glyph-name="c" horiz-adv-x="500" d="M471 348H387Q374 445 290 460Q282 461 272 462H263Q169 462 134 362Q118 316 118 254V253Q118 116 197 71Q226 54 265 54Q372 54 393 180H477Q466 43 362 -3Q319 -23 263 -23Q134 -23 72 82Q31 151 31 252V253Q31 413 123 490Q182 539 264 539Q370 539 428 471L436 461Q465 418 471 348Z"/>
+<glyph unicode="d" glyph-name="d" horiz-adv-x="556" d="M495 729V0H421V69Q363 -14 277 -22Q266 -23 254 -23Q124 -23 64 89Q26 159 26 261Q26 261 26 262V263Q26 417 115 492Q172 539 251 539Q359 539 412 458V729H495ZM265 461Q180 461 139 379Q119 341 114 290Q113 275 113 259V258Q113 136 183 82Q219 55 266 55Q348 55 387 136Q412 186 412 255V256Q412 387 340 438Q307 461 265 461Z"/>
+<glyph unicode="e" glyph-name="e" horiz-adv-x="556" d="M513 234H127Q128 162 155 122Q198 54 281 54Q383 54 418 159H502Q480 38 376 -5Q332 -23 278 -23Q142 -23 79 87Q40 155 40 253V255Q40 413 134 490Q194 539 280 539Q395 539 460 457Q480 432 492 401Q513 347 513 235V234ZM129 302H423L424 308Q424 388 365 433Q327 462 279 462Q194 462 153 387Q133 351 129 302Z"/>
+<glyph unicode="f" glyph-name="f" horiz-adv-x="278" d="M258 524V456H171V0H88V456H18V524H88V613Q88 701 162 725Q184 732 211 732Q234 732 258 727V658L229 659Q172 659 171 608V606V524H258Z"/>
+<glyph unicode="g" glyph-name="g" horiz-adv-x="556" d="M412 524H489V86Q489 -68 448 -132Q441 -142 434 -151Q386 -211 277 -217Q266 -218 255 -218Q117 -218 67 -130Q50 -99 46 -60H131Q137 -99 162 -119L163 -120Q199 -148 258 -148Q339 -148 374 -99Q404 -58 404 43V44V71Q345 -11 272 -21Q261 -23 248 -23Q247 -23 245 -23Q162 -23 101 41Q98 44 95 47Q29 123 29 252V253Q29 404 112 483Q170 539 252 539Q350 539 412 448V524ZM261 462Q173 462 136 372Q116 325 116 259V258Q116 119 194 72Q223 54 262 54Q351 54 386 146Q404 192 404 254V255Q404 405 322 448Q295 462 261 462Z"/>
+<glyph unicode="h" glyph-name="h" horiz-adv-x="556" d="M70 729H153V452Q207 522 273 535Q294 539 321 539Q431 539 470 465Q486 435 486 397V396V0H403V363Q403 418 369 442Q337 466 295 466Q211 466 174 389Q153 347 153 290V289V0H70V729Z"/>
+<glyph unicode="i" glyph-name="i" horiz-adv-x="222" d="M150 524V0H67V524H150ZM150 729V624H66V729H150Z"/>
+<glyph unicode="j" glyph-name="j" horiz-adv-x="222" d="M70 524H153V-109Q153 -212 25 -218H10L-18 -215V-144L2 -145Q54 -145 65 -113Q70 -99 70 -77V-76V524ZM153 729V624H70V729H153Z"/>
+<glyph unicode="k" glyph-name="k" horiz-adv-x="500" d="M141 729V302L363 524H470L288 343L502 0H399L222 284L141 204V0H58V729H141Z"/>
+<glyph unicode="l" glyph-name="l" horiz-adv-x="222" d="M152 729V0H68V729H152Z"/>
+<glyph unicode="m" glyph-name="m" horiz-adv-x="833" d="M70 524H147V450Q201 526 275 537Q284 538 295 539H308Q397 539 440 474Q445 467 449 459Q503 524 566 535Q574 537 583 538H584Q596 539 610 539Q732 539 757 441Q762 419 762 394V393V0H678V361Q678 442 615 461Q599 466 581 466Q520 466 483 412Q458 376 458 330V329V0H374V361Q374 448 303 463L277 466Q215 466 178 410Q154 375 154 330V329V0H70V524Z"/>
+<glyph unicode="n" glyph-name="n" horiz-adv-x="556" d="M70 524H147V436Q201 521 277 535Q297 539 321 539Q425 539 467 470Q486 439 487 398V396V0H404V363Q404 432 346 457Q324 466 296 466Q212 466 175 389Q154 347 154 290V289V0H70V524Z"/>
+<glyph unicode="o" glyph-name="o" horiz-adv-x="556" d="M272 539Q424 539 481 410Q510 345 510 255V254Q510 87 408 16Q352 -23 273 -23Q129 -23 69 96Q36 162 36 257V258Q36 432 141 502Q196 539 272 539ZM273 462Q180 462 142 370Q123 323 123 259V258Q123 121 201 73Q232 54 273 54Q363 54 402 142Q423 189 423 254V255Q423 400 341 446Q311 462 273 462Z"/>
+<glyph unicode="p" glyph-name="p" horiz-adv-x="556" d="M54 -218V524H131V445Q190 539 298 539Q425 539 485 428Q523 357 523 254V253Q523 99 434 24Q395 -9 343 -19Q322 -23 299 -23Q202 -23 139 54L138 55V-218H54ZM284 461Q201 461 162 377Q138 328 138 259V258Q138 133 207 81Q240 55 284 55Q368 55 409 134Q436 185 436 254V255Q436 382 365 435Q330 461 284 461Z"/>
+<glyph unicode="q" glyph-name="q" horiz-adv-x="556" d="M495 -218H412V60Q355 -23 250 -23Q122 -23 63 85Q26 153 26 251V252Q26 413 117 490Q174 539 254 539Q361 539 421 454V524H495V-218ZM266 461Q182 461 140 380Q113 330 113 259V258Q113 136 183 82Q219 55 266 55Q348 55 388 136Q412 186 412 254V255Q412 386 341 437Q308 461 266 461Z"/>
+<glyph unicode="r" glyph-name="r" horiz-adv-x="333" d="M69 524H146V429Q204 522 262 536Q275 539 289 539L321 536V451Q249 450 218 429Q215 427 212 425Q153 382 153 273V272V0H69V524Z"/>
+<glyph unicode="s" glyph-name="s" horiz-adv-x="500" d="M438 378H350Q347 462 245 462Q163 462 140 413Q134 400 134 384V383Q134 338 200 316L231 308L311 289Q429 261 452 191Q459 170 459 144V143Q459 47 369 3Q317 -23 243 -23Q49 -23 35 139L34 156H122Q128 109 146 89Q179 54 250 54Q334 54 362 101Q372 116 372 135V136Q372 182 318 201Q309 204 299 207H298L291 209L213 228Q94 257 63 308Q54 324 50 345L47 379Q47 472 131 514Q180 539 248 539Q393 539 428 438Q438 411 438 378Z"/>
+<glyph unicode="t" glyph-name="t" horiz-adv-x="278" d="M254 524V456H168V97Q168 59 190 53L214 50Q239 50 254 54V-16Q215 -23 186 -23Q97 -23 86 44Q85 60 85 60V456H14V524H85V668H168V524H254Z"/>
+<glyph unicode="u" glyph-name="u" horiz-adv-x="556" d="M482 0H407V73Q351 -6 277 -19Q257 -23 232 -23Q125 -23 84 47Q65 78 65 119V120V524H148V153Q148 83 207 59Q228 50 255 50H256Q341 50 379 128Q399 170 399 226V227V524H482V0Z"/>
+<glyph unicode="v" glyph-name="v" horiz-adv-x="500" d="M285 0H194L10 524H104L244 99L392 524H486L285 0Z"/>
+<glyph unicode="w" glyph-name="w" horiz-adv-x="722" d="M554 0H459L353 411L252 0H158L6 524H98L205 116L305 524H407L510 116L614 524H708L554 0Z"/>
+<glyph unicode="x" glyph-name="x" horiz-adv-x="500" d="M292 271L473 0H376L245 201L112 0H17L202 267L27 524H122L248 334L374 524H468L292 271Z"/>
+<glyph unicode="y" glyph-name="y" horiz-adv-x="500" d="M388 524H478L245 -110Q223 -167 188 -193Q154 -218 110 -218Q79 -218 54 -205V-130Q81 -136 98 -136Q143 -136 161 -96Q163 -91 165 -85L197 -2L20 524H109L243 116L388 524Z"/>
+<glyph unicode="z" glyph-name="z" horiz-adv-x="500" d="M443 524V450L132 73H457V0H31V75L344 451H52V524H443Z"/>
+<glyph unicode="{" glyph-name="braceleft" horiz-adv-x="334" d="M276 729V664H261Q214 664 203 637V637Q198 623 198 598V597V416Q198 318 157 283L156 282Q146 273 133 267Q125 263 116 259Q198 221 198 103V101V-80Q198 -130 223 -141Q236 -147 261 -147H276V-212H230Q148 -212 127 -132Q121 -110 121 -82V-81V86Q121 179 86 206Q70 218 43 224V293Q97 304 111 348Q121 376 121 430V431V598Q121 700 192 723Q210 729 230 729H276Z"/>
+<glyph unicode="|" glyph-name="bar" horiz-adv-x="260" d="M100 729H160V-212H100V729Z"/>
+<glyph unicode="}" glyph-name="braceright" horiz-adv-x="334" d="M29 -212V-147H45Q93 -147 104 -120Q108 -109 109 -90V-80V101Q109 221 191 258Q109 296 109 414V416V597Q109 647 83 658Q70 664 45 664H29V729H76Q159 729 180 648Q186 626 186 599V598V431Q186 337 222 310Q237 298 262 293V224Q210 213 195 167Q186 139 186 87V86V-81Q186 -184 113 -207Q96 -212 76 -212H29Z"/>
+<glyph unicode="~" glyph-name="asciitilde" horiz-adv-x="584" d="M455 411H508V395Q508 310 451 280Q430 268 403 268Q364 268 322 294L224 357Q201 371 181 371Q152 371 136 336Q131 323 128 295V293H75Q82 424 166 437L183 438Q210 438 237 422L354 353Q382 336 404 336Q448 336 454 385L455 411Z"/>
+
+<hkern g1="comma" g2="one" k="100"/>
+<hkern g1="hyphen" g2="A" k="7"/>
+<hkern g1="hyphen" g2="T" k="80"/>
+<hkern g1="hyphen" g2="V" k="46"/>
+<hkern g1="hyphen" g2="W" k="19"/>
+<hkern g1="hyphen" g2="Y" k="92"/>
+<hkern g1="period" g2="one" k="101"/>
+<hkern g1="zero" g2="one" k="46"/>
+<hkern g1="zero" g2="four" k="2"/>
+<hkern g1="zero" g2="seven" k="39"/>
+<hkern g1="one" g2="comma" k="74"/>
+<hkern g1="one" g2="period" k="74"/>
+<hkern g1="one" g2="zero" k="62"/>
+<hkern g1="one" g2="one" k="118"/>
+<hkern g1="one" g2="two" k="69"/>
+<hkern g1="one" g2="three" k="67"/>
+<hkern g1="one" g2="four" k="81"/>
+<hkern g1="one" g2="five" k="67"/>
+<hkern g1="one" g2="six" k="62"/>
+<hkern g1="one" g2="seven" k="90"/>
+<hkern g1="one" g2="eight" k="65"/>
+<hkern g1="one" g2="nine" k="65"/>
+<hkern g1="two" g2="one" k="36"/>
+<hkern g1="two" g2="four" k="37"/>
+<hkern g1="two" g2="seven" k="25"/>
+<hkern g1="three" g2="one" k="49"/>
+<hkern g1="three" g2="four" k="2"/>
+<hkern g1="three" g2="seven" k="33"/>
+<hkern g1="four" g2="one" k="84"/>
+<hkern g1="four" g2="four" k="-5"/>
+<hkern g1="four" g2="seven" k="56"/>
+<hkern g1="five" g2="one" k="76"/>
+<hkern g1="five" g2="four" k="-1"/>
+<hkern g1="five" g2="seven" k="26"/>
+<hkern g1="six" g2="one" k="43"/>
+<hkern g1="six" g2="four" k="-1"/>
+<hkern g1="six" g2="seven" k="30"/>
+<hkern g1="seven" g2="comma" k="119"/>
+<hkern g1="seven" g2="period" k="119"/>
+<hkern g1="seven" g2="one" k="53"/>
+<hkern g1="seven" g2="two" k="28"/>
+<hkern g1="seven" g2="three" k="23"/>
+<hkern g1="seven" g2="four" k="93"/>
+<hkern g1="seven" g2="five" k="30"/>
+<hkern g1="seven" g2="six" k="40"/>
+<hkern g1="seven" g2="seven" k="4"/>
+<hkern g1="seven" g2="eight" k="28"/>
+<hkern g1="seven" g2="colon" k="77"/>
+<hkern g1="eight" g2="one" k="48"/>
+<hkern g1="eight" g2="four" k="-1"/>
+<hkern g1="eight" g2="seven" k="33"/>
+<hkern g1="nine" g2="one" k="43"/>
+<hkern g1="nine" g2="four" k="3"/>
+<hkern g1="nine" g2="seven" k="37"/>
+<hkern g1="A" g2="comma" k="-5"/>
+<hkern g1="A" g2="hyphen" k="3"/>
+<hkern g1="A" g2="period" k="-5"/>
+<hkern g1="A" g2="C" k="36"/>
+<hkern g1="A" g2="G" k="35"/>
+<hkern g1="A" g2="O" k="33"/>
+<hkern g1="A" g2="Q" k="32"/>
+<hkern g1="A" g2="T" k="93"/>
+<hkern g1="A" g2="U" k="37"/>
+<hkern g1="A" g2="V" k="75"/>
+<hkern g1="A" g2="W" k="51"/>
+<hkern g1="A" g2="Y" k="99"/>
+<hkern g1="A" g2="a" k="4"/>
+<hkern g1="A" g2="b" k="-4"/>
+<hkern g1="A" g2="c" k="11"/>
+<hkern g1="A" g2="d" k="8"/>
+<hkern g1="A" g2="e" k="16"/>
+<hkern g1="A" g2="g" k="10"/>
+<hkern g1="A" g2="o" k="13"/>
+<hkern g1="A" g2="q" k="8"/>
+<hkern g1="A" g2="t" k="16"/>
+<hkern g1="A" g2="u" k="12"/>
+<hkern g1="A" g2="v" k="31"/>
+<hkern g1="A" g2="w" k="21"/>
+<hkern g1="A" g2="y" k="34"/>
+<hkern g1="B" g2="A" k="21"/>
+<hkern g1="B" g2="O" k="7"/>
+<hkern g1="B" g2="V" k="41"/>
+<hkern g1="B" g2="W" k="25"/>
+<hkern g1="B" g2="Y" k="44"/>
+<hkern g1="C" g2="A" k="32"/>
+<hkern g1="C" g2="H" k="12"/>
+<hkern g1="C" g2="K" k="10"/>
+<hkern g1="C" g2="O" k="8"/>
+<hkern g1="D" g2="A" k="42"/>
+<hkern g1="D" g2="J" k="5"/>
+<hkern g1="D" g2="T" k="45"/>
+<hkern g1="D" g2="V" k="51"/>
+<hkern g1="D" g2="W" k="29"/>
+<hkern g1="D" g2="X" k="53"/>
+<hkern g1="D" g2="Y" k="63"/>
+<hkern g1="F" g2="comma" k="108"/>
+<hkern g1="F" g2="hyphen" k="14"/>
+<hkern g1="F" g2="period" k="108"/>
+<hkern g1="F" g2="A" k="69"/>
+<hkern g1="F" g2="J" k="51"/>
+<hkern g1="F" g2="O" k="22"/>
+<hkern g1="F" g2="a" k="33"/>
+<hkern g1="F" g2="e" k="24"/>
+<hkern g1="F" g2="i" k="10"/>
+<hkern g1="F" g2="j" k="12"/>
+<hkern g1="F" g2="o" k="21"/>
+<hkern g1="F" g2="r" k="35"/>
+<hkern g1="F" g2="u" k="33"/>
+<hkern g1="G" g2="A" k="6"/>
+<hkern g1="G" g2="T" k="44"/>
+<hkern g1="G" g2="V" k="50"/>
+<hkern g1="G" g2="W" k="28"/>
+<hkern g1="G" g2="Y" k="62"/>
+<hkern g1="J" g2="A" k="32"/>
+<hkern g1="K" g2="hyphen" k="47"/>
+<hkern g1="K" g2="C" k="51"/>
+<hkern g1="K" g2="G" k="51"/>
+<hkern g1="K" g2="O" k="48"/>
+<hkern g1="K" g2="S" k="38"/>
+<hkern g1="K" g2="T" k="-20"/>
+<hkern g1="K" g2="a" k="11"/>
+<hkern g1="K" g2="e" k="32"/>
+<hkern g1="K" g2="o" k="29"/>
+<hkern g1="K" g2="u" k="19"/>
+<hkern g1="K" g2="y" k="62"/>
+<hkern g1="L" g2="hyphen" k="125"/>
+<hkern g1="L" g2="A" k="-17"/>
+<hkern g1="L" g2="C" k="41"/>
+<hkern g1="L" g2="G" k="42"/>
+<hkern g1="L" g2="O" k="41"/>
+<hkern g1="L" g2="S" k="19"/>
+<hkern g1="L" g2="T" k="105"/>
+<hkern g1="L" g2="U" k="35"/>
+<hkern g1="L" g2="V" k="105"/>
+<hkern g1="L" g2="W" k="68"/>
+<hkern g1="L" g2="Y" k="121"/>
+<hkern g1="L" g2="u" k="7"/>
+<hkern g1="L" g2="y" k="56"/>
+<hkern g1="N" g2="comma" k="7"/>
+<hkern g1="N" g2="period" k="7"/>
+<hkern g1="N" g2="A" k="9"/>
+<hkern g1="N" g2="C" k="3"/>
+<hkern g1="N" g2="G" k="2"/>
+<hkern g1="N" g2="a" k="5"/>
+<hkern g1="N" g2="o" k="-2"/>
+<hkern g1="O" g2="A" k="35"/>
+<hkern g1="O" g2="T" k="42"/>
+<hkern g1="O" g2="V" k="45"/>
+<hkern g1="O" g2="W" k="23"/>
+<hkern g1="O" g2="X" k="46"/>
+<hkern g1="O" g2="Y" k="59"/>
+<hkern g1="P" g2="comma" k="135"/>
+<hkern g1="P" g2="hyphen" k="40"/>
+<hkern g1="P" g2="period" k="135"/>
+<hkern g1="P" g2="A" k="78"/>
+<hkern g1="P" g2="J" k="78"/>
+<hkern g1="P" g2="a" k="28"/>
+<hkern g1="P" g2="e" k="31"/>
+<hkern g1="P" g2="o" k="27"/>
+<hkern g1="R" g2="hyphen" k="2"/>
+<hkern g1="R" g2="C" k="16"/>
+<hkern g1="R" g2="G" k="15"/>
+<hkern g1="R" g2="O" k="13"/>
+<hkern g1="R" g2="T" k="23"/>
+<hkern g1="R" g2="U" k="17"/>
+<hkern g1="R" g2="V" k="39"/>
+<hkern g1="R" g2="W" k="27"/>
+<hkern g1="R" g2="Y" k="43"/>
+<hkern g1="R" g2="a" k="15"/>
+<hkern g1="R" g2="e" k="12"/>
+<hkern g1="R" g2="o" k="9"/>
+<hkern g1="R" g2="u" k="9"/>
+<hkern g1="R" g2="y" k="8"/>
+<hkern g1="S" g2="A" k="22"/>
+<hkern g1="S" g2="T" k="28"/>
+<hkern g1="S" g2="V" k="42"/>
+<hkern g1="S" g2="W" k="28"/>
+<hkern g1="S" g2="Y" k="48"/>
+<hkern g1="S" g2="t" k="3"/>
+<hkern g1="T" g2="comma" k="100"/>
+<hkern g1="T" g2="hyphen" k="77"/>
+<hkern g1="T" g2="period" k="100"/>
+<hkern g1="T" g2="colon" k="133"/>
+<hkern g1="T" g2="semicolon" k="129"/>
+<hkern g1="T" g2="A" k="95"/>
+<hkern g1="T" g2="C" k="44"/>
+<hkern g1="T" g2="G" k="45"/>
+<hkern g1="T" g2="J" k="100"/>
+<hkern g1="T" g2="O" k="42"/>
+<hkern g1="T" g2="S" k="24"/>
+<hkern g1="T" g2="V" k="-12"/>
+<hkern g1="T" g2="W" k="-16"/>
+<hkern g1="T" g2="Y" k="-20"/>
+<hkern g1="T" g2="a" k="100"/>
+<hkern g1="T" g2="c" k="90"/>
+<hkern g1="T" g2="e" k="95"/>
+<hkern g1="T" g2="g" k="89"/>
+<hkern g1="T" g2="i" k="3"/>
+<hkern g1="T" g2="j" k="5"/>
+<hkern g1="T" g2="o" k="92"/>
+<hkern g1="T" g2="r" k="92"/>
+<hkern g1="T" g2="s" k="92"/>
+<hkern g1="T" g2="u" k="91"/>
+<hkern g1="T" g2="v" k="95"/>
+<hkern g1="T" g2="w" k="93"/>
+<hkern g1="T" g2="y" k="100"/>
+<hkern g1="U" g2="comma" k="27"/>
+<hkern g1="U" g2="period" k="25"/>
+<hkern g1="U" g2="A" k="36"/>
+<hkern g1="U" g2="m" k="4"/>
+<hkern g1="U" g2="n" k="4"/>
+<hkern g1="U" g2="p" k="-3"/>
+<hkern g1="U" g2="r" k="4"/>
+<hkern g1="V" g2="comma" k="89"/>
+<hkern g1="V" g2="hyphen" k="38"/>
+<hkern g1="V" g2="period" k="89"/>
+<hkern g1="V" g2="colon" k="66"/>
+<hkern g1="V" g2="semicolon" k="66"/>
+<hkern g1="V" g2="A" k="71"/>
+<hkern g1="V" g2="C" k="43"/>
+<hkern g1="V" g2="G" k="42"/>
+<hkern g1="V" g2="O" k="40"/>
+<hkern g1="V" g2="S" k="35"/>
+<hkern g1="V" g2="T" k="-15"/>
+<hkern g1="V" g2="a" k="59"/>
+<hkern g1="V" g2="e" k="57"/>
+<hkern g1="V" g2="g" k="50"/>
+<hkern g1="V" g2="i" k="5"/>
+<hkern g1="V" g2="o" k="54"/>
+<hkern g1="V" g2="r" k="42"/>
+<hkern g1="V" g2="u" k="41"/>
+<hkern g1="V" g2="y" k="20"/>
+<hkern g1="W" g2="comma" k="56"/>
+<hkern g1="W" g2="hyphen" k="13"/>
+<hkern g1="W" g2="period" k="56"/>
+<hkern g1="W" g2="colon" k="52"/>
+<hkern g1="W" g2="semicolon" k="53"/>
+<hkern g1="W" g2="A" k="50"/>
+<hkern g1="W" g2="C" k="23"/>
+<hkern g1="W" g2="G" k="22"/>
+<hkern g1="W" g2="O" k="20"/>
+<hkern g1="W" g2="S" k="24"/>
+<hkern g1="W" g2="T" k="-19"/>
+<hkern g1="W" g2="a" k="38"/>
+<hkern g1="W" g2="e" k="32"/>
+<hkern g1="W" g2="g" k="25"/>
+<hkern g1="W" g2="i" k="1"/>
+<hkern g1="W" g2="o" k="29"/>
+<hkern g1="W" g2="r" k="28"/>
+<hkern g1="W" g2="u" k="28"/>
+<hkern g1="W" g2="y" k="6"/>
+<hkern g1="X" g2="hyphen" k="51"/>
+<hkern g1="X" g2="C" k="48"/>
+<hkern g1="X" g2="O" k="45"/>
+<hkern g1="X" g2="Q" k="44"/>
+<hkern g1="X" g2="a" k="15"/>
+<hkern g1="X" g2="e" k="36"/>
+<hkern g1="X" g2="o" k="33"/>
+<hkern g1="X" g2="u" k="24"/>
+<hkern g1="X" g2="y" k="61"/>
+<hkern g1="Y" g2="comma" k="111"/>
+<hkern g1="Y" g2="hyphen" k="84"/>
+<hkern g1="Y" g2="period" k="111"/>
+<hkern g1="Y" g2="colon" k="87"/>
+<hkern g1="Y" g2="semicolon" k="88"/>
+<hkern g1="Y" g2="A" k="96"/>
+<hkern g1="Y" g2="C" k="58"/>
+<hkern g1="Y" g2="G" k="58"/>
+<hkern g1="Y" g2="O" k="56"/>
+<hkern g1="Y" g2="S" k="41"/>
+<hkern g1="Y" g2="T" k="-23"/>
+<hkern g1="Y" g2="a" k="88"/>
+<hkern g1="Y" g2="e" k="89"/>
+<hkern g1="Y" g2="g" k="83"/>
+<hkern g1="Y" g2="i" k="-3"/>
+<hkern g1="Y" g2="o" k="86"/>
+<hkern g1="Y" g2="p" k="54"/>
+<hkern g1="Y" g2="u" k="63"/>
+<hkern g1="Y" g2="v" k="36"/>
+<hkern g1="Z" g2="v" k="33"/>
+<hkern g1="Z" g2="y" k="38"/>
+<hkern g1="a" g2="j" k="4"/>
+<hkern g1="a" g2="v" k="21"/>
+<hkern g1="a" g2="w" k="13"/>
+<hkern g1="a" g2="y" k="26"/>
+<hkern g1="b" g2="v" k="11"/>
+<hkern g1="b" g2="w" k="3"/>
+<hkern g1="b" g2="y" k="15"/>
+<hkern g1="c" g2="h" k="-1"/>
+<hkern g1="c" g2="k" k="-7"/>
+<hkern g1="e" g2="t" k="10"/>
+<hkern g1="e" g2="v" k="15"/>
+<hkern g1="e" g2="w" k="9"/>
+<hkern g1="e" g2="x" k="27"/>
+<hkern g1="e" g2="y" k="19"/>
+<hkern g1="f" g2="a" k="9"/>
+<hkern g1="f" g2="e" k="15"/>
+<hkern g1="f" g2="f" k="-22"/>
+<hkern g1="f" g2="i" k="2"/>
+<hkern g1="f" g2="j" k="4"/>
+<hkern g1="f" g2="l" k="3"/>
+<hkern g1="f" g2="o" k="10"/>
+<hkern g1="f" g2="t" k="-24"/>
+<hkern g1="g" g2="a" k="5"/>
+<hkern g1="h" g2="y" k="18"/>
+<hkern g1="i" g2="T" k="7"/>
+<hkern g1="i" g2="j" k="3"/>
+<hkern g1="k" g2="hyphen" k="41"/>
+<hkern g1="k" g2="a" k="2"/>
+<hkern g1="k" g2="e" k="21"/>
+<hkern g1="k" g2="g" k="16"/>
+<hkern g1="k" g2="o" k="19"/>
+<hkern g1="k" g2="s" k="3"/>
+<hkern g1="k" g2="u" k="11"/>
+<hkern g1="l" g2="y" k="5"/>
+<hkern g1="m" g2="p" k="-5"/>
+<hkern g1="m" g2="v" k="13"/>
+<hkern g1="m" g2="w" k="7"/>
+<hkern g1="m" g2="y" k="18"/>
+<hkern g1="n" g2="T" k="96"/>
+<hkern g1="n" g2="p" k="-5"/>
+<hkern g1="n" g2="v" k="13"/>
+<hkern g1="n" g2="w" k="7"/>
+<hkern g1="n" g2="y" k="18"/>
+<hkern g1="o" g2="T" k="99"/>
+<hkern g1="o" g2="t" k="10"/>
+<hkern g1="o" g2="v" k="18"/>
+<hkern g1="o" g2="w" k="10"/>
+<hkern g1="o" g2="x" k="27"/>
+<hkern g1="o" g2="y" k="22"/>
+<hkern g1="p" g2="t" k="4"/>
+<hkern g1="p" g2="y" k="16"/>
+<hkern g1="q" g2="c" k="-8"/>
+<hkern g1="q" g2="u" k="-4"/>
+<hkern g1="r" g2="comma" k="69"/>
+<hkern g1="r" g2="hyphen" k="47"/>
+<hkern g1="r" g2="period" k="69"/>
+<hkern g1="r" g2="colon" k="22"/>
+<hkern g1="r" g2="semicolon" k="22"/>
+<hkern g1="r" g2="a" k="5"/>
+<hkern g1="r" g2="c" k="6"/>
+<hkern g1="r" g2="d" k="1"/>
+<hkern g1="r" g2="e" k="11"/>
+<hkern g1="r" g2="f" k="-26"/>
+<hkern g1="r" g2="g" k="4"/>
+<hkern g1="r" g2="i" k="-1"/>
+<hkern g1="r" g2="k" k="-6"/>
+<hkern g1="r" g2="l" k="-1"/>
+<hkern g1="r" g2="o" k="6"/>
+<hkern g1="r" g2="p" k="-8"/>
+<hkern g1="r" g2="q" k="3"/>
+<hkern g1="r" g2="s" k="-4"/>
+<hkern g1="r" g2="t" k="-28"/>
+<hkern g1="r" g2="u" k="-2"/>
+<hkern g1="r" g2="v" k="-29"/>
+<hkern g1="r" g2="w" k="-31"/>
+<hkern g1="r" g2="x" k="-20"/>
+<hkern g1="r" g2="y" k="-24"/>
+<hkern g1="r" g2="z" k="-9"/>
+<hkern g1="s" g2="t" k="3"/>
+<hkern g1="t" g2="colon" k="28"/>
+<hkern g1="t" g2="semicolon" k="28"/>
+<hkern g1="t" g2="S" k="8"/>
+<hkern g1="t" g2="a" k="1"/>
+<hkern g1="t" g2="e" k="14"/>
+<hkern g1="t" g2="h" k="3"/>
+<hkern g1="t" g2="o" k="12"/>
+<hkern g1="v" g2="comma" k="69"/>
+<hkern g1="v" g2="hyphen" k="12"/>
+<hkern g1="v" g2="period" k="69"/>
+<hkern g1="v" g2="colon" k="23"/>
+<hkern g1="v" g2="semicolon" k="23"/>
+<hkern g1="v" g2="a" k="18"/>
+<hkern g1="v" g2="c" k="16"/>
+<hkern g1="v" g2="e" k="21"/>
+<hkern g1="v" g2="g" k="14"/>
+<hkern g1="v" g2="o" k="17"/>
+<hkern g1="v" g2="s" k="9"/>
+<hkern g1="w" g2="comma" k="50"/>
+<hkern g1="w" g2="hyphen" k="1"/>
+<hkern g1="w" g2="period" k="50"/>
+<hkern g1="w" g2="colon" k="23"/>
+<hkern g1="w" g2="semicolon" k="23"/>
+<hkern g1="w" g2="a" k="15"/>
+<hkern g1="w" g2="c" k="7"/>
+<hkern g1="w" g2="e" k="12"/>
+<hkern g1="w" g2="g" k="6"/>
+<hkern g1="w" g2="o" k="9"/>
+<hkern g1="w" g2="s" k="5"/>
+<hkern g1="x" g2="a" k="17"/>
+<hkern g1="x" g2="c" k="23"/>
+<hkern g1="x" g2="e" k="28"/>
+<hkern g1="x" g2="o" k="25"/>
+<hkern g1="x" g2="q" k="20"/>
+<hkern g1="y" g2="comma" k="70"/>
+<hkern g1="y" g2="hyphen" k="14"/>
+<hkern g1="y" g2="period" k="70"/>
+<hkern g1="y" g2="colon" k="27"/>
+<hkern g1="y" g2="semicolon" k="27"/>
+<hkern g1="y" g2="a" k="22"/>
+<hkern g1="y" g2="c" k="19"/>
+<hkern g1="y" g2="e" k="24"/>
+<hkern g1="y" g2="g" k="17"/>
+<hkern g1="y" g2="l" k="4"/>
+<hkern g1="y" g2="o" k="20"/>
+<hkern g1="y" g2="s" k="12"/>
+</font>
+</defs>
+<g font-family="SVGFreeSansASCII" font-size="18"> 
+<text x="20" y="60">  !"#$%&amp;'()*+,-./0123456789:;&lt;&gt;?</text> 
+<text x="20" y="120">@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_</text> 
+<text x="20" y="180">`abcdefghijklmnopqrstuvwxyz|{}~</text> 
+</g>
+</svg>


### PR DESCRIPTION
#### cfbb14fd084538ad6a9a32e8a399516bf8536aae
<pre>
SVG font for some SVG tests is missing.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* LayoutTests/imported/w3c/web-platform-tests/svg/resources/SVGFreeSans.svg: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfbb14fd084538ad6a9a32e8a399516bf8536aae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13318 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16481 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12075 "4 flakes 1 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12653 "8 flakes 6 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19682 "1 flakes 74 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13151 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12817 "Exiting early after 60 failures. 54428 tests run. 60 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16037 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13367 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11231 "Exiting early after 60 failures. 54496 tests run. 60 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16976 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->