### PR TITLE
[Cocoa] Add logging for Element Fullscreen path inside WebKit

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -38,6 +38,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/IntRect.h>
 #include <WebCore/ScreenOrientationType.h>
+#include <wtf/LoggerHelper.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -45,6 +46,10 @@ using namespace WebCore;
 WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFullScreenManagerProxyClient& client)
     : m_page(page)
     , m_client(client)
+#if !RELEASE_LOG_DISABLED
+    , m_logger(page.logger())
+    , m_logIdentifier(page.logIdentifier())
+#endif
 {
     m_page.process().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
 }
@@ -58,6 +63,7 @@ WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 
 void WebFullScreenManagerProxy::willEnterFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::EnteringFullscreen;
     m_page.fullscreenClient().willEnterFullscreen(&m_page);
     m_page.send(Messages::WebFullScreenManager::WillEnterFullScreen());
@@ -65,6 +71,7 @@ void WebFullScreenManagerProxy::willEnterFullScreen()
 
 void WebFullScreenManagerProxy::didEnterFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::InFullscreen;
     m_page.fullscreenClient().didEnterFullscreen(&m_page);
     m_page.send(Messages::WebFullScreenManager::DidEnterFullScreen());
@@ -77,6 +84,7 @@ void WebFullScreenManagerProxy::didEnterFullScreen()
 
 void WebFullScreenManagerProxy::willExitFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::ExitingFullscreen;
     m_page.fullscreenClient().willExitFullscreen(&m_page);
     m_page.send(Messages::WebFullScreenManager::WillExitFullScreen());
@@ -97,6 +105,7 @@ void WebFullScreenManagerProxy::closeWithCallback(CompletionHandler<void()>&& co
 
 void WebFullScreenManagerProxy::didExitFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::NotInFullscreen;
     m_page.fullscreenClient().didExitFullscreen(&m_page);
     m_page.send(Messages::WebFullScreenManager::DidExitFullScreen());
@@ -115,11 +124,13 @@ void WebFullScreenManagerProxy::setAnimatingFullScreen(bool animating)
 
 void WebFullScreenManagerProxy::requestRestoreFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page.send(Messages::WebFullScreenManager::RequestRestoreFullScreen());
 }
 
 void WebFullScreenManagerProxy::requestExitFullScreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page.send(Messages::WebFullScreenManager::RequestExitFullScreen());
 }
 
@@ -222,6 +233,13 @@ void WebFullScreenManagerProxy::unlockFullscreenOrientation()
 {
     m_client.unlockFullscreenOrientation();
 }
+
+#if !RELEASE_LOG_DISABLED
+WTFLogChannel& WebFullScreenManagerProxy::logChannel() const
+{
+    return WebKit2LogFullscreen;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -115,6 +115,13 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "WebFullScreenManagerProxy"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
     WebPageProxy& m_page;
     WebFullScreenManagerProxyClient& m_client;
     FullscreenState m_fullscreenState { FullscreenState::NotInFullscreen };
@@ -123,6 +130,11 @@ private:
     bool m_isVideoElement { false };
 #endif
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
+
+#if !RELEASE_LOG_DISABLED
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -47,6 +47,7 @@
 #include <WebCore/Settings.h>
 #include <WebCore/TypedElementDescendantIteratorInlines.h>
 #include <WebCore/UserGestureIndicator.h>
+#include <wtf/LoggerHelper.h>
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 #include "PlaybackSessionManager.h"
@@ -73,16 +74,20 @@ static WebCore::IntRect screenRectOfContents(WebCore::Element* element)
     return element->screenRect();
 }
 
-Ref<WebFullScreenManager> WebFullScreenManager::create(WebPage* page)
+Ref<WebFullScreenManager> WebFullScreenManager::create(WebPage& page)
 {
     return adoptRef(*new WebFullScreenManager(page));
 }
 
-WebFullScreenManager::WebFullScreenManager(WebPage* page)
+WebFullScreenManager::WebFullScreenManager(WebPage& page)
     : WebCore::EventListener(WebCore::EventListener::CPPEventListenerType)
     , m_page(page)
 #if ENABLE(VIDEO)
     , m_mainVideoElementTextRecognitionTimer(RunLoop::main(), this, &WebFullScreenManager::mainVideoElementTextRecognitionTimerFired)
