### PR TITLE
RemoteVideoEncoderCallbacks and RemoteVideoDecoderCallbacks HashMaps could be corrupted by JS

### DIFF
--- a/LayoutTests/fast/mediastream/mediarecorder-close-expected.txt
+++ b/LayoutTests/fast/mediastream/mediarecorder-close-expected.txt
@@ -1,0 +1,1 @@
+PASS if not crashing

--- a/LayoutTests/fast/mediastream/mediarecorder-close.html
+++ b/LayoutTests/fast/mediastream/mediarecorder-close.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div>PASS if not crashing</div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+onload = async () => {
+  for (let i = 0; i < 25; i++) {
+    await caches.has('a');
+    const stream = await navigator.mediaDevices.getUserMedia({video: true});
+    const mediaRecorder = new MediaRecorder(stream);
+    location.hash = 'x';
+    mediaRecorder.start();
+  }
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp-expected.txt
@@ -1,0 +1,5 @@
+
+PASS VP8 decoded frames
+PASS VP9 decoded frames
+PASS H.264 decoded frames
+

--- a/LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp.html
+++ b/LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+
+function makeOffscreenCanvas(width, height, timestamp) {
+  let canvas = new OffscreenCanvas(width, height);
+  let ctx = canvas.getContext('2d');
+  ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+  ctx.fillRect(0, 0, width, height);
+  return new VideoFrame(canvas, { timestamp, duration : 10 });
+}
+
+async function doEncodeDecode(encoderConfig, timestamp)
+{
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  const decoder = new VideoDecoder({
+    output(frame) {
+      resolve(frame);
+    },
+    error(e) {
+      reject(e.message);
+    }
+  });
+
+  const encoderInit = {
+    output(chunk, metadata) {
+      let config = metadata.decoderConfig;
+      if (config) {
+        decoder.configure(config);
+      }
+      decoder.decode(chunk);
+    },
+    error(e) {
+      reject(e.message);
+    }
+  };
+
+  const encoder = new VideoEncoder(encoderInit);
+  encoder.configure(encoderConfig);
+
+  const w = encoderConfig.width;
+  const h = encoderConfig.height;
+  const frame = makeOffscreenCanvas(w, h, timestamp);
+  encoder.encode(frame, { keyFrame: true });
+  frame.close();
+
+  await encoder.flush();
+  await decoder.flush();
+  encoder.close();
+  decoder.close();
+
+  return promise;
+}
+
+function doTest(codec, title)
+{
+  const config = { codec };
+  config.width = 320;
+  config.height = 200;
+  config.bitrate = 1000000;
+  config.framerate = 30;
+
+  promise_test(async t => {
+    const frame1 = await doEncodeDecode(config, -2);
+    t.add_cleanup(() => frame1.close());
+
+    const frame2 = await doEncodeDecode(config, -1);
+    t.add_cleanup(() => frame2.close());
+
+    const frame3 = await doEncodeDecode(config, 0);
+    t.add_cleanup(() => frame3.close());
+  }, title);
+}
+
+doTest('vp8', "VP8 decoded frames");
+doTest('vp09.00.10.08', "VP9 decoded frames");
+doTest('avc1.42001E', "H.264 decoded frames");
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2657,17 +2657,6 @@ ExceptionOr<RefPtr<LocalFrame>> LocalDOMWindow::createWindow(const String& urlSt
 
 ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWindow, LocalDOMWindow& firstWindow, const String& urlStringToOpen, const AtomString& frameName, const String& windowFeaturesString)
 {
-#if ENABLE(TRACKING_PREVENTION)
-    if (RefPtr document = this->document()) {
-        if (document->settings().needsSiteSpecificQuirks() && urlStringToOpen == Quirks::BBCRadioPlayerURLString()) {
-            auto radioPlayerDomain = RegistrableDomain(URL { Quirks::staticRadioPlayerURLString() });
-            auto BBCDomain = RegistrableDomain(URL { Quirks::BBCRadioPlayerURLString() });
-            if (!ResourceLoadObserver::shared().hasCrossPageStorageAccess(radioPlayerDomain, BBCDomain))
-                return RefPtr<WindowProxy> { nullptr };
-        }
-    }
-#endif
-
     if (!isCurrentlyDisplayedInFrame())
         return RefPtr<WindowProxy> { nullptr };
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1142,31 +1142,10 @@ bool Quirks::hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>
     return true;
 }
 
-const String& Quirks::BBCRadioPlayerURLString()
-{
-    static NeverDestroyed<String> BBCRadioPlayerURLString = "https://www.bbc.co.uk/sounds/player/bbc_world_service"_s;
-    return BBCRadioPlayerURLString;
-}
-
 const String& Quirks::staticRadioPlayerURLString()
 {
     static NeverDestroyed<String> staticRadioPlayerURLString = "https://static.radioplayer.co.uk/"_s;
     return staticRadioPlayerURLString;
-}
-
-static bool isBBCDomain(const RegistrableDomain& domain)
-{
-    static NeverDestroyed<RegistrableDomain> BBCDomain = RegistrableDomain(URL { Quirks::BBCRadioPlayerURLString() });
-    return domain == BBCDomain;
-}
-
-static bool isBBCPopUpPlayerElement(const Element& element)
-{
-    auto* parentElement = element.parentElement();
-    if (!element.parentElement() || !element.parentElement()->hasClass() || !parentElement->parentElement() || !parentElement->parentElement()->hasClass())
-        return false;
-
-    return element.parentElement()->classNames().contains("p_audioButton_buttonInner"_s) && parentElement->parentElement()->classNames().contains("hidden"_s);
 }
 
 Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(CompletionHandler<void(ShouldDispatchClick)>&& completionHandler) const
@@ -1290,32 +1269,6 @@ Quirks::StorageAccessResult Quirks::triggerOptionalStorageAccessQuirk(Element& e
 
                 if (shouldDispatchClick == ShouldDispatchClick::Yes)
                     protectedElement->dispatchMouseEvent(platformEvent, eventType, detail, relatedTarget, IsSyntheticClick::Yes);
-            });
-        }
-
-        static NeverDestroyed<String> BBCRadioPlayerPopUpWindowFeatureString = "featurestring width=400,height=730"_s;
-        static NeverDestroyed<UserScript> BBCUserScript { "function triggerRedirect() { document.location.href = \"https://www.bbc.co.uk/sounds/player/bbc_world_service\"; } window.addEventListener('load', function () { triggerRedirect(); })"_s, URL(aboutBlankURL()), Vector<String>(), Vector<String>(), UserScriptInjectionTime::DocumentEnd, UserContentInjectedFrames::InjectInTopFrameOnly, WaitForNotificationBeforeInjecting::Yes };
-
-        // BBC RadioPlayer case rdar://60319532
-        if (isBBCDomain(domain) && isBBCPopUpPlayerElement(element)) {
-            return requestStorageAccessAndHandleClick([document = m_document] (ShouldDispatchClick shouldDispatchClick) mutable {
-                if (!document || shouldDispatchClick == ShouldDispatchClick::No)
-                    return;
-
-                auto domWindow = document->domWindow();
-                if (domWindow) {
-                    ExceptionOr<RefPtr<WindowProxy>> proxyOrException = domWindow->open(*domWindow, *domWindow, staticRadioPlayerURLString(), emptyAtom(), BBCRadioPlayerPopUpWindowFeatureString);
-                    if (proxyOrException.hasException())
-                        return;
-                    auto proxy = proxyOrException.releaseReturnValue();
-                    auto* abstractFrame = proxy->frame();
-                    if (is<LocalFrame>(abstractFrame)) {
-                        auto* frame = downcast<LocalFrame>(abstractFrame);
-                        auto world = ScriptController::createWorld("bbcRadioPlayerWorld"_s, ScriptController::WorldType::User);
-                        frame->addUserScriptAwaitingNotification(world.get(), BBCUserScript);
-                        return;
-                    }
-                }
             });
         }
     }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -143,7 +143,6 @@ public:
 #if ENABLE(TRACKING_PREVENTION)
     static bool isMicrosoftTeamsRedirectURL(const URL&);
     static bool hasStorageAccessForAllLoginDomains(const HashSet<RegistrableDomain>&, const RegistrableDomain&);
