### PR TITLE
CSS Custom Highlights optimization add flag for when live ranges are changed

### DIFF
--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -130,6 +130,7 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
         m_end = m_start;
     updateAssociatedSelection();
     updateDocument();
+    m_didChangeHighlight = true;
     return { };
 }
 
@@ -144,6 +145,7 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
         m_start = m_end;
     updateAssociatedSelection();
     updateDocument();
+    m_didChangeHighlight = true;
     return { };
 }
 
@@ -897,6 +899,7 @@ void Range::nodeChildrenChanged(ContainerNode& container)
     ASSERT(&container.document() == m_ownerDocument.ptr());
     boundaryNodeChildrenChanged(m_start, container);
     boundaryNodeChildrenChanged(m_end, container);
+    m_didChangeHighlight = true;
 }
 
 static inline void boundaryNodeChildrenWillBeRemoved(RangeBoundaryPoint& boundary, ContainerNode& containerOfNodesToBeRemoved)
@@ -910,6 +913,7 @@ void Range::nodeChildrenWillBeRemoved(ContainerNode& container)
     ASSERT(&container.document() == m_ownerDocument.ptr());
     boundaryNodeChildrenWillBeRemoved(m_start, container);
     boundaryNodeChildrenWillBeRemoved(m_end, container);
+    m_didChangeHighlight = true;
 }
 
 static inline void boundaryNodeWillBeRemoved(RangeBoundaryPoint& boundary, Node& nodeToBeRemoved)
@@ -927,6 +931,7 @@ void Range::nodeWillBeRemoved(Node& node)
     ASSERT(node.parentNode());
     boundaryNodeWillBeRemoved(m_start, node);
     boundaryNodeWillBeRemoved(m_end, node);
+    m_didChangeHighlight = true;
 }
 
 bool Range::parentlessNodeMovedToNewDocumentAffectsRange(Node& node)
@@ -956,6 +961,7 @@ void Range::textInserted(Node& text, unsigned offset, unsigned length)
     ASSERT(&text.document() == m_ownerDocument.ptr());
     boundaryTextInserted(m_start, text, offset, length);
     boundaryTextInserted(m_end, text, offset, length);
+    m_didChangeHighlight = true;
 }
 
 static inline void boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
@@ -976,6 +982,7 @@ void Range::textRemoved(Node& text, unsigned offset, unsigned length)
     ASSERT(&text.document() == m_ownerDocument.ptr());
     boundaryTextRemoved(m_start, text, offset, length);
     boundaryTextRemoved(m_end, text, offset, length);
+    m_didChangeHighlight = true;
 }
 
 static inline void boundaryTextNodesMerged(RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
@@ -996,6 +1003,7 @@ void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
     ASSERT(oldNode.node()->previousSibling()->isTextNode());
     boundaryTextNodesMerged(m_start, oldNode, offset);
     boundaryTextNodesMerged(m_end, oldNode, offset);
+    m_didChangeHighlight = true;
 }
 
 static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& oldNode)
@@ -1028,6 +1036,7 @@ void Range::textNodeSplit(Text& oldNode)
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling()->isTextNode());
     boundaryTextNodesSplit(m_start, oldNode);
     boundaryTextNodesSplit(m_end, oldNode);
+    m_didChangeHighlight = true;
 }
 
 ExceptionOr<void> Range::expand(const String& unit)

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -52,6 +52,9 @@ public:
     bool collapsed() const final { return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;
 
+    void resetDidChangeHighlight() { m_didChangeHighlight = false; }
+    bool didChangeHighlight() const { return m_didChangeHighlight; }
+
     WEBCORE_EXPORT ExceptionOr<void> setStart(Ref<Node>&&, unsigned offset);
     WEBCORE_EXPORT ExceptionOr<void> setEnd(Ref<Node>&&, unsigned offset);
     WEBCORE_EXPORT ExceptionOr<void> setStartBefore(Node&);
@@ -133,6 +136,7 @@ private:
     RangeBoundaryPoint m_start;
     RangeBoundaryPoint m_end;
     bool m_isAssociatedWithSelection { false };
+    bool m_didChangeHighlight { false };
 };
 
 WEBCORE_EXPORT SimpleRange makeSimpleRange(const Range&);


### PR DESCRIPTION
#### 21b682820f4a338153863fdb544d2fc12a1daf14
<pre>
CSS Custom Highlights optimization add flag for when live ranges are changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=259804">https://bugs.webkit.org/show_bug.cgi?id=259804</a>
rdar://113361192

Reviewed by Ryosuke Niwa.

Does not collect range data for live ranges that were not changed/updated.
Before, would collect range data for all live ranges all the time, and repainting them.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::collectRangeDataFromRegister):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::setStart):
(WebCore::Range::setEnd):
(WebCore::Range::nodeChildrenChanged):
(WebCore::Range::nodeChildrenWillBeRemoved):
(WebCore::Range::nodeWillBeRemoved):
(WebCore::Range::textInserted):
(WebCore::Range::textRemoved):
(WebCore::Range::textNodesMerged):
(WebCore::Range::textNodeSplit):
* Source/WebCore/dom/Range.h:

Canonical link: <a href="https://commits.webkit.org/266614@main">https://commits.webkit.org/266614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1731559070fc6f1af45077d377575caf361cd9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/14378 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17081 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14646 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14432 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/17081 "Failed to compile WebKit") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16711 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/17081 "Failed to compile WebKit") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19866 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/17081 "Failed to compile WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16221 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17184 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1699 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13409 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->