### PR TITLE
[content-visibility] Implement initial visibility determination

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Target is sized and laid out before resize observer promise_test: Unhandled rejection with value: "unexpected size 10"
+PASS Target is sized and laid out before resize observer
 

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -55,10 +55,8 @@ private:
         ASSERT(!entries.isEmpty());
 
         for (auto& entry : entries) {
-            if (auto* element = entry->target()) {
-                element->contentVisibilityViewportChange(entry->isIntersecting());
-                element->document().contentVisibilityDocumentState().updateOnScreenObservationTarget(*element, entry->isIntersecting());
-            }
+            if (auto* element = entry->target())
+                element->document().contentVisibilityDocumentState().updateViewportProximity(*element, entry->isIntersecting() ? ViewportProximity::Near : ViewportProximity::Far);
         }
         return { };
     }
@@ -81,7 +79,7 @@ void ContentVisibilityDocumentState::unobserve(Element& element)
     auto& state = element.document().contentVisibilityDocumentState();
     if (auto& intersectionObserver = state.m_observer) {
         intersectionObserver->unobserve(element);
-        state.updateOnScreenObservationTarget(element, false);
+        state.removeViewportProximity(element);
     }
     element.setContentRelevancy({ });
 }
@@ -99,56 +97,90 @@ IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Docum
     return m_observer.get();
 }
 
-DidUpdateAnyContentRelevancy ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements(const OptionSet<ContentRelevancy>& relevancyToCheck)
+bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(Element& target, OptionSet<ContentRelevancy> relevancyToCheck) const
+{
+    auto oldRelevancy = target.contentRelevancy();
+    OptionSet<ContentRelevancy> newRelevancy;
+    if (oldRelevancy)
+        newRelevancy = *oldRelevancy;
+    auto setRelevancyValue = [&](ContentRelevancy reason, bool value) {
+        if (value)
+            newRelevancy.add(reason);
+        else
+            newRelevancy.remove(reason);
+    };
+    if (relevancyToCheck.contains(ContentRelevancy::OnScreen)) {
+        auto viewportProximityIterator = m_elementViewportProximities.find(target);
+        setRelevancyValue(ContentRelevancy::OnScreen, viewportProximityIterator->value == ViewportProximity::Near);
+    }
+
+    if (relevancyToCheck.contains(ContentRelevancy::Focused))
+        setRelevancyValue(ContentRelevancy::Focused, target.hasFocusWithin());
+
+    auto targetContainsSelection = [](Element& target) {
+        auto selectionRange = target.document().selection().selection().range();
+        return selectionRange && intersects<ComposedTree>(*selectionRange, target);
+    };
+
+    if (relevancyToCheck.contains(ContentRelevancy::Selected))
+        setRelevancyValue(ContentRelevancy::Selected, targetContainsSelection(target));
+
+    auto hasTopLayerinSubtree = [](const Element& target) {
+        for (auto& element : target.document().topLayerElements()) {
+            if (element->isDescendantOf(target))
+                return true;
+        }
+        return false;
+    };
+    if (relevancyToCheck.contains(ContentRelevancy::IsInTopLayer))
+        setRelevancyValue(ContentRelevancy::IsInTopLayer, hasTopLayerinSubtree(target));
+
+    if (oldRelevancy && oldRelevancy == newRelevancy)
+        return false;
+    target.setContentRelevancy(newRelevancy);
+    target.invalidateStyle();
+    if (target.isConnected()) {
+        ContentVisibilityAutoStateChangeEvent::Init init;
+        init.skipped = newRelevancy.isEmpty();
+        target.queueTaskToDispatchEvent(TaskSource::DOMManipulation, ContentVisibilityAutoStateChangeEvent::create(eventNames().contentvisibilityautostatechangeEvent, init));
+    }
+    return true;
+}
+
+DidUpdateAnyContentRelevancy ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements(OptionSet<ContentRelevancy> relevancyToCheck) const
 {
     auto didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::No;
     for (auto target : m_observer->observationTargets()) {
         if (target) {
-            auto oldRelevancy = target->contentRelevancy();
-            OptionSet<ContentRelevancy> newRelevancy;
-            if (oldRelevancy)
-                newRelevancy = *oldRelevancy;
-            auto setRelevancyValue = [&](ContentRelevancy reason, bool value) {
-                if (value)
-                    newRelevancy.add(reason);
-                else
-                    newRelevancy.remove(reason);
-            };
-            if (relevancyToCheck.contains(ContentRelevancy::OnScreen))
-                setRelevancyValue(ContentRelevancy::OnScreen, m_onScreenObservationTargets.contains(*target));
-
-            if (relevancyToCheck.contains(ContentRelevancy::Focused))
-                setRelevancyValue(ContentRelevancy::Focused, target->hasFocusWithin());
-
-            auto targetContainsSelection = [](Element& target) {
-                auto selectionRange = target.document().selection().selection().range();
-                return selectionRange && intersects<ComposedTree>(*selectionRange, target);
-            };
-
-            if (relevancyToCheck.contains(ContentRelevancy::Selected))
-                setRelevancyValue(ContentRelevancy::Selected, targetContainsSelection(*target));
-
-            auto hasTopLayerinSubtree = [](const Element& target) {
-                for (auto& element : target.document().topLayerElements()) {
-                    if (element->isDescendantOf(target))
-                        return true;
-                }
-                return false;
-            };
-            if (relevancyToCheck.contains(ContentRelevancy::IsInTopLayer))
-                setRelevancyValue(ContentRelevancy::IsInTopLayer, hasTopLayerinSubtree(*target));
-
-            if (oldRelevancy && oldRelevancy == newRelevancy)
-                continue;
-            target->setContentRelevancy(newRelevancy);
-            target->invalidateStyle();
-            ContentVisibilityAutoStateChangeEvent::Init init;
-            init.skipped = newRelevancy.isEmpty();
-            target->queueTaskToDispatchEvent(TaskSource::DOMManipulation, ContentVisibilityAutoStateChangeEvent::create(eventNames().contentvisibilityautostatechangeEvent, init));
-            didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::Yes;
+            if (checkRelevancyOfContentVisibilityElement(*target, relevancyToCheck))
+                didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::Yes;
         }
     }
     return didUpdateAnyContentRelevancy;
+}
+
+HadInitialVisibleContentVisibilityDetermination ContentVisibilityDocumentState::determineInitialVisibleContentVisibility() const
+{
+    if (!m_observer)
+        return HadInitialVisibleContentVisibilityDetermination::No;
+    Vector<Ref<Element>> elementsToCheck;
+    for (auto target : m_observer->observationTargets()) {
+        if (target) {
+            bool checkForInitialDetermination = !m_elementViewportProximities.contains(*target) && !target->isRelevantToUser();
+            if (checkForInitialDetermination)
+                elementsToCheck.append(*target);
+        }
+    }
+    auto hadInitialVisibleContentVisibilityDetermination = HadInitialVisibleContentVisibilityDetermination::No;
+    if (!elementsToCheck.isEmpty()) {
+        elementsToCheck.first()->document().updateIntersectionObservations({ m_observer });
+        for (auto& element : elementsToCheck) {
+            checkRelevancyOfContentVisibilityElement(element, { ContentRelevancy::OnScreen });
+            if (element->isRelevantToUser())
+                hadInitialVisibleContentVisibilityDetermination = HadInitialVisibleContentVisibilityDetermination::Yes;
+        }
+    }
+    return hadInitialVisibleContentVisibilityDetermination;
 }
 
 // Workaround for lack of support for scroll anchoring. We make sure any content-visibility: auto elements
