### PR TITLE
Add memory warning simulation to the MemoryPressureHandler

### DIFF
--- a/LayoutTests/memory/memory-warning-simulation-expected.txt
+++ b/LayoutTests/memory/memory-warning-simulation-expected.txt
@@ -1,0 +1,15 @@
+Basic test for the memory warning simulation mechanism.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Verify that we're not running under memory warning from the beginning.
+PASS internals.isUnderMemoryWarning is false
+Begin simulated memory warning.
+PASS internals.isUnderMemoryWarning is true
+End simulated memory warning.
+PASS internals.isUnderMemoryWarning is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/memory/memory-warning-simulation.html
+++ b/LayoutTests/memory/memory-warning-simulation.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+
+description("Basic test for the memory warning simulation mechanism.");
+
+debug("Verify that we're not running under memory warning from the beginning.");
+shouldBe("internals.isUnderMemoryWarning", "false");
+
+debug("Begin simulated memory warning.");
+internals.beginSimulatedMemoryWarning();
+
+shouldBe("internals.isUnderMemoryWarning", "true");
+
+debug("End simulated memory warning.");
+internals.endSimulatedMemoryWarning();
+
+shouldBe("internals.isUnderMemoryWarning", "false");
+
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WTF/wtf/MemoryPressureHandler.cpp
+++ b/Source/WTF/wtf/MemoryPressureHandler.cpp
@@ -172,6 +172,10 @@ MemoryUsagePolicy MemoryPressureHandler::policyForFootprint(size_t footprint)
 
 MemoryUsagePolicy MemoryPressureHandler::currentMemoryUsagePolicy()
 {
+    if (m_isSimulatingMemoryWarning)
+        return MemoryUsagePolicy::Conservative;
+    if (m_isSimulatingMemoryPressure)
+        return MemoryUsagePolicy::Strict;
     return policyForFootprint(memoryFootprint());
 }
 
@@ -249,6 +253,23 @@ ASCIILiteral MemoryPressureHandler::processStateDescription()
         }
     }
     return "unknown"_s;
+}
+
+void MemoryPressureHandler::beginSimulatedMemoryWarning()
+{
+    if (m_isSimulatingMemoryWarning)
+        return;
+    m_isSimulatingMemoryWarning = true;
+    memoryPressureStatusChanged();
+    respondToMemoryPressure(Critical::No, Synchronous::Yes);
+}
+
+void MemoryPressureHandler::endSimulatedMemoryWarning()
+{
+    if (!m_isSimulatingMemoryWarning)
+        return;
+    m_isSimulatingMemoryWarning = false;
+    memoryPressureStatusChanged();
 }
 
 void MemoryPressureHandler::beginSimulatedMemoryPressure()

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -97,10 +97,11 @@ public:
     {
         auto memoryPressureStatus = m_memoryPressureStatus.load();
         return memoryPressureStatus == MemoryPressureStatus::SystemWarning
+            || memoryPressureStatus == MemoryPressureStatus::ProcessLimitWarning
 #if PLATFORM(MAC)
             || m_memoryUsagePolicy == MemoryUsagePolicy::Conservative
 #endif
-            || memoryPressureStatus == MemoryPressureStatus::ProcessLimitWarning;
+            || m_isSimulatingMemoryWarning;
     }
 
     bool isUnderMemoryPressure() const
@@ -113,6 +114,7 @@ public:
 #endif
             || m_isSimulatingMemoryPressure;
     }
+    bool isSimulatingMemoryWarning() const { return m_isSimulatingMemoryWarning; }
     bool isSimulatingMemoryPressure() const { return m_isSimulatingMemoryPressure; }
     void setMemoryPressureStatus(MemoryPressureStatus);
 
@@ -230,6 +232,8 @@ public:
 
     WTF_EXPORT_PRIVATE void releaseMemory(Critical, Synchronous = Synchronous::No);
 
+    WTF_EXPORT_PRIVATE void beginSimulatedMemoryWarning();
+    WTF_EXPORT_PRIVATE void endSimulatedMemoryWarning();
     WTF_EXPORT_PRIVATE void beginSimulatedMemoryPressure();
     WTF_EXPORT_PRIVATE void endSimulatedMemoryPressure();
 
@@ -268,6 +272,7 @@ private:
 
     std::atomic<MemoryPressureStatus> m_memoryPressureStatus { MemoryPressureStatus::Normal };
     bool m_installed { false };
+    bool m_isSimulatingMemoryWarning { false };
     bool m_isSimulatingMemoryPressure { false };
     bool m_shouldLogMemoryMemoryPressureEvents { true };
 

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -61,7 +61,10 @@ static OSObjectPtr<dispatch_source_t>& timerEventSource()
     return source.get();
 }
 
-static int notifyTokens[3];
+// One token for each of the memory pressure/memory warning notifications we listen for.
+// notifyutil -p org.WebKit.lowMemory[.begin/.end]
+// notifyutil -p org.WebKit.memoryWarning[.begin/.end]
+static int notifyTokens[6];
 
 // Disable memory event reception for a minimum of s_minimumHoldOffTime
 // seconds after receiving an event. Don't let events fire any sooner than
@@ -114,8 +117,32 @@ void MemoryPressureHandler::install()
         dispatch_resume(memoryPressureEventSource().get());
     });
 
