### PR TITLE
[visionOS] Crash when entering fullscreen on vimeo.com

### DIFF
--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -35,6 +35,7 @@ class PlaybackSessionInterfaceAVKit;
 @interface WebAVMediaSelectionOption : NSObject
 - (instancetype)initWithMediaType:(AVMediaType)type displayName:(NSString *)displayName;
 
+@property (nonatomic, readonly) NSString *displayName;
 @property (nonatomic, readonly) NSString *localizedDisplayName;
 @property (nonatomic, readonly) AVMediaType mediaType;
 

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -930,6 +930,11 @@ Class webAVPlayerControllerClass()
     return self;
 }
 
+- (NSString *)displayName
+{
+    return self.localizedDisplayName;
+}
+
 - (NSString *)localizedDisplayName
 {
     return _localizedDisplayName.get();


### PR DESCRIPTION
#### 078e59c40257b11569b27fd8c39928271a25d64f
<pre>
[visionOS] Crash when entering fullscreen on vimeo.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=259785">https://bugs.webkit.org/show_bug.cgi?id=259785</a>
rdar://113227148

Reviewed by Richard Robinson.

Recent changes in AVKit result in an underlying framework relying on
`-[AVMediaSelectionOption displayName]`, which is in the public interface.

Fix the crash by implementing `-displayName` on our &quot;proxy&quot; object, `WebAVMediaSelectionOption`.

* Source/WebCore/platform/ios/WebAVPlayerController.h:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVMediaSelectionOption displayName]):

`displayName` is intended to be localized, so simply return the existing localized property.

Canonical link: <a href="https://commits.webkit.org/266548@main">https://commits.webkit.org/266548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65584e3b2a0e35b733e9c565aea37f0d73a92f77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16066 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16578 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12158 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12737 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12901 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11309 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12725 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17060 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1674 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->