### PR TITLE
[css-flex][baseline-alignment] Baseline aligned flex items should be also aligned using their fallback alignment.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt
@@ -2,12 +2,6 @@ two
 lines
 hello
 
-FAIL #target > div 1 assert_equals:
-<div class="inner" data-offset-x="146">
-    <div>two<br>lines</div>
-  </div>
-offsetLeft expected 146 but got 21
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="191">hello</div>
-offsetLeft expected 191 but got 66
+PASS #target > div 1
+PASS #target > div 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt
@@ -2,12 +2,6 @@ two
 lines
 hello
 
-FAIL #target > div 1 assert_equals:
-<div class="inner" data-offset-x="146">
-    <div>two<br>lines</div>
-  </div>
-offsetLeft expected 146 but got 21
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="191">hello</div>
-offsetLeft expected 191 but got 66
+PASS #target > div 1
+PASS #target > div 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt
@@ -2,10 +2,6 @@ two
 lines
 hello
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="161">two<br>lines</div>
-offsetLeft expected 161 but got 21
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="201">hello</div>
-offsetLeft expected 201 but got 61
+PASS #target > div 1
+PASS #target > div 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt
@@ -2,16 +2,6 @@ two
 lines
 hello
 
-FAIL #target > * 1 assert_equals:
-<table class="inner" data-offset-x="140">
-    <tbody><tr>
-      <td style="vertical-align: baseline;">
-        <div>two<br>lines</div>
-      </td>
-    </tr>
-  </tbody></table>
-offsetLeft expected 140 but got 21
-FAIL #target > * 2 assert_equals:
-<div data-offset-x="188">hello</div>
-offsetLeft expected 188 but got 69
+PASS #target > * 1
+PASS #target > * 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
@@ -11,16 +11,10 @@ line2
 line1
 line2
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 15
+PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 140
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 147
+PASS #target > div 5
+PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
@@ -11,16 +11,10 @@ line2
 line1
 line2
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 15
+PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 140
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 147
+PASS #target > div 5
+PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
@@ -12,15 +12,9 @@ line1
 line2
 
 PASS #target > div 1
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 0
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 21
-FAIL #target > div 4 assert_equals:
-<div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 125
+PASS #target > div 2
+PASS #target > div 3
+PASS #target > div 4
 PASS #target > div 5
 PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
@@ -11,16 +11,10 @@ line2
 line1
 line2
 
-FAIL #target > div 1 assert_equals:
-<div data-offset-x="15">line1<br>line2</div>
-offsetLeft expected 15 but got 120
+PASS #target > div 1
 PASS #target > div 2
 PASS #target > div 3
 PASS #target > div 4
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="140">line1<br>line2</div>
-offsetLeft expected 140 but got 35
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="147">line1<br>line2</div>
-offsetLeft expected 147 but got 42
+PASS #target > div 5
+PASS #target > div 6
 

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -32,6 +32,7 @@
 
 #include "OrderIterator.h"
 #include "RenderBlock.h"