+    // Allow simulation of memory warning (80% of high watermark) with "notifyutil -p org.WebKit.memoryWarning
+    notify_register_dispatch("org.WebKit.memoryWarning", &notifyTokens[0], m_dispatchQueue.get(), ^(int) {
+#if ENABLE(FMW_FOOTPRINT_COMPARISON)
+        auto footprintBefore = pagesPerVMTag();
+#endif
+        beginSimulatedMemoryWarning();
+
+#if ENABLE(FMW_FOOTPRINT_COMPARISON)
+        auto footprintAfter = pagesPerVMTag();
+        logFootprintComparison(footprintBefore, footprintAfter);
+#endif
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), m_dispatchQueue.get(), ^{
+            endSimulatedMemoryWarning();
+        });
+    });
+
+    notify_register_dispatch("org.WebKit.memoryWarning.begin", &notifyTokens[1], m_dispatchQueue.get(), ^(int) {
+        beginSimulatedMemoryWarning();
+    });
+    notify_register_dispatch("org.WebKit.memoryWarning.end", &notifyTokens[2], m_dispatchQueue.get(), ^(int) {
+        endSimulatedMemoryWarning();
+    });
+
     // Allow simulation of memory pressure with "notifyutil -p org.WebKit.lowMemory"
-    notify_register_dispatch("org.WebKit.lowMemory", &notifyTokens[0], m_dispatchQueue.get(), ^(int) {
+    notify_register_dispatch("org.WebKit.lowMemory", &notifyTokens[3], m_dispatchQueue.get(), ^(int) {
 #if ENABLE(FMW_FOOTPRINT_COMPARISON)
         auto footprintBefore = pagesPerVMTag();
 #endif
@@ -134,10 +161,10 @@ void MemoryPressureHandler::install()
         });
     });
 
-    notify_register_dispatch("org.WebKit.lowMemory.begin", &notifyTokens[1], m_dispatchQueue.get(), ^(int) {
+    notify_register_dispatch("org.WebKit.lowMemory.begin", &notifyTokens[4], m_dispatchQueue.get(), ^(int) {
         beginSimulatedMemoryPressure();
     });
-    notify_register_dispatch("org.WebKit.lowMemory.end", &notifyTokens[2], m_dispatchQueue.get(), ^(int) {
+    notify_register_dispatch("org.WebKit.lowMemory.end", &notifyTokens[5], m_dispatchQueue.get(), ^(int) {
         endSimulatedMemoryPressure();
     });
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3474,9 +3474,24 @@ ExceptionOr<void> Internals::garbageCollectDocumentResources() const
     return { };
 }
 
+bool Internals::isUnderMemoryWarning()
+{
+    return MemoryPressureHandler::singleton().isUnderMemoryWarning();
+}
+
 bool Internals::isUnderMemoryPressure()
 {
     return MemoryPressureHandler::singleton().isUnderMemoryPressure();
+}
+
+void Internals::beginSimulatedMemoryWarning()
+{
+    MemoryPressureHandler::singleton().beginSimulatedMemoryWarning();
+}
+
+void Internals::endSimulatedMemoryWarning()
+{
+    MemoryPressureHandler::singleton().endSimulatedMemoryWarning();
 }
 
 void Internals::beginSimulatedMemoryPressure()

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -514,9 +514,13 @@ public:
 
     ExceptionOr<void> garbageCollectDocumentResources() const;
 
+    bool isUnderMemoryWarning();
+    bool isUnderMemoryPressure();
+
+    void beginSimulatedMemoryWarning();
+    void endSimulatedMemoryWarning();
     void beginSimulatedMemoryPressure();
     void endSimulatedMemoryPressure();
-    bool isUnderMemoryPressure();
 
     ExceptionOr<void> insertAuthorCSS(const String&) const;
     ExceptionOr<void> insertUserCSS(const String&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -657,7 +657,11 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined insertAuthorCSS(DOMString css);
     undefined insertUserCSS(DOMString css);
 
+    readonly attribute boolean isUnderMemoryWarning;
     readonly attribute boolean isUnderMemoryPressure;
+
+    undefined beginSimulatedMemoryWarning();
+    undefined endSimulatedMemoryWarning();
     undefined beginSimulatedMemoryPressure();
     undefined endSimulatedMemoryPressure();
 


### PR DESCRIPTION
#### 29231ce7a037fa0af2c6d8fe47bafdb23ec7309e
<pre>
Add memory warning simulation to the MemoryPressureHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=259802">https://bugs.webkit.org/show_bug.cgi?id=259802</a>
rdar://113361130

Reviewed by Simon Fraser.

This adds the ability to simulate a memory warning, complementing the
existing memory pressure simulation facility. Adds both a notification
handler (e.g. notifyutil on macOS) and a JS internals API for layout
tests.

* LayoutTests/memory/memory-warning-simulation-expected.txt: Added.
* LayoutTests/memory/memory-warning-simulation.html: Added.
* Source/WTF/wtf/MemoryPressureHandler.cpp:
(WTF::MemoryPressureHandler::currentMemoryUsagePolicy):
(WTF::MemoryPressureHandler::beginSimulatedMemoryWarning):
(WTF::MemoryPressureHandler::endSimulatedMemoryWarning):
* Source/WTF/wtf/MemoryPressureHandler.h:
(WTF::MemoryPressureHandler::isUnderMemoryWarning const):
(WTF::MemoryPressureHandler::isSimulatingMemoryWarning const):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::MemoryPressureHandler::install):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isUnderMemoryWarning):
(WebCore::Internals::beginSimulatedMemoryWarning):
(WebCore::Internals::endSimulatedMemoryWarning):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/266562@main">https://commits.webkit.org/266562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee1e4b9bac5ddd4c605a1a6da1a3b26b8ea44397

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15896 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13420 "Failed to checkout and rebase branch from PR 16368") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16615 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16135 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13422 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11335 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14204 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12627 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3672 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3426 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17091 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14591 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13320 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3485 "Passed tests") | 
<!--EWS-Status-Bubble-End-->