### PR TITLE
[git-webkit] Avoid hardcoding working tree path in hooks

### DIFF
--- a/Tools/Scripts/hooks/pre-commit
+++ b/Tools/Scripts/hooks/pre-commit
@@ -4,7 +4,13 @@ import os
 import subprocess
 import sys
 
-LOCATION = r'{{ location }}'
+ENCODING_KWARGS = dict()
+if sys.version_info >= (3, 6):
+    ENCODING_KWARGS = dict(encoding='utf-8')
+
+TOPLEVEL = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], **ENCODING_KWARGS).strip()
+
+LOCATION = os.path.join(TOPLEVEL, r'{{ location }}')
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
 
 

--- a/Tools/Scripts/hooks/pre-push
+++ b/Tools/Scripts/hooks/pre-push
@@ -12,7 +12,13 @@ if sys.stdout.isatty() and os.path.exists('/dev/tty'):
 else:
     TTY = None
 
-LOCATION = r'{{ location }}'
+ENCODING_KWARGS = dict()
+if sys.version_info >= (3, 6):
+    ENCODING_KWARGS = dict(encoding='utf-8')
+
+TOPLEVEL = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], **ENCODING_KWARGS).strip()
+
+LOCATION = os.path.join(TOPLEVEL, r'{{ location }}')
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
 sys.path.append(SCRIPTS)
 
@@ -36,10 +42,6 @@ UNPACK_SECONDARY_RE = re.compile(r' \(({})\)'.format(COMMIT_REF_BASE))
 DEV_BRANCHES = re.compile(r'.*[(eng)(dev)(bug)]/.+')
 PROD_BRANCHES = re.compile(r'\S+-[\d+\.]+-branch')
 DEFAULT_BRANCHES = ('master', 'main')
-
-ENCODING_KWARGS = dict()
-if sys.version_info >= (3, 6):
-    ENCODING_KWARGS = dict(encoding='utf-8')
 
 QUIET = -1
 VERBOSE = 1

--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -5,7 +5,13 @@ import re
 import subprocess
 import sys
 
-LOCATION = r'{{ location }}'
+ENCODING_KWARGS = dict()
+if sys.version_info >= (3, 6):
+    ENCODING_KWARGS = dict(encoding='utf-8')
+
+TOPLEVEL = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], **ENCODING_KWARGS).strip()
+
+LOCATION = os.path.join(TOPLEVEL, r'{{ location }}')
 SPACING = 8
 IDENT = 4
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
@@ -28,10 +34,6 @@ CHERRY_PICK_RE = [
     re.compile(r'\S* ?[Cc]herry[- ][Pp]icked {}'.format(COMPOUND_COMMIT_REF)),
 ]
 UNPACK_SECONDARY_RE = re.compile(r' \(({})\)'.format(COMMIT_REF_BASE))
-
-ENCODING_KWARGS = dict()
-if sys.version_info >= (3, 6):
-    ENCODING_KWARGS = dict(encoding='utf-8')
 
 sys.path.append(SCRIPTS)
 from webkitpy.common.checkout.diff_parser import DiffParser

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py
@@ -190,7 +190,7 @@ class InstallHooks(Command):
             with open(source_path, 'r') as f:
                 from jinja2 import Template
                 contents = Template(f.read()).render(
-                    location=source_path,
+                    location=os.path.relpath(source_path, repository.root_path),
                     python=os.path.basename(sys.executable),
                     prefer_radar=bool(radar.Tracker.radarclient()),
                     default_pre_push_mode="'{}'".format(getattr(args, 'mode', cls.MODES[0])),


### PR DESCRIPTION
#### 3aa38b6cb9f2d813b108cb39d90ee2b5d7a2cdf3
<pre>
[git-webkit] Avoid hardcoding working tree path in hooks
<a href="https://bugs.webkit.org/show_bug.cgi?id=259753">https://bugs.webkit.org/show_bug.cgi?id=259753</a>
rdar://problem/113294324

Reviewed by Jonathan Bedard.

This relies on git rev-parse --show-toplevel to instead find the
top-level directory of the working tree, and just stores the path from
there in the hooks.

* Tools/Scripts/hooks/pre-commit:
* Tools/Scripts/hooks/pre-push:
* Tools/Scripts/hooks/prepare-commit-msg:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/install_hooks.py:
(InstallHooks.main):

Canonical link: <a href="https://commits.webkit.org/266577@main">https://commits.webkit.org/266577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/494e2bcf93913540a71e76ffc6157945ec90201a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16021 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14827 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16524 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14170 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19715 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13189 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16062 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11264 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/13962 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17008 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1687 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->