### PR TITLE
Add in place interpreter optimizations

### DIFF
--- a/JSTests/wasm/ipint-tests/ipint-test-call-add12.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-call-add12.js
@@ -51,7 +51,7 @@ let wat = `
 async function test() {
     const instance = await instantiate(wat, {});
     const { test, add } = instance.exports
-    // assert.eq(add(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 12);
+    assert.eq(add(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), 12);
     assert.eq(test(1), 12)
 }
 

--- a/JSTests/wasm/ipint-tests/ipint-test-local-large.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-local-large.js
@@ -1,0 +1,47 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (param i32) (result i32)
+        (local 
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+            i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+        )
+        (local.get 0)
+        (local.set 199)
+        (i32.const 15)
+        (local.set 200)
+        (i32.const 16)
+        (local.tee 201)
+        (local.get 201)
+        (local.get 200)
+        (i32.add)
+        (local.tee 206)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test } = instance.exports
+    assert.eq(test(5), 31)
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-nesting.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-nesting.js
@@ -1,0 +1,84 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (result i32)
+        (block (result i32)
+            (block (result i32)
+                (block (result i32)
+                    (block (result i32)
+                        (block (result i32)
+                            (block (result i32)
+                                (block (result i32)
+                                    (block (result i32)
+                                        (block (result i32)
+                                            (block (result i32)
+                                                (block (result i32)
+                                                    (i32.const 3)
+                                                    (br 5)
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        (block (param i32) (result i32)
+            (block (result i32)
+                (i32.const 2)
+            )
+            (i32.add)
+        )
+        (return)
+    )
+    (func (export "test2") (param i32) (result i32)
+        (block
+            (block
+                (block
+                    (loop
+                        (block
+                            (loop
+                                (block
+                                    (local.get 0)
+                                    (i32.const 1)
+                                    (i32.add)
+                                    (local.set 0)
+                                )
+                            )
+                        )
+                        (loop
+                            (block
+                                (nop)
+                            )
+                        )
+                    )
+                )
+            )
+            (loop
+                (loop
+                    (loop
+                        (local.get 0)
+                        (local.set 0)
+                    )
+                )
+            )
+        )
+        (local.get 0)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test, test2 } = instance.exports
+    assert.eq(test(), 5)
+    assert.eq(test2(5), 6)
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/ipint-tests/ipint-test-return-minus.js
+++ b/JSTests/wasm/ipint-tests/ipint-test-return-minus.js
@@ -1,0 +1,19 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func (export "test") (result i32)
+        (i32.const -1)
+        (return)
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {});
+    const { test } = instance.exports
+    assert.eq(test(), -1)
+}
+
+assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -171,9 +171,10 @@ IPIntCallee::IPIntCallee(FunctionIPIntMetadataGenerator& generator, size_t index
     , m_bytecodeLength(generator.m_bytecodeLength - generator.m_bytecodeOffset)
     , m_metadataVector(WTFMove(generator.m_metadata))
     , m_metadata(m_metadataVector.data())
+    , m_argumINTBytecode(WTFMove(generator.m_argumINTBytecode))
+    , m_argumINTBytecodePointer(m_argumINTBytecode.data())
     , m_returnMetadata(generator.m_returnMetadata)
-    // size to allocate = 16 + number of stack arguments + number of non-argument locals
-    , m_localSizeToAlloc(roundUpToMultipleOf(16, 16 + generator.m_numArgumentsOnStack + generator.m_numLocals - generator.m_numArguments))
+    , m_localSizeToAlloc(roundUpToMultipleOf(2, generator.m_numLocals))
     , m_numLocals(generator.m_numLocals)
     , m_numArgumentsOnStack(generator.m_numArgumentsOnStack)
 {

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -360,6 +360,8 @@ public:
     const uint32_t m_bytecodeLength;
     Vector<uint8_t> m_metadataVector;
     const uint8_t* m_metadata;
+    Vector<uint8_t> m_argumINTBytecode;
+    const uint8_t* m_argumINTBytecodePointer;
     const uint32_t m_returnMetadata;
 
     unsigned m_localSizeToAlloc;

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -86,6 +86,7 @@ private:
     void addBlankSpace(uint32_t size);
     void addRawValue(uint64_t value);
     void addLEB128ConstantInt32AndLength(uint32_t value, uint32_t length);
+    void addCondensedLocalIndexAndLength(uint32_t index, uint32_t length);
     void addLEB128ConstantAndLengthForType(Type, uint64_t value, uint32_t length);
     void addReturnData(const Vector<Type, 16>& types);
 
@@ -103,9 +104,13 @@ private:
     unsigned m_numArguments { 0 };
     unsigned m_numArgumentsOnStack { 0 };
     unsigned m_nonArgLocalOffset { 0 };
-    Vector<uint32_t> m_argumentLocations { };
+    Vector<uint8_t, 16> m_argumINTBytecode { };
 
     Vector<const TypeDefinition*> m_signatures;
+
+    // Optimization to skip large numbers of blocks
+
+    Vector<uint32_t> m_repeatedControlFlowInstructionMetadataOffsets;
 };
 
 } } // namespace JSC::Wasm


### PR DESCRIPTION
#### 6f23b5f4342c809f33e206690b8bde942a9daa1d
<pre>
Add in place interpreter optimizations
<a href="https://bugs.webkit.org/show_bug.cgi?id=259798">https://bugs.webkit.org/show_bug.cgi?id=259798</a>
rdar://113358427

Reviewed by Justin Michaud.

Added a variety of optimizations to improve the performance of the in-place interpreter:
- Added new mini-interpreters (mINT, uINT, and argumINT) to optimize the calling convention by not loading/storing registers pessimistically.
  - argumINT also allows locals to index directly using their original index.
- Added a &quot;condensing&quot; behavior that allows long runs of block/loop and end instructions to be skipped when interpreting by modifying metadata entries to jump past these groups of instructions.
- Transitioned to unaligned metadata, allowing almost all instructions to save bytes by compacting their metadata.
- Added compact forms for i32.const and local.get/set, which allow IPInt to read directly from the bytecode if the index is &lt;128, saving 4B of metadata.

Scores 37.755 on JS2&apos;s Wasm tests, versus 34.926 for LLInt.

Startup time on UE4 Zen Garden: starts up 7.2% faster (220 ms vs 237 ms), while utilizing 9.1% less memory (421 MB vs 463 MB)

* JSTests/wasm/ipint-tests/ipint-test-nesting.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.export.string_appeared_here.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.block.result.i32.i32.const.3.br.5.block.param.i32.result.i32.block.result.i32.i32.const.2.i32.add.return.func.export.string_appeared_here.param.i32.result.i32.block.block.block.loop.block.loop.block.local.0.i32.const.1.i32.add.local.0.loop.block.nop.loop.loop.loop.local.0.local.0.local.0.return.async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter.asm:
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.cpp:
(JSC::Wasm::FunctionIPIntMetadataGenerator::addBlankSpace):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addRawValue):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantInt32AndLength):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addLEB128ConstantAndLengthForType):
(JSC::Wasm::FunctionIPIntMetadataGenerator::addReturnData):
* Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h:
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::condenseControlFlowInstructions):
(JSC::Wasm::IPIntGenerator::addBlock):
(JSC::Wasm::IPIntGenerator::addLoop):

Canonical link: <a href="https://commits.webkit.org/266826@main">https://commits.webkit.org/266826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/067d37bebfe01c4591948ff992e13334b6ddb5ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15271 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/15046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17347 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13411 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/20387 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12724 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16818 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14134 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14131 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11944 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/15065 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13268 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3588 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17752 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15295 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13973 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3653 "Passed tests") | 
<!--EWS-Status-Bubble-End-->