### PR TITLE
REGRESSION(255736@main): [JSC] Fix FP register offsets in ScratchRegisterAllocator

### DIFF
--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
@@ -165,7 +165,8 @@ unsigned ScratchRegisterAllocator::preserveRegistersToStackForCall(AssemblyHelpe
     ASSERT(!usedRegisters.hasAnyWideRegisters() || Options::useWebAssemblySIMD());
     JIT_COMMENT(jit, "Preserve registers to stack for call: ", usedRegisters, "; Extra bytes at top of stack: ", extraBytesAtTopOfStack);
 
-    unsigned stackOffset = usedRegisters.byteSizeOfSetRegisters();
+    unsigned byteSizeOfSetRegisters = usedRegisters.byteSizeOfSetRegisters();
+    unsigned stackOffset = byteSizeOfSetRegisters;
     stackOffset += extraBytesAtTopOfStack;
     stackOffset = WTF::roundUpToMultipleOf(stackAlignmentBytes(), stackOffset);
     jit.subPtr(
@@ -174,29 +175,32 @@ unsigned ScratchRegisterAllocator::preserveRegistersToStackForCall(AssemblyHelpe
 
     AssemblyHelpers::StoreRegSpooler spooler(jit, MacroAssembler::stackPointerRegister);
 
-    unsigned count = 0;
+    unsigned offset = 0;
     for (GPRReg reg = MacroAssembler::firstRegister(); reg <= MacroAssembler::lastRegister(); reg = MacroAssembler::nextRegister(reg)) {
         if (usedRegisters.contains(reg, IgnoreVectors)) {
-            spooler.storeGPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (count * conservativeRegisterBytesWithoutVectors(reg))), conservativeWidthWithoutVectors(reg) });
-            count++;
+            spooler.storeGPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidthWithoutVectors(reg) });
+            offset += conservativeRegisterBytesWithoutVectors(reg);
         }
     }
+#if !CPU(REGISTER64)
+    if (byteSizeOfSetRegisters > offset)
+        offset = WTF::roundUpToMultipleOf<2*bytesForWidth(pointerWidth())>(offset);
+#endif
     spooler.finalizeGPR();
 
     for (FPRReg reg = MacroAssembler::firstFPRegister(); reg <= MacroAssembler::lastFPRegister(); reg = MacroAssembler::nextFPRegister(reg)) {
         if (conservativeWidth(reg) == Width128 && usedRegisters.contains(reg, conservativeWidth(reg))) {
-            spooler.storeVector({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (count * conservativeRegisterBytesWithoutVectors(reg))), conservativeWidth(reg) });
-            count += 2;
+            spooler.storeVector({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidth(reg) });
+            offset += conservativeRegisterBytes(reg);
         } else if (usedRegisters.contains(reg, IgnoreVectors)) {
-            spooler.storeFPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (count * conservativeRegisterBytesWithoutVectors(reg))), conservativeWidthWithoutVectors(reg) });
-            count++;
+            spooler.storeFPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidthWithoutVectors(reg) });
+            offset += conservativeRegisterBytesWithoutVectors(reg);
         }
     }
     spooler.finalizeFPR();
 
-#if USE(JSVALUE64)
-    ASSERT(count * sizeof(EncodedJSValue) == usedRegisters.byteSizeOfSetRegisters());
-#endif
+    ASSERT(offset == byteSizeOfSetRegisters);
+
     return stackOffset;
 }
 
@@ -212,14 +216,20 @@ void ScratchRegisterAllocator::restoreRegistersFromStackForCall(AssemblyHelpers&
 
     AssemblyHelpers::LoadRegSpooler spooler(jit, MacroAssembler::stackPointerRegister);
 
-    unsigned count = 0;
+    unsigned byteSizeOfSetRegisters = usedRegisters.byteSizeOfSetRegisters();
+
+    unsigned offset = 0;
     for (GPRReg reg = MacroAssembler::firstRegister(); reg <= MacroAssembler::lastRegister(); reg = MacroAssembler::nextRegister(reg)) {
         if (usedRegisters.contains(reg, IgnoreVectors)) {
             if (!ignore.contains(reg, IgnoreVectors))
-                spooler.loadGPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (conservativeRegisterBytesWithoutVectors(reg) * count)), conservativeWidthWithoutVectors(reg) });
-            count++;
+                spooler.loadGPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidthWithoutVectors(reg) });
+            offset += conservativeRegisterBytesWithoutVectors(reg);
         }
     }