-    static const String& BBCRadioPlayerURLString();
     WEBCORE_EXPORT static const String& staticRadioPlayerURLString();
     StorageAccessResult requestStorageAccessAndHandleClick(CompletionHandler<void(ShouldDispatchClick)>&&) const;
 #endif

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp
@@ -75,6 +75,7 @@ MediaRecorderPrivateAVFImpl::MediaRecorderPrivateAVFImpl(Ref<MediaRecorderPrivat
 
 MediaRecorderPrivateAVFImpl::~MediaRecorderPrivateAVFImpl()
 {
+    m_writer->close();
 }
 
 void MediaRecorderPrivateAVFImpl::startRecording(StartRecordingCallback&& callback)

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
@@ -80,6 +80,8 @@ public:
     unsigned audioBitRate() const;
     unsigned videoBitRate() const;
 
+    void close();
+
 private:
     MediaRecorderPrivateWriter(bool hasAudio, bool hasVideo);
 

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -132,6 +132,8 @@ MediaRecorderPrivateWriter::MediaRecorderPrivateWriter(bool hasAudio, bool hasVi
 MediaRecorderPrivateWriter::~MediaRecorderPrivateWriter()
 {
     ASSERT(isMainThread());
+    ASSERT(!m_audioCompressor);
+    ASSERT(!m_videoCompressor);
 
     m_pendingAudioSampleQueue.clear();
     m_pendingVideoFrameQueue.clear();
@@ -145,6 +147,12 @@ MediaRecorderPrivateWriter::~MediaRecorderPrivateWriter()
 
     if (auto completionHandler = WTFMove(m_fetchDataCompletionHandler))
         completionHandler(nullptr, 0);
+}
+
+void MediaRecorderPrivateWriter::close()
+{
+    m_audioCompressor = nullptr;
+    m_videoCompressor = nullptr;
 }
 
 bool MediaRecorderPrivateWriter::initialize(const MediaRecorderPrivateOptions& options)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -62,6 +62,7 @@ RemoteMediaRecorder::RemoteMediaRecorder(GPUConnectionToWebProcess& gpuConnectio
 
 RemoteMediaRecorder::~RemoteMediaRecorder()
 {
+    m_writer->close();
 }
 
 void RemoteMediaRecorder::audioSamplesStorageChanged(ConsumerSharedCARingBuffer::Handle&& handle, const WebCore::CAAudioStreamDescription& description)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6823,18 +6823,7 @@ void WebPageProxy::createNewPage(FrameInfoData&& originatingFrameInfoData, WebPa
 #endif
     };
 
-    RefPtr<API::UserInitiatedAction> userInitiatedActivity;
-    
-#if ENABLE(TRACKING_PREVENTION)
-    // WebKit cancels the original gesture to open the BBC radio player so
-    // we can call the Storage Access API first. When we re-initiate the open,
-    // we should make sure the client knows that this was user initiated so it
-    // does not block the popup.
-    if (request.url().string() == Quirks::staticRadioPlayerURLString())
-        userInitiatedActivity = API::UserInitiatedAction::create();
-    else
-#endif
-        userInitiatedActivity = m_process->userInitiatedActivity(navigationActionData.userGestureTokenIdentifier);
+    RefPtr<API::UserInitiatedAction> userInitiatedActivity = m_process->userInitiatedActivity(navigationActionData.userGestureTokenIdentifier);
 
     if (userInitiatedActivity && m_preferences->verifyWindowOpenUserGestureFromUIProcess() && request.url().string() != Quirks::staticRadioPlayerURLString())
         m_process->consumeIfNotVerifiablyFromUIProcess(*userInitiatedActivity, navigationActionData.userGestureAuthorizationToken);


### PR DESCRIPTION
#### 147a80d7a4244276a735f43b17aa21177dcd9541
<pre>
RemoteVideoEncoderCallbacks and RemoteVideoDecoderCallbacks HashMaps could be corrupted by JS
<a href="https://bugs.webkit.org/show_bug.cgi?id=258123">https://bugs.webkit.org/show_bug.cgi?id=258123</a>
rdar://110777506

Reviewed by Eric Carlson.

JS can provide signed timestamps, which are used as keys in RemoteVideoDecoderCallbacks and RemoteVideoEncoderCallbacks maps.
Move to StdUnorderedMap to support all keys.

* LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/videoFrame-negative-timestamp.html: Added.
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoDecoderCallbacks::addDuration):
(WebKit::RemoteVideoEncoderCallbacks::addDuration):
(WebKit::RemoteVideoDecoderCallbacks::notifyDecodingResult):
(WebKit::RemoteVideoEncoderCallbacks::notifyEncodedChunk):

Originally-landed-as: 259548.831@safari-7615-branch (d263e8a08a93). rdar://113285399
Canonical link: <a href="https://commits.webkit.org/266598@main">https://commits.webkit.org/266598@main</a>
</pre>
----------------------------------------------------------------------
#### 9b58b4bed53b93f81335017b9f732e9a189ce800
<pre>
<a href="https://bugs.webkit.org/show_bug.cgi?id=257352">https://bugs.webkit.org/show_bug.cgi?id=257352</a>
rdar://106974958

Reviewed by John Wilander and Brent Fulgham.

This quirk is no longer nessesary to get favorites and recents to show up
in the radio player, which is why it was added in the first place. Therefore
it can be removed.

* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::open):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessQuirk const):
(WebCore::Quirks::BBCRadioPlayerURLString): Deleted.
(WebCore::Quirks::staticRadioPlayerURLString): Deleted.
(WebCore::isBBCDomain): Deleted.
(WebCore::isBBCPopUpPlayerElement): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):

