### PR TITLE
Unreviewed, relanding 266466@main

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -587,10 +587,10 @@ void Heap::releaseDelayedReleasedObjects()
 #endif
 }
 
-void Heap::reportExtraMemoryAllocatedSlowCase(size_t size)
+void Heap::reportExtraMemoryAllocatedSlowCase(GCDeferralContext* deferralContext, size_t size)
 {
     didAllocate(size);
-    collectIfNecessaryOrDefer();
+    collectIfNecessaryOrDefer(deferralContext);
 }
 
 void Heap::deprecatedReportExtraMemorySlowCase(size_t size)
@@ -600,7 +600,7 @@ void Heap::deprecatedReportExtraMemorySlowCase(size_t size)
     CheckedSize checkedNewSize = m_deprecatedExtraMemorySize;
     checkedNewSize += size;
     m_deprecatedExtraMemorySize = UNLIKELY(checkedNewSize.hasOverflowed()) ? std::numeric_limits<size_t>::max() : checkedNewSize.value();
-    reportExtraMemoryAllocatedSlowCase(size);
+    reportExtraMemoryAllocatedSlowCase(nullptr, size);
 }
 
 bool Heap::overCriticalMemoryThreshold(MemoryThresholdCallType memoryThresholdCallType)

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -388,6 +388,7 @@ public:
     // call both of these functions: Calling only one may trigger catastropic
     // memory growth.
     void reportExtraMemoryAllocated(size_t);
+    void reportExtraMemoryAllocated(GCDeferralContext*, size_t);
     JS_EXPORT_PRIVATE void reportExtraMemoryVisited(size_t);
 
 #if ENABLE(RESOURCE_USAGE)
@@ -612,7 +613,7 @@ private:
 
     Lock& lock() { return m_lock; }
 
-    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(size_t);
+    JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, size_t);
     JS_EXPORT_PRIVATE void deprecatedReportExtraMemorySlowCase(size_t);
     
     bool shouldCollectInCollectorThread(const AbstractLocker&);

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -212,8 +212,14 @@ inline HashSet<MarkedVectorBase*>& Heap::markListSet()
 
 inline void Heap::reportExtraMemoryAllocated(size_t size)
 {
-    if (size > minExtraMemory) 
-        reportExtraMemoryAllocatedSlowCase(size);
+    if (size > minExtraMemory)
+        reportExtraMemoryAllocatedSlowCase(nullptr, size);
+}
+
+inline void Heap::reportExtraMemoryAllocated(GCDeferralContext* deferralContext, size_t size)
+{
+    if (size > minExtraMemory)
+        reportExtraMemoryAllocatedSlowCase(deferralContext, size);
 }
 
 inline void Heap::deprecatedReportExtraMemory(size_t size)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -175,6 +175,14 @@ private:
         vm.heap.reportExtraMemoryAllocated(cost);
     }
 
+    void finishCreation(VM& vm, GCDeferralContext* deferralContext, unsigned length, size_t cost)
+    {
+        ASSERT_UNUSED(length, length > 0);
+        ASSERT(!valueInternal().isNull());
+        Base::finishCreation(vm);
+        vm.heap.reportExtraMemoryAllocated(deferralContext, cost);
+    }
+
     static JSString* createEmptyString(VM&);
 
     static JSString* create(VM& vm, Ref<StringImpl>&& value)
@@ -184,6 +192,16 @@ private:
         size_t cost = value->cost();
         JSString* newString = new (NotNull, allocateCell<JSString>(vm)) JSString(vm, WTFMove(value));
         newString->finishCreation(vm, length, cost);
+        return newString;
+    }
+
+    static JSString* create(VM& vm, GCDeferralContext* deferralContext, Ref<StringImpl>&& value)
+    {
+        unsigned length = value->length();
+        ASSERT(length > 0);
+        size_t cost = value->cost();
+        JSString* newString = new (NotNull, allocateCell<JSString>(vm, deferralContext)) JSString(vm, WTFMove(value));
+        newString->finishCreation(vm, deferralContext, length, cost);
         return newString;
     }
     static JSString* createHasOtherOwner(VM& vm, Ref<StringImpl>&& value)
@@ -968,24 +986,6 @@ inline JSString* jsSubstring(VM& vm, JSGlobalObject* globalObject, JSString* bas
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
     return jsSubstringOfResolved(vm, nullptr, base, offset, length);
-}
-
-inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContext, JSString* s, unsigned offset, unsigned length)
-{
-    ASSERT(offset <= s->length());
-    ASSERT(length <= s->length());
-    ASSERT(offset + length <= s->length());
-    ASSERT(!s->isRope());
-    if (!length)
-        return vm.smallStrings.emptyString();
-    if (!offset && length == s->length())
-        return s;
-    if (length == 1) {
-        auto& base = s->valueInternal();
-        if (auto c = base.characterAt(offset); c <= maxSingleCharacterString)
-            return vm.smallStrings.singleCharacterString(c);
-    }
-    return JSRopeString::createSubstringOfResolved(vm, deferralContext, s, offset, length);
 }
 
 inline JSString* jsSubstringOfResolved(VM& vm, JSString* s, unsigned offset, unsigned length)


### PR DESCRIPTION
#### cb6afa2ba34b9138e7492fe3bb5e61305fdd6e5e
<pre>
Unreviewed, relanding 266466@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=259757">https://bugs.webkit.org/show_bug.cgi?id=259757</a>
rdar://113302470

Limiting this to ASCII since this is the motivation (2-character atom is for minified scripts&apos; property names, which is ASCII).

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::reportExtraMemoryAllocatedSlowCase):
(JSC::Heap::deprecatedReportExtraMemorySlowCase):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapInlines.h:
(JSC::Heap::reportExtraMemoryAllocated):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::finishCreation):
(JSC::JSString::create):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::jsSubstringOfResolved):

Canonical link: <a href="https://commits.webkit.org/266532@main">https://commits.webkit.org/266532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7473485c2ac49e3bb8332ecd6cce9c32a330523

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16024 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16527 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19718 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12024 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13195 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16065 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13340 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11268 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14120 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12678 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3656 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17011 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14508 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13241 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3469 "Passed tests") | 
<!--EWS-Status-Bubble-End-->