### PR TITLE
Handle potential overflow of gamepadEventListenerCount.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6552,3 +6552,5 @@ webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]
 
 # Only some OSes have support for auto word breaking.
 imported/w3c/web-platform-tests/css/css-text/word-break/auto [ Pass Failure ImageOnlyFailure ]
+
+webkit.org/b/255970 [ Debug ] fullscreen/exit-full-screen-video-crash.html [ Crash ]

--- a/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt
+++ b/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash.

--- a/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html
+++ b/LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html
@@ -1,0 +1,9 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    d.attributeStyleMap.set('content', 'url(A)');
+  };
+</script>
+<div id="d"></div>
+<p>PASS if no crash.</p>

--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt
@@ -1,0 +1,9 @@
+No crash when property 'x' is assigned
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
+++ b/LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("No crash when property 'x' is assigned");
+
+// This structure has a non-reified static property "isTrusted".
+const EVENT = new Event('a');
+
+
+function opt(use_event, proxy) {
+    let tmp = Object.create(null);
+    if (use_event)
+        tmp = Object.create(EVENT);
+
+    tmp.isTrusted = 1;  // Here the compiler expects that it'll transition but at runtime it'll fail due to the setter from EVENT.
+
+    tmp.a0 = 0x1111;
+    tmp.a1 = 0x2222;
+    tmp.a2 = 0x3333;
+    tmp.a3 = 0x4444;
+    tmp.a4 = 0x5555;
+    tmp.a5 = 0x6666;
+    
+    proxy.set_getter_on = tmp;
+
+    const value = tmp.a5;
+
+    return value;
+}
+
+
+function initialize() {
+    {
+        const object = Object.create(EVENT);
+        Object.defineProperty(object, 'isTrusted', {value: 1, writable: true, enumerable: true, configurable: true});
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+
+    {
+        const object = Object.create(EVENT);
+
+        object.a0 = 1;
+        object.a1 = 1;
+        object.a2 = 1;
+        object.a3 = 1;
+        object.a4 = 1;
+        object.a5 = 1;
+    }
+}
+
+
+function main() {
+    const proxy = new Proxy({}, {
+        set: (object, property, value) => {
+            const tmp = {};
+            tmp[26] = 2.3023e-320;
+            value[26] = 1.1;
+
+            return true;
+        }
+    });
+
+    initialize();
+
+    for (let i = 0; i < 1000; i++) {
+        opt(/* use_event */ false, /* proxy */ 1.1);
+        opt(/* use_event */ true, /* proxy */ 1.1);
+    }
+    
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    setTimeout(() => {
+        const value = opt(/* use_event */ true, proxy);
+
+        // Should crash here.
+        value.x = 1234;
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+}
+
+main();
+
+</script>

--- a/LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt
+++ b/LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fullscreen/exit-full-screen-video-crash.html
+++ b/LayoutTests/fullscreen/exit-full-screen-video-crash.html
@@ -1,0 +1,17 @@
+<script>
+  onload = async () => {
+    if (window.testRunner)
+      testRunner.dumpAsText();
+    internals.withUserGesture(() => {});
+    let video0 = document.createElement('video');
+    video0.src = 'data:video/mp4;';
+    document.body.append(video0);
+    $vm.print(await video0.requestFullscreen());
+    navigator.mediaSession.callActionHandler({action: 'play'});
+    let div0 = document.createElement('div');
+    video0.append(div0);
+    $vm.print(await div0.requestFullscreen());
+    video0.webkitSetPresentationMode('inline');
+    document.body.innerHTML = 'PASS if no crash';
+  };
+</script>

--- a/LayoutTests/platform/gtk/fullscreen/exit-full-screen-video-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fullscreen/exit-full-screen-video-crash-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: TypeError: video0.webkitSetPresentationMode is not a function. (In 'video0.webkitSetPresentationMode('inline')', 'video0.webkitSetPresentationMode' is undefined)
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2516,6 +2516,9 @@ imported/w3c/web-platform-tests/geolocation-API/permission.https.html [ WontFix 
 # Per-process limit is only for WK2
 http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ]
 
+# IPC is for WK2
+ipc/shared-video-frame-size.html [ Skip ]
+
 # Displays blank on WK1
 fullscreen/fullscreen-iframe-navigation.html [ Skip ]
 

--- a/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyCondition.cpp
@@ -190,6 +190,14 @@ bool PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint(
             if (PropertyConditionInternal::verbose)
                 dataLog("Invalid because its put() override may treat ", uid(), " property as special non-structure one.\n");
             return false;
+        } else if (structure->hasNonReifiedStaticProperties()) {
+            if (auto entry = structure->findPropertyHashEntry(uid())) {
+                if (entry->value->attributes() & PropertyAttribute::ReadOnlyOrAccessorOrCustomAccessorOrValue) {
+                    if (PropertyConditionInternal::verbose)
+                        dataLog("Invalid because we expected not to have a setter, but we have one in non-reified static property table: ", uid(), ".\n");
+                    return false;
+                }
+            }
         }
 
         if (structure->hasPolyProto()) {

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -473,7 +473,7 @@ private:
 #endif
 
 #if ENABLE(GAMEPAD)
-    unsigned m_gamepadEventListenerCount { 0 };
+    uint64_t m_gamepadEventListenerCount { 0 };
 #endif
 
     mutable RefPtr<Storage> m_sessionStorage;

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h
@@ -75,6 +75,7 @@ private:
     uint32_t m_heightPlaneB { 0 };
     uint32_t m_bytesPerRowPlaneB { 0 };
     uint32_t m_bytesPerRowPlaneAlpha { 0 };
+    size_t m_storageSize { 0 };
 };
 
 

--- a/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
+++ b/Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm
@@ -76,6 +76,9 @@ bool SharedVideoFrameInfo::isReadWriteSupported() const
 
 size_t SharedVideoFrameInfo::storageSize() const
 {
+    if (m_storageSize)
+        return m_storageSize;
+
     size_t sizePlaneA;
     if (!WTF::safeMultiply(m_bytesPerRow, m_height, sizePlaneA))
         return 0;
@@ -91,7 +94,8 @@ size_t SharedVideoFrameInfo::storageSize() const
     if (m_bufferType == kCVPixelFormatType_420YpCbCr8VideoRange_8A_TriPlanar && !WTF::safeAdd(sizePlaneA, size, size))
         return 0;
 
-    return size;
+    const_cast<SharedVideoFrameInfo*>(this)->m_storageSize = size;
+    return m_storageSize;
 }
 
 void SharedVideoFrameInfo::encode(uint8_t* destination)
@@ -106,7 +110,7 @@ void SharedVideoFrameInfo::encode(uint8_t* destination)
     encoder << m_heightPlaneB;
     encoder << m_bytesPerRowPlaneB;
     encoder << m_bytesPerRowPlaneAlpha;
-    ASSERT(sizeof(SharedVideoFrameInfo) == encoder.bufferSize());
+    ASSERT(sizeof(SharedVideoFrameInfo) == encoder.bufferSize() + sizeof(size_t));
     std::memcpy(destination, encoder.buffer(), encoder.bufferSize());
 }
 

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm
@@ -409,8 +409,15 @@ void VideoFullscreenManager::enterVideoFullscreenForVideoElement(HTMLVideoElemen
 void VideoFullscreenManager::exitVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, CompletionHandler<void(bool)>&& completionHandler)
 {
     INFO_LOG(LOGIDENTIFIER);
+    LOG(Fullscreen, "VideoFullscreenManager::exitVideoFullscreenForVideoElement(%p)", this);
+
     ASSERT(m_page);
     ASSERT(m_videoElements.contains(videoElement));
+
+    if (!m_videoElements.contains(videoElement)) {
+        completionHandler(false);
+        return;
+    }
 
     auto contextId = m_videoElements.get(videoElement);
     auto& interface = ensureInterface(contextId);
@@ -441,6 +448,9 @@ void VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVideo
 
     ASSERT(m_page);
     ASSERT(m_videoElements.contains(videoElement));
+
+    if (!m_videoElements.contains(videoElement))
+        return;
 
     if (m_videoElementInPictureInPicture == &videoElement)
         m_videoElementInPictureInPicture = nullptr;


### PR DESCRIPTION
#### 6e63c9facca092bb4e3d0ab86014b6767925c6b8
<pre>
Handle potential overflow of gamepadEventListenerCount.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256205.">https://bugs.webkit.org/show_bug.cgi?id=256205.</a>
rdar://80838189.

Reviewed by Ryosuke Niwa.

m_gamepadEventListenerCount can overflow if addEventListener() is called UINT_MAX+1 times.
Once the window is freed, we will be left with a dangling pointer in the GamepadManager.
This change adds a flag to check for overflow and keep the behavior same in the event of overflow..

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::~DOMWindow):
(WebCore::DOMWindow::incrementGamepadEventListenerCount):
(WebCore::DOMWindow::decrementGamepadEventListenerCount):
* Source/WebCore/page/DOMWindow.h:

Originally-landed-as: 259548.729@safari-7615-branch (5cc2ead4986a). rdar://113169820
Canonical link: <a href="https://commits.webkit.org/266586@main">https://commits.webkit.org/266586@main</a>
</pre>
----------------------------------------------------------------------
#### 067d7d9bd14860f25f32e8334c8c6b0898b08979
<pre>
Fix type confusion in BuilderConverter::applyValueContent.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255955.">https://bugs.webkit.org/show_bug.cgi?id=255955.</a>
rdar://108499561.

Reviewed by Antti Koivisto.

This change fixes applyValueContent so that it can deal with single
values instead of expecting a list of values towards the end.

* LayoutTests/fast/css/style-builder-apply-value-content-type-confusion-expected.txt: Added.
* LayoutTests/fast/css/style-builder-apply-value-content-type-confusion.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
  (WebCore::Style::BuilderCustom::applyValueContent):

Originally-landed-as: 259548.730@safari-7615-branch (c123784dc828). rdar://113168576
Canonical link: <a href="https://commits.webkit.org/266585@main">https://commits.webkit.org/266585@main</a>
</pre>
----------------------------------------------------------------------
#### 549d44e287b72e8ef61a07b54494990d8528307e
<pre>
Fix crash when HTMLMediaElement::exitFullscreen is called on a video
element which is not currently full screen
<a href="https://bugs.webkit.org/show_bug.cgi?id=255970">https://bugs.webkit.org/show_bug.cgi?id=255970</a>
rdar://108489504

Reviewed by Jer Noble.

This change fixes an issue where exitFullScreen is called on video, but
the current full screen element is div, due to which we end up
scheduling the webkitendfullscreenEvent event for video, which trips
over an assertion.

* LayoutTests/fullscreen/exit-full-screen-video-crash-expected.txt: Added.
* LayoutTests/fullscreen/exit-full-screen-video-crash.html: Added.
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):

Originally-landed-as: 259548.703@safari-7615-branch (0ffc79d64999). rdar://113167859
Canonical link: <a href="https://commits.webkit.org/266584@main">https://commits.webkit.org/266584@main</a>
</pre>
----------------------------------------------------------------------
#### e4c0a68634713df2f29808131c7dca900a3dc7e7
<pre>
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read
rdar://107023292

Reviewed by Eric Carlson.

Compute with safeMultitply/safeAdd the total size of the frame.
If there is an overflow, we now fail the decoding of SharedVideoFrameInfo.
We store the size of the frame in SharedVideoFrameInfo to not recompute it a second time.

Covered by provided IPC test.

* LayoutTests/ipc/shared-video-frame-size-expected.txt: Added.
* LayoutTests/ipc/shared-video-frame-size.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.h:
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::storageSize const):
(WebCore::SharedVideoFrameInfo::decode):