@@ -174,21 +206,28 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
         for (auto target : m_observer->observationTargets()) {
             if (target) {
                 ASSERT(target->renderer() && target->renderStyle()->contentVisibility() == ContentVisibility::Auto);
-                updateOnScreenObservationTarget(*target, false);
+                updateViewportProximity(*target, ViewportProximity::Far);
             }
         }
-        updateOnScreenObservationTarget(*scrollAnchorRoot, true);
-        scrollAnchorRoot->document().scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
+        updateViewportProximity(*scrollAnchorRoot, ViewportProximity::Near);
         scrollAnchorRoot->document().updateRelevancyOfContentVisibilityElements();
     }
 }
 
-void ContentVisibilityDocumentState::updateOnScreenObservationTarget(const Element& element, bool onScreen)
+void ContentVisibilityDocumentState::updateViewportProximity(const Element& element, ViewportProximity viewportProximity)
 {
-    if (onScreen)
-        m_onScreenObservationTargets.add(element);
-    else
-        m_onScreenObservationTargets.remove(element);
+    // No need to schedule content relevancy update for first time call, since
+    // that will be handled by determineInitialVisibleContentVisibility.
+    if (m_elementViewportProximities.contains(element))
+        element.document().scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
+    m_elementViewportProximities.ensure(element, [] {
+        return ViewportProximity::Far;
+    }).iterator->value = viewportProximity;
+}
+
+void ContentVisibilityDocumentState::removeViewportProximity(const Element& element)
+{
+    m_elementViewportProximities.remove(element);
 }
 
 }

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include "IntersectionObserver.h"
-#include <wtf/WeakHashSet.h>
+#include <wtf/WeakHashMap.h>
 
 namespace WebCore {
 
@@ -34,6 +34,10 @@ class Document;
 class Element;
 
 enum class DidUpdateAnyContentRelevancy : bool { No, Yes };
+// https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
+enum class ViewportProximity : bool { Far, Near };
+
+enum class HadInitialVisibleContentVisibilityDetermination : bool { No, Yes };
 
 class ContentVisibilityDocumentState {
     WTF_MAKE_FAST_ALLOCATED;
@@ -44,16 +48,22 @@ public:
     void updateContentRelevancyForScrollIfNeeded(const Element& scrollAnchor);
 
     bool hasObservationTargets() const { return m_observer && m_observer->hasObservationTargets(); }
-    DidUpdateAnyContentRelevancy updateRelevancyOfContentVisibilityElements(const OptionSet<ContentRelevancy>&);
 
-    void updateOnScreenObservationTarget(const Element&, bool);
+    DidUpdateAnyContentRelevancy updateRelevancyOfContentVisibilityElements(OptionSet<ContentRelevancy>) const;
+    HadInitialVisibleContentVisibilityDetermination determineInitialVisibleContentVisibility() const;
+
+    void updateViewportProximity(const Element&, ViewportProximity);
 
 private:
+    bool checkRelevancyOfContentVisibilityElement(Element&, OptionSet<ContentRelevancy>) const;
+
+    void removeViewportProximity(const Element&);
+
     IntersectionObserver* intersectionObserver(Document&);
 
     RefPtr<IntersectionObserver> m_observer;
 
-    WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_onScreenObservationTargets;
+    WeakHashMap<Element, ViewportProximity, WeakPtrImplWithEventTargetData> m_elementViewportProximities;
 };
 
 } // namespace

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1530,6 +1530,7 @@ public:
     void removeIntersectionObserver(IntersectionObserver&);
     unsigned numberOfIntersectionObservers() const { return m_intersectionObservers.size(); }
     void updateIntersectionObservations();
