### PR TITLE
[Buildstream SDK] Include a couple more GStreamer patches from 1.22 branch

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -28,6 +28,8 @@ sources:
   path: patches/fdo-0009-gst-plugins-bad-Enable-x265-encoder.patch
 - kind: patch
   path: patches/fdo-0001-gst-plugins-base-Vendor-patch-scheduled-for-1.22.6.patch
+- kind: patch
+  path: patches/fdo-0001-gst-plugins-base-Vendor-patches-scheduled-for-1.22.6.patch
 config:
   options:
     target_arch: '%{arch}'

--- a/Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patches-scheduled-for-1.22.6.patch
+++ b/Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patches-scheduled-for-1.22.6.patch
@@ -1,0 +1,203 @@
+From 1dbbfc12fa6ff2155bd4906449d76793affe8be1 Mon Sep 17 00:00:00 2001
+From: Philippe Normand <philn@igalia.com>
+Date: Thu, 3 Aug 2023 09:14:12 +0100
+Subject: [PATCH] gst-plugins-base: Vendor patches scheduled for 1.22.6
+
+---
+ ...e-the-slot-is-unlinked-before-linkin.patch |  32 ++++
+ ...ixes-for-upstream-selectable-support.patch | 144 ++++++++++++++++++
+ 2 files changed, 176 insertions(+)
+ create mode 100644 patches/gstreamer/0001-decodebin3-Ensure-the-slot-is-unlinked-before-linkin.patch
+ create mode 100644 patches/gstreamer/0001-transcodebin-Fixes-for-upstream-selectable-support.patch
+
+diff --git a/patches/gstreamer/0001-decodebin3-Ensure-the-slot-is-unlinked-before-linkin.patch b/patches/gstreamer/0001-decodebin3-Ensure-the-slot-is-unlinked-before-linkin.patch
+new file mode 100644
+index 000000000..be4240d8d
+--- /dev/null
++++ b/patches/gstreamer/0001-decodebin3-Ensure-the-slot-is-unlinked-before-linkin.patch
+@@ -0,0 +1,32 @@
++From b979ca0dcc0438257891fb000b71c2113489f33d Mon Sep 17 00:00:00 2001
++From: Philippe Normand <philn@igalia.com>
++Date: Tue, 1 Aug 2023 15:14:29 +0100
++Subject: [PATCH] decodebin3: Ensure the slot is unlinked before linking to
++ decoder
++
++When switching from a raw stream to an encoded stream we need to make sure the
++slot is unlinked, there is code in place for this but it wasn't triggered
++because the slot being reconfigured wasn't advertised as linked beforehand.
++
++Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5133>
++---
++ subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c | 3 +++
++ 1 file changed, 3 insertions(+)
++
++diff --git a/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c b/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
++index 804f017241..017fa2293e 100644
++--- a/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
+++++ b/subprojects/gst-plugins-base/gst/playback/gstdecodebin3.c
++@@ -2909,6 +2909,9 @@ reconfigure_output_stream (DecodebinOutputStream * output,
++     ret = FALSE;
++     goto cleanup;
++   }
+++
+++  output->linked = TRUE;
+++
++   if (output->src_exposed == FALSE) {
++     GstEvent *stream_start;
++ 
++-- 
++2.41.0
++
+diff --git a/patches/gstreamer/0001-transcodebin-Fixes-for-upstream-selectable-support.patch b/patches/gstreamer/0001-transcodebin-Fixes-for-upstream-selectable-support.patch
+new file mode 100644
+index 000000000..c183da26a
+--- /dev/null
++++ b/patches/gstreamer/0001-transcodebin-Fixes-for-upstream-selectable-support.patch
+@@ -0,0 +1,144 @@
++From c506748c6f71fa8a92237e7a82247cb996465e59 Mon Sep 17 00:00:00 2001
++From: Philippe Normand <philn@igalia.com>
++Date: Sat, 22 Jul 2023 10:42:39 +0100
++Subject: [PATCH] transcodebin: Fixes for upstream selectable support
++
++The upstream selectable query was not performed in all situations where we
++handle the stream-start event. This could potentially lead to unlinked pads
++between decodebin3 and encodebin later on.
++
++Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5089>
++---
++ .../gst/transcode/gsttranscodebin.c           | 59 +++++++++++++------
++ 1 file changed, 41 insertions(+), 18 deletions(-)
++
++diff --git a/subprojects/gst-plugins-bad/gst/transcode/gsttranscodebin.c b/subprojects/gst-plugins-bad/gst/transcode/gsttranscodebin.c
++index aab0bbd9a3..484ee68388 100644
++--- a/subprojects/gst-plugins-bad/gst/transcode/gsttranscodebin.c
+++++ b/subprojects/gst-plugins-bad/gst/transcode/gsttranscodebin.c
++@@ -124,6 +124,9 @@ typedef struct
++ 
++ #define DEFAULT_AVOID_REENCODING   FALSE
++ 
+++GST_DEBUG_CATEGORY_STATIC(gst_transcodebin_debug);
+++#define GST_CAT_DEFAULT gst_transcodebin_debug
+++
++ G_DEFINE_TYPE (GstTranscodeBin, gst_transcode_bin, GST_TYPE_BIN);
++ GST_ELEMENT_REGISTER_DEFINE_WITH_CODE (transcodebin, "transcodebin", GST_RANK_NONE,
++       GST_TYPE_TRANSCODE_BIN, transcodebin_element_init (plugin));
++@@ -303,6 +306,9 @@ find_stream (GstTranscodeBin * self, const gchar * stream_id, GstPad * pad)
++   TranscodingStream *res = NULL;
++ 
++   GST_OBJECT_LOCK (self);
+++  GST_DEBUG_OBJECT (self,
+++      "Looking for stream %s in %u existing transcoding streams",
+++      stream_id, self->transcoding_streams->len);
++   for (i = 0; i < self->transcoding_streams->len; i = i + 1) {
++     TranscodingStream *s = self->transcoding_streams->pdata[i];
++ 
++@@ -317,6 +323,7 @@ find_stream (GstTranscodeBin * self, const gchar * stream_id, GstPad * pad)
++ 
++ done:
++   GST_OBJECT_UNLOCK (self);
+++  GST_DEBUG_OBJECT (self, "Look-up result: %p", res);
++ 
++   return res;
++ }
++@@ -327,6 +334,9 @@ setup_stream (GstTranscodeBin * self, GstStream * stream)
++   TranscodingStream *res = NULL;
++   GstPad *encodebin_pad = get_encodebin_pad_from_stream (self, stream);
++ 
+++  GST_DEBUG_OBJECT (self,
+++      "Encodebin pad for stream %" GST_PTR_FORMAT " : %" GST_PTR_FORMAT, stream,
+++      encodebin_pad);
++   if (encodebin_pad) {
++     GST_INFO_OBJECT (self,
++         "Going to transcode stream %s (encodebin pad: %" GST_PTR_FORMAT ")",
++@@ -410,6 +420,31 @@ gst_transcode_bin_link_encodebin_pad (GstTranscodeBin * self, GstPad * pad,
++   }
++ }
++ 
+++static void
+++query_upstream_selectable (GstTranscodeBin * self, GstPad * pad)
+++{
+++  GstQuery *query;
+++  gboolean result;
+++
+++  /* Query whether upstream can handle stream selection or not */
+++  query = gst_query_new_selectable ();
+++  result = GST_PAD_IS_SINK (pad) ? gst_pad_peer_query (pad, query)
+++      : gst_pad_query (pad, query);
+++  if (result) {
+++    GST_FIXME_OBJECT (self,
+++        "We force `transcodebin` to upstream selection"
+++        " mode if *any* of the inputs is. This means things might break if"
+++        " there's a mix");
+++    gst_query_parse_selectable (query, &self->upstream_selected);
+++    GST_DEBUG_OBJECT (pad, "Upstream is selectable : %d",
+++        self->upstream_selected);
+++  } else {
+++    self->upstream_selected = FALSE;
+++    GST_DEBUG_OBJECT (pad, "Upstream does not handle SELECTABLE query");
+++  }
+++  gst_query_unref (query);
+++}
+++
++ static GstPadProbeReturn
++ wait_stream_start_probe (GstPad * pad,
++     GstPadProbeInfo * info, GstTranscodeBin * self)
++@@ -420,6 +455,7 @@ wait_stream_start_probe (GstPad * pad,
++   GST_INFO_OBJECT (self,
++       "Got pad %" GST_PTR_FORMAT " with stream:: %" GST_PTR_FORMAT, pad,
++       info->data);
+++  query_upstream_selectable (self, pad);
++   gst_transcode_bin_link_encodebin_pad (self, pad, info->data);
++ 
++   return GST_PAD_PROBE_REMOVE;
++@@ -440,6 +476,7 @@ decodebin_pad_added_cb (GstElement * decodebin, GstPad * pad,
++     gst_event_parse_stream_start (sstart_event, &stream_id);
++     GST_INFO_OBJECT (self, "Got pad %" GST_PTR_FORMAT " with stream ID: %s",
++         pad, stream_id);
+++    query_upstream_selectable (self, pad);
++     gst_transcode_bin_link_encodebin_pad (self, pad, sstart_event);
++     return;
++   }
++@@ -773,25 +810,8 @@ sink_event_function (GstPad * sinkpad, GstTranscodeBin * self, GstEvent * event)
++ 
++   switch (GST_EVENT_TYPE (event)) {
++     case GST_EVENT_STREAM_START:
++-    {
++-      GstQuery *q = gst_query_new_selectable ();
++-
++-      /* Query whether upstream can handle stream selection or not */
++-      if (gst_pad_peer_query (sinkpad, q)) {
++-        GST_FIXME_OBJECT (self, "We force `transcodebin` to upstream selection"
++-            " mode if *any* of the inputs is. This means things might break if"
++-            " there's a mix");
++-        gst_query_parse_selectable (q, &self->upstream_selected);
++-        GST_DEBUG_OBJECT (sinkpad, "Upstream is selectable : %d",
++-            self->upstream_selected);
++-      } else {
++-        self->upstream_selected = FALSE;
++-        GST_DEBUG_OBJECT (sinkpad, "Upstream does not handle SELECTABLE query");
++-      }
++-      gst_query_unref (q);
++-
+++      query_upstream_selectable (self, sinkpad);
++       break;
++-    }
++     default:
++       break;
++   }
++@@ -997,6 +1017,9 @@ gst_transcode_bin_class_init (GstTranscodeBinClass * klass)
++   object_class->get_property = gst_transcode_bin_get_property;
++   object_class->set_property = gst_transcode_bin_set_property;
++ 
+++  GST_DEBUG_CATEGORY_INIT (gst_transcodebin_debug, "transcodebin", 0,
+++      "Transcodebin element");
+++
++   gstelement_klass = (GstElementClass *) klass;
++   gstelement_klass->change_state =
++       GST_DEBUG_FUNCPTR (gst_transcode_bin_change_state);
++-- 
++2.41.0
++
+-- 
+2.41.0
+


### PR DESCRIPTION
#### d6feac720da0c3d30ed03c68899b14da8ed7d079
<pre>
[Buildstream SDK] Include a couple more GStreamer patches from 1.22 branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=259766">https://bugs.webkit.org/show_bug.cgi?id=259766</a>

Reviewed by Carlos Alberto Lopez Perez.

Patches needed for the bug 254212 fix.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/patches/fdo-0001-gst-plugins-base-Vendor-patches-scheduled-for-1.22.6.patch: Added.

Canonical link: <a href="https://commits.webkit.org/266580@main">https://commits.webkit.org/266580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79365d08fb879045cf904e2736a7bf7575e3c856

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16041 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16546 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19733 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13210 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16079 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11285 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17030 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1688 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->