### PR TITLE
[visionOS] WebGL content is empty in private browsing

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -42,7 +42,6 @@
 #import <pal/SessionID.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/Function.h>
-#import <wtf/MathExtras.h>
 
 #import "MediaRemoteSoftLink.h"
 #include <pal/cocoa/AVFoundationSoftLink.h>
@@ -173,7 +172,7 @@ void MediaSessionManagerCocoa::updateSessionState()
     else if (captureCount || audioMediaStreamTrackCount) {
         // In case of audio capture or audio MediaStreamTrack playing, we want to grab 20 ms chunks to limit the latency so that it is not noticeable by users
         // while having a large enough buffer so that the audio rendering remains stable, hence a computation based on sample rate.
-        bufferSize = WTF::roundUpToPowerOfTwo(AudioSession::sharedSession().sampleRate() / 50);
+        bufferSize = AudioSession::sharedSession().sampleRate() / 50;
     } else if (m_supportedAudioHardwareBufferSizes && DeprecatedGlobalSettings::lowPowerVideoAudioBufferSizeEnabled())
         bufferSize = m_supportedAudioHardwareBufferSizes.nearest(kLowPowerVideoBufferSize);
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -476,6 +476,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto metalFEDirectory = WebsiteDataStore::cacheDirectoryInContainerOrHomeDirectory("/Library/Caches/com.apple.WebKit.WebContent/com.apple.metalfe"_s);
     if (auto metalFEDirectoryHandle = SandboxExtension::createHandleForReadWriteDirectory(metalFEDirectory))
         parameters.metalCacheDirectoryExtensionHandles.append(WTFMove(*metalFEDirectoryHandle));
+    auto gpuArchiverDirectory = WebsiteDataStore::cacheDirectoryInContainerOrHomeDirectory("Library/Caches/com.apple.WebKit.WebContent/com.apple.gpuarchiver"_s);
+    if (auto gpuArchiverDirectoryHandle = SandboxExtension::createHandleForReadWriteDirectory(gpuArchiverDirectory))
+        parameters.metalCacheDirectoryExtensionHandles.append(WTFMove(*gpuArchiverDirectoryHandle));
 #endif
 
     parameters.systemHasBattery = systemHasBattery();

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -49,10 +49,6 @@ namespace WebKit {
 // Allocate a ring buffer large enough to contain 2 seconds of audio.
 constexpr size_t ringBufferSizeInSecond = 2;
 
-#if PLATFORM(COCOA)
-constexpr unsigned maxAudioBufferListSampleCount = 4096;
-#endif
-
 using AudioIOCallback = WebCore::AudioIOCallback;
 
 Ref<RemoteAudioDestinationProxy> RemoteAudioDestinationProxy::create(AudioIOCallback& callback,
@@ -79,11 +75,7 @@ void RemoteAudioDestinationProxy::startRenderingThread()
             if (m_shouldStopThread)
                 break;
 
-            unsigned frameCount = WebCore::AudioUtilities::renderQuantumSize;
-            while (m_renderSemaphore.waitFor(0_s))
-                frameCount += WebCore::AudioUtilities::renderQuantumSize;
-
-            renderAudio(frameCount);
+            renderQuantum();
         } while (!m_shouldStopThread);
     };
     m_renderThread = Thread::create("RemoteAudioDestinationProxy render thread", WTFMove(offThreadRendering), ThreadType::Audio, Thread::QOS::UserInteractive);
@@ -118,7 +110,7 @@ IPC::Connection* RemoteAudioDestinationProxy::connection()
         m_ringBuffer = WTFMove(ringBuffer);
         gpuProcessConnection->connection().send(Messages::RemoteAudioDestinationManager::AudioSamplesStorageChanged { m_destinationID, WTFMove(handle) }, 0);
         m_audioBufferList = makeUnique<WebCore::WebAudioBufferList>(streamFormat);
-        m_audioBufferList->setSampleCount(maxAudioBufferListSampleCount);
+        m_audioBufferList->setSampleCount(WebCore::AudioUtilities::renderQuantumSize);
 #endif
 
         startRenderingThread();
@@ -188,32 +180,29 @@ void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& 
     });
 }
 