Originally-landed-as: 259548.824@safari-7615-branch (cff01e3a9ba5). rdar://113285349
Canonical link: <a href="https://commits.webkit.org/266597@main">https://commits.webkit.org/266597@main</a>
</pre>
----------------------------------------------------------------------
#### b08d8686ee799d28d585b8d6468fb328bd151c18
<pre>
jsc_fuz/wktr: *flaky* RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!retainedPointer || !m_controlBlock-&gt;objectHasBeenDeleted()); in MediaRecorderPrivateWriter::compressedVideoOutputBufferCallback MediaRecorderPrivateWriterCocoa.mm:107
<a href="https://bugs.webkit.org/show_bug.cgi?id=257780">https://bugs.webkit.org/show_bug.cgi?id=257780</a>
rdar://109659987

Reviewed by Eric Carlson.

After the introduction of ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr,
we are now lazily creating our weak pointer on various threads, and this can happen while destroying the object in main thread.
To make sure we do not end up in that situation, we are now closing MediaRecorderPrivateWriter before destroying it.
In closing, we destroy the compressors which are the ones calling the callbacks that can create the weak pointers.

* LayoutTests/fast/mediastream/mediarecorder-close-expected.txt: Added.
* LayoutTests/fast/mediastream/mediarecorder-close.html: Added.
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.cpp:
(WebCore::MediaRecorderPrivateAVFImpl::MediaRecorderPrivateAVFImpl):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm:
(WebCore::MediaRecorderPrivateWriter::~MediaRecorderPrivateWriter):
(WebCore::MediaRecorderPrivateWriter::close):
* Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp:
(WebKit::RemoteMediaRecorder::~RemoteMediaRecorder):

Originally-landed-as: 259548.822@safari-7615-branch (3282e8c968c7). rdar://113224891
Canonical link: <a href="https://commits.webkit.org/266596@main">https://commits.webkit.org/266596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35aaf0280d73c3029f2f4608dd656cd649c476db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15952 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13467 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16138 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16672 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19834 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11387 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3445 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->