### PR TITLE
Dropping frames on visionOS while scrolling due to number of glow layers on some websites

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -110,38 +110,38 @@
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-          (layer position [x: 400 y: 400])
-          (layer opacity 0)
-          (sublayers
-            (
-              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-              (layer position [x: 397 y: 397])
-              (layer zPosition 1000)
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-                  (layer position [x: 397 y: 397])
-                  (layer cornerRadius 4.760000000000001))))
-            (
-              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
-              (layer position [x: 397 y: 397])
-              (layer opacity 0.005))))
-        (
-          (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+          (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
           (layer position [x: 792.9200000000001 y: 792.9200000000001])
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
               (layer position [x: 4.08 y: 4.08])
               (layer zPosition 1000)
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+                  (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
                   (layer position [x: 4.08 y: 4.08])
                   (layer cornerRadius 4.760000000000001))))
             (
-              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 36])
               (layer position [x: 4.08 y: 4.08])
+              (layer opacity 0.005))))
+        (
+          (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
+          (layer position [x: 395.84000000000003 y: 395.84000000000003])
+          (layer opacity 0)
+          (sublayers
+            (
+              (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
+              (layer position [x: 393 y: 393])
+              (layer zPosition 1000)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
+                  (layer position [x: 393 y: 393])
+                  (layer cornerRadius 4.760000000000001))))
+            (
+              (layer bounds [x: 0 y: 0 width: 786 height: 8.16])
+              (layer position [x: 393 y: 393])
               (layer opacity 0.005))))))))

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2730,7 +2730,7 @@ void GraphicsLayerCA::updateCoverage(const CommitState& commitState)
     }
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    m_layer->setCoverageRect(m_coverageRect);
+    m_layer->setVisibleRect(m_visibleRect);
 #endif
 
     bool requiresBacking = m_intersectsCoverageRect

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -215,7 +215,7 @@ public:
     virtual bool backingStoreAttached() const = 0;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    virtual void setCoverageRect(const FloatRect&) = 0;
+    virtual void setVisibleRect(const FloatRect&) = 0;
 #endif
 
     virtual void setMinificationFilter(FilterType) = 0;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h
@@ -100,7 +100,7 @@ public:
     bool backingStoreAttached() const override;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    void setCoverageRect(const FloatRect&) override;
+    void setVisibleRect(const FloatRect&) override;
 #endif
 
     bool geometryFlipped() const override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -699,7 +699,7 @@ bool PlatformCALayerCocoa::backingStoreAttached() const
 }
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-void PlatformCALayerCocoa::setCoverageRect(const FloatRect&)
+void PlatformCALayerCocoa::setVisibleRect(const FloatRect&)
 {
 }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -84,7 +84,7 @@ enum class LayerChange : uint64_t {
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CoverageRectChanged                 = 1LLU << 42,
+    VisibleRectChanged                  = 1LLU << 42,
 #endif
 };
 
@@ -180,7 +180,7 @@ struct LayerProperties {
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    WebCore::FloatRect coverageRect;
+    WebCore::FloatRect visibleRect;
 #endif
 };
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -72,7 +72,7 @@ header: "RemoteLayerTreeTransaction.h"
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CoverageRectChanged
+    VisibleRectChanged
 #endif
 };
 
@@ -244,6 +244,6 @@ struct WebKit::LayerProperties {
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    [OptionalTupleBit=WebKit::LayerChange::CoverageRectChanged] WebCore::FloatRect coverageRect;
+    [OptionalTupleBit=WebKit::LayerChange::VisibleRectChanged] WebCore::FloatRect visibleRect;
 #endif
 };

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -318,13 +318,13 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
     updateMask(node, properties, relatedLayers);
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if (properties.changedProperties & LayerChange::CoverageRectChanged)
-        node.setCoverageRect(properties.coverageRect);
+    if (properties.changedProperties & LayerChange::VisibleRectChanged)
+        node.setVisibleRect(properties.visibleRect);
     applyCommonPropertiesToLayer(node.interactionRegionsLayer(), properties);
     // Replicate animations on the InteractionRegion layers, the LayerTreeHost only keeps track of the original animations.
     if (properties.changedProperties & LayerChange::AnimationsChanged)
         PlatformCAAnimationRemote::updateLayerAnimations(node.interactionRegionsLayer(), nullptr, properties.animationChanges.addedAnimations, properties.animationChanges.keysOfAnimationsToRemove);
