### PR TITLE
[WebXR] Move MachSendRights for textures and events

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -156,8 +156,8 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     auto colorTextureSource = makeEGLImageSource({ data.surface->createSendRight(), false });
     auto depthStencilBufferSource = makeEGLImageSource({ MachSendRight(), false });
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
-    auto colorTextureSource = makeEGLImageSource(data.colorTexture);
-    auto depthStencilBufferSource = makeEGLImageSource(data.depthStencilBuffer);
+    auto colorTextureSource = makeEGLImageSource({ WTFMove(data.colorTexture.handle), data.colorTexture.isShared });
+    auto depthStencilBufferSource = makeEGLImageSource({ WTFMove(data.depthStencilBuffer.handle), data.depthStencilBuffer.isShared });
 #endif
 
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA) || USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
@@ -198,7 +198,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
 #endif
 
 #if USE(MTLSHAREDEVENT_FOR_XR_FRAME_COMPLETION)
-    m_completionSyncEvent = data.completionSyncEvent;
+    m_completionSyncEvent = { WTFMove(data.completionSyncEvent.handle), data.completionSyncEvent.signalValue };
 #endif
 }
 

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -160,7 +160,7 @@ void SimulatedXRDevice::frameTimerFired()
         data.layers.add(layer.key, FrameData::LayerData { .surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB()) });
 #elif USE(MTLTEXTURE_FOR_XR_LAYER_DATA)
         auto surface = IOSurface::create(nullptr, recommendedResolution(PlatformXR::SessionMode::ImmersiveVr), DestinationColorSpace::SRGB());
-        data.layers.add(layer.key, FrameData::LayerData { .colorTexture = std::make_tuple(surface->createSendRight(), false) });
+        data.layers.add(layer.key, FrameData::LayerData { .colorTexture = { surface->createSendRight(), false } });
 #else
         data.layers.add(layer.key, FrameData::LayerData { .opaqueTexture = layer.value });
 #endif


### PR DESCRIPTION
#### 644a3dc070053c373fa1d2549ce59525b6889c9a
<pre>
[WebXR] Move MachSendRights for textures and events
<a href="https://bugs.webkit.org/show_bug.cgi?id=259816">https://bugs.webkit.org/show_bug.cgi?id=259816</a>
rdar://problem/113376570

Reviewed by NOBODY (OOPS!).

After 266327@main, MachSendRight need to be explicitly copied. Change to custom
structs with mutable MachSendRight so the handles can be moved, avoiding the
kernel overhead of copying.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::FrameData::SharedTexture::encode const):
(PlatformXR::Device::FrameData::SharedTexture::decode):
(PlatformXR::Device::FrameData::SyncEvent::encode const):
(PlatformXR::Device::FrameData::SyncEvent::decode):
(PlatformXR::Device::FrameData::LayerData::encode const):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/644a3dc070053c373fa1d2549ce59525b6889c9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13438 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16641 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19810 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16160 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->