### PR TITLE
[JSC] Use libpas' zeroed-allocation for zero-filling typed array allocations

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -129,15 +129,16 @@ void ArrayBufferContents::tryAllocate(size_t numElements, unsigned elementByteSi
     if (!allocationSize)
         allocationSize = 1; // Make sure malloc actually allocates something, but not too much. We use null to mean that the buffer is detached.
 
-    void* data = Gigacage::tryMalloc(Gigacage::Primitive, allocationSize);
+    void* data = nullptr;
+    if (policy == InitializationPolicy::ZeroInitialize)
+        data = Gigacage::tryZeroedMalloc(Gigacage::Primitive, allocationSize);
+    else
+        data = Gigacage::tryMalloc(Gigacage::Primitive, allocationSize);
     m_data = DataType(data, sizeInBytes.value());
     if (!data) {
         reset();
         return;
     }
-    
-    if (policy == InitializationPolicy::ZeroInitialize)
-        memset(data, 0, allocationSize);
 
     m_sizeInBytes = sizeInBytes.value();
     RELEASE_ASSERT(m_sizeInBytes <= MAX_ARRAY_BUFFER_SIZE);

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -90,12 +90,15 @@ JSArrayBufferView::ConstructionContext::ConstructionContext(VM& vm, Structure* s
     if (size.hasOverflowed() || size > MAX_ARRAY_BUFFER_SIZE)
         return;
 
-    m_vector = VectorType(Gigacage::tryMalloc(Gigacage::Primitive, size.value()), m_length);
+    void* memory = nullptr;
+    if (mode == ZeroFill)
+        memory = Gigacage::tryZeroedMalloc(Gigacage::Primitive, size.value());
+    else
+        memory = Gigacage::tryMalloc(Gigacage::Primitive, size.value());
+    m_vector = VectorType(memory, m_length);
     if (!m_vector)
         return;
-    if (mode == ZeroFill)
-        memset(vector(), 0, size);
-    
+
     vm.heap.reportExtraMemoryAllocated(size.value());
     
     m_structure = structure;

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -117,13 +117,6 @@ void fastSetMaxSingleAllocationSize(size_t size)
 
 #endif // !defined(NDEBUG)
 
-void* fastZeroedMalloc(size_t n) 
-{
-    void* result = fastMalloc(n);
-    memset(result, 0, n);
-    return result;
-}
-
 char* fastStrDup(const char* src)
 {
     size_t len = strlen(src) + 1;
@@ -139,15 +132,6 @@ void* fastMemDup(const void* mem, size_t bytes)
 
     void* result = fastMalloc(bytes);
     memcpy(result, mem, bytes);
-    return result;
-}
-
-TryMallocReturnValue tryFastZeroedMalloc(size_t n) 
-{
-    void* result;
-    if (!tryFastMalloc(n).getValue(result))
-        return nullptr;
-    memset(result, 0, n);
     return result;
 }
 
@@ -241,6 +225,22 @@ void* fastMalloc(size_t n)
     if (!result)
         CRASH();
 
+    return result;
+}
+
+void* fastZeroedMalloc(size_t n)
+{
+    void* result = fastMalloc(n);
+    memset(result, 0, n);
+    return result;
+}
+
+TryMallocReturnValue tryFastZeroedMalloc(size_t n)
+{
+    void* result;
+    if (!tryFastMalloc(n).getValue(result))
+        return nullptr;
+    memset(result, 0, n);
     return result;
 }
 
@@ -536,6 +536,25 @@ void* fastMalloc(size_t size)
         MallocCallTracker::singleton().recordMalloc(result, size);
 #endif
     return result;
+}
+
+void* fastZeroedMalloc(size_t size)
+{
+    ASSERT_IS_WITHIN_LIMIT(size);
+    ASSERT(!forbidMallocUseScopeCount || disableMallocRestrictionScopeCount);
+    void* result = bmalloc::api::zeroedMalloc(size);
+#if ENABLE(MALLOC_HEAP_BREAKDOWN) && TRACK_MALLOC_CALLSTACK
+    if (!AvoidRecordingScope::avoidRecordingCount())
+        MallocCallTracker::singleton().recordMalloc(result, size);
+#endif
+    return result;
+}
+
+TryMallocReturnValue tryFastZeroedMalloc(size_t size)
+{
+    FAIL_IF_EXCEEDS_LIMIT(size);
+    ASSERT(!forbidMallocUseScopeCount || disableMallocRestrictionScopeCount);
+    return bmalloc::api::tryZeroedMalloc(size);
 }
 
 void* fastCalloc(size_t numElements, size_t elementSize)

--- a/Source/WTF/wtf/Gigacage.cpp
+++ b/Source/WTF/wtf/Gigacage.cpp
@@ -39,6 +39,11 @@ void* tryMalloc(Kind, size_t size)
     return FastMalloc::tryMalloc(size);
 }
 
+void* tryZeroedMalloc(Kind, size_t size)
+{
+    return FastMalloc::tryZeroedMalloc(size);
+}
+
 void* tryRealloc(Kind, void* pointer, size_t size)
 {
     return FastMalloc::tryRealloc(pointer, size);
@@ -96,6 +101,13 @@ void* tryMalloc(Kind kind, size_t size)
     return result;
 }
 
