### PR TITLE
Signals.cpp implementation for Windows

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -26,8 +26,7 @@
 #include "config.h"
 #include "WasmFaultSignalHandler.h"
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=259108 Support signal handlers on Windows
-#if ENABLE(WEBASSEMBLY) && OS(UNIX)
+#if ENABLE(WEBASSEMBLY)
 
 #include "ExecutableAllocator.h"
 #include "LLIntData.h"
@@ -133,5 +132,5 @@ void prepareSignalingMemory()
     
 } } // namespace JSC::Wasm
 
-#endif // ENABLE(WEBASSEMBLY) && OS(UNIX)
+#endif // ENABLE(WEBASSEMBLY)
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -29,7 +29,7 @@ namespace JSC {
 
 namespace Wasm {
 
-#if ENABLE(WEBASSEMBLY) && OS(UNIX)
+#if ENABLE(WEBASSEMBLY)
 void activateSignalingMemory();
 void prepareSignalingMemory();
 #else

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -15,6 +15,7 @@ if (WIN32)
         win/MainThreadWin.cpp
         win/OSAllocatorWin.cpp
         win/PathWalker.cpp
+        win/SignalsWin.cpp
         win/ThreadingWin.cpp
     )
     list(APPEND WTF_PUBLIC_HEADERS

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -36,6 +36,7 @@ list(APPEND WTF_SOURCES
     win/OSAllocatorWin.cpp
     win/PathWalker.cpp
     win/RunLoopWin.cpp
+    win/SignalsWin.cpp
     win/ThreadingWin.cpp
     win/Win32Handle.cpp
 )

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -83,9 +83,7 @@ struct Config {
     bool isThreadSuspendResumeSignalConfigured;
     int sigThreadSuspendResume;
 #endif
-#if OS(UNIX)
     SignalHandlers signalHandlers;
-#endif
     PtrTagLookup* ptrTagLookupHead;
 
     uint64_t spaceForExtensions[1];

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include <wtf/threads/Signals.h>
 
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=259108 Support signal handlers on Windows
 #if OS(UNIX)
 
 #if HAVE(MACH_EXCEPTIONS)
@@ -335,6 +334,38 @@ void registerThreadForMachExceptionHandling(Thread& thread)
 }
 
 #endif // HAVE(MACH_EXCEPTIONS)
+
+inline std::tuple<int, std::optional<int>> toSystemSignal(Signal signal)
+{
+    switch (signal) {
+    case Signal::AccessFault: return std::make_tuple(SIGSEGV, SIGBUS);
+    case Signal::IllegalInstruction: return std::make_tuple(SIGILL, std::nullopt);
+    case Signal::Usr: return std::make_tuple(SIGUSR2, std::nullopt);
+    case Signal::FloatingPoint: return std::make_tuple(SIGFPE, std::nullopt);
+    case Signal::Breakpoint: return std::make_tuple(SIGTRAP, std::nullopt);
+#if !OS(DARWIN)
+    case Signal::Abort: return std::make_tuple(SIGABRT, std::nullopt);
+#endif
+    default: break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+inline Signal fromSystemSignal(int signal)
+{
+    switch (signal) {
+    case SIGSEGV: return Signal::AccessFault;
+    case SIGBUS: return Signal::AccessFault;
+    case SIGFPE: return Signal::FloatingPoint;
+    case SIGTRAP: return Signal::Breakpoint;
+    case SIGILL: return Signal::IllegalInstruction;
+    case SIGUSR2: return Signal::Usr;
+#if !OS(DARWIN)
+    case SIGABRT: return Signal::Abort;
+#endif
+    default: return Signal::Unknown;
+    }
+}
 
 inline size_t offsetForSystemSignal(int sig)
 {

--- a/Source/WTF/wtf/win/SignalsWin.cpp
+++ b/Source/WTF/wtf/win/SignalsWin.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2023 Ian Grunert <ian.grunert@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/threads/Signals.h>
+
+#if OS(WINDOWS)
+
+#include <cstdio>
+#include <mutex>
+#include <signal.h>
+#include <winnt.h>
+
+#include <wtf/Atomics.h>
+#include <wtf/DataLog.h>
+#include <wtf/MathExtras.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/PlatformRegisters.h>
+#include <wtf/ThreadGroup.h>
+#include <wtf/Threading.h>
+#include <wtf/WTFConfig.h>
+
+namespace WTF {
+
+void SignalHandlers::add(Signal signal, SignalHandler&& handler)
+{
+    Config::AssertNotFrozenScope assertScope;
+    static Lock lock;
+    Locker locker { lock };
+
+    size_t signalIndex = static_cast<size_t>(signal);
+    size_t nextFree = numberOfHandlers[signalIndex];
+    RELEASE_ASSERT(nextFree < maxNumberOfHandlers);
+    SignalHandlerMemory* memory = &handlers[signalIndex][nextFree];
+    new (memory) SignalHandler(WTFMove(handler));
+
+    // We deliberately do not want to increment the count until after we've
+    // fully initialized the memory. This way, forEachHandler() won't see a
+    // partially initialized handler.
+    storeStoreFence();
+    numberOfHandlers[signalIndex]++;
+    loadLoadFence();
+}
+
+template<typename Func>
+inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) const
+{
+    size_t signalIndex = static_cast<size_t>(signal);
+    size_t handlerIndex = numberOfHandlers[signalIndex];
+    while (handlerIndex--) {
+        auto* memory = const_cast<SignalHandlerMemory*>(&handlers[signalIndex][handlerIndex]);
+        const SignalHandler& handler = *bitwise_cast<SignalHandler*>(memory);
+        func(handler);
+    }
+}
+
+inline Signal fromSystemException(int signal)
+{
+    switch (signal) {
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+    case EXCEPTION_FLT_INEXACT_RESULT:
+    case EXCEPTION_FLT_INVALID_OPERATION:
+    case EXCEPTION_FLT_OVERFLOW:
+    case EXCEPTION_FLT_STACK_CHECK:
+    case EXCEPTION_FLT_UNDERFLOW:
+        return Signal::FloatingPoint;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        return Signal::IllegalInstruction;
+    case EXCEPTION_ACCESS_VIOLATION:
+        return Signal::AccessFault;
+    default:
+        return Signal::Unknown;
+    }
+}
+
+LONG WINAPI vectoredHandler(struct _EXCEPTION_POINTERS *exceptionInfo)
+{
+    Signal signal = fromSystemException(exceptionInfo->ExceptionRecord->ExceptionCode);
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+
+    SigInfo sigInfo;
+    if (signal == Signal::AccessFault) {
+        // The second array element specifies the virtual address of the inaccessible data.
+        // https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-exception_record
+        sigInfo.faultingAddress = reinterpret_cast<void*>(exceptionInfo->ExceptionRecord->ExceptionInformation[1]);
+    }
+
+    PlatformRegisters& registers = *(exceptionInfo->ContextRecord);
+
+    long result = EXCEPTION_EXECUTE_HANDLER;
+    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
+        switch (handler(signal, sigInfo, registers)) {
+        case SignalAction::Handled:
+            result = EXCEPTION_CONTINUE_EXECUTION;
+            break;
+        default:
+            break;
+        }
+    });
+
+    return result;
+}
+
+void addSignalHandler(Signal signal, SignalHandler&& handler)
+{
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    ASSERT(signal < Signal::Unknown);
+
+    static std::once_flag initializeOnceFlags[static_cast<size_t>(Signal::NumberOfSignals)];
+    std::call_once(initializeOnceFlags[static_cast<size_t>(signal)], [&] {
+        Config::AssertNotFrozenScope assertScope;
+        AddVectoredExceptionHandler(1, vectoredHandler);
+    });
+
+    handlers.add(signal, WTFMove(handler));
+}
+
+void activateSignalHandlersFor(Signal signal)
+{
+    UNUSED_PARAM(signal);
+}
+
+void SignalHandlers::initialize()
+{
+    // noop
+}
+
+} // namespace WTF
+
+#endif // OS(WINDOWS)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -96,6 +96,7 @@ set(TestWTF_SOURCES
     Tests/WTF/ScopedLambda.cpp
     Tests/WTF/SentinelLinkedList.cpp
     Tests/WTF/SetForScope.cpp
+    Tests/WTF/Signals.cpp
     Tests/WTF/StackTraceTest.cpp
     Tests/WTF/StdLibExtrasTests.cpp
     Tests/WTF/StringBuilder.cpp


### PR DESCRIPTION
#### 66b9bc907a2e984b5f6c15729edad082f0a59a83
<pre>
Signals.cpp implementation for Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=259108">https://bugs.webkit.org/show_bug.cgi?id=259108</a>

Reviewed by Yusuke Suzuki.

Signals is implemented using a VectoredExceptionHandler on Windows, so
we cannot support all the Signal types as the other OS&apos;s. We need
support for AccessFault, which is used for WASM memory.

Test: Tools/TestWebKitAPI/Tests/WTF/Signals.cpp

* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/WTF/wtf/WTFConfig.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::toSystemSignal):
(WTF::fromSystemSignal):
* Source/WTF/wtf/threads/Signals.h:
(WTF::toSystemSignal): Deleted.
(WTF::fromSystemSignal): Deleted.
* Source/WTF/wtf/win/SignalsWin.cpp: Added.
(WTF::SignalHandlers::add):
(WTF::SignalHandlers::forEachHandler const):
(WTF::fromSystemException):
(WTF::vectoredHandler):
(WTF::addSignalHandler):
(WTF::activateSignalHandlersFor):
(WTF::SignalHandlers::initialize):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WTF/Signals.cpp:
(TEST):

Canonical link: <a href="https://commits.webkit.org/266716@main">https://commits.webkit.org/266716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c0cb3f77cc8214203839b0b6a17fc73666de145

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14929 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17017 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20128 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12451 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13281 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16523 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13827 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14586 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13122 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3775 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3516 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17459 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14975 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13674 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3589 "Passed tests") | 
<!--EWS-Status-Bubble-End-->