### PR TITLE
CSS Custom Highlights add WPT painting-prioritization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Highlight API Test: Non-conflicting attributes</title>
+<style>
+    #blue {
+        background-color: blue;
+        color: white;
+    }
+    #yellow {
+        background-color: yellow;
+    }
+</style>
+<body>
+    <p>This <span id="blue">is an</span><span id="yellow"> example</span> of two overlapping highlights</p>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Highlight API Test: Non-conflicting attributes</title>
+<style>
+    #blue {
+        background-color: blue;
+        color: white;
+    }
+    #yellow {
+        background-color: yellow;
+    }
+</style>
+<body>
+    <p>This <span id="blue">is an</span><span id="yellow"> example</span> of two overlapping highlights</p>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>CSS Highlight API Test: Non-conflicting attributes</title>
+<link rel="help" href="https://drafts.csswg.org/css-highlight-api-1/#priorities">
+<link rel="match" href="custom-highlight-painting-prioritization-003-ref.html">
+<meta name="assert" value="Non-conflicting attributes for highlights will be painted even if lower priority">
+<style>
+    ::highlight(highlight-1) {
+        background-color: blue;
+        color: white;
+    }
+    ::highlight(highlight-2) {
+        background-color: yellow;
+    }
+</style>
+<body>
+    <p>This is an example of two overlapping highlights</p>
+</body>
+<script>
+    const text = document.querySelector("p").firstChild;
+
+    // Create two overlapping highlights
+    const range1 = new Range();
+    range1.setStart(text, 5);
+    range1.setEnd(text, 10);
+
+    const range2 = new Range();
+    range2.setStart(text, 10);
+    range2.setEnd(text, 18);
+
+    const highlight1 = new Highlight(range1);
+    const highlight2 = new Highlight(range2);
+
+    CSS.highlights.set("highlight-1", highlight1);
+    CSS.highlights.set("highlight-2", highlight2);
+</script>


### PR DESCRIPTION
#### 33bc17e9351eadef51f130dc3451edddaf516d4e
<pre>
CSS Custom Highlights add WPT painting-prioritization
<a href="https://bugs.webkit.org/show_bug.cgi?id=259837">https://bugs.webkit.org/show_bug.cgi?id=259837</a>
rdar://113411814

Reviewed by Tim Nguyen.

WPT that tests for non-conflicting attributes to still display despite lower priority.

* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-prioritization-003.html: Added.

Canonical link: <a href="https://commits.webkit.org/266611@main">https://commits.webkit.org/266611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd44f398eb83d771891debda7ea89164471578e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15991 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13500 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14647 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16712 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19867 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16222 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11419 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/12714 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3455 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13410 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->