+void* tryZeroedMalloc(Kind kind, size_t size)
+{
+    void* result = bmalloc::api::tryZeroedMalloc(size, bmalloc::heapKind(kind));
+    WTF::compilerFence();
+    return result;
+}
+
 void* tryRealloc(Kind kind, void* pointer, size_t size)
 {
     void* result = bmalloc::api::tryRealloc(pointer, size, bmalloc::heapKind(kind));
@@ -145,6 +157,13 @@ void* tryMallocArray(Kind kind, size_t numElements, size_t elementSize)
 void* malloc(Kind kind, size_t size)
 {
     void* result = tryMalloc(kind, size);
+    RELEASE_ASSERT(result);
+    return result;
+}
+
+void* zeroedMalloc(Kind kind, size_t size)
+{
+    void* result = tryZeroedMalloc(kind, size);
     RELEASE_ASSERT(result);
     return result;
 }

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -86,6 +86,7 @@ inline bool isCaged(Kind, const void*) { return false; }
 inline void* tryAlignedMalloc(Kind, size_t alignment, size_t size) { return tryFastAlignedMalloc(alignment, size); }
 inline void alignedFree(Kind, void* p) { fastAlignedFree(p); }
 WTF_EXPORT_PRIVATE void* tryMalloc(Kind, size_t size);
+WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 inline void free(Kind, void* p) { fastFree(p); }
 
@@ -101,6 +102,7 @@ namespace Gigacage {
 WTF_EXPORT_PRIVATE void* tryAlignedMalloc(Kind, size_t alignment, size_t size);
 WTF_EXPORT_PRIVATE void alignedFree(Kind, void*);
 WTF_EXPORT_PRIVATE void* tryMalloc(Kind, size_t);
+WTF_EXPORT_PRIVATE void* tryZeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* tryRealloc(Kind, void*, size_t);
 WTF_EXPORT_PRIVATE void free(Kind, void*);
 
@@ -115,6 +117,7 @@ namespace Gigacage {
 WTF_EXPORT_PRIVATE void* tryMallocArray(Kind, size_t numElements, size_t elementSize);
 
 WTF_EXPORT_PRIVATE void* malloc(Kind, size_t);
+WTF_EXPORT_PRIVATE void* zeroedMalloc(Kind, size_t);
 WTF_EXPORT_PRIVATE void* mallocArray(Kind, size_t numElements, size_t elementSize);
 
 } // namespace Gigacage

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -76,6 +76,34 @@ BINLINE void* malloc(size_t size, HeapKind kind = HeapKind::Primary)
 #endif
 }
 
+BINLINE void* tryZeroedMalloc(size_t size, HeapKind kind = HeapKind::Primary)
+{
+#if BUSE(LIBPAS)
+    if (!isGigacage(kind))
+        return bmalloc_try_allocate_zeroed_inline(size);
+    return bmalloc_try_allocate_auxiliary_zeroed_inline(&heapForKind(gigacageKind(kind)), size);
+#else
+    auto* mem = Cache::tryAllocate(kind, size);
+    if (mem)
+        memset(mem, 0, size);
+    return mem;
+#endif
+}
+
+// Crashes on failure.
+BINLINE void* zeroedMalloc(size_t size, HeapKind kind = HeapKind::Primary)
+{
+#if BUSE(LIBPAS)
+    if (!isGigacage(kind))
+        return bmalloc_allocate_zeroed_inline(size);
+    return bmalloc_allocate_auxiliary_zeroed_inline(&heapForKind(gigacageKind(kind)), size);
+#else
+    auto* mem = Cache::allocate(kind, size);
+    memset(mem, 0, size);
+    return mem;
+#endif
+}
+
 BEXPORT void* mallocOutOfLine(size_t size, HeapKind kind = HeapKind::Primary);
 
 // Returns null on failure.


### PR DESCRIPTION
#### ad82b5545b504a00555bc7f6d8f6fb94bb8dc896
<pre>
[JSC] Use libpas&apos; zeroed-allocation for zero-filling typed array allocations
<a href="https://bugs.webkit.org/show_bug.cgi?id=259765">https://bugs.webkit.org/show_bug.cgi?id=259765</a>
rdar://113315414

Reviewed by Mark Lam.

It turned out that large typed array can consume long time for zeroing its backing store.
But libpas already knows that this is zero-filled or not (for example, newly allocated pages are zeroed),
and libpas have try_allocate_zeroed APIs to return efficiently zero-filled memory.
This patch leverages this for TypedArray allocations.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBufferContents::tryAllocate):
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
(JSC::JSArrayBufferView::ConstructionContext::ConstructionContext):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastZeroedMalloc):
(WTF::tryFastZeroedMalloc):
* Source/WTF/wtf/Gigacage.cpp:
(Gigacage::tryZeroedMalloc):
(Gigacage::zeroedMalloc):
* Source/WTF/wtf/Gigacage.h:
* Source/bmalloc/bmalloc/bmalloc.h:
(bmalloc::api::tryZeroedMalloc):
(bmalloc::api::zeroedMalloc):

Canonical link: <a href="https://commits.webkit.org/266536@main">https://commits.webkit.org/266536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bee6fcc9290c76ed83b4aad53105580b9bb62a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15831 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14490 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16035 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14844 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16542 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12127 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12706 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12037 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13206 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16075 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13354 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11279 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14133 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12693 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/3658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17026 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14521 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1667 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13255 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3471 "Passed tests") | 
<!--EWS-Status-Bubble-End-->