### PR TITLE
screen orientation should match other browsers

### DIFF
--- a/LayoutTests/fast/screen-orientation/orientation-in-resize-event.html
+++ b/LayoutTests/fast/screen-orientation/orientation-in-resize-event.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta name="viewport" content="initial-scale=1.0">
-<script src="../../resources/js-test.js"></script
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/fast/screen-orientation/orientation-types-and-angles-expected.txt
+++ b/LayoutTests/fast/screen-orientation/orientation-types-and-angles-expected.txt
@@ -1,0 +1,25 @@
+Checks that screen.orientation.type and angles are as expected when device is rotated (for a portrait device).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS isPortrait is true
+
+Simulating rotation to "landscape-right".
+PASS screen.orientation.type is "landscape-secondary"
+PASS screen.orientation.angle is 270
+PASS window.orientation is -90
+
+Simulating rotation to "portrait".
+PASS screen.orientation.type is "portrait-primary"
+PASS screen.orientation.angle is 0
+PASS window.orientation is 0
+
+Simulating rotation to "landscape-left".
+PASS screen.orientation.type is "landscape-primary"
+PASS screen.orientation.angle is 90
+PASS window.orientation is 90
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/screen-orientation/orientation-types-and-angles.html
+++ b/LayoutTests/fast/screen-orientation/orientation-types-and-angles.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="initial-scale=1.0" />
+        <script src="../../resources/js-test.js"></script>
+    </head>
+    <body>
+        <script>
+            description(
+                "Checks that screen.orientation.type and angles are as expected when device is rotated (for a portrait device)."
+            );
+            jsTestIsAsync = true;
+
+            const rotations = new Map([
+                [
+                    "landscape-right",
+                    {
+                        type: "landscape-secondary",
+                        angle: 270,
+                        orientation: -90,
+                    },
+                ],
+                [
+                    "portrait",
+                    {
+                        type: "portrait-primary",
+                        angle: 0,
+                        orientation: 0,
+                    },
+                ],
+                [
+                    "landscape-left",
+                    {
+                        type: "landscape-primary",
+                        angle: 90,
+                        orientation: 90,
+                    },
+                ],
+                // Would only work with .lock() enabled
+                // [
+                //     "portrait-upsidedown",
+                //     {
+                //         type: "portrait-secondary",
+                //         angle: 180,
+                //         orientation: 8,
+                //     },
+                // ],
+            ]);
+
+            function runRotationUIScript(rotation) {
+                debug(`\nSimulating rotation to "${rotation}".`);
+                const script = `
+                    (async () => {
+                        await new Promise(r => uiController.simulateRotationLikeSafari("${rotation}", r));
+                        await new Promise(r => uiController.doAfterVisibleContentRectUpdate(r));
+                        uiController.uiScriptComplete();
+                    })();
+                `;
+                const orientationChangeEventPromise = new Promise((r) =>
+                    screen.orientation.addEventListener("change", r, {
+                        once: true,
+                    })
+                );
+                const uiScriptPromise = new Promise((r) =>
+                    testRunner.runUIScript(script, r)
+                );
+                return Promise.all([
+                    orientationChangeEventPromise,
+                    uiScriptPromise,
+                ]);
+            }
+
+            onload = async () => {
+                isPortrait = screen.orientation.type.startsWith("portrait");
+                shouldBeTrue("isPortrait");
+                type = null;
+                for (const [rotation, expected] of rotations.entries()) {
+                    await runRotationUIScript(rotation);
+                    shouldBeEqualToString("screen.orientation.type", expected.type);
+                    shouldBeEqualToNumber("screen.orientation.angle", expected.angle);
+                    shouldBeEqualToNumber("window.orientation", expected.orientation);
+                }
+                finishJSTest();
+            };
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -269,6 +269,7 @@ webaudio/codec-tests/mp3/128kbps-44khz.html [ Pass ]
 
 # uiController.simulateRotationLikeSafari() is not implemented on glib ports.
 fast/screen-orientation/orientation-in-resize-event.html [ Skip ]
+fast/screen-orientation/orientation-types-and-angles.html [ Skip ]
 
 # Pass since r273206
 imported/w3c/web-platform-tests/css/css-sizing/range-percent-intrinsic-size-2.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -137,6 +137,7 @@ accessibility/multiselect-list-reports-active-option.html
 
 # uiController.simulateRotationLikeSafari() is not implemented on macOS.
 fast/screen-orientation/orientation-in-resize-event.html [ Skip ]