+#if !CPU(REGISTER64)
+    if (byteSizeOfSetRegisters > offset)
+        offset = WTF::roundUpToMultipleOf<2*bytesForWidth(pointerWidth())>(offset);
+#endif
     spooler.finalizeGPR();
 
     for (FPRReg reg = MacroAssembler::firstFPRegister(); reg <= MacroAssembler::lastFPRegister(); reg = MacroAssembler::nextFPRegister(reg)) {
@@ -227,27 +237,23 @@ void ScratchRegisterAllocator::restoreRegistersFromStackForCall(AssemblyHelpers&
             // You should never have to ignore only part of a register.
             ASSERT(ignore.contains(reg, IgnoreVectors) == ignore.contains(reg, Width128));
             if (conservativeWidth(reg) == Width128 && usedRegisters.contains(reg, conservativeWidth(reg))) {
-                if (!ignore.contains(reg, IgnoreVectors)) {
-                    spooler.loadVector({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (conservativeRegisterBytesWithoutVectors(reg) * count)), conservativeWidth(reg) });
-                    count += 2;
-                }
+                if (!ignore.contains(reg, IgnoreVectors))
+                    spooler.loadVector({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidth(reg) });
+                offset += conservativeRegisterBytes(reg);
             } else if (usedRegisters.contains(reg, IgnoreVectors)) {
-                if (!ignore.contains(reg, IgnoreVectors)) {
-                    spooler.loadFPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + (conservativeRegisterBytesWithoutVectors(reg) * count)), conservativeWidthWithoutVectors(reg) });
-                    count++;
-                }
+                if (!ignore.contains(reg, IgnoreVectors))
+                    spooler.loadFPR({ reg, static_cast<ptrdiff_t>(extraBytesAtTopOfStack + offset), conservativeWidthWithoutVectors(reg) });
+                offset += conservativeRegisterBytesWithoutVectors(reg);
             }
         }
     }
     spooler.finalizeFPR();
 
-    unsigned stackOffset = usedRegisters.byteSizeOfSetRegisters();
+    unsigned stackOffset = byteSizeOfSetRegisters;
     stackOffset += extraBytesAtTopOfStack;
     stackOffset = WTF::roundUpToMultipleOf(stackAlignmentBytes(), stackOffset);
 
-#if USE(JSVALUE64)
-    ASSERT(count * sizeof(EncodedJSValue) <= usedRegisters.byteSizeOfSetRegisters());
-#endif
+    ASSERT(offset == byteSizeOfSetRegisters);
     RELEASE_ASSERT(stackOffset == numberOfStackBytesUsedForRegisterPreservation);
 
     jit.addPtr(


### PR DESCRIPTION
#### cb49ec55ee3b6f49db87dc9818732b462279188a
<pre>
REGRESSION(255736@main): [JSC] Fix FP register offsets in ScratchRegisterAllocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=259778">https://bugs.webkit.org/show_bug.cgi?id=259778</a>

Reviewed by Justin Michaud.

On 32-bit targets, count was multiplied by 4 bytes in GPR loop, then by 8 bytes in FPR loop,
using more than the computed stackOffset (so overwriting previous saved values on the stack).
In restoreRegistersFromStackForCall, the ignored FP registers didn&apos;t increase the count, so
the following registers wouln&apos;t be restored from the correct offset.

We now use an offset instead of a count, and the ASSERT checks it on all targets.
The roundUpToMultipleOf call matches the code in byteSizeOfSetRegisters (aligning the FP
registers save location).

* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::preserveRegistersToStackForCall):
(JSC::ScratchRegisterAllocator::restoreRegistersFromStackForCall):

Canonical link: <a href="https://commits.webkit.org/267228@main">https://commits.webkit.org/267228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a0b0c99ed941e97cada1b376578137393dd8cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16557 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19743 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12049 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16090 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13367 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13424 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11291 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14146 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12705 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3824 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17039 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14533 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13268 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3475 "Passed tests") | 
<!--EWS-Status-Bubble-End-->