+    void updateIntersectionObservations(const Vector<WeakPtr<IntersectionObserver>>&);
     void scheduleInitialIntersectionObservationUpdate();
     IntersectionObserverData& ensureIntersectionObserverData();
     IntersectionObserverData* intersectionObserverDataIfExists() { return m_intersectionObserverData.get(); }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5395,12 +5395,6 @@ void Element::setContentRelevancy(OptionSet<ContentRelevancy> contentRelevancy)
     ensureElementRareData().setContentRelevancy(contentRelevancy);
 }
 
-void Element::contentVisibilityViewportChange(bool)
-{
-    ASSERT(renderStyle() && renderStyle()->contentVisibility() == ContentVisibility::Auto);
-    document().scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
-}
-
 AtomString Element::makeTargetBlankIfHasDanglingMarkup(const AtomString& target)
 {
     if ((target.contains('\n') || target.contains('\r') || target.contains('\t')) && target.contains('<'))

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -737,8 +737,6 @@ public:
 
     bool isRelevantToUser() const;
 
-    void contentVisibilityViewportChange(bool);
-
     std::optional<OptionSet<ContentRelevancy>> contentRelevancy() const;
     void setContentRelevancy(OptionSet<ContentRelevancy>);
 


### PR DESCRIPTION
#### b8c6566d556809935878157344ab89bedf59279d
<pre>
[content-visibility] Implement initial visibility determination
<a href="https://bugs.webkit.org/show_bug.cgi?id=259825">https://bugs.webkit.org/show_bug.cgi?id=259825</a>

Reviewed by Tim Nguyen.

Implement initial visibility determination as specified in [1].
This replaces the custom onscreen bookkeeping with the specified
proximity to viewport concept. The updateIntersectionObservations
logic is refactored a bit so it can be used for updating any given
collection of intersection observers.

This PR also changed behaviour to not dispatch ContentVisibilityAutoStateChange
on disconnected elements, this problem is now exposed with the different timing
of initial visibility determination.

[1] <a href="https://github.com/whatwg/html/pull/9312">https://github.com/whatwg/html/pull/9312</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-first-observation-immediate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-012-expected.txt:
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::unobserve):
(WebCore::ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement const): extract per element content relevancy check logic
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements const): bail out early if no update is specified
(WebCore::ContentVisibilityDocumentState::determineInitialVisibleContentVisibility const):
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyStatusForScrollIfNeeded):
(WebCore::ContentVisibilityDocumentState::updateViewportProximity): keep track of per element viewport proximity
(WebCore::ContentVisibilityDocumentState::removeViewportProximity):
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements): Deleted.
(WebCore::ContentVisibilityDocumentState::updateOnScreenObservationTarget): Deleted.
* Source/WebCore/dom/ContentVisibilityDocumentState.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateIntersectionObservations): allow specifying the intersection observers
(WebCore::Document::updateResizeObservations): integrate according to [1]
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::contentVisibilityViewportChange): Deleted.
* Source/WebCore/dom/Element.h:

Canonical link: <a href="https://commits.webkit.org/267779@main">https://commits.webkit.org/267779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74d4bcccbf1e7dedaf5be94fa15321ec1577f782

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/16957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/17280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/17741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/18741 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/15875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/20512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/17419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18107 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/17157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/17508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/14683 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/19554 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/14751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/15378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22105 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/15735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/15545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/19867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/13685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/15316 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4209 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/19681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/15985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->