### PR TITLE
CSS Custom Highlights WPT painting 008 fail due to not initializing SetLike before removal

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4896,7 +4896,6 @@ webkit.org/b/217931 imported/w3c/web-platform-tests/html/semantics/scripting-1/t
 webkit.org/b/220325 http/wpt/css/css-highlight-api/highlight-text-cascade.html [ ImageOnlyFailure ]
 
 # Tests need updating relating to Highlight Spec
-imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-008.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/css-target-text-decoration-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-below-target-text.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-inheritance-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/Modules/highlight/Highlight.idl
+++ b/Source/WebCore/Modules/highlight/Highlight.idl
@@ -38,5 +38,4 @@ enum HighlightType {
     setlike<AbstractRange>;
     attribute long priority;
     attribute HighlightType type;
-    // FIXME: Add readonly attribute CSSStyleDeclaration style;
 };

--- a/Source/WebCore/bindings/js/JSDOMSetLike.h
+++ b/Source/WebCore/bindings/js/JSDOMSetLike.h
@@ -155,11 +155,14 @@ JSC::JSValue forwardAddToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::
 template<typename WrapperClass, typename ItemType>
 JSC::JSValue forwardDeleteToSetLike(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame, WrapperClass& setLike, ItemType&& item)
 {
+    // Initialize backingSet before removing value so assertion below actually holds.
+    auto& backingSet = getAndInitializeBackingSet(lexicalGlobalObject, setLike);
+
     auto isDeleted = setLike.wrapped().removeFromSetLike(std::forward<ItemType>(item));
     UNUSED_PARAM(isDeleted);
 
     auto& vm = JSC::getVM(&lexicalGlobalObject);
-    auto result = forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, getAndInitializeBackingSet(lexicalGlobalObject, setLike), vm.propertyNames->builtinNames().deletePrivateName());
+    auto result = forwardFunctionCallToBackingSet(lexicalGlobalObject, callFrame, backingSet, vm.propertyNames->builtinNames().deletePrivateName());
     ASSERT_UNUSED(result, result.asBoolean() == isDeleted);
     return result;
 }


### PR DESCRIPTION
#### cf2caed3a2f91074568bb267dfa85aae0a6112bd
<pre>
CSS Custom Highlights WPT painting 008 fail due to not initializing SetLike before removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=259755">https://bugs.webkit.org/show_bug.cgi?id=259755</a>
rdar://113300782

Reviewed by Chris Dumez.

Before setlike removal, backingSet was never initialized,
thus not matching the setlike in implementation leading to crash due to
failing assertion.
Removed outdated fixme comment in highlight idl.

* LayoutTests/TestExpectations:
* Source/WebCore/Modules/highlight/Highlight.idl:
* Source/WebCore/bindings/js/JSDOMSetLike.h:
(WebCore::forwardDeleteToSetLike):

Canonical link: <a href="https://commits.webkit.org/266552@main">https://commits.webkit.org/266552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdcdfee3e359561c58950ce54ca65b656c5184bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14526 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16067 "126 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16582 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19760 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16108 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11312 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12728 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3417 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->