### PR TITLE
Add reset function to CanvasRenderingContext2D

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6629,29 +6629,6 @@ imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.
 imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.transform.infinity.html [ Skip ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.transform.invalid.html [ Skip ]
 
-# CanvasReneringContext2D.reset()
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.clip.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.clip.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.clip.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.drop_shadow.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.global_composite_operation.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.line.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.misc.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.miter_limit.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.render.text.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.drop_shadow.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.global_composite_operation.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.line.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.line.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.misc.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.misc.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.miter_limit.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.miter_limit.w.html [ Timeout ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.text.html [ ImageOnlyFailure ]
-webkit.org/b/225349 imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.render.text.w.html [ Timeout ]
-
 # We only support import-attributes and do not support import-assertions.
 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/import-assertions
 

--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,2 +1,3 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/idl-conversions/canvas-filter-sequence-conversion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/idl-conversions/canvas-filter-sequence-conversion-expected.txt
@@ -2,5 +2,5 @@ canvas-filter-sequence-conversion
 Test converting types into sequences
 Actual output:
 
-FAIL Test pixels on CanvasFilter() various inputs to tableValues (which is a sequence) ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL Test pixels on CanvasFilter() various inputs to tableValues (which is a sequence) Can't find variable: CanvasFilter
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.basic-expected.txt
@@ -2,5 +2,5 @@
 reset clears to transparent black
 Actual output:
 
-FAIL reset clears to transparent black ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS reset clears to transparent black
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.direction-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.fill_style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.fill_style-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_kerning-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontKerning == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_stretch-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontStretch == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_variant_caps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_variant_caps-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontVariantCaps == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_alpha-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_alpha-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_composite_operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_composite_operation-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_quality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_quality-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_cap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_cap-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash-expected.txt
@@ -2,5 +2,5 @@
 check that the line dash is reset
 Actual output:
 
-FAIL check that the line dash is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the line dash is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash_offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash_offset-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_join-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_join-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_width-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.miter_limit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.miter_limit-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_blur-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_blur-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_color-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_x-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_x-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_y-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_y-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.stroke_style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.stroke_style-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_align-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_baseline-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_rendering-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.textRendering == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.transformation_matrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.transformation_matrix-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt
@@ -2,5 +2,5 @@
 check that the state is reset
 Actual output:
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic-expected.txt
@@ -3,5 +3,5 @@
 reset clears to transparent black
 
 
-FAIL reset clears to transparent black ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS reset clears to transparent black
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL reset clears to transparent black ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS reset clears to transparent black
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.filter == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontKerning == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontKerning == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontStretch == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontStretch == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontVariantCaps == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.fontVariantCaps == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.letterSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash-expected.txt
@@ -3,5 +3,5 @@
 check that the line dash is reset
 
 
-FAIL check that the line dash is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the line dash is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the line dash is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the line dash is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.textRendering == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.textRendering == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+PASS check that the state is reset
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt
@@ -3,5 +3,5 @@
 check that the state is reset
 
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL check that the state is reset ctx.reset is not a function. (In 'ctx.reset()', 'ctx.reset' is undefined)
+FAIL check that the state is reset assert_true: ctx.wordSpacing == default_value expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt
@@ -448,7 +448,7 @@ PASS CanvasRenderingContext2D interface: attribute canvas
 PASS CanvasRenderingContext2D interface: operation getContextAttributes()
 PASS CanvasRenderingContext2D interface: operation save()
 PASS CanvasRenderingContext2D interface: operation restore()
-FAIL CanvasRenderingContext2D interface: operation reset() assert_own_property: interface prototype object missing non-static operation expected property "reset" missing
+PASS CanvasRenderingContext2D interface: operation reset()
 FAIL CanvasRenderingContext2D interface: operation isContextLost() assert_own_property: interface prototype object missing non-static operation expected property "isContextLost" missing
 PASS CanvasRenderingContext2D interface: operation scale(unrestricted double, unrestricted double)
 PASS CanvasRenderingContext2D interface: operation rotate(unrestricted double)
@@ -535,7 +535,7 @@ PASS CanvasRenderingContext2D interface: document.createElement("canvas").getCon
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "getContextAttributes()" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "save()" with the proper type
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "restore()" with the proper type
-FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "reset()" with the proper type assert_inherits: property "reset" not found in prototype chain
+PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "reset()" with the proper type
 FAIL CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "isContextLost()" with the proper type assert_inherits: property "isContextLost" not found in prototype chain
 PASS CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "scale(unrestricted double, unrestricted double)" with the proper type
 PASS CanvasRenderingContext2D interface: calling scale(unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError
@@ -764,7 +764,7 @@ PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()
-FAIL OffscreenCanvasRenderingContext2D interface: operation reset() assert_own_property: interface prototype object missing non-static operation expected property "reset" missing
+PASS OffscreenCanvasRenderingContext2D interface: operation reset()
 FAIL OffscreenCanvasRenderingContext2D interface: operation isContextLost() assert_own_property: interface prototype object missing non-static operation expected property "isContextLost" missing
 PASS OffscreenCanvasRenderingContext2D interface: operation scale(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation rotate(unrestricted double)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -350,7 +350,7 @@ PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()
-FAIL OffscreenCanvasRenderingContext2D interface: operation reset() assert_own_property: interface prototype object missing non-static operation expected property "reset" missing
+PASS OffscreenCanvasRenderingContext2D interface: operation reset()
 FAIL OffscreenCanvasRenderingContext2D interface: operation isContextLost() assert_own_property: interface prototype object missing non-static operation expected property "isContextLost" missing
 PASS OffscreenCanvasRenderingContext2D interface: operation scale(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation rotate(unrestricted double)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt
@@ -349,7 +349,7 @@ PASS OffscreenCanvasRenderingContext2D interface: operation commit()
 PASS OffscreenCanvasRenderingContext2D interface: attribute canvas
 PASS OffscreenCanvasRenderingContext2D interface: operation save()
 PASS OffscreenCanvasRenderingContext2D interface: operation restore()
-FAIL OffscreenCanvasRenderingContext2D interface: operation reset() assert_own_property: interface prototype object missing non-static operation expected property "reset" missing
+PASS OffscreenCanvasRenderingContext2D interface: operation reset()
 FAIL OffscreenCanvasRenderingContext2D interface: operation isContextLost() assert_own_property: interface prototype object missing non-static operation expected property "isContextLost" missing
 PASS OffscreenCanvasRenderingContext2D interface: operation scale(unrestricted double, unrestricted double)
 PASS OffscreenCanvasRenderingContext2D interface: operation rotate(unrestricted double)

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,2 +1,3 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
 

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -135,6 +135,8 @@ public:
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
     void recordLastFillText(const String&);
 
+    void resetGraphicsContextState() const;
+
 protected:
     explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
 
@@ -145,8 +147,6 @@ protected:
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
     virtual bool hasCreatedImageBuffer() const { return false; }
     static size_t activePixelMemory();
-
-    void resetGraphicsContextState() const;
 
     RefPtr<ImageBuffer> allocateImageBuffer(bool avoidBackendSizeCheckForTesting) const;
     String lastFillText() const { return m_lastFillText; }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -583,9 +583,10 @@ void HTMLCanvasElement::reset()
     int w = limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(widthAttr), defaultWidth);
     int h = limitToOnlyHTMLNonNegative(attributeWithoutSynchronization(heightAttr), defaultHeight);
 
-    resetGraphicsContextState();
     if (is<CanvasRenderingContext2D>(m_context))
         downcast<CanvasRenderingContext2D>(*m_context).reset();
+    else
+        resetGraphicsContextState();
 
     IntSize oldSize = size();
     IntSize newSize(w, h);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -238,12 +238,12 @@ void CanvasRenderingContext2DBase::unwindStateStack()
     // Ensure that the state stack in the ImageBuffer's context
     // is cleared before destruction, to avoid assertions in the
     // GraphicsContext dtor.
-    if (size_t stackSize = m_stateStack.size()) {
-        if (auto* context = canvasBase().existingDrawingContext()) {
-            while (--stackSize)
-                context->restore();
-        }
-    }
+    size_t stackSize = m_stateStack.size();
+    if (stackSize <= 1)
+        return;
+    // We need to keep the last state because it is tracked by CanvasBase::m_contextStateSaver.
+    if (auto* context = canvasBase().existingDrawingContext())
+        context->unwindStateStack(stackSize - 1);
 }
 
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
@@ -266,13 +266,21 @@ bool CanvasRenderingContext2DBase::isAccelerated() const
 void CanvasRenderingContext2DBase::reset()
 {
     unwindStateStack();
+
     m_stateStack.resize(1);
     m_stateStack.first() = State();
+
     m_path.clear();
     m_unrealizedSaveCount = 0;
     m_cachedImageData = std::nullopt;
 
     m_recordingContext = nullptr;
+
+    clearAccumulatedDirtyRect();
+    resetTransform();
+
+    canvasBase().resetGraphicsContextState();
+    clearCanvas();
 }
 
 CanvasRenderingContext2DBase::State::State()

--- a/Source/WebCore/html/canvas/CanvasState.idl
+++ b/Source/WebCore/html/canvas/CanvasState.idl
@@ -28,4 +28,5 @@ interface mixin CanvasState {
     // state
     undefined save(); // push state on state stack
     undefined restore(); // pop state stack and restore state
+    undefined reset(); // reset the rendering context to its default state
 };

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -87,6 +87,23 @@ void GraphicsContext::restore(GraphicsContextState::Purpose purpose)
         m_stack.clear();
 }
 
+void GraphicsContext::unwindStateStack(unsigned count)
+{
+    ASSERT(count <= stackSize());
+    while (count-- > 0) {
+        switch (m_state.purpose()) {
+        case GraphicsContextState::Purpose::SaveRestore:
+            restore();
+            break;
+        case GraphicsContextState::Purpose::TransparencyLayer:
+            endTransparencyLayer();
+            break;
+        default:
+            ASSERT_NOT_REACHED();
+        }
+    }
+}
+
 void GraphicsContext::mergeLastChanges(const GraphicsContextState& state, const std::optional<GraphicsContextState>& lastDrawingState)
 {
     m_state.mergeLastChanges(state, lastDrawingState);

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -175,6 +175,9 @@ public:
     WEBCORE_EXPORT virtual void save(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
     WEBCORE_EXPORT virtual void restore(GraphicsContextState::Purpose = GraphicsContextState::Purpose::SaveRestore);
 
+    void unwindStateStack(unsigned count);
+    void unwindStateStack() { unwindStateStack(stackSize()); }
+
     unsigned stackSize() const { return m_stack.size(); }
 
 #if USE(CG)


### PR DESCRIPTION
#### 65dc23bfda96b7011b0d15c4aec089f79a75d0e0
<pre>
Add reset function to CanvasRenderingContext2D
<a href="https://bugs.webkit.org/show_bug.cgi?id=225349">https://bugs.webkit.org/show_bug.cgi?id=225349</a>
rdar://77842434

Reviewed by Simon Fraser.

Make sure CanvasRenderingContext2D::reset() clear all the context state settings.
Restore the GraphicsContext state to the canvas default setting by calling
CanvasBase::resetGraphicsContextState().

Add the method GraphicsContext::unwindStateStack() to unwind the state stack
and the transparency layers in the right order. Call this method wherever we
need to reset the GraphicsContext state stack.

* LayoutTests/TestExpectations:
* LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/manual/filters/tentative/idl-conversions/canvas-filter-sequence-conversion-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.fill_style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.font_variant_caps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_alpha-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.global_composite_operation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_enabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.image_smoothing_quality-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.letter_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_cap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_dash_offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_join-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.line_width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.miter_limit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_blur-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_x-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.shadow_offset_y-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.stroke_style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.text_rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.transformation_matrix-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/element/reset/2d.reset.state.word_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.basic.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.direction.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.fill_style.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.filter.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_kerning.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_stretch.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.font_variant_caps.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_alpha.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.global_composite_operation.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_enabled.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.image_smoothing_quality.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.letter_spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_cap.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_dash_offset.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_join.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.line_width.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.miter_limit.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_blur.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_color.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_x.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.shadow_offset_y.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.stroke_style.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_align.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_baseline.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.text_rendering.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.transformation_matrix.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/canvas/offscreen/reset/2d.reset.state.word_spacing.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.https_exclude=(Document_Window_HTML._)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/dom/idlharness.worker-expected.txt:
* LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::reset):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::reset):
* Source/WebCore/html/canvas/CanvasState.idl:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::unwindStateStack):
* Source/WebCore/platform/graphics/GraphicsContext.h:
(WebCore::GraphicsContext::unwindStateStack):

Canonical link: <a href="https://commits.webkit.org/267824@main">https://commits.webkit.org/267824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/621fdd5d6562c84ed219e675c652fc3003f6b810

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/17787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/18112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/18655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/19612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/16637 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/17982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/21408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/18263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/18677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/18000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/18286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/15451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/20479 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/15514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/16205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/22763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/16530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/16373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/20628 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/16944 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/14348 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/16055 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4242 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/20417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/16791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->