+#endif
+#if !RELEASE_LOG_DISABLED
+    , m_logger(page.logger())
+    , m_logIdentifier(page.logIdentifier())
 #endif
 {
 }
@@ -94,6 +99,7 @@ WebFullScreenManager::~WebFullScreenManager()
 
 void WebFullScreenManager::invalidate()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     clearElement();
 #if ENABLE(VIDEO)
     setMainVideoElement(nullptr);
@@ -109,7 +115,7 @@ WebCore::Element* WebFullScreenManager::element()
 void WebFullScreenManager::videoControlsManagerDidChange()
 {
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
-    LOG(Fullscreen, "WebFullScreenManager %p videoControlsManagerDidChange()", this);
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     auto* currentPlaybackControlsElement = m_page->playbackSessionManager().currentPlaybackControlsElement();
     if (!m_element || !is<WebCore::HTMLVideoElement>(currentPlaybackControlsElement)) {
@@ -127,7 +133,8 @@ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipSt
     if (pipStandbyElement == m_pipStandbyElement)
         return;
 
-    LOG(Fullscreen, "WebFullScreenManager %p setPIPStandbyElement() - old element %p, new element %p", this, m_pipStandbyElement.get(), pipStandbyElement);
+    auto logIdentifierForElement = [] (auto* element) { return element ? element->logIdentifier() : nullptr; };
+    ALWAYS_LOG(LOGIDENTIFIER, "old element ", logIdentifierForElement(m_pipStandbyElement.get()), ", new element ", logIdentifierForElement(pipStandbyElement));
 
     if (m_pipStandbyElement)
         m_pipStandbyElement->setVideoFullscreenStandby(false);
@@ -149,7 +156,7 @@ bool WebFullScreenManager::supportsFullScreen(bool withKeyboard)
     if (!m_page->corePage()->settings().fullScreenEnabled())
         return false;
 
-    return m_page->injectedBundleFullScreenClient().supportsFullScreen(m_page.get(), withKeyboard);
+    return m_page->injectedBundleFullScreenClient().supportsFullScreen(m_page.ptr(), withKeyboard);
 }
 
 static auto& eventsToObserve()
@@ -187,11 +194,11 @@ void WebFullScreenManager::clearElement()
 
 void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
 {
-    LOG(Fullscreen, "WebFullScreenManager %p enterFullScreenForElement(%p)", this, element);
-
     ASSERT(element);
     if (!element)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
 
     setElement(*element);
 
@@ -214,13 +221,17 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element)
     if (m_mainVideoElement)
         videoDimensions = FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight());
 #endif
