### PR TITLE
[watchOS] Turning on lockdown mode should not cause certain web fonts to be enabled

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4461,7 +4461,14 @@ static void adjustSettingsForLockdownMode(Settings& settings, const WebPreferenc
 #if ENABLE(WEB_AUDIO)
     settings.setWebAudioEnabled(false);
 #endif
-    settings.setDownloadableBinaryFontAllowedTypes(DownloadableBinaryFontAllowedTypes::Restricted);
+    switch (settings.downloadableBinaryFontAllowedTypes()) {
+    case DownloadableBinaryFontAllowedTypes::Any:
+        settings.setDownloadableBinaryFontAllowedTypes(DownloadableBinaryFontAllowedTypes::Restricted);
+        break;
+    case DownloadableBinaryFontAllowedTypes::Restricted:
+    case DownloadableBinaryFontAllowedTypes::None:
+        break;
+    }
 #if ENABLE(WEB_CODECS)
     settings.setWebCodecsEnabled(false);
     settings.setWebCodecsAV1Enabled(false);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm
@@ -157,7 +157,11 @@ TEST(LockdownMode, NotAllowedFont)
         auto targetResult = static_cast<NSNumber *>([webView objectByEvaluatingJavaScript:@"target.offsetWidth"]).intValue;
         auto referenceResult = static_cast<NSNumber *>([webView objectByEvaluatingJavaScript:@"reference.offsetWidth"]).intValue;
 
+#if PLATFORM(WATCHOS)
+        EXPECT_NE(targetResult, referenceResult);
+#else
         EXPECT_EQ(targetResult, referenceResult);
+#endif
     }
 }
 }


### PR DESCRIPTION
#### eb66cb9547364e0a6565d017cc90aa590ea26ed3
<pre>
[watchOS] Turning on lockdown mode should not cause certain web fonts to be enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=259791">https://bugs.webkit.org/show_bug.cgi?id=259791</a>
rdar://112281112

Reviewed by Aditya Keerthi.

To optimize performance and data use, web fonts are currently always disabled on watchOS. However,
enabling lockdown mode on watchOS actually causes us to *enable* support for a small subset for web
fonts, since we change `DownloadableBinaryFontAllowedTypes` state from `None` (i.e. no web fonts
allowed at all) to `Restricted`. This subsequently causes cached fonts in the GPU process to end up
in an unexpected state on watchOS, triggering a `MESSAGE_CHECK` and causing the web process to
terminate.

It doesn&apos;t make sense for Lockdown mode to make web fonts *less* restrictive, so we can simply fix
this by maintaining `DownloadableBinaryFontAllowedTypes::None` in the case where web fonts are
already unconditionally disabled.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::adjustSettingsForLockdownMode):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LockdownModeFonts.mm:

Rebaseline an API test for compatibility with watchOS as well, where web fonts are always disabled.

Canonical link: <a href="https://commits.webkit.org/266563@main">https://commits.webkit.org/266563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55ce2b03874dfede84b618e68befb09af1243132

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14547 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16086 "127 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14327 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14902 "An unexpected error occured. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16609 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19780 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16129 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11329 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12750 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3427 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->