-void RemoteAudioDestinationProxy::renderAudio(unsigned frameCount)
+void RemoteAudioDestinationProxy::renderQuantum()
 {
     ASSERT(!isMainRunLoop());
 
 #if PLATFORM(COCOA)
-    while (frameCount) {
-        auto sampleTime = m_currentFrame / static_cast<double>(m_remoteSampleRate);
-        auto hostTime =  MonotonicTime::fromMachAbsoluteTime(mach_absolute_time());
-        size_t numberOfFrames = std::min(frameCount, maxAudioBufferListSampleCount);
-        frameCount -= numberOfFrames;
-        auto* ioData = m_audioBufferList->list();
+    auto sampleTime = m_currentFrame / static_cast<double>(m_remoteSampleRate);
+    auto hostTime =  MonotonicTime::fromMachAbsoluteTime(mach_absolute_time());
+    size_t numberOfFrames = WebCore::AudioUtilities::renderQuantumSize;
+    auto* ioData = m_audioBufferList->list();
 
-        auto* buffers = ioData->mBuffers;
-        auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
+    auto* buffers = ioData->mBuffers;
+    auto numberOfBuffers = std::min<UInt32>(ioData->mNumberBuffers, m_outputBus->numberOfChannels());
 
-        // Associate the destination data array with the output bus then fill the FIFO.
-        for (UInt32 i = 0; i < numberOfBuffers; ++i) {
-            auto* memory = reinterpret_cast<float*>(buffers[i].mData);
-            size_t channelNumberOfFrames = std::min<size_t>(numberOfFrames, buffers[i].mDataByteSize / sizeof(float));
-            m_outputBus->setChannelMemory(i, memory, channelNumberOfFrames);
-        }
-        size_t framesToRender = pullRendered(numberOfFrames);
-        m_ringBuffer->store(m_audioBufferList->list(), numberOfFrames, m_currentFrame);
-        render(sampleTime, hostTime, framesToRender);
-        m_currentFrame += numberOfFrames;
+    // Associate the destination data array with the output bus then fill the FIFO.
+    for (UInt32 i = 0; i < numberOfBuffers; ++i) {
+        auto* memory = reinterpret_cast<float*>(buffers[i].mData);
+        size_t channelNumberOfFrames = std::min<size_t>(numberOfFrames, buffers[i].mDataByteSize / sizeof(float));
+        m_outputBus->setChannelMemory(i, memory, channelNumberOfFrames);
     }
+    size_t framesToRender = pullRendered(numberOfFrames);
+    m_ringBuffer->store(m_audioBufferList->list(), WebCore::AudioUtilities::renderQuantumSize, m_currentFrame);
+    render(sampleTime, hostTime, framesToRender);
+    m_currentFrame += WebCore::AudioUtilities::renderQuantumSize;
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -69,7 +69,7 @@ private:
 
     void startRenderingThread();
     void stopRenderingThread();
-    void renderAudio(unsigned frameCount);
+    void renderQuantum();
 
     IPC::Connection* connection();
     IPC::Connection* existingConnection();


### PR DESCRIPTION
#### 60d29d4ae57fe96d8e2c21474b415d65e65ae510
<pre>
[visionOS] WebGL content is empty in private browsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=259780">https://bugs.webkit.org/show_bug.cgi?id=259780</a>
&lt;radar://113278323&gt;

Reviewed by NOBODY (OOPS!).

WebGL is still in the WebContent process on visionOS, so we need
to add a sandbox exception in private browsing so Metal can write
to one if its cache directories.

Similar to the change made for WebXR in 266346@main

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
</pre>
----------------------------------------------------------------------
#### 0482749f3f9cb43cfa811313f338557de1dc0fc9
<pre>
Need a short description (OOPS!).
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::startRenderingThread):
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::renderQuantum):
(WebKit::RemoteAudioDestinationProxy::renderAudio): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60d29d4ae57fe96d8e2c21474b415d65e65ae510

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14117 "Failed to checkout and rebase branch from PR 16349") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/14433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14770 "Failed to checkout and rebase branch from PR 16349") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/15859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14205 "Failed to checkout and rebase branch from PR 16349") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16943 "Failed to checkout and rebase branch from PR 16349") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/14516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/15859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14291 "Failed to checkout and rebase branch from PR 16349") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/16943 "Failed to checkout and rebase branch from PR 16349") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/14770 "Failed to checkout and rebase branch from PR 16349") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/16943 "Failed to checkout and rebase branch from PR 16349") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/14770 "Failed to checkout and rebase branch from PR 16349") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/16572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/16943 "Failed to checkout and rebase branch from PR 16349") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/14770 "Failed to checkout and rebase branch from PR 16349") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/16572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/14516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/12719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/14770 "Failed to checkout and rebase branch from PR 16349") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/17054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->