### PR TITLE
Fix build failure when gstreamer support is disabled

### DIFF
--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -33,6 +33,8 @@
 #include "ContentSecurityPolicy.h"
 #include "Document.h"
 #include "Frame.h"
+#include "FrameLoader.h"
+#include "FrameLoaderClient.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### f2c794600ed626b8d5d24a9a0489003b2a5e1a3e
<pre>
Fix build failure when gstreamer support is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=259931">https://bugs.webkit.org/show_bug.cgi?id=259931</a>
<a href="https://bugs.gentoo.org/911663">https://bugs.gentoo.org/911663</a>

Reviewed by Carlos Alberto Lopez Perez.

* Source/WebCore/loader/MixedContentChecker.cpp:

Canonical link: <a href="https://commits.webkit.org/260527.429@fix-build">https://commits.webkit.org/260527.429@fix-build</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ea311b64e2b902737e86bc42fc109af2e8f8b52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14466 "check-webkit-style (failure)") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14776 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15119 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16215 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13681 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14600 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17291 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14853 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16346 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14646 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/17291 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/15119 "Failed to compile WebKit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16950 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/17291 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/15119 "Failed to compile WebKit") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20068 "") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/17291 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/15119 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16448 "9 api tests failed or timed out") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13765 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/14853 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13053 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/15119 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17390 "Failed to compile WebKit") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1731 "Failed to push commit to Webkit repository") | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13609 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->