+fast/screen-orientation/orientation-types-and-angles.html [ Skip ]
 
 # Need to implement AccessibilityUIElement::clearSelectedChildren()
 accessibility/aria-listbox-clear-selection-crash.html

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -376,7 +376,7 @@ void LocalFrame::orientationChanged()
 IntDegrees LocalFrame::orientation() const
 {
     if (auto* page = this->page())
-        return page->chrome().client().deviceOrientation();
+        return page->chrome().client().deviceOrientation() * -1;
     return 0;
 }
 #endif // ENABLE(ORIENTATION_EVENTS)

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -184,7 +184,7 @@ uint16_t ScreenOrientation::angle() const
     auto* manager = this->manager();
     auto orientation = manager ? manager->currentOrientation() : naturalScreenOrientationType();
 
-    // https://w3c.github.io/screen-orientation/#dfn-screen-orientation-values-table
+    // https://w3c.github.io/screen-orientation/#the-current-screen-orientation-type-and-angle
     if (isPortrait(naturalScreenOrientationType())) {
         switch (orientation) {
         case Type::PortraitPrimary:

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -763,9 +763,9 @@ static UIInterfaceOrientationMask toUIInterfaceOrientationMask(WebCore::ScreenOr
     case WebCore::ScreenOrientationType::PortraitSecondary:
         return UIInterfaceOrientationMaskPortraitUpsideDown;
     case WebCore::ScreenOrientationType::LandscapePrimary:
-        return UIInterfaceOrientationMaskLandscapeRight;
-    case WebCore::ScreenOrientationType::LandscapeSecondary:
         return UIInterfaceOrientationMaskLandscapeLeft;
+    case WebCore::ScreenOrientationType::LandscapeSecondary:
+        return UIInterfaceOrientationMaskLandscapeRight;
     }
     ASSERT_NOT_REACHED();
     return UIInterfaceOrientationMaskPortrait;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -316,11 +316,11 @@ void WebPageProxy::setForceAlwaysUserScalable(bool userScalable)
 WebCore::ScreenOrientationType WebPageProxy::toScreenOrientationType(IntDegrees angle)
 {
     if (angle == -90)
-        return WebCore::ScreenOrientationType::LandscapeSecondary;
+        return WebCore::ScreenOrientationType::LandscapePrimary;
     if (angle == 180)
         return WebCore::ScreenOrientationType::PortraitSecondary;
     if (angle == 90)
-        return WebCore::ScreenOrientationType::LandscapePrimary;
+        return WebCore::ScreenOrientationType::LandscapeSecondary;
     return WebCore::ScreenOrientationType::PortraitPrimary;
 }
 

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -536,10 +536,10 @@ void TestController::lockScreenOrientation(WKScreenOrientationType orientation)
         webView.supportedInterfaceOrientations = UIInterfaceOrientationMaskPortraitUpsideDown;
         break;
     case kWKScreenOrientationTypeLandscapePrimary:
-        webView.supportedInterfaceOrientations = UIInterfaceOrientationMaskLandscapeRight;
+        webView.supportedInterfaceOrientations = UIInterfaceOrientationMaskLandscapeLeft;
         break;
     case kWKScreenOrientationTypeLandscapeSecondary:
-        webView.supportedInterfaceOrientations = UIInterfaceOrientationMaskLandscapeLeft;
+        webView.supportedInterfaceOrientations = UIInterfaceOrientationMaskLandscapeRight;
         break;
     }
     [UIView performWithoutAnimation:^{


### PR DESCRIPTION
#### 8df6fffd2980f76772db9727294efa1e91335a32
<pre>
screen orientation should match other browsers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259762">https://bugs.webkit.org/show_bug.cgi?id=259762</a>
rdar://113312337

Reviewed by NOBODY (OOPS!).

Flipped the order so it matches what browsers on Android report, that is:

  - Device turned clockwise is &quot;landscape-secondary&quot;, angle 270.
  - Device turned counter-clockwise, &quot;landscape-primary&quot;, angle 90.
  - iOS actual legacy angles are the opposite of Android.

* LayoutTests/fast/screen-orientation/orientation-in-resize-event.html:
* LayoutTests/fast/screen-orientation/orientation-types-and-angles-expected.txt: Added.
* LayoutTests/fast/screen-orientation/orientation-types-and-angles.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::orientation const):
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::toUIInterfaceOrientationMask):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::toScreenOrientationType):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::lockScreenOrientation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8df6fffd2980f76772db9727294efa1e91335a32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16328 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17059 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13150 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13638 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11830 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13007 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->