### PR TITLE
Pausing media playback after suspending media playback, and then later unsuspending media

### DIFF
--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -279,6 +279,10 @@ void PlatformMediaSession::clientWillBeDOMSuspended()
 void PlatformMediaSession::pauseSession()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
+
+    if (state() == Interrupted)
+        m_stateToRestore = Paused;
+
     m_client.suspendPlayback();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm
@@ -77,3 +77,34 @@ TEST(WKWebViewSuspendAllMediaPlayback, AfterLoading)
 
     TestWebKitAPI::Util::run(&isPlaying);
 }
+
+TEST(WKWebViewSuspendAllMediaPlayback, PauseWhenResume)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+#if TARGET_OS_IPHONE
+    configuration.get().allowsInlineMediaPlayback = YES;
+#endif
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+
+    __block bool completionHandlerCalled = false;
+    auto completionHandler = ^{
+        completionHandlerCalled = true;
+    };
+
+    [webView suspendAllMediaPlayback:completionHandler];
+    TestWebKitAPI::Util::run(&completionHandlerCalled);
+
+    completionHandlerCalled = false;
+    [webView pauseAllMediaPlaybackWithCompletionHandler:completionHandler];
+    TestWebKitAPI::Util::run(&completionHandlerCalled);
+
+    completionHandlerCalled = false;
+    [webView resumeAllMediaPlayback:completionHandler];
+    TestWebKitAPI::Util::run(&completionHandlerCalled);
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"document.querySelector('video').paused"] boolValue]);
+
+}


### PR DESCRIPTION
#### e6ac3419306c15f2b830078c89afaf47ab1fde55
<pre>
Pausing media playback after suspending media playback, and then later unsuspending media
playback should not unpause media that was playing before the original suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=259801">https://bugs.webkit.org/show_bug.cgi?id=259801</a>
rdar://111917263

Reviewed by Eric Carlson.

Currently, if playing media is suspended, then a user pauses the media, when
playback is unsuspended the media begins playing again. However the desired behavior is for
the pause to be honored when media is unsuspended. This bug happens because when playback is
suspended, PlatformMediaSession::beginInterruption records the playback state to restore when
unsuspended in m_stateToRestore. But this data member is not updated if pausing occurs while
suspended.

Now, when playback is paused, PlatformMediaSession::pauseSession checks if playback is currently
interrupted (meaning it is suspended), and if so, sets m_stateToRestore to &apos;paused&apos;.

1 API test added that checks that after doing suspend -&gt; pause -&gt; unsuspend, media that was playing
originally is now paused.

* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::pauseSession):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSuspendAllMediaPlayback.mm:

Canonical link: <a href="https://commits.webkit.org/266590@main">https://commits.webkit.org/266590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6865b060f24e7728bbf8c25ac16eb14386f63c6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16091 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16616 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19785 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16134 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11336 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12757 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3443 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->