### PR TITLE
[JSC] Array#splice should skip result array creation if it is not used at all

### DIFF
--- a/JSTests/stress/array-split-ignore-result.js
+++ b/JSTests/stress/array-split-ignore-result.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(array) {
+    array.splice(0, 3);
+}
+noInline(test);
+
+var count = 0;
+
+for (var i = 0; i < 1e4; ++i) {
+    var array = [0, 1, 2, 3];
+    var set = null;
+    Reflect.defineProperty(array, 0, {
+        get() {
+            ++count;
+            return 42;
+        },
+        set(value) {
+            set = value;
+        },
+        configurable: true,
+    });
+    test(array);
+    shouldBe(array.length, 1);
+    shouldBe(set, 3);
+}
+shouldBe(count, 1e4);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2744,6 +2744,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case ArraySpliceExtract:
+        clobberWorld();
+        makeBytecodeTopForNode(node);
+        break;
+
     case ArrayIndexOf: {
         setNonCellTypeForNode(node, SpecInt32Only);
         break;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -753,6 +753,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case DeleteByVal:
     case ArrayPush:
     case ArrayPop:
+    case ArraySpliceExtract:
     case Call:
     case DirectCall:
     case TailCallInlinedCaller:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -268,6 +268,7 @@ bool doesGC(Graph& graph, Node* node)
 #if ASSERT_ENABLED
     case ArrayPush:
     case ArrayPop:
+    case ArraySpliceExtract:
     case PushWithScope:
     case CreateActivation:
     case CreateDirectArguments:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1533,6 +1533,13 @@ private:
             break;
         }
 
+        case ArraySpliceExtract: {
+            fixEdge<ArrayUse>(node->child1());
+            fixEdge<Int32Use>(node->child2());
+            fixEdge<Int32Use>(node->child3());
+            break;
+        }
+
         case ArrayIndexOf:
             fixupArrayIndexOf(node);
             break;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1943,6 +1943,7 @@ public:
         case GetArgument:
         case ArrayPop:
         case ArrayPush:
+        case ArraySpliceExtract:
         case RegExpExec:
         case RegExpExecNonGlobalOrSticky:
         case RegExpTest:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -331,6 +331,7 @@ namespace JSC { namespace DFG {
     macro(ArrayPop, NodeResultJS | NodeMustGenerate) \
     macro(ArraySlice, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(ArrayIndexOf, NodeResultInt32 | NodeHasVarArgs) \
+    macro(ArraySpliceExtract, NodeResultJS | NodeMustGenerate) \
     \
     /* Optimizations for regular expression matching. */\
     macro(RegExpExec, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1240,7 +1240,126 @@ JSC_DEFINE_JIT_OPERATION(operationArrayPopAndRecoverLength, EncodedJSValue, (JSG
     
     return JSValue::encode(array->pop(globalObject));
 }
-        
+
+JSC_DEFINE_JIT_OPERATION(operationArraySpliceExtract, EncodedJSValue, (JSGlobalObject* globalObject, JSArray* base, int32_t start, int32_t deleteCount, unsigned refCount))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    uint64_t length = base->length();
+    if (!length) {
+        scope.release();
+        setLength(globalObject, vm, base, length);
+        constexpr bool throwException = true;
+        base->setLength(globalObject, 0, throwException);
+        return JSValue::encode(jsUndefined());
+    }
+
+    uint64_t actualStart = 0;
+    int64_t startInt64 = start;
+    if (startInt64 < 0) {
+        startInt64 += length;
+        actualStart = startInt64 < 0 ? 0 : static_cast<uint64_t>(startInt64);
+    } else
+        actualStart = std::min(static_cast<uint64_t>(startInt64), length);
+
+    uint64_t actualDeleteCount = 0;
+    if (deleteCount < 0)
+        actualDeleteCount = 0;
+    else if (deleteCount > static_cast<int64_t>(length - actualStart))
+        actualDeleteCount = length - actualStart;
+    else
+        actualDeleteCount = static_cast<uint64_t>(deleteCount);
+
+    std::pair<SpeciesConstructResult, JSObject*> speciesResult = speciesConstructArray(globalObject, base, actualDeleteCount);
+    EXCEPTION_ASSERT(!!scope.exception() == (speciesResult.first == SpeciesConstructResult::Exception));
+    if (speciesResult.first == SpeciesConstructResult::Exception)
+        return JSValue::encode(jsUndefined());
+
+    JSValue result;
+    if (LIKELY(speciesResult.first == SpeciesConstructResult::FastPath)) {
+        // DFG / FTL tells the hint that the result array is not used at all.
+        // If this condition is met, we can skip creation of this array completely.
+        auto canFastSliceWithoutSideEffect = [](JSGlobalObject* globalObject, JSArray* base, uint64_t count) {
+            auto arrayType = base->indexingType() | IsArray;
+            switch (arrayType) {
+            case ArrayWithDouble:
+            case ArrayWithInt32:
+            case ArrayWithContiguous: {
+                if (count >= MIN_SPARSE_ARRAY_INDEX || base->structure()->holesMustForwardToPrototype(base))
+                    return false;
+
+                Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(arrayType);
+                if (UNLIKELY(hasAnyArrayStorage(resultStructure->indexingType())))
+                    return false;
+
+                return true;
+            }
+            case ArrayWithArrayStorage: {
+                if (count >= MIN_SPARSE_ARRAY_INDEX || base->structure()->holesMustForwardToPrototype(base))
+                    return false;
+
+                Structure* resultStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithContiguous);
+                if (UNLIKELY(hasAnyArrayStorage(resultStructure->indexingType())))
+                    return false;
+                return true;
+            }
+            case ArrayWithUndecided: {
+                return true;
+            }
+            default:
+                return false;
+            }
+        };
+
+        if (!refCount && canFastSliceWithoutSideEffect(globalObject, base, actualDeleteCount))
+            result = jsUndefined();
+        else {
+            result = JSArray::fastSlice(globalObject, base, actualStart, actualDeleteCount);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+    }
+
+    if (UNLIKELY(!result)) {
+        JSObject* resultObject = nullptr;
+        if (speciesResult.first == SpeciesConstructResult::CreatedObject)
+            resultObject = speciesResult.second;
+        else {
+            if (UNLIKELY(actualDeleteCount > std::numeric_limits<uint32_t>::max())) {
+                throwRangeError(globalObject, scope, LengthExceededTheMaximumArrayLengthError);
+                return { };
+            }
+            resultObject = JSArray::tryCreate(vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(ArrayWithUndecided), static_cast<uint32_t>(actualDeleteCount));
+            if (UNLIKELY(!resultObject)) {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
+            }
+        }
+        for (uint64_t k = 0; k < actualDeleteCount; ++k) {
+            JSValue v = getProperty(globalObject, base, k + actualStart);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (UNLIKELY(!v))
+                continue;
+            resultObject->putDirectIndex(globalObject, k, v, 0, PutDirectIndexShouldThrow);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+        setLength(globalObject, vm, resultObject, actualDeleteCount);
+        RETURN_IF_EXCEPTION(scope, { });
+        result = resultObject;
+    }
+
+    if (actualDeleteCount) {
+        shift<JSArray::ShiftCountForSplice>(globalObject, base, actualStart, actualDeleteCount, 0, length);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    scope.release();
+    setLength(globalObject, vm, base, length - actualDeleteCount);
+    return JSValue::encode(result);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* argument))
 {
     SuperSamplerScope superSamplerScope(false);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -201,6 +201,7 @@ JSC_DECLARE_JIT_OPERATION(operationArrayPushDouble, EncodedJSValue, (JSGlobalObj
 JSC_DECLARE_JIT_OPERATION(operationArrayPushDoubleMultiple, EncodedJSValue, (JSGlobalObject*, JSArray*, void* buffer, int32_t elementCount));
 JSC_DECLARE_JIT_OPERATION(operationArrayPop, EncodedJSValue, (JSGlobalObject*, JSArray*));
 JSC_DECLARE_JIT_OPERATION(operationArrayPopAndRecoverLength, EncodedJSValue, (JSGlobalObject*, JSArray*));
+JSC_DECLARE_JIT_OPERATION(operationArraySpliceExtract, EncodedJSValue, (JSGlobalObject*, JSArray*, int32_t start, int32_t deleteCount, unsigned refCount));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecString, EncodedJSValue, (JSGlobalObject*, RegExpObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExec, EncodedJSValue, (JSGlobalObject*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationRegExpExecGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -978,6 +978,7 @@ private:
         case GetByValMegamorphic:
         case ArrayPop:
         case ArrayPush:
+        case ArraySpliceExtract:
         case RegExpExec:
         case RegExpExecNonGlobalOrSticky:
         case RegExpTest:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -725,6 +725,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringLocaleCompare:
     case FunctionBind:
     case DateSetTime:
+    case ArraySpliceExtract:
         return false;
 
     case StringReplaceString:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1525,6 +1525,7 @@ public:
     void compileNewArrayWithSpread(Node*);
     void compileGetRestLength(Node*);
     void compileArraySlice(Node*);
+    void compileArraySpliceExtract(Node*);
     void compileArrayIndexOf(Node*);
     void compileArrayPush(Node*);
     void compileNotifyWrite(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2900,6 +2900,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArraySpliceExtract: {
+        compileArraySpliceExtract(node);
+        break;
+    }
+
     case ArrayIndexOf: {
         compileArrayIndexOf(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3930,6 +3930,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArraySpliceExtract: {
+        compileArraySpliceExtract(node);
+        break;
+    }
+
     case ArrayIndexOf: {
         compileArrayIndexOf(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -399,6 +399,7 @@ inline CapabilityLevel canCompile(Node* node)
     case CallDOM:
     case CallDOMGetter:
     case ArraySlice:
+    case ArraySpliceExtract:
     case ArrayIndexOf:
     case ArrayPop:
     case ArrayPush:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1134,6 +1134,9 @@ private:
         case ArraySlice:
             compileArraySlice();
             break;
+        case ArraySpliceExtract:
+            compileArraySpliceExtract();
+            break;
         case ArrayIndexOf:
             compileArrayIndexOf();
             break;
@@ -7328,6 +7331,20 @@ IGNORE_CLANG_WARNINGS_END
 
         mutatorFence();
         setJSValue(arrayResult.array);
+    }
+
+    void compileArraySpliceExtract()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        unsigned refCount = m_node->refCount();
+        bool mustGenerate = m_node->mustGenerate();
+        if (mustGenerate)
+            --refCount;
+
+        LValue base = lowCell(m_node->child1());
+        speculateArray(m_node->child1(), base);
+        setJSValue(vmCall(Int64, operationArraySpliceExtract, weakPointer(globalObject), base, lowInt32(m_node->child2()), lowInt32(m_node->child3()), m_out.constInt32(refCount)));
     }
 
     void compileArrayIndexOf()

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -93,7 +93,7 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().shiftPrivateName(), arrayProtoFuncShift, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly, 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, arrayProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, ArraySliceIntrinsic);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().sortPublicName(), arrayPrototypeSortCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("splice"_s, arrayProtoFuncSplice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("splice"_s, arrayProtoFuncSplice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, ArraySpliceIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("unshift"_s, arrayProtoFuncUnShift, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().everyPublicName(), arrayPrototypeEveryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().forEachPublicName(), arrayPrototypeForEachCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -157,33 +157,6 @@ void ArrayPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 
 // ------------------------------ Array Functions ----------------------------
 
-static ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject* object, uint64_t index)
-{
-    if (JSValue result = object->tryGetIndexQuickly(index))
-        return result;
-
-    // Don't return undefined if the property is not found.
-    return object->getIfPropertyExists(globalObject, index);
-}
-
-static ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj, uint64_t value)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    static constexpr bool throwException = true;
-    if (LIKELY(isJSArray(obj))) {
-        if (UNLIKELY(value > UINT32_MAX)) {
-            throwRangeError(globalObject, scope, "Invalid array length"_s);
-            return;
-        }
-        scope.release();
-        jsCast<JSArray*>(obj)->setLength(globalObject, static_cast<uint32_t>(value), throwException);
-        return;
-    }
-    scope.release();
-    PutPropertySlot slot(obj, throwException);
-    obj->methodTable()->put(obj, globalObject, vm.propertyNames->length, jsNumber(value), slot);
-}
-
 static inline uint64_t argumentClampedIndexFromStartOrEnd(JSGlobalObject* globalObject, JSValue value, uint64_t length, uint64_t undefinedValue = 0)
 {
     if (value.isUndefined())
@@ -205,120 +178,6 @@ static inline uint64_t argumentClampedIndexFromStartOrEnd(JSGlobalObject* global
         return indexDouble < 0 ? 0 : static_cast<uint64_t>(indexDouble);
     }
     return indexDouble > length ? length : static_cast<uint64_t>(indexDouble);
-}
-
-// The shift/unshift function implement the shift/unshift behaviour required
-// by the corresponding array prototype methods, and by splice. In both cases,
-// the methods are operating an an array or array like object.
-//
-//  header  currentCount  (remainder)
-// [------][------------][-----------]
-//  header  resultCount  (remainder)
-// [------][-----------][-----------]
-//
-// The set of properties in the range 'header' must be unchanged. The set of
-// properties in the range 'remainder' (where remainder = length - header -
-// currentCount) will be shifted to the left or right as appropriate; in the
-// case of shift this must be removing values, in the case of unshift this
-// must be introducing new values.
-
-template<JSArray::ShiftCountMode shiftCountMode>
-static void shift(JSGlobalObject* globalObject, JSObject* thisObj, uint64_t header, uint64_t currentCount, uint64_t resultCount, uint64_t length)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    RELEASE_ASSERT(currentCount > resultCount);
-    uint64_t count = currentCount - resultCount;
-
-    RELEASE_ASSERT(header <= length);
-    RELEASE_ASSERT(currentCount <= (length - header));
-
-    if (isJSArray(thisObj)) {
-        JSArray* array = asArray(thisObj);
-        uint32_t header32 = static_cast<uint32_t>(header);
-        ASSERT(header32 == header);
-        if (array->length() == length && array->shiftCount<shiftCountMode>(globalObject, header32, static_cast<uint32_t>(count)))
-            return;
-        header = header32;
-    }
-
-    for (uint64_t k = header; k < length - currentCount; ++k) {
-        uint64_t from = k + currentCount;
-        uint64_t to = k + resultCount;
-        JSValue value = getProperty(globalObject, thisObj, from);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (value) {
-            thisObj->putByIndexInline(globalObject, to, value, true);
-            RETURN_IF_EXCEPTION(scope, void());
-        } else {
-            bool success = thisObj->deleteProperty(globalObject, to);
-            RETURN_IF_EXCEPTION(scope, void());
-            if (!success) {
-                throwTypeError(globalObject, scope, UnableToDeletePropertyError);
-                return;
-            }
-        }
-    }
-    for (uint64_t k = length; k > length - count; --k) {
-        bool success = thisObj->deleteProperty(globalObject, k - 1);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (!success) {
-            throwTypeError(globalObject, scope, UnableToDeletePropertyError);
-            return;
-        }
-    }
-}
-
-static void unshift(JSGlobalObject* globalObject, JSObject* thisObj, uint64_t header, uint64_t currentCount, uint64_t resultCount, uint64_t length)
-{
-    ASSERT(header <= maxSafeInteger());
-    ASSERT(currentCount <= maxSafeInteger());
-    ASSERT(resultCount <= maxSafeInteger());
-    ASSERT(length <= maxSafeInteger());
-
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    RELEASE_ASSERT(resultCount > currentCount);
-    uint64_t count = resultCount - currentCount;
-
-    RELEASE_ASSERT(header <= length);
-    RELEASE_ASSERT(currentCount <= (length - header));
-
-    if (isJSArray(thisObj)) {
-        // Spec says if we would produce an array of this size, we must throw a range error.
-        if (count + length > std::numeric_limits<uint32_t>::max()) {
-            throwRangeError(globalObject, scope, LengthExceededTheMaximumArrayLengthError);
-            return;
-        }
-
-        JSArray* array = asArray(thisObj);
-        if (array->length() == length) {
-            bool handled = array->unshiftCount(globalObject, static_cast<uint32_t>(header), static_cast<uint32_t>(count));
-            EXCEPTION_ASSERT(!scope.exception() || handled);
-            if (handled)
-                return;
-        }
-    }
-
-    for (uint64_t k = length - currentCount; k > header; --k) {
-        uint64_t from = k + currentCount - 1;
-        uint64_t to = k + resultCount - 1;
-        JSValue value = getProperty(globalObject, thisObj, from);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (value) {
-            thisObj->putByIndexInline(globalObject, to, value, true);
-            RETURN_IF_EXCEPTION(scope, void());
-        } else {
-            bool success = thisObj->deleteProperty(globalObject, to);
-            RETURN_IF_EXCEPTION(scope, void());
-            if (UNLIKELY(!success)) {
-                throwTypeError(globalObject, scope, UnableToDeletePropertyError);
-                return;
-            }
-        }
-    }
 }
 
 inline bool canUseFastJoin(const JSObject* thisObject)

--- a/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h
@@ -27,6 +27,7 @@
 
 #include "ArrayConstructor.h"
 #include "ArrayPrototype.h"
+#include "Error.h"
 #include "ExceptionHelpers.h"
 #include "GetVM.h"
 #include "JSGlobalObject.h"
@@ -99,6 +100,147 @@ ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstructArray
     JSObject* newObject = construct(globalObject, constructor, args, "Species construction did not get a valid constructor"_s);
     RETURN_IF_EXCEPTION(scope, exceptionResult);
     return std::pair { SpeciesConstructResult::CreatedObject, newObject };
+}
+
+ALWAYS_INLINE JSValue getProperty(JSGlobalObject* globalObject, JSObject* object, uint64_t index)
+{
+    if (JSValue result = object->tryGetIndexQuickly(index))
+        return result;
+
+    // Don't return undefined if the property is not found.
+    return object->getIfPropertyExists(globalObject, index);
+}
+
+ALWAYS_INLINE void setLength(JSGlobalObject* globalObject, VM& vm, JSObject* obj, uint64_t value)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    static constexpr bool throwException = true;
+    if (LIKELY(isJSArray(obj))) {
+        if (UNLIKELY(value > UINT32_MAX)) {
+            throwRangeError(globalObject, scope, "Invalid array length"_s);
+            return;
+        }
+        scope.release();
+        jsCast<JSArray*>(obj)->setLength(globalObject, static_cast<uint32_t>(value), throwException);
+        return;
+    }
+    scope.release();
+    PutPropertySlot slot(obj, throwException);
+    obj->methodTable()->put(obj, globalObject, vm.propertyNames->length, jsNumber(value), slot);
+}
+
+// The shift/unshift function implement the shift/unshift behaviour required
+// by the corresponding array prototype methods, and by splice. In both cases,
+// the methods are operating an an array or array like object.
+//
+//  header  currentCount  (remainder)
+// [------][------------][-----------]
+//  header  resultCount  (remainder)
+// [------][-----------][-----------]
+//
+// The set of properties in the range 'header' must be unchanged. The set of
+// properties in the range 'remainder' (where remainder = length - header -
+// currentCount) will be shifted to the left or right as appropriate; in the
+// case of shift this must be removing values, in the case of unshift this
+// must be introducing new values.
+
+template<JSArray::ShiftCountMode shiftCountMode>
+void shift(JSGlobalObject* globalObject, JSObject* thisObj, uint64_t header, uint64_t currentCount, uint64_t resultCount, uint64_t length)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    RELEASE_ASSERT(currentCount > resultCount);
+    uint64_t count = currentCount - resultCount;
+
+    RELEASE_ASSERT(header <= length);
+    RELEASE_ASSERT(currentCount <= (length - header));
+
+    if (isJSArray(thisObj)) {
+        JSArray* array = asArray(thisObj);
+        uint32_t header32 = static_cast<uint32_t>(header);
+        ASSERT(header32 == header);
+        if (array->length() == length && array->shiftCount<shiftCountMode>(globalObject, header32, static_cast<uint32_t>(count)))
+            return;
+        header = header32;
+    }
+
+    for (uint64_t k = header; k < length - currentCount; ++k) {
+        uint64_t from = k + currentCount;
+        uint64_t to = k + resultCount;
+        JSValue value = getProperty(globalObject, thisObj, from);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (value) {
+            thisObj->putByIndexInline(globalObject, to, value, true);
+            RETURN_IF_EXCEPTION(scope, void());
+        } else {
+            bool success = thisObj->deleteProperty(globalObject, to);
+            RETURN_IF_EXCEPTION(scope, void());
+            if (!success) {
+                throwTypeError(globalObject, scope, UnableToDeletePropertyError);
+                return;
+            }
+        }
+    }
+    for (uint64_t k = length; k > length - count; --k) {
+        bool success = thisObj->deleteProperty(globalObject, k - 1);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (!success) {
+            throwTypeError(globalObject, scope, UnableToDeletePropertyError);
+            return;
+        }
+    }
+}
+
+inline void unshift(JSGlobalObject* globalObject, JSObject* thisObj, uint64_t header, uint64_t currentCount, uint64_t resultCount, uint64_t length)
+{
+    ASSERT(header <= maxSafeInteger());
+    ASSERT(currentCount <= maxSafeInteger());
+    ASSERT(resultCount <= maxSafeInteger());
+    ASSERT(length <= maxSafeInteger());
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    RELEASE_ASSERT(resultCount > currentCount);
+    uint64_t count = resultCount - currentCount;
+
+    RELEASE_ASSERT(header <= length);
+    RELEASE_ASSERT(currentCount <= (length - header));
+
+    if (isJSArray(thisObj)) {
+        // Spec says if we would produce an array of this size, we must throw a range error.
+        if (count + length > std::numeric_limits<uint32_t>::max()) {
+            throwRangeError(globalObject, scope, LengthExceededTheMaximumArrayLengthError);
+            return;
+        }
+
+        JSArray* array = asArray(thisObj);
+        if (array->length() == length) {
+            bool handled = array->unshiftCount(globalObject, static_cast<uint32_t>(header), static_cast<uint32_t>(count));
+            EXCEPTION_ASSERT(!scope.exception() || handled);
+            if (handled)
+                return;
+        }
+    }
+
+    for (uint64_t k = length - currentCount; k > header; --k) {
+        uint64_t from = k + currentCount - 1;
+        uint64_t to = k + resultCount - 1;
+        JSValue value = getProperty(globalObject, thisObj, from);
+        RETURN_IF_EXCEPTION(scope, void());
+        if (value) {
+            thisObj->putByIndexInline(globalObject, to, value, true);
+            RETURN_IF_EXCEPTION(scope, void());
+        } else {
+            bool success = thisObj->deleteProperty(globalObject, to);
+            RETURN_IF_EXCEPTION(scope, void());
+            if (UNLIKELY(!success)) {
+                throwTypeError(globalObject, scope, UnableToDeletePropertyError);
+                return;
+            }
+        }
+    }
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -55,6 +55,7 @@ namespace JSC {
     macro(ArrayPushIntrinsic) \
     macro(ArrayPopIntrinsic) \
     macro(ArraySliceIntrinsic) \
+    macro(ArraySpliceIntrinsic) \
     macro(ArrayIndexOfIntrinsic) \
     macro(ArrayValuesIntrinsic) \
     macro(ArrayKeysIntrinsic) \


### PR DESCRIPTION
#### ebb72756b2c74492690c9f9dc1e83e29ac16be5e
<pre>
[JSC] Array#splice should skip result array creation if it is not used at all
<a href="https://bugs.webkit.org/show_bug.cgi?id=259809">https://bugs.webkit.org/show_bug.cgi?id=259809</a>
rdar://113367762

Reviewed by Keith Miller.

This patch adds ArraySpliceExtract DFG node, which only accepts `array.splice(x, y)` form, which does not insert any elements.
We leverage call_ignore_result etc.&apos;s feedback information in DFG / FTL: we can see `array.splice(x, y)` result is not used,
and DFG / FTL tells this hint to the operationArraySpliceExtract function. And then it can skip the result array creation when
it is not used! This form is particularly frequently seen since `array.splice(x, y)` is a form of removing some elements in the
middle of arrays.

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::hasHeapPrediction):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileArraySpliceExtract):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::getProperty): Deleted.
(JSC::setLength): Deleted.
(JSC::shift): Deleted.
(JSC::unshift): Deleted.
* Source/JavaScriptCore/runtime/ArrayPrototypeInlines.h:
(JSC::getProperty):
(JSC::setLength):
(JSC::shift):
(JSC::unshift):
* Source/JavaScriptCore/runtime/Intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/266591@main">https://commits.webkit.org/266591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55b1033d7ce51b39e10d3191957fe87190b59288

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13436 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14360 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14927 "2 new passes 2 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16639 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19808 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12118 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13289 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16158 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11358 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14227 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12779 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3685 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17114 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14615 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1691 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13344 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3498 "Passed tests") | 
<!--EWS-Status-Bubble-End-->