-    m_page->injectedBundleFullScreenClient().enterFullScreenForElement(m_page.get(), element, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), isVideoElement, videoDimensions);
+    m_page->injectedBundleFullScreenClient().enterFullScreenForElement(m_page.ptr(), element, m_element->document().quirks().blocksReturnToFullscreenFromPictureInPictureQuirk(), isVideoElement, videoDimensions);
 }
 
 void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element)
 {
-    LOG(Fullscreen, "WebFullScreenManager %p exitFullScreenForElement(%p) - fullscreen element %p", this, element, m_element.get());
-    m_page->injectedBundleFullScreenClient().exitFullScreenForElement(m_page.get(), element);
+    if (element)
+        ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
+    else
+        ALWAYS_LOG(LOGIDENTIFIER, "null");
+
+    m_page->injectedBundleFullScreenClient().exitFullScreenForElement(m_page.ptr(), element);
 #if ENABLE(VIDEO)
     setMainVideoElement(nullptr);
 #endif
@@ -228,10 +239,11 @@ void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element)
 
 void WebFullScreenManager::willEnterFullScreen()
 {
-    LOG(Fullscreen, "WebFullScreenManager %p willEnterFullScreen() - element %p", this, m_element.get());
     ASSERT(m_element);
     if (!m_element)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
     if (!m_element->document().fullscreenManager().willEnterFullscreen(*m_element)) {
         close();
@@ -248,15 +260,16 @@ void WebFullScreenManager::willEnterFullScreen()
 #endif
     m_element->document().updateLayout();
     m_finalFrame = screenRectOfContents(m_element.get());
-    m_page->injectedBundleFullScreenClient().beganEnterFullScreen(m_page.get(), m_initialFrame, m_finalFrame);
+    m_page->injectedBundleFullScreenClient().beganEnterFullScreen(m_page.ptr(), m_initialFrame, m_finalFrame);
 }
 
 void WebFullScreenManager::didEnterFullScreen()
 {
-    LOG(Fullscreen, "WebFullScreenManager %p didEnterFullScreen() - element %p", this, m_element.get());
     ASSERT(m_element);
     if (!m_element)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
     if (!m_element->document().fullscreenManager().didEnterFullscreen()) {
         close();
@@ -309,9 +322,9 @@ void WebFullScreenManager::updateMainVideoElement()
 
 void WebFullScreenManager::willExitFullScreen()
 {
-    LOG(Fullscreen, "WebFullScreenManager %p willExitFullScreen() - element %p", this, m_element.get());
     if (!m_element)
         return;
+    ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
 #if ENABLE(VIDEO)
     setPIPStandbyElement(nullptr);
@@ -325,14 +338,15 @@ void WebFullScreenManager::willExitFullScreen()
 #if !PLATFORM(IOS_FAMILY)
     m_page->showPageBanners();
 #endif
-    m_page->injectedBundleFullScreenClient().beganExitFullScreen(m_page.get(), m_finalFrame, m_initialFrame);
+    m_page->injectedBundleFullScreenClient().beganExitFullScreen(m_page.ptr(), m_finalFrame, m_initialFrame);
 }
 
 void WebFullScreenManager::didExitFullScreen()
 {
-    LOG(Fullscreen, "WebFullScreenManager %p didExitFullScreen() - element %p", this, m_element.get());
     if (!m_element)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
     setFullscreenInsets(WebCore::FloatBoxExtent());
     setFullscreenAutoHideDuration(0_s);
@@ -355,9 +369,12 @@ void WebFullScreenManager::requestRestoreFullScreen()
         return;
 
     auto element = RefPtr { m_elementToRestore.get() };
-    if (!element)
+    if (!element) {
+        ALWAYS_LOG(LOGIDENTIFIER, "no element to restore");
         return;
+    }
 
+    ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
     WebCore::UserGestureIndicator gestureIndicator(WebCore::ProcessingUserGesture, &element->document());
     element->document().fullscreenManager().requestFullscreenForElement(*element, nullptr, WebCore::FullscreenManager::ExemptIFrameAllowFullscreenRequirement);
 }
@@ -365,15 +382,18 @@ void WebFullScreenManager::requestRestoreFullScreen()
 void WebFullScreenManager::requestExitFullScreen()
 {
     if (!m_element) {
+        ALWAYS_LOG(LOGIDENTIFIER, "no element, closing");
         close();
         return;
     }
 
     auto& topDocument = m_element->document().topDocument();
     if (!topDocument.fullscreenManager().fullscreenElement()) {
+        ALWAYS_LOG(LOGIDENTIFIER, "top document not in fullscreen, closing");
         close();
         return;
     }
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_element->document().fullscreenManager().cancelFullscreen();
 }
 
@@ -382,8 +402,8 @@ void WebFullScreenManager::close()
     if (m_closing)
         return;
     m_closing = true;
-    LOG(Fullscreen, "WebFullScreenManager %p close()", this);
-    m_page->injectedBundleFullScreenClient().closeFullScreen(m_page.get());
+    ALWAYS_LOG(LOGIDENTIFIER);
+    m_page->injectedBundleFullScreenClient().closeFullScreen(m_page.ptr());
     invalidate();
     m_closing = false;
 }
@@ -512,6 +532,13 @@ void WebFullScreenManager::setMainVideoElement(RefPtr<WebCore::HTMLVideoElement>
 }
 
 #endif // ENABLE(VIDEO)
+
+#if !RELEASE_LOG_DISABLED
+WTFLogChannel& WebFullScreenManager::logChannel() const
+{
+    return WebKit2LogFullscreen;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -55,7 +55,7 @@ class WebPage;
 
 class WebFullScreenManager final : public WebCore::EventListener {
 public:
-    static Ref<WebFullScreenManager> create(WebPage*);
+    static Ref<WebFullScreenManager> create(WebPage&);
     virtual ~WebFullScreenManager();
 
     void invalidate();
@@ -81,7 +81,7 @@ public:
     bool operator==(const WebCore::EventListener& listener) const final { return this == &listener; }
 
 protected:
-    WebFullScreenManager(WebPage*);
+    WebFullScreenManager(WebPage&);
 
     void setPIPStandbyElement(WebCore::HTMLVideoElement*);
 
@@ -98,7 +98,7 @@ protected:
     WebCore::IntRect m_finalFrame;
     WebCore::IntPoint m_scrollPosition;
     float m_topContentInset { 0 };
-    RefPtr<WebPage> m_page;
+    Ref<WebPage> m_page;
     RefPtr<WebCore::Element> m_element;
     WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> m_elementToRestore;
 #if ENABLE(VIDEO)
@@ -113,6 +113,13 @@ private:
     void setElement(WebCore::Element&);
     void clearElement();
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "WebFullScreenManager"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
 #if ENABLE(VIDEO)
     void scheduleTextRecognitionForMainVideo();
     void endTextRecognitionForMainVideoIfNeeded();
@@ -126,6 +133,11 @@ private:
 #endif // ENABLE(VIDEO)
 
     bool m_closing { false };
+
+#if !RELEASE_LOG_DISABLED
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4952,7 +4952,7 @@ void WebPage::setAllowsMediaDocumentInlinePlayback(bool allows)
 WebFullScreenManager* WebPage::fullScreenManager()
 {
     if (!m_fullScreenManager)
-        m_fullScreenManager = WebFullScreenManager::create(this);
+        m_fullScreenManager = WebFullScreenManager::create(*this);
     return m_fullScreenManager.get();
 }
 #endif


### PR DESCRIPTION
#### 20b21450ef4de9f80bd2d7ed1263294cb4799ccf
<pre>
[Cocoa] Add logging for Element Fullscreen path inside WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=259761">https://bugs.webkit.org/show_bug.cgi?id=259761</a>
rdar://113308053

Reviewed by Simon Fraser.

Add LoggerHelper-style logging to WebFullScreenManager, WebFullScreenManagerProxy,
and WKFullScreenWindowController (iOS).

Drive-by Fix: Ensure the WebPage parameter to the WebFullScreenManagerProxy::create()
method is non-null by making it a reference (&amp;) rather than pointer (*).

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::willExitFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
(WebKit::WebFullScreenManagerProxy::requestRestoreFullScreen):
(WebKit::WebFullScreenManagerProxy::requestExitFullScreen):
(WebKit::WebFullScreenManagerProxy::logChannel const):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::logger const):
(WebKit::WebFullScreenManagerProxy::logIdentifier const):
(WebKit::WebFullScreenManagerProxy::logClassName const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WTF::LogArgument&lt;WebKit::FullScreenState&gt;::toString):
(-[WKFullScreenWindowController initWithWebView:]):
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController requestRestoreFullScreen]):
(-[WKFullScreenWindowController requestExitFullScreen]):
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _completedExitFullScreen]):
(-[WKFullScreenWindowController close]):
(-[WKFullScreenWindowController webViewDidRemoveFromSuperviewWhileInFullscreen]):
(-[WKFullScreenWindowController didEnterPictureInPicture]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
(-[WKFullScreenWindowController _startToDismissFullscreenChanged:]):
(-[WKFullScreenWindowController _dismissFullscreenViewController]):
(-[WKFullScreenWindowController _interactiveDismissChanged:]):
(-[WKFullScreenWindowController _interactivePinchDismissChanged:]):
(-[WKFullScreenWindowController _configureSpatialFullScreenTransition]):
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
(-[WKFullScreenWindowController logIdentifier]):
(-[WKFullScreenWindowController loggerPtr]):
(-[WKFullScreenWindowController logChannel]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::create):
(WebKit::WebFullScreenManager::WebFullScreenManager):
(WebKit::WebFullScreenManager::invalidate):
(WebKit::WebFullScreenManager::videoControlsManagerDidChange):
(WebKit::WebFullScreenManager::setPIPStandbyElement):
(WebKit::WebFullScreenManager::supportsFullScreen):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::exitFullScreenForElement):
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::didEnterFullScreen):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::WebFullScreenManager::didExitFullScreen):
(WebKit::WebFullScreenManager::requestRestoreFullScreen):
(WebKit::WebFullScreenManager::requestExitFullScreen):
(WebKit::WebFullScreenManager::close):
(WebKit::WebFullScreenManager::logChannel const):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::fullScreenManager):

Canonical link: <a href="https://commits.webkit.org/266541@main">https://commits.webkit.org/266541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e16da3697f00fec6572767b4aa80cf39efdd58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14110 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13377 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16053 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16564 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12146 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19748 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12712 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3409 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->