### PR TITLE
[UI-side compositing] Webpage going blank when navigating diffs in https://whatpr.org/html/9537/238086f...f400a41/canvas.html#drawing-state

### DIFF
--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-and-position-expected.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-and-position-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(0, 100);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-and-position.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-and-position.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(0, 50);
+            window.scrollTo(0, 100);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-expected.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(0, 100);
+            
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-delta.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(0, 50);
+            window.scrollBy(0, 50);
+            
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-position-and-delta-expected.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-position-and-delta-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollBy(0, 100);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/programmatic-scroll-merge-position-and-delta.html
+++ b/LayoutTests/fast/scrolling/programmatic-scroll-merge-position-and-delta.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Only the green part of the div should be visible</title>
+    <style>
+        body {
+            height: 2000px;
+            background-image: repeating-linear-gradient(white, silver 200px);
+            margin: 0px;
+        }
+        
+        .box {
+            width: 200px;
+            height: 200px;
+            background-image: linear-gradient(0deg, green 50%, red 50%);
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function doTest()
+        {
+            window.scrollTo(0, 50);
+            window.scrollBy(0, 50);
+
+            await UIHelper.ensurePresentationUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', doTest, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -43,6 +43,19 @@ void RequestedScrollData::merge(RequestedScrollData&& other)
             other.requestedDataBeforeAnimatedScroll = requestedDataBeforeAnimatedScroll;
             break;
         }
+    } else if (other.requestType == ScrollRequestType::DeltaUpdate && animated == ScrollIsAnimated::No) {
+        switch (requestType) {
+        case ScrollRequestType::PositionUpdate: {
+            other.requestType = ScrollRequestType::PositionUpdate;
+            other.scrollPositionOrDelta = std::get<FloatPoint>(scrollPositionOrDelta) + std::get<FloatSize>(other.scrollPositionOrDelta);
+            break;
+        }
+        case ScrollRequestType::DeltaUpdate:
+            std::get<FloatSize>(other.scrollPositionOrDelta) += std::get<FloatSize>(scrollPositionOrDelta);
+            break;
+        default:
+            break;
+        }
     }
     *this = WTFMove(other);
 }


### PR DESCRIPTION
#### 2f97007c9a1e30bf7b5df766ddd68ed029af4fd4
<pre>
[UI-side compositing] Webpage going blank when navigating diffs in <a href="https://whatpr.org/html/9537/238086f...f400a41/canvas.html#drawing-state">https://whatpr.org/html/9537/238086f...f400a41/canvas.html#drawing-state</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=259813">https://bugs.webkit.org/show_bug.cgi?id=259813</a>
rdar://113366817

Reviewed by Simon Fraser and Cameron McCormack.

When getting multiple non-animated scroll requests, the current merging code loses the previous
scroll request if a new delta update comes in. To resolve this, add the two scroll requests together
if either or both are a delta update. Added a couple new tests for this since the tests in
imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-* do not cover this since they
are testing the web process position.

* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::merge):

Canonical link: <a href="https://commits.webkit.org/266646@main">https://commits.webkit.org/266646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d9341913e332a7320cb3a0c54f1935f21adac97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16009 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17099 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14663 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16181 "13 flakes 159 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12105 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16729 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19876 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16235 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12726 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17202 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1713 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->