+#include "RenderStyleInlines.h"
 
 namespace WebCore {
 
@@ -46,6 +47,8 @@ public:
     RenderFlexibleBox(Element&, RenderStyle&&);
     RenderFlexibleBox(Document&, RenderStyle&&);
     virtual ~RenderFlexibleBox();
+
+    using Direction = BlockFlowDirection;
 
     bool isFlexibleBox() const override { return true; }
 
@@ -66,6 +69,30 @@ public:
     void paintChildren(PaintInfo& forSelf, const LayoutPoint&, PaintInfo& forChild, bool usePrintRect) override;
 
     bool isHorizontalFlow() const;
+    inline Direction crossAxisDirection() const
+    {
+        switch (writingModeToBlockFlowDirection(style().writingMode())) {
+        case BlockFlowDirection::TopToBottom:
+            if (style().isRowFlexDirection())
+                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
+            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
+        case BlockFlowDirection::BottomToTop:
+            if (style().isRowFlexDirection())
+                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::TopToBottom : Direction::BottomToTop;
+            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
+        case BlockFlowDirection::LeftToRight:
+            if (style().isRowFlexDirection())
+                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::RightToLeft : Direction::LeftToRight;
+            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
+        case BlockFlowDirection::RightToLeft:
+            if (style().isRowFlexDirection())
+                return (style().flexWrap() == FlexWrap::Reverse) ? Direction::LeftToRight : Direction::RightToLeft;
+            return (style().flexWrap() == FlexWrap::Reverse) ? Direction::BottomToTop : Direction::TopToBottom;
+        default:
+            ASSERT_NOT_REACHED();
+            return Direction::TopToBottom;
+        }
+    }
 
     const OrderIterator& orderIterator() const { return m_orderIterator; }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -731,6 +731,7 @@ public:
     inline const StyleSelfAlignmentData& alignItems() const;
     inline const StyleSelfAlignmentData& alignSelf() const;
     inline FlexDirection flexDirection() const;
+    inline bool isRowFlexDirection() const;
     inline bool isColumnFlexDirection() const;
     inline bool isReverseFlexDirection() const;
     inline FlexWrap flexWrap() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -502,6 +502,7 @@ inline Length RenderStyle::initialWordSpacing() { return zeroLength(); }
 constexpr WritingMode RenderStyle::initialWritingMode() { return WritingMode::HorizontalTb; }
 inline InputSecurity RenderStyle::inputSecurity() const { return static_cast<InputSecurity>(m_nonInheritedData->rareData->inputSecurity); }
 inline bool RenderStyle::isColumnFlexDirection() const { return flexDirection() == FlexDirection::Column || flexDirection() == FlexDirection::ColumnReverse; }
+inline bool RenderStyle::isRowFlexDirection() const { return flexDirection() == FlexDirection::Row || flexDirection() == FlexDirection::RowReverse; }
 constexpr bool RenderStyle::isDisplayBlockLevel() const { return isDisplayBlockType(display()); }
 constexpr bool RenderStyle::isDisplayDeprecatedFlexibleBox(DisplayType display) { return display == DisplayType::Box || display == DisplayType::InlineBox; }
 constexpr bool RenderStyle::isDisplayFlexibleBox(DisplayType display) { return display == DisplayType::Flex || display == DisplayType::InlineFlex; }


### PR DESCRIPTION
#### c4b5ac727df88b0b59f8e541b87e3ef091af5518
<pre>
[css-flex][baseline-alignment] Baseline aligned flex items should be also aligned using their fallback alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256947">https://bugs.webkit.org/show_bug.cgi?id=256947</a>
rdar://109496710

Reviewed by Alan Baradlay.

css-align-3 states the following to be done after items have been aligned
within their baseline sharing groups:

9.3. Aligning Boxes by Baseline step 3:
Position the aligned baseline-sharing group within the alignment container
according to its fallback alignment. The fallback alignment of a
baseline-sharing group is the fallback alignment of its items as
resolved to physical directions.

For flex layout we only need to consider the case where we may need to
push a baseline sharing group towards the cross axis end of the flexbox.
This is because when we align items within the baseline sharing group,
we align the items with respect to the item that has the highest ascent
in the flexbox. In other words, the item that has this max ascent value,
will already be placed flush against the cross axis start of the flexbox,
so the baseline sharing group could not be pushed closer towards it.

shouldAdjustItemTowardsCrossAxisEnd is a small helper function that will
help us determine if we need to move a baseline sharing group towards
the end of the cross axis. This is done by iterating over each item in
the baseline sharing group and taking 3 things into consideration:

1.) The alignment of the flex item (first vs last baseline)
2.) The used writing mode of the flex item
3.) The direction of the flexbox&apos;s cross axis

We need these 3 things in order to be able to resolve the fallback
alignment of the group/item in terms of physical directions.

First baseline aligned items need to be be adjusted when their block
flow direction is opposite of the cross axis direction. This is because
the self-start will be in that direction. Example:

&lt;div style=&quot;outline: 1px solid black; display: flex; flex-direction: column; align-items: baseline; width: 200px; height: 200px&quot;&gt;
  &lt;div style=&quot;writing-mode: vertical-rl;&quot;&gt;
    one &lt;br/&gt; two &lt;br/&gt; three
  &lt;/div&gt;
&lt;/div&gt;

Last baseline aligned items need to be adjusted when their block
direction is the same as the flexbox&apos;s cross axis direction. self-end
will be in that direction. Example:

&lt;div style=&quot;outline: 1px solid black; display: flex; flex-direction: column; align-items: last baseline; width: 200px; height: 200px&quot;&gt;
  &lt;div style=&quot;writing-mode: vertical-lr;&quot;&gt;
    one &lt;br/&gt; two &lt;br/&gt; three
  &lt;/div&gt;
&lt;/div&gt;

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::performBaselineAlignment):
* Source/WebCore/rendering/RenderFlexibleBox.h:
(WebCore::RenderFlexibleBox::crossAxisDirection const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::isRowFlexDirection const):

Canonical link: <a href="https://commits.webkit.org/267026@main">https://commits.webkit.org/267026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4858864ad07a10cc3888e4b0dbcef5d09566f575

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/15378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/16044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/17133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/14432 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/15525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/18197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/17026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/13081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17872 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/13260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20822 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/14342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/14045 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/17303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/12391 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13883 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/18234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/14446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->