### PR TITLE
Media: Update fullscreen controls for 1360 PPM

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -69,6 +69,11 @@ namespace WebKit {
 using namespace WebKit;
 using namespace WebCore;
 
+static constexpr float ZoomForFullscreenWindow = 1.0;
+#if PLATFORM(VISION)
+static constexpr float ZoomForVisionFullscreenVideoWindow = 1.36;
+#endif
+
 static CGSize sizeExpandedToSize(CGSize initial, CGSize other)
 {
     return CGSizeMake(std::max(initial.width, other.width),  std::max(initial.height, other.height));
@@ -898,10 +903,18 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
             manager->setAnimatingFullScreen(true);
 
         WebCore::ViewportArguments arguments { WebCore::ViewportArguments::CSSDeviceAdaptation };
-        arguments.zoom = 1;
-        arguments.minZoom = 1;
-        arguments.maxZoom = 1;
-        arguments.userZoom = 1;
+        arguments.zoom = WebKit::ZoomForFullscreenWindow;
+        arguments.minZoom = WebKit::ZoomForFullscreenWindow;
+        arguments.maxZoom = WebKit::ZoomForFullscreenWindow;
+        arguments.userZoom = WebKit::ZoomForFullscreenWindow;
+#if PLATFORM(VISION)
+        if (manager->isVideoElement()) {
+            arguments.zoom = WebKit::ZoomForVisionFullscreenVideoWindow;
+            arguments.minZoom = WebKit::ZoomForVisionFullscreenVideoWindow;
+            arguments.maxZoom = WebKit::ZoomForVisionFullscreenVideoWindow;
+            arguments.userZoom = WebKit::ZoomForVisionFullscreenVideoWindow;
+        }
+#endif
         page->setOverrideViewportArguments(arguments);
 
         page->forceRepaint([protectedSelf = retainPtr(self), self, logIdentifier = logIdentifier] {


### PR DESCRIPTION
#### 17723aacd5f56e3299fbe876bed81b7c2bac02b2
<pre>
Media: Update fullscreen controls for 1360 PPM
<a href="https://bugs.webkit.org/show_bug.cgi?id=259845">https://bugs.webkit.org/show_bug.cgi?id=259845</a>
rdar://112866983

Reviewed by Eric Carlson.

The visionOS media controls are too small when in
fullscreen.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Canonical link: <a href="https://commits.webkit.org/266607@main">https://commits.webkit.org/266607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9afd7325a7b2633ed420dd3e5bb8eb7c98c16148

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16004 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/13510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/16180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15001 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16724 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/12285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/19875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/13363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/13028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16234 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/13575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/11426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12861 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17197 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1697 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/13420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->