Originally-landed-as: 259548.590@safari-7615-branch (dd4ad7b0b286). rdar://113166244
Canonical link: <a href="https://commits.webkit.org/266583@main">https://commits.webkit.org/266583@main</a>
</pre>
----------------------------------------------------------------------
#### 8a1997806028a9b1490488a6503a238dca0239ff
<pre>
[JSC] PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() should take non-reified static properties into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=255952">https://bugs.webkit.org/show_bug.cgi?id=255952</a>
&lt;rdar://108334411&gt;

Reviewed by Yusuke Suzuki.

Currently, PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint() is not checking the
structure&apos;s non-reified static properties against the condition. This can lead to incorrect analysis
of side effects: AbsenceOfSetEffect condition with a non-reified static setter is considered pure
even though a setter with arbitrary code can be invoked.

This patch fixes AbsenceOfSetEffect validity check for structures with non-reified static properties
while takes extra care to make the fix as precise as possible to avoid unnecessary slowdowns.

* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash-expected.txt: Added.
* LayoutTests/fast/dom/non-reified-event-isTrusted-ic-crash.html: Added.
* Source/JavaScriptCore/bytecode/PropertyCondition.cpp:
(JSC::PropertyCondition::isStillValidAssumingImpurePropertyWatchpoint const):

Originally-landed-as: 259548.775@safari-7615-branch (ffe32d106cb2). rdar://113160398
Canonical link: <a href="https://commits.webkit.org/266582@main">https://commits.webkit.org/266582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87ba78a1e928cc3c82387374a15abd0b08225d7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15904 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14911 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16623 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19794 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13273 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16143 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13433 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11341 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14212 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12632 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3439 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17099 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14599 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13328 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3488 "Passed tests") | 
<!--EWS-Status-Bubble-End-->