### PR TITLE
Regression: NetworkDataTask's ThreadSafeWeakPtrControlBlock are leaking

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -73,7 +73,6 @@ NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTas
 
     m_blobData = session.blobRegistry().getBlobDataFromURL(request.url());
 
-    m_session->registerNetworkDataTask(*this);
     LOG(NetworkSession, "%p - Created NetworkDataTaskBlob for %s", this, request.url().string().utf8().data());
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -62,7 +62,6 @@ Ref<NetworkDataTask> NetworkDataTaskDataURL::create(NetworkSession& session, Net
 NetworkDataTaskDataURL::NetworkDataTaskDataURL(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation)
 {
-    m_session->registerNetworkDataTask(*this);
 }
 
 NetworkDataTaskDataURL::~NetworkDataTaskDataURL()

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -592,13 +592,13 @@ std::unique_ptr<WebSocketTask> NetworkSession::createWebSocketTask(WebPageProxyI
 
 void NetworkSession::registerNetworkDataTask(NetworkDataTask& task)
 {
-    // Unregistration happens automatically in ThreadSafeWeakHashSet::amortizedCleanupIfNeeded.
+    ASSERT(!m_dataTaskSet.contains(task));
     m_dataTaskSet.add(task);
+}
 
-    // FIXME: This is not in a good place. It should probably be in the NetworkDataTask constructor.
-#if ENABLE(INSPECTOR_NETWORK_THROTTLING)
-    task.setEmulatedConditions(m_bytesPerSecondLimit);
-#endif
+void NetworkSession::unregisterNetworkDataTask(NetworkDataTask& task)
+{
+    m_dataTaskSet.remove(task);
 }
 
 NetworkLoadScheduler& NetworkSession::networkLoadScheduler()

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -125,6 +125,7 @@ public:
     WebCore::NetworkStorageSession* networkStorageSession() const;
 
     void registerNetworkDataTask(NetworkDataTask&);
+    void unregisterNetworkDataTask(NetworkDataTask&);
 
     void destroyPrivateClickMeasurementStore(CompletionHandler<void()>&&);
 
@@ -267,6 +268,7 @@ public:
 #endif
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
+    std::optional<int64_t> bytesPerSecondLimit() const { return m_bytesPerSecondLimit; }
     void setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit);
 #endif
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -327,8 +327,6 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     if (parameters.networkActivityTracker)
         m_task.get()._nw_activity = parameters.networkActivityTracker->getPlatformObject();
 #endif
-
-    m_session->registerNetworkDataTask(*this);
 }
 
 NetworkDataTaskCocoa::~NetworkDataTaskCocoa()

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -61,8 +61,6 @@ NetworkDataTaskCurl::NetworkDataTaskCurl(NetworkSession& session, NetworkDataTas
     , m_shouldRelaxThirdPartyCookieBlocking(parameters.shouldRelaxThirdPartyCookieBlocking)
     , m_sourceOrigin(parameters.sourceOrigin)
 {
-    m_session->registerNetworkDataTask(*this);
-
     auto request = parameters.request;
     if (request.url().protocolIsInHTTPFamily()) {
         if (m_storedCredentialsPolicy == StoredCredentialsPolicy::Use) {

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -65,8 +65,6 @@ NetworkDataTaskSoup::NetworkDataTaskSoup(NetworkSession& session, NetworkDataTas
     , m_sourceOrigin(parameters.sourceOrigin)
     , m_timeoutSource(RunLoop::main(), this, &NetworkDataTaskSoup::timeoutFired)
 {
-    m_session->registerNetworkDataTask(*this);
-
     auto request = parameters.request;
     if (request.url().protocolIsInHTTPFamily()) {
 #if USE(SOUP2)

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -2888,6 +2888,100 @@ TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSet)
     EXPECT_EQ(ThreadSafeInstanceCounter::instanceCount, 0u);
 }
 
+class ObjectAddingAndRemovingItself : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ObjectAddingAndRemovingItself> {
+public:
+    static Ref<ObjectAddingAndRemovingItself> create(ThreadSafeWeakHashSet<ObjectAddingAndRemovingItself>& set)
+    {
+        return adoptRef(*new ObjectAddingAndRemovingItself(set));
+    }
+
+    ~ObjectAddingAndRemovingItself()
+    {
+        EXPECT_TRUE(m_set.contains(*this));
+        m_set.remove(*this);
+        EXPECT_FALSE(m_set.contains(*this));
+    }
+
+private:
+    ObjectAddingAndRemovingItself(ThreadSafeWeakHashSet<ObjectAddingAndRemovingItself>& set)
+        : m_set(set)
+    {
+        EXPECT_FALSE(m_set.contains(*this));
+        m_set.add(*this);
+        EXPECT_TRUE(m_set.contains(*this));
+    }
+
+    ThreadSafeWeakHashSet<ObjectAddingAndRemovingItself>& m_set;
+};
+
+TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashSetRemoveOnDestruction)
+{
+    ThreadSafeWeakHashSet<ObjectAddingAndRemovingItself> set;
+    Vector<Ref<ObjectAddingAndRemovingItself>> objects;
+    for (int i = 0; i < 10; ++i)
+        objects.append(ObjectAddingAndRemovingItself::create(set));
+    unsigned setSize = 0;
+    set.forEach([&](auto& object) { ++setSize; });
+    EXPECT_EQ(setSize, 10u);
+
+    objects.removeLast();
+    setSize = 0;
+    set.forEach([&](auto& object) { ++setSize; });
+    EXPECT_EQ(setSize, 9u);
+
+    objects.clear();
+    setSize = 0;
+    set.forEach([&](auto& object) { ++setSize; });
+    EXPECT_EQ(setSize, 0u);
+}
+
+class ObjectAddingItselfOnly : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ObjectAddingAndRemovingItself> {
+public:
+    static Ref<ObjectAddingItselfOnly> create(ThreadSafeWeakHashSet<ObjectAddingItselfOnly>& set)
+    {
+        return adoptRef(*new ObjectAddingItselfOnly(set));
+    }
+
+private:
+    ObjectAddingItselfOnly(ThreadSafeWeakHashSet<ObjectAddingItselfOnly>& set)
+        : m_set(set)
+    {
+        m_set.add(*this);
+    }
+
+    ThreadSafeWeakHashSet<ObjectAddingItselfOnly>& m_set;
+};
+
+TEST(WTF_ThreadSafeWeakPtr, ThreadSafeWeakHashAmortizedCleanupWhenOnlyAdding)
+{
+    struct Struct : ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Struct> {
+        Struct() = default;
+    };
+
+    ThreadSafeWeakHashSet<Struct> set;
+    for (int i = 0; i < 10000; ++i) {
+        auto obj = adoptRef(*new Struct);
+        set.add(obj.get());
+    }
+    EXPECT_LT(set.sizeIncludingEmptyEntriesForTesting(), 1000u);
+}
+
+// The test passes if it doesn't time out.
+TEST(WTF_ThreadSafeWeakPtr, AmortizedCleanupNotQuadratic)
+{
+    struct Struct : ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<Struct> {
+        Struct() = default;
+    };
+
+    ThreadSafeWeakHashSet<Struct> set;
+    HashSet<Ref<Struct>> strongSet;
+    for (int i = 0; i < 1000000; ++i) {
+        auto obj = adoptRef(*new Struct);
+        set.add(obj.get());
+        strongSet.add(WTFMove(obj));
+    }
+}
+
 TEST(WTF_ThreadSafeWeakPtr, MultipleInheritance)
 {
     enum class Destructor : uint8_t { Cat, Dog, CatDog };


### PR DESCRIPTION
#### 177d6881d88dfc4e1306156c513b7e9c81d41710
<pre>
Regression: NetworkDataTask&apos;s ThreadSafeWeakPtrControlBlock are leaking
<a href="https://bugs.webkit.org/show_bug.cgi?id=259808">https://bugs.webkit.org/show_bug.cgi?id=259808</a>
rdar://112162921

Reviewed by Alex Christensen.

The NetworkProcess memory was growing unboundedly during long-running browsing
benchmarks, which the number of NetworkDataTask&apos;s ThreadSafeWeakPtrControlBlock
objects growing very large.

The issue was with the `ThreadSafeWeakHashSet&lt;NetworkDataTask&gt; m_dataTaskSet`
container on the NetworkSession. We would add NetworkDataTask objects to this
WeakHashSet and never explicitly remove them. We had a comment in the code
indicating that the ThreadSafeWeakHashSet&apos;s amortized clean up would take care
of removing them. The issue though is that amortized clean up would never happen
and m_dataTaskSet&apos;s internal Set would just grow unboundedly, keeping control
blocks alive.

The reason amortized clean up never triggered is that we only add to m_dataTaskSet,
we never remove from it, never clear it and we only very rarely call forEach() on
it. As a result, ThreadSafeWeakHashSet::m_operationCountSinceLastCleanup would only
increment due to the add() calls. The condition for amortized clean up was:
`++m_operationCountSinceLastCleanup / 2 &gt; m_set.size()`.

Since m_operationCountSinceLastCleanup would only increase due to the add() calls
and since nothing would ever get removed from the set, `m_operationCountSinceLastCleanup / 2`
could never reach the size of the set.

I am making several fixes in this patch:
1. I added a `|| m_operationCountSinceLastCleanup &gt; m_maxOperationCountWithoutCleanup`
   check to amortized clean up to guarantee that amortized clean up eventually happens
   and that such weak containers can never grow unboundedly, no matter how they are used.
   m_maxOperationCountWithoutCleanup gets multiplied by 2 whenever the clean up finds
   nothing for proper amortization.
2. I made it so that NetworkDataTask objects remove themselves from the ThreadSafeWeakHashSet
   in their destructor. This is good practice no matter what and makes such the set stays
   small.
3. I actually found a bug in `ThreadSafeWeakHashSet::remove()` when implementing the fix in
   (2). ThreadSafeWeakHashSet::remove() would fail to remove the object from the set if the
   call if made after the object destructor has started running! The reason for this is that
   the ThreadSafeWeakHashSet was using a `std::pair&lt;ControlBlockRefPtr, const T*&gt;` as set
   key internally. This means that we needed to create a ControlBlockRefPtr of the object&apos;s
   control block in remove() in order to remove the object from the map. However, 265344@main
   made it so that ref&apos;ing a control block returns nullptr after the object has started
   destruction. As a result, the first item in the key pair would be nullptr and we&apos;d fail
   to remove. To address the issue, I am dropping the ControlBlockRefPtr from the key and
   using a `HashMap&lt;const T*, ControlBlockRefPtr&gt;` instead of a HashSet.

* Source/WTF/wtf/ThreadSafeWeakHashSet.h:
* Source/WTF/wtf/WeakHashMap.h:
* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakListHashSet.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::~NetworkDataTask):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::registerNetworkDataTask):
(WebKit::NetworkSession::unregisterNetworkDataTask):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::ObjectAddingAndRemovingItself::create):
(TestWebKitAPI::ObjectAddingAndRemovingItself::~ObjectAddingAndRemovingItself):
(TestWebKitAPI::ObjectAddingAndRemovingItself::ObjectAddingAndRemovingItself):
(TestWebKitAPI::TEST):
(TestWebKitAPI::ObjectAddingItselfOnly::create):
(TestWebKitAPI::ObjectAddingItselfOnly::ObjectAddingItselfOnly):

Canonical link: <a href="https://commits.webkit.org/266594@main">https://commits.webkit.org/266594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c8250cbe9fc101a45c34dccd825d0250a12f25f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14612 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16684 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12820 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12162 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12984 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/16197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13509 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13535 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11390 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14262 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12813 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3442 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17150 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14649 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13378 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3504 "Passed tests") | 
<!--EWS-Status-Bubble-End-->