-    if (properties.changedProperties & LayerChange::EventRegionChanged || properties.changedProperties & LayerChange::CoverageRectChanged)
+    if (properties.changedProperties & LayerChange::EventRegionChanged || properties.changedProperties & LayerChange::VisibleRectChanged)
         updateLayersForInteractionRegions(node);
 #endif
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -219,8 +219,8 @@ static void dumpChangedLayers(TextStream& ts, const LayerPropertiesMap& changedL
             ts.dumpProperty("eventRegion", layerProperties.eventRegion);
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        if (layerProperties.changedProperties & LayerChange::CoverageRectChanged)
-            ts.dumpProperty("coverageRect", layerProperties.coverageRect);
+        if (layerProperties.changedProperties & LayerChange::VisibleRectChanged)
+            ts.dumpProperty("visibleRect", layerProperties.visibleRect);
 #endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         if (layerProperties.changedProperties & LayerChange::SeparatedChanged)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -193,7 +193,7 @@ void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node)
     for (const WebCore::InteractionRegion& region : node.eventRegion().interactionRegions()) {
         IntRect rect = region.rectInLayerCoordinates;
 
-        if (node.coverageRect() && !node.coverageRect()->intersects(rect))
+        if (!node.visibleRect() || !node.visibleRect()->intersects(rect))
             continue;
 
         bool foundInPosition = false;
@@ -245,7 +245,6 @@ void updateLayersForInteractionRegions(const RemoteLayerTreeNode& node)
                 }
                 break;
             }
-            [layer insertSublayer:regionLayer.get() atIndex:insertionPoint];
         }
 
         if (!foundInPosition)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -59,7 +59,7 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     CALayer *interactionRegionsLayer() const { return m_interactionRegionsLayer.get(); }
 
-    struct CoverageRectMarkableTraits {
+    struct VisibleRectMarkableTraits {
         static bool isEmptyValue(const WebCore::FloatRect& value)
         {
             return value.isEmpty();
@@ -71,8 +71,8 @@ public:
         }
     };
 
-    const Markable<WebCore::FloatRect, CoverageRectMarkableTraits> coverageRect() const { return m_coverageRect; }
-    void setCoverageRect(const WebCore::FloatRect& value) { m_coverageRect = value; }
+    const Markable<WebCore::FloatRect, VisibleRectMarkableTraits> visibleRect() const { return m_visibleRect; }
+    void setVisibleRect(const WebCore::FloatRect& value) { m_visibleRect = value; }
 #endif
 #if PLATFORM(IOS_FAMILY)
     UIView *uiView() const { return m_uiView.get(); }
@@ -139,7 +139,7 @@ private:
     RetainPtr<CALayer> m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     RetainPtr<CALayer> m_interactionRegionsLayer;
-    Markable<WebCore::FloatRect, CoverageRectMarkableTraits> m_coverageRect;
+    Markable<WebCore::FloatRect, VisibleRectMarkableTraits> m_visibleRect;
 #endif
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UIView> m_uiView;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -121,7 +121,7 @@ public:
     bool backingStoreAttached() const override;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    void setCoverageRect(const WebCore::FloatRect&) override;
+    void setVisibleRect(const WebCore::FloatRect&) override;
 #endif
 
     bool geometryFlipped() const override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -649,10 +649,10 @@ bool PlatformCALayerRemote::backingStoreAttached() const
 }
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-void PlatformCALayerRemote::setCoverageRect(const FloatRect& value)
+void PlatformCALayerRemote::setVisibleRect(const FloatRect& value)
 {
-    m_properties.coverageRect = value;
-    m_properties.notePropertiesChanged(LayerChange::CoverageRectChanged);
+    m_properties.visibleRect = value;
+    m_properties.notePropertiesChanged(LayerChange::VisibleRectChanged);
 }
 #endif
 


### PR DESCRIPTION
#### bb28148509967bf8b3e923fc71adb69895055a4d
<pre>
Dropping frames on visionOS while scrolling due to number of glow layers on some websites
<a href="https://bugs.webkit.org/show_bug.cgi?id=259739">https://bugs.webkit.org/show_bug.cgi?id=259739</a>
&lt;radar://113094884&gt;

Reviewed by Dean Jackson.

Cull glow regions outside of visible areas as the user will not be able
to interact with them.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
Update test expectation.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateCoverage):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::setVisibleRect):
(WebCore::PlatformCALayerCocoa::setCoverageRect): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::LayerProperties::encode const):
(WebKit::LayerProperties::decode):
(WebKit::dumpChangedLayers):
Change use of coverageRect to visibleRect.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
Layer was being inserted twice, correct this.

Also instead of testing if the rect exists and it did not intersect to return early,
test that either the rect does not exist or it does not interesect to return early.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
(WebKit::RemoteLayerTreeNode::visibleRect const):
(WebKit::RemoteLayerTreeNode::setVisibleRect):
(WebKit::RemoteLayerTreeNode::CoverageRectMarkableTraits::isEmptyValue): Deleted.
(WebKit::RemoteLayerTreeNode::CoverageRectMarkableTraits::emptyValue): Deleted.
(WebKit::RemoteLayerTreeNode::coverageRect const): Deleted.
(WebKit::RemoteLayerTreeNode::setCoverageRect): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::setVisibleRect):
(WebKit::PlatformCALayerRemote::setCoverageRect): Deleted.
Change use of coverageRect to visibleRect.

Canonical link: <a href="https://commits.webkit.org/266604@main">https://commits.webkit.org/266604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef0ac5330296fbd852ab9dc879a8e885cf4caac6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14546 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12834 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16213 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12826 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3448 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->