### PR TITLE
WebKit Media: Toggling fullscreen fails to work

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKView.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKView.mm
@@ -913,14 +913,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
 }
 
-- (void)_web_windowWillEnterFullScreen
-{
-}
-
-- (void)_web_windowWillExitFullScreen
-{
-}
-
 - (void)_didHandleAcceptedCandidate
 {
 }

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -134,12 +134,25 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
     _impl->prepareContentInRect(NSRectToCGRect(rect));
 }
 
+- (BOOL)_holdWindowResizeSnapshotIfNeeded
+{
+#if HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)
+    if (self->_windowSnapshotReadinessHandler)
+        return NO;
+
+    if (!self.window || ![self.window respondsToSelector:@selector(_holdResizeSnapshotWithReason:)])
+        return NO;
+
+    _windowSnapshotReadinessHandler = makeBlockPtr([self.window _holdResizeSnapshotWithReason:@"full screen"]);
+    return !!_windowSnapshotReadinessHandler;
+#else
+    return NO;
+#endif
+}
+
 - (void)_doWindowSnapshotReadinessUpdate
 {
 #if HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)
-    if (!self->_windowSnapshotReadinessHandler)
-        return;
-
     [self _doAfterNextPresentationUpdate:makeBlockPtr([weakSelf = WeakObjCPtr<WKWebView>(self)] {
         auto strongSelf = weakSelf.get();
         if (!strongSelf)
@@ -152,6 +165,8 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
 
 - (void)setFrameSize:(NSSize)size
 {
+    BOOL didCreateWindowSnapshotReadinessHandler = [self _holdWindowResizeSnapshotIfNeeded];
+
     [super setFrameSize:size];
     [_safeBrowsingWarning setFrame:self.bounds];
     if (_impl)
@@ -159,7 +174,8 @@ std::optional<WebCore::ScrollbarOverlayStyle> toCoreScrollbarStyle(_WKOverlayScr
 
     [self _recalculateViewportSizesWithMinimumViewportInset:_minimumViewportInset maximumViewportInset:_maximumViewportInset throwOnInvalidInput:NO];
 
-    [self _doWindowSnapshotReadinessUpdate];
+    if (didCreateWindowSnapshotReadinessHandler)
+        [self _doWindowSnapshotReadinessUpdate];
 }
 
 - (void)setUserInterfaceLayoutDirection:(NSUserInterfaceLayoutDirection)userInterfaceLayoutDirection
@@ -1193,26 +1209,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_web_didChangeContentSize:(NSSize)newSize
 {
-}
-
-- (void)_holdWindowResizeSnapshotWithReason:(NSString *)reason
-{
-#if HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)
-    if (!self.window || ![self.window respondsToSelector:@selector(_holdResizeSnapshotWithReason:)])
-        return;
-
-    _windowSnapshotReadinessHandler = makeBlockPtr([self.window _holdResizeSnapshotWithReason:reason]);
-#endif
-}
-
-- (void)_web_windowWillEnterFullScreen
-{
-    [self _holdWindowResizeSnapshotWithReason:@"web view entering full screen"];
-}
-
-- (void)_web_windowWillExitFullScreen
-{
-    [self _holdWindowResizeSnapshotWithReason:@"web view exiting full screen"];
 }
 
 #if ENABLE(DRAG_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -139,9 +139,6 @@ struct TranslationContextMenuInfo;
 
 - (void)_web_didChangeContentSize:(NSSize)newSize;
 
-- (void)_web_windowWillEnterFullScreen;
-- (void)_web_windowWillExitFullScreen;
-
 #if ENABLE(DRAG_SUPPORT)
 - (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo;
 - (void)_web_didPerformDragOperation:(BOOL)handled;
@@ -231,9 +228,6 @@ public:
     bool frameSizeUpdatesDisabled() const;
     void setFrameAndScrollBy(CGRect, CGSize);
     void updateWindowAndViewFrames();
-
-    void windowWillEnterFullScreen();
-    void windowWillExitFullScreen();
 
     void setFixedLayoutSize(CGSize);
     CGSize fixedLayoutSize() const;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -323,9 +323,6 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeLayerHosting:) name:_NSWindowDidChangeContentsHostedInLayerSurfaceNotification object:window];
     [defaultNotificationCenter addObserver:self selector:@selector(_windowDidChangeOcclusionState:) name:NSWindowDidChangeOcclusionStateNotification object:window];
 
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillEnterFullScreen:) name:NSWindowWillEnterFullScreenNotification object:window];
-    [defaultNotificationCenter addObserver:self selector:@selector(_windowWillExitFullScreen:) name:NSWindowWillExitFullScreenNotification object:window];
-
     [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:NSScreenColorSpaceDidChangeNotification object:nil];
 
     if (_shouldObserveFontPanel)
@@ -359,8 +356,6 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     [defaultNotificationCenter removeObserver:self name:NSWindowDidChangeScreenNotification object:window];
     [defaultNotificationCenter removeObserver:self name:_NSWindowDidChangeContentsHostedInLayerSurfaceNotification object:window];
     [defaultNotificationCenter removeObserver:self name:NSWindowDidChangeOcclusionStateNotification object:window];
-    [defaultNotificationCenter removeObserver:self name:NSWindowWillEnterFullScreenNotification object:window];
-    [defaultNotificationCenter removeObserver:self name:NSWindowWillExitFullScreenNotification object:window];
 
     [defaultNotificationCenter removeObserver:self name:NSScreenColorSpaceDidChangeNotification object:nil];
 
@@ -452,16 +447,6 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 - (void)_windowDidChangeOcclusionState:(NSNotification *)notification
 {
     _impl->windowDidChangeOcclusionState();
-}
-
-- (void)_windowWillEnterFullScreen:(NSNotification *)notification
-{
-    _impl->windowWillEnterFullScreen();
-}
-
-- (void)_windowWillExitFullScreen:(NSNotification *)notification
-{
-    _impl->windowWillExitFullScreen();
 }
 
 - (void)_screenDidChangeColorSpace:(NSNotification *)notification
@@ -2073,16 +2058,6 @@ void WebViewImpl::windowDidChangeOcclusionState()
 {
     LOG(ActivityState, "WebViewImpl %p (page %llu) windowDidChangeOcclusionState", this, m_page->identifier().toUInt64());
     m_page->activityStateDidChange(WebCore::ActivityState::IsVisible);
-}
-
-void WebViewImpl::windowWillEnterFullScreen()
-{
-    [m_view _web_windowWillEnterFullScreen];
-}
-
-void WebViewImpl::windowWillExitFullScreen()
-{
-    [m_view _web_windowWillExitFullScreen];
 }
 
 void WebViewImpl::screenDidChangeColorSpace()


### PR DESCRIPTION
#### 43da1fd1587ab9c839f236204f090b0034ae9fc2
<pre>
WebKit Media: Toggling fullscreen fails to work
<a href="https://bugs.webkit.org/show_bug.cgi?id=259760">https://bugs.webkit.org/show_bug.cgi?id=259760</a>
rdar://111534888

Reviewed by Aditya Keerthi.

The window resize handler is created when receiving the `will{Enter|Exit}FullScreen` notification,
and is then invalidated as a result of `setFrameSize` being called. However, when transiting to/from
element full screen, `setFrameSize` is called before the notification is posted, instead of after.
This causes the handler to never be invalidated.

Fix by creating the handler directly inside `setFrameSize`, and not rely on the full screen
notifications at all. This is ok since `_holdResizeSnapshotWithReason` only returns a non-nil block
when entering or exiting full screen, so it has no effect in other cases.

No new tests, since all tests in `FullscreenVideoTextRecognition` already test this behavior in some
configurations.

* Source/WebKit/UIProcess/API/mac/WKView.mm:
(-[WKView _web_windowWillEnterFullScreen]): Deleted.
(-[WKView _web_windowWillExitFullScreen]): Deleted.
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _holdWindowResizeSnapshotWithReason:]):
(-[WKWebView setFrameSize:]):
(-[WKWebView _web_windowWillEnterFullScreen]): Deleted.
(-[WKWebView _web_windowWillExitFullScreen]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver stopObserving:]):
(-[WKWindowVisibilityObserver _windowWillEnterFullScreen:]): Deleted.
(-[WKWindowVisibilityObserver _windowWillExitFullScreen:]): Deleted.
(WebKit::WebViewImpl::windowWillEnterFullScreen): Deleted.
(WebKit::WebViewImpl::windowWillExitFullScreen): Deleted.

Canonical link: <a href="https://commits.webkit.org/266558@main">https://commits.webkit.org/266558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f680e434d168370faa656e66f1d89e76646f6554

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13409 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14542 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16603 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12186 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19775 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16124 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12745 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->