### PR TITLE
Restore exact BitsInIncreasingOrder check in generated serializers

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -596,7 +596,7 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result.append('    static constexpr bool value = true;')
     result.append('};')
     result.append('template<uint64_t firstBit, uint64_t secondBit, uint64_t... remainingBits> struct BitsInIncreasingOrder<firstBit, secondBit, remainingBits...> {')
-    result.append('    static constexpr bool value = firstBit < secondBit && BitsInIncreasingOrder<secondBit, remainingBits...>::value;')
+    result.append('    static constexpr bool value = firstBit == secondBit >> 1 && BitsInIncreasingOrder<secondBit, remainingBits...>::value;')
     result.append('};')
     result.append('')
     result.append('template<bool, bool> struct VirtualTableAndRefCountOverhead;')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -66,7 +66,7 @@ template<uint64_t onlyBit> struct BitsInIncreasingOrder<onlyBit> {
     static constexpr bool value = true;
 };
 template<uint64_t firstBit, uint64_t secondBit, uint64_t... remainingBits> struct BitsInIncreasingOrder<firstBit, secondBit, remainingBits...> {
-    static constexpr bool value = firstBit < secondBit && BitsInIncreasingOrder<secondBit, remainingBits...>::value;
+    static constexpr bool value = firstBit == secondBit >> 1 && BitsInIncreasingOrder<secondBit, remainingBits...>::value;
 };
 
 template<bool, bool> struct VirtualTableAndRefCountOverhead;

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -77,14 +77,14 @@ enum class LayerChange : uint64_t {
     ScrollingNodeIDChanged              = 1LLU << 39,
 #endif
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
-    SeparatedChanged                    = 1LLU << 40,
+    SeparatedChanged                    = 1LLU << 39,
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)
-    SeparatedPortalChanged              = 1LLU << 41,
-    DescendentOfSeparatedPortalChanged  = 1LLU << 42,
+    SeparatedPortalChanged              = 1LLU << 40,
+    DescendentOfSeparatedPortalChanged  = 1LLU << 41,
 #endif
 #endif
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    CoverageRectChanged                 = 1LLU << 43,
+    CoverageRectChanged                 = 1LLU << 42,
 #endif
 };
 


### PR DESCRIPTION
#### 01cc4e849538b2d383e95f4e0a05f98d0626e737
<pre>
Restore exact BitsInIncreasingOrder check in generated serializers
<a href="https://bugs.webkit.org/show_bug.cgi?id=259792">https://bugs.webkit.org/show_bug.cgi?id=259792</a>
rdar://113352975

Reviewed by Dean Jackson.

266549@main shifted things around to fix the visionOS build, but it relaxed an important order check.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_impl):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:

Canonical link: <a href="https://commits.webkit.org/266553@main">https://commits.webkit.org/266553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0190760c79cf3a7a8bdeb8b60efc6bfab7a5e88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13399 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14532 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14307 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/14884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/11987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16588 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/14231 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/12912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16119 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17069 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1677 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13298 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->