### PR TITLE
[JSC] IntrinsicGetter AccessCase should not use Equivalent condition

### DIFF
--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -391,15 +391,13 @@ ObjectPropertyConditionSet generateConditionsForIndexedMiss(VM& vm, JSCell* owne
 
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHit(
     VM& vm, JSCell* owner, JSGlobalObject* globalObject, Structure* headStructure, JSObject* prototype,
-    UniquedStringImpl* uid, PropertyCondition::Kind prototypeConditionKind)
+    UniquedStringImpl* uid)
 {
-    ASSERT(prototypeConditionKind == PropertyCondition::Presence || prototypeConditionKind == PropertyCondition::Equivalence);
-
     return generateConditions(
         globalObject, headStructure, prototype, uid,
         [&](auto& conditions, JSObject* object, Structure* structure) -> bool {
             PropertyCondition::Kind kind =
-                object == prototype ? prototypeConditionKind : PropertyCondition::Absence;
+                object == prototype ? PropertyCondition::Presence : PropertyCondition::Absence;
             ObjectPropertyCondition result =
                 generateCondition(vm, owner, object, structure, uid, kind, Concurrency::MainThread);
             if (!result)

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h
@@ -168,7 +168,7 @@ ObjectPropertyConditionSet generateConditionsForPropertySetterMiss(
 ObjectPropertyConditionSet generateConditionsForIndexedMiss(VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure);
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHit(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, JSObject* prototype,
-    UniquedStringImpl* uid, PropertyCondition::Kind prototypeConditionKind = PropertyCondition::Presence);
+    UniquedStringImpl* uid);
 ObjectPropertyConditionSet generateConditionsForPrototypePropertyHitCustom(
     VM&, JSCell* owner, JSGlobalObject*, Structure* headStructure, JSObject* prototype,
     UniquedStringImpl* uid, unsigned attributes);


### PR DESCRIPTION
#### 41847fe79586f5031cd0af2b87858561a0c46f63
<pre>
[JSC] IntrinsicGetter AccessCase should not use Equivalent condition
<a href="https://bugs.webkit.org/show_bug.cgi?id=259841">https://bugs.webkit.org/show_bug.cgi?id=259841</a>
rdar://113416758

Reviewed by Keith Miller.

265594@main leveraged Equivalent condition in AccessCase, but this is wrong.
DFG cannot use Equivalent condition for AccessCase (see planLoad, ComplexGetByStatus etc.),
and breaking a key invariant / heuristics for DFG.

This patch reverts 265594@main and fixes the original issue in different way.
Instead of using Equivalent condition, we just check getter in AccessCase.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateImpl):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::generateConditionsForPrototypePropertyHit):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):

Canonical link: <a href="https://commits.webkit.org/266659@main">https://commits.webkit.org/266659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d7f971689892a86c0439c9bb73da80d3006f611

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13504 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16174 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14994 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16716 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19879 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13356 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13021 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16227 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/13551 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11420 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14303 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12852 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3699 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17189 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/14692 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1717 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13414 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3512 "Passed tests") | 
<!--EWS-Status-Bubble-End-->